### PR TITLE
Ensure build directory exists before generating POM into it (Fixes #235)

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.3-all.zip

--- a/runners/maven-plugin/build.gradle
+++ b/runners/maven-plugin/build.gradle
@@ -20,12 +20,16 @@ dependencies {
     shadow "org.apache.maven.plugin-tools:maven-plugin-annotations:$maven_plugin_tools_version"
 }
 
-task ("generatePom") doLast {
-    final pomTemplate = new File(projectDir, "pom.tpl.xml")
-    final pom = new File(buildDir, "pom.xml")
-    pom.text = pomTemplate.text.replace("<version>dokka_version</version>", "<version>$dokka_version</version>")
-            .replace("<maven.version></maven.version>", "<maven.version>$maven_version</maven.version>")
-            .replace("<version>maven-plugin-plugin</version>", "<version>$maven_plugin_tools_version</version>")
+task generatePom() {
+    inputs.file(new File(projectDir, "pom.tpl.xml"))
+    outputs.file(new File(buildDir, "pom.xml"))
+    doLast {
+        final pomTemplate = new File(projectDir, "pom.tpl.xml")
+        final pom = new File(buildDir, "pom.xml")
+        pom.text = pomTemplate.text.replace("<version>dokka_version</version>", "<version>$dokka_version</version>")
+                .replace("<maven.version></maven.version>", "<maven.version>$maven_version</maven.version>")
+                .replace("<version>maven-plugin-plugin</version>", "<version>$maven_plugin_tools_version</version>")
+    }
 }
 
 task pluginDescriptor(type: CrossPlatformExec) {


### PR DESCRIPTION
This declares the inputs and outputs for the maven-plugin
generatePom task, which improves incremental build support and
as of Gradle 4.3 (updated) automatically creates directory paths
for declared outputs.

Issue: #235