### PR TITLE
Pick correct closure type in the gradle plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ The available configuration options are shown below:
         <!-- Default: ${project.artifactId} -->
         <moduleName>data</moduleName>
         <!-- See list of possible formats below -->
-        <outFormat>html</outFormat>
+        <outputFormat>html</outputFormat>
         <!-- Default: ${project.basedir}/target/dokka -->
         <outputDir>some/out/dir</outputDir>
         

--- a/runners/gradle-plugin/src/main/kotlin/main.kt
+++ b/runners/gradle-plugin/src/main/kotlin/main.kt
@@ -124,7 +124,7 @@ open class DokkaTask : DefaultTask() {
         kotlinTasksConfigurator = { closure.call() as? List<Any?> }
     }
 
-    fun linkMapping(closure: Closure<Any?>) {
+    fun linkMapping(closure: Closure<Unit>) {
         val mapping = LinkMapping()
         closure.delegate = mapping
         closure.call()
@@ -139,21 +139,21 @@ open class DokkaTask : DefaultTask() {
         linkMappings.add(mapping)
     }
 
-    fun sourceRoot(closure: Closure<Any?>) {
+    fun sourceRoot(closure: Closure<Unit>) {
         val sourceRoot = SourceRoot()
         closure.delegate = sourceRoot
         closure.call()
         sourceRoots.add(sourceRoot)
     }
 
-    fun packageOptions(closure: Closure<Any?>) {
+    fun packageOptions(closure: Closure<Unit>) {
         val packageOptions = PackageOptions()
         closure.delegate = packageOptions
         closure.call()
         perPackageOptions.add(packageOptions)
     }
 
-    fun externalDocumentationLink(closure: Closure<Any?>) {
+    fun externalDocumentationLink(closure: Closure<Unit>) {
         val builder = DokkaConfiguration.ExternalDocumentationLink.Builder()
         closure.delegate = builder
         closure.call()


### PR DESCRIPTION
Replace Closure<Any?> with Closure<Unit> in the gradle plugin. Fixes #241