### PR TITLE
Fix dokka-android plugin with Android Gradle 2.4.0 build tools

### DIFF
--- a/runners/android-gradle-plugin/src/main/kotlin/mainAndroid.kt
+++ b/runners/android-gradle-plugin/src/main/kotlin/mainAndroid.kt
@@ -1,9 +1,6 @@
 package org.jetbrains.dokka.gradle
 
-import com.android.build.gradle.AppExtension
-import com.android.build.gradle.BasePlugin
-import com.android.build.gradle.LibraryExtension
-import com.android.build.gradle.api.BaseVariant
+import com.android.build.gradle.*
 import com.android.build.gradle.internal.VariantManager
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -13,51 +10,11 @@ import kotlin.reflect.jvm.isAccessible
 import kotlin.reflect.memberProperties
 
 open class DokkaAndroidPlugin : Plugin<Project> {
-    val allVariantsClassPath = mutableSetOf<File>()
-
     override fun apply(project: Project) {
-
         DokkaVersion.loadFrom(javaClass.getResourceAsStream("/META-INF/gradle-plugins/org.jetbrains.dokka-android.properties"))
         project.tasks.create("dokka", DokkaAndroidTask::class.java).apply {
             moduleName = project.name
             outputDirectory = File(project.buildDir, "dokka").absolutePath
-        }
-
-        if (project.hasAndroidPlugin()) {
-            project.afterEvaluate {
-                collectClasspath(project)
-            }
-        }
-        else {
-            project.plugins.whenPluginAdded {
-                if (project.hasAndroidPlugin()) {
-                    collectClasspath(project)
-                }
-            }
-        }
-    }
-
-
-    private fun getVariantManagerOld(plugin: BasePlugin): VariantManager? {
-        val variantManagerProperty =
-                plugin.javaClass.kotlin.memberProperties
-                        .find { it.name == "variantManager" } ?: return null
-        variantManagerProperty.isAccessible = true
-        return variantManagerProperty.get(plugin) as VariantManager
-    }
-
-    private fun getVariantManager(plugin: BasePlugin): VariantManager = plugin.variantManager
-
-    private fun collectClasspath(project: Project) {
-        val plugin = (project.plugins.findPlugin("android")
-                ?: project.plugins.findPlugin("android-library")
-                ?: project.plugins.findPlugin("com.android.test")
-                ?: throw Exception("Android plugin not found, please use dokka-android with android or android-library plugin.")) as BasePlugin
-        try {
-            val variantManager = getVariantManagerOld(plugin) ?: getVariantManager(plugin)
-            variantManager.variantDataList.flatMapTo(allVariantsClassPath) { it.variantConfiguration.compileClasspath }
-        } catch(e: Exception) {
-            throw Exception("Unsupported version of android build tools, could not access variant manager.", e)
         }
     }
 }
@@ -66,32 +23,42 @@ open class DokkaAndroidTask : DokkaTask() {
     override val sdkProvider: SdkProvider? = AndroidSdkProvider(project)
 }
 
-private fun Project.hasAndroidPlugin() = plugins.hasPlugin("com.android.library") || plugins.hasPlugin("com.android.application")
-
-private fun Project.findDokkaAndroidPlugin() = plugins.findPlugin(DokkaAndroidPlugin::class.java)
-
-private fun Project.collectAllVariants(): Collection<BaseVariant> {
-    extensions.findByType(LibraryExtension::class.java)?.let {
-        return it.libraryVariants
-    }
-    extensions.findByType(AppExtension::class.java)?.let {
-        return it.applicationVariants
-    }
-    return emptyList()
-}
-
 private class AndroidSdkProvider(private val project: Project) : SdkProvider {
-    private val ext by lazy {
-        project.extensions.findByType(LibraryExtension::class.java) ?: project.extensions.findByType(AppExtension::class.java)
+    private val ext: BaseExtension? by lazy {
+        project.extensions.findByType(LibraryExtension::class.java)
+                ?: project.extensions.findByType(AppExtension::class.java)
+                ?: project.extensions.findByType(TestExtension::class.java)
+    }
+
+    private val isAndroidProject: Boolean get() = ext != null
+
+    private val variantManager: VariantManager? by lazy {
+        val plugin = (project.plugins.findPlugin("android")
+                ?: project.plugins.findPlugin("android-library")
+                ?: project.plugins.findPlugin("com.android.test")
+                ?: throw Exception("Android plugin not found, please use dokka-android with android or android-library plugin.")) as BasePlugin
+        plugin.javaClass.kotlin.memberProperties
+                .find { it.name == "variantManager" }
+                ?.apply { isAccessible = true }
+                ?.let { it.get(plugin) as VariantManager }
+                ?: plugin.variantManager
+    }
+
+    private val allVariantsClassPath by lazy {
+        try {
+            variantManager?.variantDataList?.flatMap { it.variantConfiguration.compileClasspath }.orEmpty()
+        } catch(e: Exception) {
+            throw Exception("Unsupported version of android build tools, could not access variant manager.", e)
+        }
     }
 
     override val name: String = "android"
 
     override val isValid: Boolean
-        get() = project.hasAndroidPlugin()
+        get() = isAndroidProject
 
     override val classpath: List<File>
-        get() = ext.bootClasspath + (project.findDokkaAndroidPlugin()?.allVariantsClassPath ?: emptyList<File>())
+        get() = ext?.bootClasspath.orEmpty() + allVariantsClassPath
 
     override val sourceDirs: Set<File>?
         get() {


### PR DESCRIPTION
The 2.4.0 build tools delay variant dependency analysis until needed,
thus we do the same; delay processing variant configurations until
Dokka task execution.

Changes also tested on Android Gradle 2.2.0 and 2.3.0.