### PR TITLE
Avoid unnecessary logging.

### DIFF
--- a/core/src/main/kotlin/javadoc/dokka-adapters.kt
+++ b/core/src/main/kotlin/javadoc/dokka-adapters.kt
@@ -14,7 +14,6 @@ class JavadocGenerator @Inject constructor(val options: DocumentationOptions, va
     override fun buildPages(nodes: Iterable<DocumentationNode>) {
         val module = nodes.single() as DocumentationModule
 
-        DokkaConsoleLogger.report()
         HtmlDoclet.start(ModuleNodeAdapter(module, StandardReporter(logger), options.outputDir))
     }
 


### PR DESCRIPTION
It looks like if you configure the `outputFormat` to `javadoc` you get a unnecessary log line printed out.

```
$ ./gradlew clean dokka

> Task :dokka 
generation completed successfully


BUILD SUCCESSFUL in 1s
2 actionable tasks: 2 executed
```

When activating Gradle `info` logging it also looks weird (see my `<---` marker)

```
> Task :dokka 
Task ':dokka' is not up-to-date because:
  Output property (...) has been removed.
Module: foo.bar
Output: (...)
Analysing sources and libraries... 
  package foo.bar: 4 declarations
done in 0 secs
Generating pages... 
generation completed successfully                         <-------
Standard Doclet version 1.8.0_121
Building tree for all the packages and classes...
Generating (..)
Building index for all the packages and classes...
Generating (...)
Building index for all classes...
Generating (...)
done in 0 secs

:dokka (Thread[Task worker for ':',5,main]) completed. Took 0.96 secs.
```

It appears that it's logged before any generation is done - and it isn't logged via the default Gradle `logger` (messing up the output a bit).

Looking through the code and its history a bit, it looks like a left-over remain from very early days of this plugin, see https://github.com/Kotlin/dokka/blob/12f91ee7d491b21359ff8e8822c594f35b904def/javadoc/src/main/kotlin/main.kt#L20

Can it be removed?