### PR TITLE
Fix missing whitespace around links and tokens in Markdown formatted text

### DIFF
--- a/core/src/main/kotlin/Kotlin/ContentBuilder.kt
+++ b/core/src/main/kotlin/Kotlin/ContentBuilder.kt
@@ -87,9 +87,16 @@ fun buildContentTo(tree: MarkdownNode, target: ContentBlock, linkResolver: (Stri
                     parent.append(link)
                 }
             }
-            MarkdownTokenTypes.WHITE_SPACE,
+            MarkdownTokenTypes.WHITE_SPACE -> {
+                // Don't append first space if start of header (it is added during formatting later)
+                //                   v
+                //               #### Some Heading
+                if (nodeStack.peek() !is ContentHeading || node.parent?.children?.first() != node) {
+                    parent.append(ContentText(node.text))
+                }
+            }
             MarkdownTokenTypes.EOL -> {
-                if (keepWhitespace(nodeStack.peek()) && node.parent?.children?.last() != node) {
+                if (keepEol(nodeStack.peek()) && node.parent?.children?.last() != node) {
                     parent.append(ContentText(node.text))
                 }
             }
@@ -148,7 +155,7 @@ fun buildContentTo(tree: MarkdownNode, target: ContentBlock, linkResolver: (Stri
 
 private fun MarkdownNode.getLabelText() = children.filter { it.type == MarkdownTokenTypes.TEXT || it.type == MarkdownTokenTypes.EMPH }.joinToString("") { it.text }
 
-private fun keepWhitespace(node: ContentNode) = node is ContentParagraph || node is ContentSection || node is ContentBlockCode
+private fun keepEol(node: ContentNode) = node is ContentParagraph || node is ContentSection || node is ContentBlockCode
 
 fun buildInlineContentTo(tree: MarkdownNode, target: ContentBlock, linkResolver: (String) -> ContentBlock) {
     val inlineContent = tree.children.singleOrNull { it.type == MarkdownElementTypes.PARAGRAPH }?.children ?: listOf(tree)

--- a/core/src/test/kotlin/format/MarkdownFormatTest.kt
+++ b/core/src/test/kotlin/format/MarkdownFormatTest.kt
@@ -332,6 +332,30 @@ class MarkdownFormatTest {
         }
     }
 
+    @Test fun linksInEmphasis() {
+        verifyMarkdownNode("linksInEmphasis")
+    }
+
+    @Test fun linksInStrong() {
+        verifyMarkdownNode("linksInStrong")
+    }
+
+    @Test fun linksInHeaders() {
+        verifyMarkdownNode("linksInHeaders")
+    }
+
+    @Test fun tokensInEmphasis() {
+        verifyMarkdownNode("tokensInEmphasis")
+    }
+
+    @Test fun tokensInStrong() {
+        verifyMarkdownNode("tokensInStrong")
+    }
+
+    @Test fun tokensInHeaders() {
+        verifyMarkdownNode("tokensInHeaders")
+    }
+
     private fun buildMultiplePlatforms(path: String): DocumentationModule {
         val module = DocumentationModule("test")
         val options = DocumentationOptions("", "html", generateIndexPages = false)

--- a/core/testdata/format/linksInEmphasis.kt
+++ b/core/testdata/format/linksInEmphasis.kt
@@ -1,0 +1,13 @@
+/**
+ * An emphasised class.
+ *
+ * _This class [Bar] is awesome._
+ *
+ * _Even more awesomer is the function [Bar.foo]_
+ *
+ * _[Bar.hello] is also OK_
+ */
+class Bar {
+    fun foo() {}
+    fun hello() {}
+}

--- a/core/testdata/format/linksInEmphasis.md
+++ b/core/testdata/format/linksInEmphasis.md
@@ -1,0 +1,23 @@
+[test](test/index) / [Bar](test/-bar/index)
+
+# Bar
+
+`class Bar`
+
+An emphasised class.
+
+*This class [Bar](test/-bar/index) is awesome.*
+
+*Even more awesomer is the function [Bar.foo](test/-bar/foo)*
+
+*[Bar.hello](test/-bar/hello) is also OK*
+
+### Constructors
+
+| [&lt;init&gt;](test/-bar/-init-) | `Bar()`<br>An emphasised class. |
+
+### Functions
+
+| [foo](test/-bar/foo) | `fun foo(): Unit` |
+| [hello](test/-bar/hello) | `fun hello(): Unit` |
+

--- a/core/testdata/format/linksInHeaders.kt
+++ b/core/testdata/format/linksInHeaders.kt
@@ -1,0 +1,24 @@
+/**
+ * Some class with really useless documentation.
+ *
+ * # Beer o'clock - time to go to the [Bar]
+ *
+ * ## But __is [it](isitbeeroclock.com)__ really?
+ *
+ * ### [Bar.hello] to the [Bar.world]!
+ *
+ * #### _Kotlin is amazing, [Bar.none]_
+ *
+ * ##### We need to go [Bar.deeper]
+ *
+ * ###### End of the [Bar.line] - we need to go back!
+ */
+class Bar {
+    fun foo() {}
+    fun hello() {}
+    fun world() {}
+    fun kotlin() {}
+    fun none() {}
+    fun deeper() {}
+    fun line() {}
+}

--- a/core/testdata/format/linksInHeaders.md
+++ b/core/testdata/format/linksInHeaders.md
@@ -1,0 +1,34 @@
+[test](test/index) / [Bar](test/-bar/index)
+
+# Bar
+
+`class Bar`
+
+Some class with really useless documentation.
+
+# Beer o'clock - time to go to the [Bar](test/-bar/index)
+
+## But **is [it](isitbeeroclock.com)** really?
+
+### [Bar.hello](test/-bar/hello) to the [Bar.world](test/-bar/world)!
+
+#### *Kotlin is amazing, [Bar.none](test/-bar/none)*
+
+##### We need to go [Bar.deeper](test/-bar/deeper)
+
+###### End of the [Bar.line](test/-bar/line) - we need to go back!
+
+### Constructors
+
+| [&lt;init&gt;](test/-bar/-init-) | `Bar()`<br>Some class with really useless documentation. |
+
+### Functions
+
+| [deeper](test/-bar/deeper) | `fun deeper(): Unit` |
+| [foo](test/-bar/foo) | `fun foo(): Unit` |
+| [hello](test/-bar/hello) | `fun hello(): Unit` |
+| [kotlin](test/-bar/kotlin) | `fun kotlin(): Unit` |
+| [line](test/-bar/line) | `fun line(): Unit` |
+| [none](test/-bar/none) | `fun none(): Unit` |
+| [world](test/-bar/world) | `fun world(): Unit` |
+

--- a/core/testdata/format/linksInStrong.kt
+++ b/core/testdata/format/linksInStrong.kt
@@ -1,0 +1,13 @@
+/**
+ * A strong class.
+ *
+ * __This class [Bar] is awesome.__
+ *
+ * __Even more awesomer is the function [Bar.foo]__
+ *
+ * __[Bar.hello] is also OK__
+ */
+class Bar {
+    fun foo() {}
+    fun hello() {}
+}

--- a/core/testdata/format/linksInStrong.md
+++ b/core/testdata/format/linksInStrong.md
@@ -1,0 +1,23 @@
+[test](test/index) / [Bar](test/-bar/index)
+
+# Bar
+
+`class Bar`
+
+A strong class.
+
+**This class [Bar](test/-bar/index) is awesome.**
+
+**Even more awesomer is the function [Bar.foo](test/-bar/foo)**
+
+**[Bar.hello](test/-bar/hello) is also OK**
+
+### Constructors
+
+| [&lt;init&gt;](test/-bar/-init-) | `Bar()`<br>A strong class. |
+
+### Functions
+
+| [foo](test/-bar/foo) | `fun foo(): Unit` |
+| [hello](test/-bar/hello) | `fun hello(): Unit` |
+

--- a/core/testdata/format/markdownInLinks.html
+++ b/core/testdata/format/markdownInLinks.html
@@ -9,6 +9,6 @@
 <h1>foo</h1>
 <a name="$foo()"></a>
 <code><span class="keyword">fun </span><span class="identifier">foo</span><span class="symbol">(</span><span class="symbol">)</span><span class="symbol">: </span><span class="identifier">Unit</span></code>
-<p><a href="http://www.ibm.com">a<strong>b</strong><strong>d</strong>kas</a></p>
+<p><a href="http://www.ibm.com">a<strong>b</strong><strong>d</strong> kas </a></p>
 </BODY>
 </HTML>

--- a/core/testdata/format/tokensInEmphasis.kt
+++ b/core/testdata/format/tokensInEmphasis.kt
@@ -1,0 +1,10 @@
+/**
+ * Another emphasised class.
+ *
+ * _This class, [Bar] is just meh._
+ *
+ * _For a semicolon; [Bar.foo] is for you!._
+ */
+class Bar {
+    fun foo() = ";"
+}

--- a/core/testdata/format/tokensInEmphasis.md
+++ b/core/testdata/format/tokensInEmphasis.md
@@ -1,0 +1,20 @@
+[test](test/index) / [Bar](test/-bar/index)
+
+# Bar
+
+`class Bar`
+
+Another emphasised class.
+
+*This class, [Bar](test/-bar/index) is just meh.*
+
+*For a semicolon; [Bar.foo](test/-bar/foo) is for you!.*
+
+### Constructors
+
+| [&lt;init&gt;](test/-bar/-init-) | `Bar()`<br>Another emphasised class. |
+
+### Functions
+
+| [foo](test/-bar/foo) | `fun foo(): String` |
+

--- a/core/testdata/format/tokensInHeaders.kt
+++ b/core/testdata/format/tokensInHeaders.kt
@@ -1,0 +1,27 @@
+/**
+ * Why did the token cross the road?
+ *
+ * # Because it was Beer o'clock @ [The.bar]
+ *
+ * ## But __waz *\[sic\]* [it](isitbeeroclock.com)__ really?
+ *
+ * ### [The.bar] has? [The.foo]est drinks ever!
+ *
+ * #### _[The.kotlinz] is [The.bestests], [Bar.none]_
+ *
+ * ##### So many lame code "puns" (in) [The.house]
+ *
+ * ###### End of the?? [Bar.line]! - we need to go back!
+ */
+class The {
+    object Bar {
+        fun none() {}
+    }
+
+    fun bar() {}
+    fun foo() {}
+    fun bestests() {}
+    fun kotlinz() {}
+    fun house() {}
+    fun line() {}
+}

--- a/core/testdata/format/tokensInHeaders.md
+++ b/core/testdata/format/tokensInHeaders.md
@@ -1,0 +1,37 @@
+[test](test/index) / [The](test/-the/index)
+
+# The
+
+`class The`
+
+Why did the token cross the road?
+
+# Because it was Beer o'clock @ [The.bar](test/-the/bar)
+
+## But **waz *\[sic\]* [it](isitbeeroclock.com)** really?
+
+### [The.bar](test/-the/bar) has? [The.foo](test/-the/foo)est drinks ever!
+
+#### *[The.kotlinz](test/-the/kotlinz) is [The.bestests](test/-the/bestests), [Bar.none](test/-the/-bar/none)*
+
+##### So many lame code "puns" (in) [The.house](test/-the/house)
+
+###### End of the?? [Bar.line](test/-the/line)! - we need to go back!
+
+### Types
+
+| [Bar](test/-the/-bar/index) | `object Bar` |
+
+### Constructors
+
+| [&lt;init&gt;](test/-the/-init-) | `The()`<br>Why did the token cross the road? |
+
+### Functions
+
+| [bar](test/-the/bar) | `fun bar(): Unit` |
+| [bestests](test/-the/bestests) | `fun bestests(): Unit` |
+| [foo](test/-the/foo) | `fun foo(): Unit` |
+| [house](test/-the/house) | `fun house(): Unit` |
+| [kotlinz](test/-the/kotlinz) | `fun kotlinz(): Unit` |
+| [line](test/-the/line) | `fun line(): Unit` |
+

--- a/core/testdata/format/tokensInStrong.kt
+++ b/core/testdata/format/tokensInStrong.kt
@@ -1,0 +1,10 @@
+/**
+ * __YASC: [Yasc] Yet Another Strong Class__
+ *
+ * __This class, [Yasc] *is* just meh.__
+ *
+ * __For a semicolon; [Yasc.foo] is for you!.__
+ */
+class Yasc {
+    fun foo() = ";"
+}

--- a/core/testdata/format/tokensInStrong.md
+++ b/core/testdata/format/tokensInStrong.md
@@ -1,0 +1,20 @@
+[test](test/index) / [Yasc](test/-yasc/index)
+
+# Yasc
+
+`class Yasc`
+
+**YASC: [Yasc](test/-yasc/index) Yet Another Strong Class**
+
+**This class, [Yasc](test/-yasc/index) *is* just meh.**
+
+**For a semicolon; [Yasc.foo](test/-yasc/foo) is for you!.**
+
+### Constructors
+
+| [&lt;init&gt;](test/-yasc/-init-) | `Yasc()`<br>**YASC: [Yasc](test/-yasc/index) Yet Another Strong Class** |
+
+### Functions
+
+| [foo](test/-yasc/foo) | `fun foo(): String` |
+


### PR DESCRIPTION
When a link or non-text token (e.g. comma) is inside an emphasis, strong, or header node, the whitespace surrounding the link (or following the non-text token) is dropped.
This PR fixes this and adds tests.

Of note - a previous test `markdownInLinks` changed as a result of this.
Was there a reason the spaces surrounding "kas" were being dropped? This seemed like a related bug, thus the expected markdownInLinks.html file was adjusted.