### PR TITLE
updated style.css to better fit wide monitor resolutions

### DIFF
--- a/core/src/main/resources/dokka/styles/style.css
+++ b/core/src/main/resources/dokka/styles/style.css
@@ -1,10 +1,13 @@
-@import url(https://fonts.googleapis.com/css?family=Lato:300italic,700italic,300,700);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans:300i,400,700);
 
 body, table {
     padding:50px;
-    font:14px/1.5 Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font:14px/1.5 'Open Sans', "Helvetica Neue", Helvetica, Arial, sans-serif;
     color:#555;
     font-weight:300;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 1440px;
 }
 
 .keyword {


### PR DESCRIPTION
I propose that the default styles.css should be updated so that the documentation generated is more comfortable to view on high resolution displays (above 1080p) at 100% scaling. I am on 1440p and documentation currently looks like this:

![unknown](https://cloud.githubusercontent.com/assets/14130413/23829534/25374d0e-06c2-11e7-8eae-76508bf64ab0.png)

Tiny text and text bunched up all the way to the left side of the screen. Adding a max-width to the body and left/right auto-margin to center the body, and using a thicker font (Lato is **really** thin) makes the documentation more pleasant to view on 1440p or above. See below for change.

![chrome_2017-03-12_01-22-03](https://cloud.githubusercontent.com/assets/14130413/23829546/8685ca86-06c2-11e7-91ff-974adbb3bdbb.png)

Of course, this change does not affect lower resolutions:

![chrome_2017-03-12_01-25-18](https://cloud.githubusercontent.com/assets/14130413/23829555/cc486bbe-06c2-11e7-9838-09294a4a7622.png)
