### PR TITLE
Suppress all generated files (Java and Android projects)

### DIFF
--- a/runners/android-gradle-plugin/src/main/kotlin/mainAndroid.kt
+++ b/runners/android-gradle-plugin/src/main/kotlin/mainAndroid.kt
@@ -22,11 +22,6 @@ open class DokkaAndroidTask : DokkaTask() {
 
     @Input var noAndroidSdkLink: Boolean = false
 
-    override fun collectSuppressedFiles(sourceRoots: List<SourceRoot>): List<String> {
-        val generatedSubpath = "${project.buildDir}/generated/source".replace("/", File.separator)
-        return sourceRoots.filter { generatedSubpath in it.path }.flatMap { File(it.path).walk().toList() }.map { it.absolutePath }
-    }
-
     init {
         project.afterEvaluate {
             if (!noAndroidSdkLink) externalDocumentationLinks.add(ANDROID_REFERENCE_URL)

--- a/runners/gradle-plugin/src/main/kotlin/main.kt
+++ b/runners/gradle-plugin/src/main/kotlin/main.kt
@@ -232,7 +232,10 @@ open class DokkaTask : DefaultTask() {
 
     private fun Iterable<File>.toSourceRoots(): List<SourceRoot> = this.filter { it.exists() }.map { SourceRoot().apply { path = it.path } }
 
-    protected open fun collectSuppressedFiles(sourceRoots: List<SourceRoot>): List<String> = emptyList()
+    protected open fun collectSuppressedFiles(sourceRoots: List<SourceRoot>): List<String> {
+        val generatedSubpath = "${project.buildDir}/generated/source".replace("/", File.separator)
+        return sourceRoots.filter { generatedSubpath in it.path }.flatMap { File(it.path).walk().toList() }.map { it.absolutePath }
+    }
 
     @TaskAction
     fun generate() {


### PR DESCRIPTION
Documentation for generated files (in the `generated/source` path of the project build directory) were being suppressed for Android projects (`R`, `BuildConfig`). However, generated files were included in Java projects. This caused all generated classes in Java projects (such as Dagger annotation processing) to be documented which is not expected.

Moved the body of `collectSuppressedFiles()` function to `main.kt` from `androidMain.kt`.

Fixes #197.