### PR TITLE
Fix ReportNotDocumented in the Gradle plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ dokka {
     skipDeprecated = false 
    
     // Emit warnings about not documented members. Applies globally, also can be overridden by packageOptions
-    reportUnocumented = true 
+    reportUndocumented = true 
     
     skipEmptyPackages = true // Do not create index pages for empty packages
  

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ dokka {
     skipDeprecated = false 
    
     // Emit warnings about not documented members. Applies globally, also can be overridden by packageOptions
-    reportNotDocumented = true 
+    reportUnocumented = true 
     
     skipEmptyPackages = true // Do not create index pages for empty packages
  

--- a/runners/gradle-plugin/src/main/kotlin/main.kt
+++ b/runners/gradle-plugin/src/main/kotlin/main.kt
@@ -103,7 +103,7 @@ open class DokkaTask : DefaultTask() {
     @Input var includeNonPublic = false
     @Input var skipDeprecated = false
     @Input var skipEmptyPackages = true
-    @Input var reportNotDocumented = true
+    @Input var reportUndocumented = true
     @Input var perPackageOptions: MutableList<PackageOptions> = arrayListOf()
     @Input var impliedPlatforms: MutableList<String> = arrayListOf()
 
@@ -269,7 +269,7 @@ open class DokkaTask : DefaultTask() {
                     outputFormat,
                     includeNonPublic,
                     false,
-                    reportNotDocumented,
+                    reportUndocumented,
                     skipEmptyPackages,
                     skipDeprecated,
                     jdkVersion,


### PR DESCRIPTION
Replace ReportNotDocumented with ReportUndocumented in the Gradle plugin for consistency. Fixes #243