### PR TITLE
many markdown fixes

### DIFF
--- a/core/src/main/kotlin/Formats/HtmlFormatService.kt
+++ b/core/src/main/kotlin/Formats/HtmlFormatService.kt
@@ -27,6 +27,10 @@ open class HtmlFormatService @Inject constructor(@Named("folders") locationServi
         return "<span class=\"identifier\"$id>${formatText(text)}</span>"
     }
 
+    override fun appendCode(to: StringBuilder, bodyAsText: ()->String) {
+        to.append("<code>${bodyAsText()}</code>")
+    }
+
     override fun appendBlockCode(to: StringBuilder, language: String, bodyAsLines: ()->List<String>) {
         to.append("<pre><code>")
         to.append(bodyAsLines().joinToString("\n"))
@@ -91,10 +95,6 @@ open class HtmlFormatService @Inject constructor(@Named("folders") locationServi
 
     override fun formatStrikethrough(text: String): String {
         return "<s>${text}</s>"
-    }
-
-    override fun formatCode(code: String): String {
-        return "<code>${code}</code>"
     }
 
     override fun formatUnorderedList(text: String): String = "<ul>${text}</ul>"

--- a/core/src/main/kotlin/Formats/HtmlFormatService.kt
+++ b/core/src/main/kotlin/Formats/HtmlFormatService.kt
@@ -27,9 +27,9 @@ open class HtmlFormatService @Inject constructor(@Named("folders") locationServi
         return "<span class=\"identifier\"$id>${formatText(text)}</span>"
     }
 
-    override fun appendBlockCode(to: StringBuilder, lines: List<String>, language: String) {
+    override fun appendBlockCode(to: StringBuilder, language: String, bodyAsLines: ()->List<String>) {
         to.append("<pre><code>")
-        to.append(lines.joinToString("\n"))
+        to.append(bodyAsLines().joinToString("\n"))
         to.append("</code></pre>")
     }
 
@@ -45,20 +45,18 @@ open class HtmlFormatService @Inject constructor(@Named("folders") locationServi
         to.appendln("$text<br/>")
     }
 
+    override fun appendList(to: StringBuilder, body: () -> Unit) {
+        body()
+    }
+
     override fun appendAnchor(to: StringBuilder, anchor: String) {
         to.appendln("<a name=\"${anchor.htmlEscape()}\"></a>")
     }
 
-    override fun appendTable(to: StringBuilder, body: () -> Unit) {
+    override fun appendTable(to: StringBuilder, columnCount: Int, body: () -> Unit) {
         to.appendln("<table>")
         body()
         to.appendln("</table>")
-    }
-
-    override fun appendTableHeader(to: StringBuilder, body: () -> Unit) {
-        to.appendln("<thead>")
-        body()
-        to.appendln("</thead>")
     }
 
     override fun appendTableBody(to: StringBuilder, body: () -> Unit) {

--- a/core/src/main/kotlin/Formats/KotlinWebsiteFormatService.kt
+++ b/core/src/main/kotlin/Formats/KotlinWebsiteFormatService.kt
@@ -77,16 +77,10 @@ class KotlinWebsiteFormatService @Inject constructor(locationService: LocationSe
         }
     }
 
-    override fun appendTable(to: StringBuilder, body: () -> Unit) {
+    override fun appendTable(to: StringBuilder, columnCount: Int, body: () -> Unit) {
         to.appendln("<table class=\"api-docs-table\">")
         body()
         to.appendln("</table>")
-    }
-
-    override fun appendTableHeader(to: StringBuilder, body: () -> Unit) {
-        to.appendln("<thead>")
-        body()
-        to.appendln("</thead>")
     }
 
     override fun appendTableBody(to: StringBuilder, body: () -> Unit) {
@@ -107,12 +101,12 @@ class KotlinWebsiteFormatService @Inject constructor(locationService: LocationSe
         to.appendln("\n</td>")
     }
 
-    override fun appendBlockCode(to: StringBuilder, lines: List<String>, language: String) {
+    override fun appendBlockCode(to: StringBuilder, language: String, bodyAsLines: ()->List<String>) {
         if (language.isNotEmpty()) {
-            super.appendBlockCode(to, lines, language)
+            super.appendBlockCode(to, language, bodyAsLines)
         } else {
             to.append("<pre markdown=\"1\">")
-            to.append(lines.joinToString { "\n" }.trimStart())
+            to.append(bodyAsLines().joinToString { "\n" }.trimStart())
             to.append("</pre>")
         }
     }

--- a/core/src/main/kotlin/Formats/KotlinWebsiteFormatService.kt
+++ b/core/src/main/kotlin/Formats/KotlinWebsiteFormatService.kt
@@ -25,7 +25,11 @@ class KotlinWebsiteFormatService @Inject constructor(locationService: LocationSe
         return ""
     }
 
-    override fun formatCode(code: String): String = if (code.length > 0) "<code>$code</code>" else ""
+    override fun appendCode(to: StringBuilder, bodyAsText: ()->String) {
+        val code =  bodyAsText()
+        to.append(if (code.length > 0) "<code>$code</code>" else "")
+    }
+
 
     override fun formatStrikethrough(text: String): String = "<s>$text</s>"
 

--- a/core/src/main/kotlin/Formats/MarkdownFormatService.kt
+++ b/core/src/main/kotlin/Formats/MarkdownFormatService.kt
@@ -167,7 +167,7 @@ open class MarkdownFormatService(locationService: LocationService,
     }
 
     override fun appendTable(to: StringBuilder, columnCount: Int, body: () -> Unit) {
-        to.appendln("|" + "&nbsp;|".repeat(columnCount))
+        to.appendln("|" + " |".repeat(columnCount))
         to.appendln("|" + "---|".repeat(columnCount))
         body()
     }
@@ -183,9 +183,9 @@ open class MarkdownFormatService(locationService: LocationService,
     }
 
     override fun appendTableCell(to: StringBuilder, body: () -> Unit) {
-        to.append(" ")
+        to.append("")
         changeLf(LfPriority.HtmlBr) { body() }
-        to.append(" |")
+        to.append("|")
     }
 
     override fun formatNonBreakingSpace(): String = allowedLf().nbsp

--- a/core/src/main/kotlin/Formats/StructuredFormatService.kt
+++ b/core/src/main/kotlin/Formats/StructuredFormatService.kt
@@ -21,6 +21,7 @@ abstract class StructuredFormatService(locationService: LocationService,
     abstract fun appendParagraph(to: StringBuilder, text: String)
     abstract fun appendLine(to: StringBuilder, text: String = "")
     abstract fun appendAnchor(to: StringBuilder, anchor: String)
+    abstract fun appendCode(to: StringBuilder, bodyAsText: ()->String)
 
     abstract fun appendList(to: StringBuilder, body: () -> Unit)
     abstract fun appendTable(to: StringBuilder, columnCount: Int, body: () -> Unit)
@@ -38,7 +39,7 @@ abstract class StructuredFormatService(locationService: LocationService,
     abstract fun formatStrong(text: String): String
     abstract fun formatStrikethrough(text: String): String
     abstract fun formatEmphasis(text: String): String
-    abstract fun formatCode(code: String): String
+
     abstract fun formatUnorderedList(text: String): String
     abstract fun formatOrderedList(text: String): String
     abstract fun formatListItem(text: String, kind: ListKind): String
@@ -80,7 +81,7 @@ abstract class StructuredFormatService(locationService: LocationService,
             is ContentEntity -> to.append(formatEntity(content.text))
             is ContentStrong -> to.append(formatStrong(formatText(location, content.children)))
             is ContentStrikethrough -> to.append(formatStrikethrough(formatText(location, content.children)))
-            is ContentCode -> to.append(formatCode(formatText(location, content.children)))
+            is ContentCode -> appendCode(to) { formatText(location, content.children) }
             is ContentEmphasis -> to.append(formatEmphasis(formatText(location, content.children)))
             is ContentUnorderedList -> appendList(to) { to.append(formatUnorderedList(formatText(location, content.children, ListKind.Unordered))) }
             is ContentOrderedList -> appendList(to) { to.append(formatOrderedList(formatText(location, content.children, ListKind.Ordered))) }
@@ -206,7 +207,7 @@ abstract class StructuredFormatService(locationService: LocationService,
                     appendAnchor(to, it.name)
                 }
                 appendAsSignature(to, rendered) {
-                    to.append(formatCode(formatText(location, rendered)))
+                    appendCode(to) { formatText(location, rendered) }
                     it.appendSourceLink()
                 }
                 it.appendOverrides()
@@ -291,7 +292,8 @@ abstract class StructuredFormatService(locationService: LocationService,
                     }
 
                     appendAnchor(to, subjectName)
-                    to.append(formatCode(subjectName)).append(" - ")
+                    appendCode(to) { subjectName }
+                    to.append(" - ")
                     formatText(location, it, to)
                     appendLine(to)
                 }

--- a/core/src/main/kotlin/Formats/StructuredFormatService.kt
+++ b/core/src/main/kotlin/Formats/StructuredFormatService.kt
@@ -420,7 +420,12 @@ abstract class StructuredFormatService(locationService: LocationService,
                 }
             }
             appendAsSignature(to, renderedSignatures.last()) {
-                appendLine(to, renderedSignatures.last().signatureToText(location))
+                val sigText = renderedSignatures.last().signatureToText(location)
+                if (sigText.isNotBlank()) {
+                    appendLine(to, sigText)
+                } else {
+                    to.append(sigText)
+                }
             }
         }
     }

--- a/core/src/main/kotlin/Formats/StructuredFormatService.kt
+++ b/core/src/main/kotlin/Formats/StructuredFormatService.kt
@@ -16,14 +16,14 @@ abstract class StructuredFormatService(locationService: LocationService,
                                        val linkExtension: String = extension) : FormatService {
     val locationService: LocationService = locationService.withExtension(linkExtension)
 
-    abstract fun appendBlockCode(to: StringBuilder, lines: List<String>, language: String)
+    abstract fun appendBlockCode(to: StringBuilder, langauge: String, bodyAsLines: ()->List<String>)
     abstract fun appendHeader(to: StringBuilder, text: String, level: Int = 1)
     abstract fun appendParagraph(to: StringBuilder, text: String)
     abstract fun appendLine(to: StringBuilder, text: String = "")
     abstract fun appendAnchor(to: StringBuilder, anchor: String)
 
-    abstract fun appendTable(to: StringBuilder, body: () -> Unit)
-    abstract fun appendTableHeader(to: StringBuilder, body: () -> Unit)
+    abstract fun appendList(to: StringBuilder, body: () -> Unit)
+    abstract fun appendTable(to: StringBuilder, columnCount: Int, body: () -> Unit)
     abstract fun appendTableBody(to: StringBuilder, body: () -> Unit)
     abstract fun appendTableRow(to: StringBuilder, body: () -> Unit)
     abstract fun appendTableCell(to: StringBuilder, body: () -> Unit)
@@ -55,6 +55,19 @@ abstract class StructuredFormatService(locationService: LocationService,
         return StringBuilder().apply { formatText(location, content, this, listKind) }.toString()
     }
 
+    fun List<ContentNode>.ignoreParagraphMarker(): List<ContentNode> {
+        return if (this.size == 1) {
+            val possibleParagraph = this.first()
+            if (possibleParagraph is ContentParagraph) {
+                possibleParagraph.children
+            } else {
+                this
+            }
+        } else {
+            this
+        }
+    }
+
     open fun formatText(location: Location, content: ContentNode, to: StringBuilder, listKind: ListKind = ListKind.Unordered) {
         when (content) {
             is ContentText -> to.append(formatText(content.text))
@@ -69,9 +82,9 @@ abstract class StructuredFormatService(locationService: LocationService,
             is ContentStrikethrough -> to.append(formatStrikethrough(formatText(location, content.children)))
             is ContentCode -> to.append(formatCode(formatText(location, content.children)))
             is ContentEmphasis -> to.append(formatEmphasis(formatText(location, content.children)))
-            is ContentUnorderedList -> to.append(formatUnorderedList(formatText(location, content.children, ListKind.Unordered)))
-            is ContentOrderedList -> to.append(formatOrderedList(formatText(location, content.children, ListKind.Ordered)))
-            is ContentListItem -> to.append(formatListItem(formatText(location, content.children), listKind))
+            is ContentUnorderedList -> appendList(to) { to.append(formatUnorderedList(formatText(location, content.children, ListKind.Unordered))) }
+            is ContentOrderedList -> appendList(to) { to.append(formatOrderedList(formatText(location, content.children, ListKind.Ordered))) }
+            is ContentListItem -> to.append(formatListItem(formatText(location, content.children.ignoreParagraphMarker()), listKind))
 
             is ContentNodeLink -> {
                 val node = content.node
@@ -92,7 +105,7 @@ abstract class StructuredFormatService(locationService: LocationService,
                 }
             }
             is ContentParagraph -> appendParagraph(to, formatText(location, content.children))
-            is ContentBlockCode -> appendBlockCode(to, content.children.map { formatText(location, it) }, content.language)
+            is ContentBlockCode -> appendBlockCode(to, content.language) { content.children.map { formatText(location, it) } }
             is ContentHeading -> appendHeader(to, formatText(location, content.children), content.level)
             is ContentBlock -> to.append(formatText(location, content.children))
         }
@@ -342,6 +355,7 @@ abstract class StructuredFormatService(locationService: LocationService,
 
             if (node.kind == NodeKind.Module) {
                 appendHeader(to, "Index", 3)
+                appendLine(to)
                 node.members(NodeKind.AllTypes).singleOrNull()?.let { allTypes ->
                     to.append(formatLink(link(node, allTypes, { "All Types" })))
                 }
@@ -352,11 +366,12 @@ abstract class StructuredFormatService(locationService: LocationService,
             if (members.isEmpty()) return
 
             appendHeader(to, caption, 3)
+            appendLine(to)
 
             val children = if (sortMembers) members.sortedBy { it.name } else members
             val membersMap = children.groupBy { link(node, it) }
 
-            appendTable(to) {
+            appendTable(to, 2) {
                 appendTableBody(to) {
                     for ((memberLocation, members) in membersMap) {
                         appendTableRow(to) {
@@ -404,8 +419,9 @@ abstract class StructuredFormatService(locationService: LocationService,
         override fun build() {
             to.append(formatText(location, node.owner!!.summary))
             appendHeader(to, "All Types", 3)
+            appendLine(to)
 
-            appendTable(to) {
+            appendTable(to, 2) {
                 appendTableBody(to) {
                     for (type in node.members) {
                         appendTableRow(to) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 kotlin_version=1.0.2
-dokka_version=0.9.8
+dokka_version=0.9.9-SNAPSHOT
 dokka_eap=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 kotlin_version=1.0.2
-dokka_version=0.9.9-SNAPSHOT
+dokka_version=0.9.9-jrm-02
 dokka_eap=false


### PR DESCRIPTION
Don't escape within code blocks because HTML entities are not processed by markdown
Fence a triple backtick code block with 4 invisible spaces per line in case the code block contains backticks that might confuse the fencing
Check for backticks in inline code snippets and fence with more backticks than those present (which is the standard way to escape)
Change LF to <br/> or empty depending on the container (i.e. list items cannot have LF but rather can have <p> or <br/>, and tables as well in markdown cannot have LF but can have the <p> and <br/>
Fix bug where list items copied from includes add a line after the * and before the text (markdown parser generates a paragraph which is NOT intended to be a line break in the middle of a list item
Fix tables, they require a header row and the divider |---|---| style thing

should fix:  #71, #72 and others not yet reported