### PR TITLE
Add a per-package option to allow suppression of KDoc and JavaDoc.

### DIFF
--- a/core/src/main/kotlin/DokkaBootstrapImpl.kt
+++ b/core/src/main/kotlin/DokkaBootstrapImpl.kt
@@ -17,7 +17,8 @@ fun parsePerPackageOptions(arg: String): List<PackageOptions> {
         val deprecated = args.find { it.endsWith("deprecated") }?.startsWith("+") ?: true
         val reportUndocumented = args.find { it.endsWith("warnUndocumented") }?.startsWith("+") ?: true
         val privateApi = args.find { it.endsWith("privateApi") }?.startsWith("+") ?: false
-        PackageOptionsImpl(prefix, includeNonPublic = privateApi, reportUndocumented = reportUndocumented, skipDeprecated = !deprecated)
+        val suppress = args.find { it.endsWith("suppress") }?.startsWith("+") ?: false
+        PackageOptionsImpl(prefix, includeNonPublic = privateApi, reportUndocumented = reportUndocumented, skipDeprecated = !deprecated, suppress = suppress)
     }
 }
 

--- a/core/src/main/kotlin/Generation/configurationImpl.kt
+++ b/core/src/main/kotlin/Generation/configurationImpl.kt
@@ -32,7 +32,8 @@ class SourceRootImpl(path: String, override val platforms: List<String> = emptyL
 data class PackageOptionsImpl(override val prefix: String,
                               override val includeNonPublic: Boolean = false,
                               override val reportUndocumented: Boolean = true,
-                              override val skipDeprecated: Boolean = false) : DokkaConfiguration.PackageOptions
+                              override val skipDeprecated: Boolean = false,
+                              override val suppress: Boolean = false) : DokkaConfiguration.PackageOptions
 
 data class DokkaConfigurationImpl(override val moduleName: String,
                                   override val classpath: List<String>,

--- a/core/src/main/kotlin/Java/JavaPsiDocumentationBuilder.kt
+++ b/core/src/main/kotlin/Java/JavaPsiDocumentationBuilder.kt
@@ -57,7 +57,7 @@ class JavaPsiDocumentationBuilder : JavaDocumentationBuilder {
     }
 
     override fun appendFile(file: PsiJavaFile, module: DocumentationModule, packageContent: Map<String, Content>) {
-        if (file.classes.all { skipElement(it) }) {
+        if (skipFile(file) || file.classes.all { skipElement(it) }) {
             return
         }
         val packageNode = module.findOrCreatePackageNode(file.packageName, emptyMap(), refGraph)
@@ -130,6 +130,8 @@ class JavaPsiDocumentationBuilder : JavaDocumentationBuilder {
             }
         }
     }
+
+    private fun skipFile(javaFile: PsiJavaFile): Boolean = options.effectivePackageOptions(javaFile.packageName).suppress
 
     private fun skipElement(element: Any) = skipElementByVisibility(element) || hasSuppressDocTag(element)
 

--- a/core/src/main/kotlin/Kotlin/DocumentationBuilder.kt
+++ b/core/src/main/kotlin/Kotlin/DocumentationBuilder.kt
@@ -786,7 +786,7 @@ fun DeclarationDescriptor.isDocumented(options: DocumentationOptions): Boolean {
     return (options.effectivePackageOptions(fqNameSafe).includeNonPublic
             || this !is MemberDescriptor
             || this.visibility in visibleToDocumentation) &&
-            !isDocumentationSuppressed(options) &&
+            !isDocumentationSuppressed(options) && !options.effectivePackageOptions(fqNameSafe).suppress &&
             (!options.effectivePackageOptions(fqNameSafe).skipDeprecated || !isDeprecated())
 }
 

--- a/core/src/test/kotlin/TestAPI.kt
+++ b/core/src/test/kotlin/TestAPI.kt
@@ -24,6 +24,7 @@ fun verifyModel(vararg roots: ContentRoot,
                 withKotlinRuntime: Boolean = false,
                 format: String = "html",
                 includeNonPublic: Boolean = true,
+                perPackageOptions: List<DokkaConfiguration.PackageOptions> = emptyList(),
                 verifier: (DocumentationModule) -> Unit) {
     val documentation = DocumentationModule("test")
 
@@ -32,6 +33,7 @@ fun verifyModel(vararg roots: ContentRoot,
             skipEmptyPackages = false,
             includeRootPackage = true,
             sourceLinks = listOf<SourceLinkDefinition>(),
+            perPackageOptions = perPackageOptions,
             generateIndexPages = false,
             noStdlibLink = true,
             cacheRoot = "default")

--- a/core/src/test/kotlin/model/PackageTest.kt
+++ b/core/src/test/kotlin/model/PackageTest.kt
@@ -2,10 +2,10 @@ package org.jetbrains.dokka.tests
 
 import org.jetbrains.dokka.Content
 import org.jetbrains.dokka.NodeKind
+import org.jetbrains.dokka.PackageOptionsImpl
 import org.jetbrains.kotlin.config.KotlinSourceRoot
+import org.junit.Assert.*
 import org.junit.Test
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 
 public class PackageTest {
     @Test fun rootPackage() {
@@ -76,6 +76,35 @@ public class PackageTest {
             with(model.members.elementAt(0)) {
                 assertEquals(NodeKind.Package, kind)
                 assertEquals("simple", name)
+                assertEquals(Content.Empty, content)
+                assertTrue(details.none())
+                assertTrue(members.none())
+                assertTrue(links.none())
+            }
+        }
+    }
+
+    @Test fun classAtPackageLevel() {
+        verifyModel(KotlinSourceRoot("testdata/packages/classInPackage.kt")) { model ->
+            assertEquals(1, model.members.count())
+            with(model.members.elementAt(0)) {
+                assertEquals(NodeKind.Package, kind)
+                assertEquals("simple.name", name)
+                assertEquals(Content.Empty, content)
+                assertTrue(details.none())
+                assertEquals(1, members.size)
+                assertTrue(links.none())
+            }
+        }
+    }
+
+    @Test fun suppressAtPackageLevel() {
+        verifyModel(KotlinSourceRoot("testdata/packages/classInPackage.kt"),
+                perPackageOptions = listOf(PackageOptionsImpl(prefix = "simple.name", suppress = true))) { model ->
+            assertEquals(1, model.members.count())
+            with(model.members.elementAt(0)) {
+                assertEquals(NodeKind.Package, kind)
+                assertEquals("simple.name", name)
                 assertEquals(Content.Empty, content)
                 assertTrue(details.none())
                 assertTrue(members.none())

--- a/core/testdata/packages/classInPackage.kt
+++ b/core/testdata/packages/classInPackage.kt
@@ -1,0 +1,3 @@
+package simple.name
+
+class Foo {}

--- a/integration/src/main/kotlin/org/jetbrains/dokka/configuration.kt
+++ b/integration/src/main/kotlin/org/jetbrains/dokka/configuration.kt
@@ -56,6 +56,7 @@ interface DokkaConfiguration {
         val includeNonPublic: Boolean
         val reportUndocumented: Boolean
         val skipDeprecated: Boolean
+        val suppress: Boolean
     }
 
     interface ExternalDocumentationLink {

--- a/runners/ant/src/main/kotlin/ant/dokka.kt
+++ b/runners/ant/src/main/kotlin/ant/dokka.kt
@@ -28,7 +28,8 @@ class AntPackageOptions(
         override var prefix: String = "",
         override var includeNonPublic: Boolean = false,
         override var reportUndocumented: Boolean = true,
-        override var skipDeprecated: Boolean = false) : DokkaConfiguration.PackageOptions
+        override var skipDeprecated: Boolean = false,
+        override var suppress: Boolean = false) : DokkaConfiguration.PackageOptions
 
 
 class DokkaAntTask: Task() {

--- a/runners/cli/src/main/kotlin/cli/main.kt
+++ b/runners/cli/src/main/kotlin/cli/main.kt
@@ -44,7 +44,7 @@ class DokkaArguments {
     @set:Argument(value = "impliedPlatforms", description = "List of implied platforms (comma-separated)")
     var impliedPlatforms: String = ""
 
-    @set:Argument(value = "packageOptions", description = "List of package options in format \"prefix,-deprecated,-privateApi,+warnUndocumented;...\" ")
+    @set:Argument(value = "packageOptions", description = "List of package options in format \"prefix,-deprecated,-privateApi,+warnUndocumented,+suppress;...\" ")
     var packageOptions: String = ""
 
     @set:Argument(value = "links", description = "External documentation links in format url^packageListUrl^^url2...")

--- a/runners/gradle-plugin/src/main/kotlin/main.kt
+++ b/runners/gradle-plugin/src/main/kotlin/main.kt
@@ -414,4 +414,5 @@ class PackageOptions : Serializable, DokkaConfiguration.PackageOptions {
     override var includeNonPublic: Boolean = false
     override var reportUndocumented: Boolean = true
     override var skipDeprecated: Boolean = false
+    override var suppress: Boolean = false
 }

--- a/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
+++ b/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
@@ -50,6 +50,8 @@ abstract class AbstractDokkaMojo : AbstractMojo() {
         override var reportUndocumented: Boolean = true
         @Parameter
         override var skipDeprecated: Boolean = false
+        @Parameter
+        override var suppress: Boolean = false
     }
 
     @Parameter(required = true, defaultValue = "\${project.compileSourceRoots}")


### PR DESCRIPTION
Allow the following per-package option, rather than annotating every single class in this package with `@suppress`:
```gradle
packageOptions {
    prefix = 'org.testing'
    suppress = true
}
```