### PR TITLE
Fix ClassCastException when generating JavaDoc

### DIFF
--- a/core/src/main/kotlin/Kotlin/DocumentationBuilder.kt
+++ b/core/src/main/kotlin/Kotlin/DocumentationBuilder.kt
@@ -887,7 +887,7 @@ fun DeclarationDescriptor.isDocumentationSuppressed(options: DocumentationOption
 }
 
 fun DeclarationDescriptor.sourcePsi() =
-        ((original as DeclarationDescriptorWithSource).source as? PsiSourceElement)?.psi
+        ((original as? DeclarationDescriptorWithSource)?.source as? PsiSourceElement)?.psi
 
 fun DeclarationDescriptor.isDeprecated(): Boolean = annotations.any {
     DescriptorUtils.getFqName(it.type.constructor.declarationDescriptor!!).asString() == "kotlin.Deprecated"


### PR DESCRIPTION
When generating JavaDoc, dokka crashes when generating documentation for certain modules. I've seen this, particularly for my Android modules. This fix, suggested by @Gh0u1L5 solves this. Please refer to the original issue for more details

Fixes #287 