### PR TITLE
#221 - Updates external documentation link configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ dokka {
         
         // If package-list file located in non-standard location
         // packageListUrl = new URL("file:///home/user/localdocs/package-list") 
+
+        // If the external documentation uses the dot as separator between a class and its inner class instead of a slash
+        // useDotAsSubclassSeparator = true
+
+        // If the external documentation uses the dash as separator between parameters
+        // useDashAsParameterSeparator = true
     }
     
     // Allows to customize documentation generation options on a per-package basis
@@ -308,6 +314,12 @@ The available configuration options are shown below:
                 <url>https://example.com/docs/</url>
                 <!-- If package-list file located in non-standard location -->
                 <!-- <packageListUrl>file:///home/user/localdocs/package-list</packageListUrl> -->
+                
+                <!-- If the external documentation uses the dot as separator between a class and its inner class instead of a slash -->
+                <!-- useDotAsSubclassSeparator = true -->
+
+                <!-- If the external documentation uses the dash as separator between parameters -->
+                <!-- useDashAsParameterSeparator = true -->
             </link>
         </externalDocumentationLinks>
 
@@ -361,8 +373,8 @@ The Ant task supports the following attributes:
   * `<packageOptions prefix="kotlin" includeNonPublic="false" reportUndocumented="true" skipDeprecated="false"/>` - 
     Per package options for package `kotlin` and sub-packages of it
   * `noStdlibLink` - No default documentation link to kotlin-stdlib
-  * `<externalDocumentationLink url="https://example.com/docs/" packageListUrl="file:///home/user/localdocs/package-list"/>` -
-    linking to external documentation, packageListUrl should be used if package-list located not in standard location
+  * `<externalDocumentationLink url="https://example.com/docs/" packageListUrl="file:///home/user/localdocs/package-list" useDotAsSubclassSeparator="true" useDashAsParameterSeparator="true" />` -
+    linking to external documentation, packageListUrl should be used if package-list located not in standard location, useDotAsSubclassSeparator should be used if the external documentation uses the dot as separator between a class and its inner, useDashAsParameterSeparator should be used if the external documentation uses the dash as separator between parameters
   * `cacheRoot` - Use `default` or set to custom path to cache directory to enable package-list caching. When set to `default`, caches stored in $USER_HOME/.cache/dokka
     
 

--- a/integration/src/main/kotlin/org/jetbrains/dokka/configuration.kt
+++ b/integration/src/main/kotlin/org/jetbrains/dokka/configuration.kt
@@ -61,17 +61,21 @@ interface DokkaConfiguration {
     interface ExternalDocumentationLink {
         @CustomSerializer(UrlSerializer::class) val url: URL
         @CustomSerializer(UrlSerializer::class) val packageListUrl: URL
+        val useDashAsParameterSeparator: Boolean
+        val useDotAsSubclassSeparator: Boolean
 
         open class Builder(open var url: URL? = null,
-                           open var packageListUrl: URL? = null) {
+                           open var packageListUrl: URL? = null,
+                           open var useDashAsParameterSeparator: Boolean = false,
+                           open var useDotAsSubclassSeparator: Boolean = false) {
 
-            constructor(root: String, packageList: String? = null) : this(URL(root), packageList?.let { URL(it) })
+            constructor(root: String, packageList: String? = null, dash: Boolean = false, dot: Boolean = false) : this(URL(root), packageList?.let { URL(it) }, dash, dot)
 
             fun build(): DokkaConfiguration.ExternalDocumentationLink =
                     if (packageListUrl != null && url != null)
-                        ExternalDocumentationLinkImpl(url!!, packageListUrl!!)
+                        ExternalDocumentationLinkImpl(url!!, packageListUrl!!, useDashAsParameterSeparator, useDotAsSubclassSeparator)
                     else if (url != null)
-                        ExternalDocumentationLinkImpl(url!!, URL(url!!, "package-list"))
+                        ExternalDocumentationLinkImpl(url!!, URL(url!!, "package-list"), useDashAsParameterSeparator, useDotAsSubclassSeparator)
                     else
                         throw IllegalArgumentException("url or url && packageListUrl must not be null for external documentation link")
         }
@@ -102,4 +106,6 @@ data class SerializeOnlyDokkaConfiguration(override val moduleName: String,
 
 
 data class ExternalDocumentationLinkImpl(@CustomSerializer(UrlSerializer::class) override val url: URL,
-                                         @CustomSerializer(UrlSerializer::class) override val packageListUrl: URL) : Serializable, DokkaConfiguration.ExternalDocumentationLink
+                                         @CustomSerializer(UrlSerializer::class) override val packageListUrl: URL,
+                                         override val useDashAsParameterSeparator: Boolean,
+                                         override val useDotAsSubclassSeparator: Boolean) : Serializable, DokkaConfiguration.ExternalDocumentationLink

--- a/runners/android-gradle-plugin/src/main/kotlin/mainAndroid.kt
+++ b/runners/android-gradle-plugin/src/main/kotlin/mainAndroid.kt
@@ -16,7 +16,7 @@ open class DokkaAndroidPlugin : Plugin<Project> {
     }
 }
 
-private val ANDROID_REFERENCE_URL = Builder("https://developer.android.com/reference/").build()
+private val ANDROID_REFERENCE_URL = Builder("https://developer.android.com/reference/", null, false, true).build()
 
 open class DokkaAndroidTask : DokkaTask() {
 

--- a/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
+++ b/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
@@ -30,6 +30,10 @@ class ExternalDocumentationLinkBuilder : DokkaConfiguration.ExternalDocumentatio
     override var url: URL? = null
     @Parameter(name = "packageListUrl", required = true)
     override var packageListUrl: URL? = null
+    @Parameter(name = "useDashAsParameterSeparator", required = false)
+    override var useDashAsParameterSeparator: Boolean = false
+    @Parameter(name = "useDotAsSubclassSeparator", required = false)
+    override var useDotAsSubclassSeparator: Boolean = false
 }
 
 abstract class AbstractDokkaMojo : AbstractMojo() {


### PR DESCRIPTION
Fix for #221 
Updates external documentation link generation configuration to support keeping the dot as separator between a class and its inner class, as well as using the dash for as a parameter separator, since both are used in Google API documentations.

Adds `useDotAsSubclassSeparator` to keep `.` as separator between a class and its subclass. Fixes links to Android documentation (e.g. https://developer.android.com/reference/android/view/View.OnClickListener.html)

Adds `useDashAsParameterSeparator` to replaces parenthesis and commas as parameters separator, to support some Google API documentations (like http://google.github.io/guice/api-docs/latest/javadoc/com/google/inject/grapher/Edge.html#copy-com.google.inject.grapher.NodeId-com.google.inject.grapher.NodeId- or https://google.github.io/ExoPlayer/doc/reference/com/google/android/exoplayer2/Player.EventListener.html#onLoadingChanged-boolean-) 

I have tested the gradle plugins. The maven plugin and ant task should also work, since I didn't see anything specific in the code, but are untested.
The command line is not supported, since I don't know how we would want to add the additional parameters to the command line (adding ^ separators might not be really clear since both new parameters are booleans).