### PR TITLE
fix doc linkMapping, requires absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ dokka {
     // Repeat for multiple mappings
     linkMapping {
         // Source directory
-        dir = "src/main/kotlin"
+        dir = file("${project.projectDir}/src/main/kotlin").absolutePath
          
         // URL showing where the source code can be accessed through the web browser
         url = "https://github.com/cy6erGn0m/vertx3-lang-kotlin/blob/master/src/main/kotlin"


### PR DESCRIPTION
Might be that the implementation is wrong (https://github.com/Kotlin/dokka/blob/54c3c87acfb31afc22afc5f20229384f755b677f/core/src/main/kotlin/Model/SourceLinks.kt#L16) but it requires an absolute path and not a relative path. Also `/` or `\` plays a role and thus it is best to create a file and get the absolute path to it