### PR TITLE
Update plugin-publish-plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ allprojects {
             classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
             classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.1'
 
-            classpath "com.gradle.publish:plugin-publish-plugin:0.9.6"
+            classpath "com.gradle.publish:plugin-publish-plugin:0.9.9"
         }
     }
 


### PR DESCRIPTION
Hiya, Tim from Gradle here.

There was a [bug in versions prior to 0.9.7](https://discuss.gradle.org/t/plugin-authors-please-use-the-latest-plugin-publish-plugin-others-may-result-in-a-broken-upload/23573) of the gradle `plugin-publish-plugin`, where artifacts would sometimes  silently not be pushed into the repo.

Your plugin has not been affected by the bug yet, but you should still upgrade.

This won't fix issue 146 (I'm not sure what has caused the pom differences seen in that issue), but it should avoid any problems publishing future versions.