### PR TITLE
Apply Gradle Plugin Publishing Plugin 0.9.5

### DIFF
--- a/dokka-gradle-plugin/build.gradle
+++ b/dokka-gradle-plugin/build.gradle
@@ -2,9 +2,14 @@ group 'org.jetbrains.dokka'
 version dokka_version
 
 buildscript {
+    repositories {
+        jcenter()
+        maven { url "https://plugins.gradle.org/m2/" }
+    }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
+        classpath "com.gradle.publish:plugin-publish-plugin:0.9.5"
     }
 }
 
@@ -12,6 +17,7 @@ apply plugin: 'java'
 apply plugin: 'kotlin'
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
+apply plugin: 'com.gradle.plugin-publish'
 
 sourceCompatibility = 1.6
 
@@ -65,4 +71,18 @@ bintray {
     }
 
     publications = ['mavenJava']
+}
+
+pluginBundle {
+    website = 'http://www.kotlinlang.org/'
+    vcsUrl = 'https://github.com/kotlin/dokka.git'
+    description = 'Dokka, the Kotlin documentation tool'
+    tags = ['dokka', 'kotlin']
+
+    plugins {
+        dokkaPlugin {
+            id = 'org.jetbrains.dokka'
+            displayName = 'Dokka plugin'
+        }
+    }
 }


### PR DESCRIPTION
- Includes fix for [GRADLE-3509](https://issues.gradle.org/browse/GRADLE-3509) (Fatjar dependency artifactId correctly resolved)
- See the [plugin portal](https://plugins.gradle.org/plugin/com.gradle.plugin-publish) for details on release 0.9.5.
- Stems from an initial discussion on the [Gradle Forum](https://discuss.gradle.org/t/publishplugins-does-not-generate-pom-correctly/12629/6).
