### PR TITLE
Document that kotlin-android plugin is required even for non-kotlin p…

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android' // You will need this even if all source files are in Java, not in Kotlin
 apply plugin: 'org.jetbrains.dokka-android'
 ```
 


### PR DESCRIPTION
…rojects

I'm not actually confident that this is in fact required or the most proper way to do this; hopefully reviewers can tell me whether this is expected.

I made a small project at https://github.com/mathjeff/dokka-tests/blob/master/kotlin-android-required/README.txt demonstrating missing documentation until the kotlin-android plugin is added.