### PR TITLE
Maven : Avoid crash when no javadoc generated

### DIFF
--- a/maven-plugin/src/main/kotlin/DokkaMojo.kt
+++ b/maven-plugin/src/main/kotlin/DokkaMojo.kt
@@ -148,6 +148,10 @@ class DokkaJavadocJarMojo : AbstractDokkaMojo() {
 
     override fun execute() {
         super.execute()
+        if(!File(outputDir).exists()) {
+            log.warn("No javadoc generated so no javadoc jar will be generated")
+            return
+        }
         val outputFile = generateArchive("$finalName-$classifier.jar")
         if (attach) {
             projectHelper?.attachArtifact(project, "javadoc", classifier, outputFile)


### PR DESCRIPTION
To avoid this stacktrace : 

Caused by: org.apache.maven.plugin.PluginExecutionException: Execution default-cli of goal org.jetbrains.dokka:dokka-maven-plugin:0.9.8:javadocJar failed: (skipped)/target/dokkaJavadocJar isn't a directory.
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:143)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
	... 19 more
Caused by: org.codehaus.plexus.archiver.ArchiverException: (skipped)/target/dokkaJavadocJar isn't a directory.
	at org.codehaus.plexus.archiver.AbstractArchiver.addFileSet(AbstractArchiver.java:291)
	at org.codehaus.plexus.archiver.AbstractArchiver.addDirectory(AbstractArchiver.java:268)
	at org.jetbrains.dokka.maven.DokkaJavadocJarMojo.generateArchive(DokkaMojo.kt:163)
	at org.jetbrains.dokka.maven.DokkaJavadocJarMojo.execute(DokkaMojo.kt:151)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:132)
