### PR TITLE
@Suppress("NOT_DOCUMENTED"), fix for linking to targets with underscores, gradle plugin improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,17 @@ buildscript {
 apply plugin: 'org.jetbrains.dokka'
 ```
 
-To configure plugin use dokka lambda in the root scope. For example:
+The plugin adds a task named "dokka" to the project. The available configuration
+options are shown below:
 
 ```groovy
 dokka {
+    moduleName = 'data'
+    outputFormat = 'javadoc'
+    outputDirectory = "$buildDir/javadoc"
+    processConfigurations = ['compile', 'extra']
+    includes = ['packages.md', 'extra.md']
+    samples = ['samples/basic.kt', 'samples/advanced.kt']
     linkMapping {
         dir = "src/main/kotlin"
         url = "https://github.com/cy6erGn0m/vertx3-lang-kotlin/blob/master/src/main/kotlin"
@@ -149,6 +156,16 @@ To get it generated use gradle `dokka` task
 ```bash
 ./gradlew dokka
 ```
+
+More dokka tasks can be added to a project like this:
+
+```groovy
+task dokkaJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
+    outputFormat = 'javadoc'
+    outputDirectory = "$buildDir/javadoc"
+}
+```
+
 
 Please see the [Dokka Gradle example project](https://github.com/JetBrains/kotlin-examples/tree/master/gradle/dokka-gradle-example) for an example.
 

--- a/core/src/main/kotlin/Kotlin/ContentBuilder.kt
+++ b/core/src/main/kotlin/Kotlin/ContentBuilder.kt
@@ -48,27 +48,27 @@ public fun buildContentTo(tree: MarkdownNode, target: ContentBlock, linkResolver
             MarkdownElementTypes.PARAGRAPH -> appendNodeWithChildren(ContentParagraph())
 
             MarkdownElementTypes.INLINE_LINK -> {
-                val label = node.child(MarkdownElementTypes.LINK_TEXT)?.child(MarkdownTokenTypes.TEXT)
+                val labelText = node.child(MarkdownElementTypes.LINK_TEXT)?.getLabelText()
                 val destination = node.child(MarkdownElementTypes.LINK_DESTINATION)
-                if (label != null) {
+                if (labelText != null) {
                     if (destination != null) {
                         val link = ContentExternalLink(destination.text)
-                        link.append(ContentText(label.text))
+                        link.append(ContentText(labelText))
                         parent.append(link)
                     } else {
-                        val link = ContentExternalLink(label.text)
-                        link.append(ContentText(label.text))
+                        val link = ContentExternalLink(labelText)
+                        link.append(ContentText(labelText))
                         parent.append(link)
                     }
                 }
             }
             MarkdownElementTypes.SHORT_REFERENCE_LINK,
             MarkdownElementTypes.FULL_REFERENCE_LINK -> {
-                val label = node.child(MarkdownElementTypes.LINK_LABEL)?.child(MarkdownTokenTypes.TEXT)
-                if (label != null) {
-                    val link = linkResolver(label.text)
-                    val linkText = node.child(MarkdownElementTypes.LINK_TEXT)?.child(MarkdownTokenTypes.TEXT)
-                    link.append(ContentText(linkText?.text ?: label.text))
+                val labelText = node.child(MarkdownElementTypes.LINK_LABEL)?.getLabelText()
+                if (labelText != null) {
+                    val link = linkResolver(labelText)
+                    val linkText = node.child(MarkdownElementTypes.LINK_TEXT)?.getLabelText()
+                    link.append(ContentText(linkText ?: labelText))
                     parent.append(link)
                 }
             }
@@ -126,6 +126,8 @@ public fun buildContentTo(tree: MarkdownNode, target: ContentBlock, linkResolver
         }
     }
 }
+
+private fun MarkdownNode.getLabelText() = children.filter { it.type == MarkdownTokenTypes.TEXT || it.type == MarkdownTokenTypes.EMPH }.joinToString("") { it.text }
 
 private fun keepWhitespace(node: ContentNode) = node is ContentParagraph || node is ContentSection
 

--- a/core/src/test/kotlin/model/LinkTest.kt
+++ b/core/src/test/kotlin/model/LinkTest.kt
@@ -25,6 +25,16 @@ public class LinkTest {
         }
     }
 
+    @Test fun linkToConstantWithUnderscores() {
+        verifyModel("testdata/links/linkToConstantWithUnderscores.kt") { model ->
+            with(model.members.single().members.single()) {
+                assertEquals("Foo", name)
+                assertEquals(DocumentationNode.Kind.Class, kind)
+                assertEquals("This is link to [MY_CONSTANT_VALUE -> CompanionObjectProperty:MY_CONSTANT_VALUE]", content.summary.toTestString())
+            }
+        }
+    }
+
     @Test fun linkToQualifiedMember() {
         verifyModel("testdata/links/linkToQualifiedMember.kt") { model ->
             with(model.members.single().members.single()) {

--- a/core/testdata/links/linkToConstantWithUnderscores.kt
+++ b/core/testdata/links/linkToConstantWithUnderscores.kt
@@ -1,0 +1,8 @@
+/**
+ * This is link to [MY_CONSTANT_VALUE]
+ */
+class Foo {
+    companion object {
+        val MY_CONSTANT_VALUE = 0
+    }
+}

--- a/dokka-gradle-plugin/build.gradle
+++ b/dokka-gradle-plugin/build.gradle
@@ -23,7 +23,6 @@ apply plugin: 'com.jfrog.bintray'
 sourceCompatibility = 1.6
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven {
         url 'http://oss.sonatype.org/content/repositories/snapshots'

--- a/dokka-gradle-plugin/src/main/kotlin/main.kt
+++ b/dokka-gradle-plugin/src/main/kotlin/main.kt
@@ -95,7 +95,9 @@ public open class DokkaTask : DefaultTask() {
 
     @InputFiles
     @SkipWhenEmpty
-    fun getIncludedFiles() : FileCollection = project.files(getSourceDirectories().map { project.fileTree(it) })
+    fun getInputFiles() : FileCollection = project.files(getSourceDirectories().map { project.fileTree(it) }) +
+        project.files(includes) +
+        project.files(samples)
 
     @OutputDirectory
     fun getOutputDirectoryAsFile() : File = project.file(outputDirectory)

--- a/dokka-gradle-plugin/src/main/kotlin/main.kt
+++ b/dokka-gradle-plugin/src/main/kotlin/main.kt
@@ -34,13 +34,13 @@ public open class DokkaTask : DefaultTask() {
     var outputFormat: String = "html"
     var outputDirectory: String = ""
     @Input
-    var processConfigurations: ArrayList<String> = arrayListOf("compile")
+    var processConfigurations: List<Any?> = arrayListOf("compile")
     @Input
-    var includes: ArrayList<String> = arrayListOf()
+    var includes: List<Any?> = arrayListOf()
     @Input
     var linkMappings: ArrayList<LinkMapping> = arrayListOf()
     @Input
-    var samples: ArrayList<String> = arrayListOf()
+    var samples: List<Any?> = arrayListOf()
 
     fun linkMapping(closure: Closure<Any?>) {
         val mapping = LinkMapping()
@@ -65,7 +65,7 @@ public open class DokkaTask : DefaultTask() {
 
         val classpath =
                 processConfigurations
-                .map { allConfigurations?.getByName(it) ?: throw IllegalArgumentException("No configuration $it found") }
+                .map { allConfigurations?.getByName(it.toString()) ?: throw IllegalArgumentException("No configuration $it found") }
                 .flatMap { it }
 
         if (sourceDirectories.isEmpty()) {
@@ -77,8 +77,8 @@ public open class DokkaTask : DefaultTask() {
                 DokkaGradleLogger(logger),
                 classpath.map { it.absolutePath },
                 sourceDirectories.map { it.absolutePath },
-                samples,
-                includes,
+                samples.filterNotNull().map { project.file(it).absolutePath },
+                includes.filterNotNull().map { project.file(it).absolutePath },
                 moduleName,
                 outputDirectory,
                 outputFormat,


### PR DESCRIPTION
@Suppress("NOT_DOCUMENTED"): Sometimes you have classes that you do not want to document without getting swamped by warnings.

Btw, the recent revision of kotlin-for-upsource.jar does not work with kotlin beta 4. Is beta 5 expected soon?