### PR TITLE
Fix NotSerializableException for ExternalDocumentationLinkImpl

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ dokka {
     // Repeat for multiple links
     externalDocumentationLink {
         // URL of the generated documentation 
-        url = new URL("https://example.com/docs")
+        url = "https://example.com/docs"
         
         // If package-list file located in non-standard location
-        // packageListUrl = new URL("file:///home/user/localdocs/package-list") 
+        // packageListUrl = "file:///home/user/localdocs/package-list" 
     }
     
     // Allows to customize documentation generation options on a per-package basis

--- a/core/src/main/kotlin/Kotlin/ExternalDocumentationLinkResolver.kt
+++ b/core/src/main/kotlin/Kotlin/ExternalDocumentationLinkResolver.kt
@@ -25,8 +25,10 @@ class ExternalDocumentationLinkResolver @Inject constructor(
 
     fun loadPackageLists() {
         options.externalDocumentationLinks.forEach { link ->
+            val linkUrl = URL(link.url)
+            val packageListUrl = link.packageListUrl?.let { URL(it) } ?: URL(linkUrl, "package-list")
             val (params, packages) =
-                    link.packageListUrl
+                    packageListUrl
                             .openStream()
                             .bufferedReader()
                             .useLines { lines -> lines.partition { it.startsWith(DOKKA_PARAM_PREFIX) } }
@@ -50,7 +52,7 @@ class ExternalDocumentationLinkResolver @Inject constructor(
                 InboundExternalLinkResolutionService.Dokka(linkExtension)
             }
 
-            val rootInfo = ExternalDocumentationRoot(link.url, resolver, locations)
+            val rootInfo = ExternalDocumentationRoot(linkUrl, resolver, locations)
 
             packages.map { FqName(it) }.forEach { packageFqNameToLocation[it] = rootInfo }
         }

--- a/integration/src/main/kotlin/org/jetbrains/dokka/configuration.kt
+++ b/integration/src/main/kotlin/org/jetbrains/dokka/configuration.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.dokka
 
-import java.net.URL
+import java.io.Serializable
 
 
 interface DokkaConfiguration {
@@ -42,22 +42,17 @@ interface DokkaConfiguration {
         val skipDeprecated: Boolean
     }
 
-    interface ExternalDocumentationLink {
-        val url: URL
-        val packageListUrl: URL
+    interface ExternalDocumentationLink : Serializable {
+        val url: String
+        val packageListUrl: String?
 
-        open class Builder(open var url: URL? = null,
-                           open var packageListUrl: URL? = null) {
-
-            constructor(root: String) : this(URL(root), null)
+        open class Builder(open var url: String? = null,
+                           open var packageListUrl: String? = null) {
 
             fun build(): DokkaConfiguration.ExternalDocumentationLink =
-                    if (packageListUrl != null && url != null)
-                        ExternalDocumentationLinkImpl(url!!, packageListUrl!!)
-                    else if (url != null)
-                        ExternalDocumentationLinkImpl(url!!, URL(url!!, "package-list"))
-                    else
-                        throw IllegalArgumentException("url or url && packageListUrl must not be null for external documentation link")
+                    ExternalDocumentationLinkImpl(
+                            url ?: throw IllegalArgumentException("url must not be null for external documentation link"),
+                            packageListUrl)
         }
     }
 }
@@ -83,5 +78,5 @@ data class SerializeOnlyDokkaConfiguration(override val moduleName: String,
                                            override val noStdlibLink: Boolean) : DokkaConfiguration
 
 
-data class ExternalDocumentationLinkImpl internal constructor(override val url: URL,
-                                                              override val packageListUrl: URL) : DokkaConfiguration.ExternalDocumentationLink
+data class ExternalDocumentationLinkImpl internal constructor(override val url: String,
+                                                              override val packageListUrl: String? = null) : DokkaConfiguration.ExternalDocumentationLink

--- a/runners/cli/src/main/kotlin/cli/main.kt
+++ b/runners/cli/src/main/kotlin/cli/main.kt
@@ -6,8 +6,6 @@ import org.jetbrains.kotlin.cli.common.arguments.ValueDescription
 import org.jetbrains.kotlin.cli.common.parser.com.sampullara.cli.Args
 import org.jetbrains.kotlin.cli.common.parser.com.sampullara.cli.Argument
 import java.io.File
-import java.net.MalformedURLException
-import java.net.URL
 import java.net.URLClassLoader
 
 class DokkaArguments {
@@ -72,14 +70,7 @@ object MainKt {
                 .partition { it.size == 1 }
 
         return parsedLinks.map { (root) -> ExternalDocumentationLink.Builder(root).build() } +
-                parsedOfflineLinks.map { (root, packageList) ->
-                    val rootUrl = URL(root)
-                    val packageListUrl =
-                            try {
-                                URL(packageList)
-                            } catch (ex: MalformedURLException) {
-                                File(packageList).toURI().toURL()
-                            }
+                parsedOfflineLinks.map { (rootUrl, packageListUrl) ->
                     ExternalDocumentationLink.Builder(rootUrl, packageListUrl).build()
                 }
     }

--- a/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
+++ b/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
@@ -11,7 +11,6 @@ import org.codehaus.plexus.archiver.Archiver
 import org.codehaus.plexus.archiver.jar.JarArchiver
 import org.jetbrains.dokka.*
 import java.io.File
-import java.net.URL
 
 class SourceLinkMapItem {
     @Parameter(name = "dir", required = true)
@@ -27,9 +26,9 @@ class SourceLinkMapItem {
 class ExternalDocumentationLinkBuilder : DokkaConfiguration.ExternalDocumentationLink.Builder() {
 
     @Parameter(name = "url", required = true)
-    override var url: URL? = null
+    override var url: String? = null
     @Parameter(name = "packageListUrl", required = true)
-    override var packageListUrl: URL? = null
+    override var packageListUrl: String? = null
 }
 
 abstract class AbstractDokkaMojo : AbstractMojo() {


### PR DESCRIPTION
This PR changes the type used in `ExternalDocumentationLink` from `URL` to `String`.

Gradle attempts to serialize `ExternalDocumentationLink` for task changes/history tracking and failed.  
I tried just slapping on `Serializable` but Kotlin throws an exception during serialization (unable to access private property value in `URL`)

I haven't tested the changes beyond my own project - all the tests passed, but I'm not sure if they cover the CLI/Mojo changes.

### Reproduction
When using Gradle 3.5

```gradle
dokka {
    externalDocumentationLink {
        url = new URL("https://example.com/module/")
    }
}
```


Gradle error:
```
Error:Unable to store input properties for task ':project:module'. Property 'externalDocumentationLinks' with value '[ExternalDocumentationLinkImpl(url=https://example.com/module/, packageListUrl=https://example.com/module/package-list)]' cannot be serialized.
> java.io.NotSerializableException: org.jetbrains.dokka.ExternalDocumentationLinkImpl
```
Exception:
```
org.gradle.api.GradleException: Unable to store input properties for task ':project:module'. Property 'externalDocumentationLinks' with value '[ExternalDocumentationLinkImpl(url=https://example.com/module/, packageListUrl=https://example.com/module/package-list)]' cannot be serialized.
	at org.gradle.api.internal.changedetection.rules.InputPropertiesTaskStateChanges.<init>(InputPropertiesTaskStateChanges.java:63)
	at org.gradle.api.internal.changedetection.rules.TaskUpToDateState.<init>(TaskUpToDateState.java:50)
	at org.gradle.api.internal.changedetection.changes.DefaultTaskArtifactStateRepository$TaskArtifactStateImpl.getStates(DefaultTaskArtifactStateRepository.java:170)
	at org.gradle.api.internal.changedetection.changes.DefaultTaskArtifactStateRepository$TaskArtifactStateImpl.isUpToDate(DefaultTaskArtifactStateRepository.java:85)
	at org.gradle.api.internal.tasks.execution.SkipUpToDateTaskExecuter.execute(SkipUpToDateTaskExecuter.java:51)
	at org.gradle.api.internal.tasks.execution.ValidatingTaskExecuter.execute(ValidatingTaskExecuter.java:58)
	at org.gradle.api.internal.tasks.execution.SkipEmptySourceFilesTaskExecuter.execute(SkipEmptySourceFilesTaskExecuter.java:88)
	at org.gradle.api.internal.tasks.execution.ResolveTaskArtifactStateTaskExecuter.execute(ResolveTaskArtifactStateTaskExecuter.java:46)
	at org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter.execute(SkipTaskWithNoActionsExecuter.java:51)
	at org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter.execute(SkipOnlyIfTaskExecuter.java:54)
	at org.gradle.api.internal.tasks.execution.ExecuteAtMostOnceTaskExecuter.execute(ExecuteAtMostOnceTaskExecuter.java:43)
	at org.gradle.api.internal.tasks.execution.CatchExceptionTaskExecuter.execute(CatchExceptionTaskExecuter.java:34)
	at org.gradle.execution.taskgraph.DefaultTaskGraphExecuter$EventFiringTaskWorker$1.execute(DefaultTaskGraphExecuter.java:236)
	at org.gradle.execution.taskgraph.DefaultTaskGraphExecuter$EventFiringTaskWorker$1.execute(DefaultTaskGraphExecuter.java:228)
	at org.gradle.internal.Transformers$4.transform(Transformers.java:169)
	at org.gradle.internal.progress.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:106)
	at org.gradle.internal.progress.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:61)
	at org.gradle.execution.taskgraph.DefaultTaskGraphExecuter$EventFiringTaskWorker.execute(DefaultTaskGraphExecuter.java:228)
	at org.gradle.execution.taskgraph.DefaultTaskGraphExecuter$EventFiringTaskWorker.execute(DefaultTaskGraphExecuter.java:215)
	at org.gradle.execution.taskgraph.AbstractTaskPlanExecutor$TaskExecutorWorker.processTask(AbstractTaskPlanExecutor.java:77)
	at org.gradle.execution.taskgraph.AbstractTaskPlanExecutor$TaskExecutorWorker.run(AbstractTaskPlanExecutor.java:58)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:63)
	at org.gradle.internal.concurrent.StoppableExecutorImpl$1.run(StoppableExecutorImpl.java:46)
Caused by: org.gradle.api.UncheckedIOException: java.io.NotSerializableException: org.jetbrains.dokka.ExternalDocumentationLinkImpl
	at org.gradle.api.internal.changedetection.state.ValueSnapshotter.serialize(ValueSnapshotter.java:126)
	at org.gradle.api.internal.changedetection.state.ValueSnapshotter.snapshot(ValueSnapshotter.java:115)
	at org.gradle.api.internal.changedetection.state.ValueSnapshotter.snapshot(ValueSnapshotter.java:63)
	at org.gradle.api.internal.changedetection.rules.InputPropertiesTaskStateChanges.<init>(InputPropertiesTaskStateChanges.java:59)
	... 22 more
Caused by: java.io.NotSerializableException: org.jetbrains.dokka.ExternalDocumentationLinkImpl
	at org.gradle.api.internal.changedetection.state.ValueSnapshotter.serialize(ValueSnapshotter.java:123)
	... 25 more
```