### PR TITLE
Proxy support with basic authentication has been added using system properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,3 +456,8 @@ Basically, given the `documentation` as a model, we do this:
 
 Dokka is built with Gradle. To build it, use `./gradlew build`.
 Alternatively, open the project directory in IntelliJ IDEA and use the IDE to build and run Dokka.
+
+## Using proxy with maven
+```
+mvn -Dhttp.proxyHost=host.domain.com -Dhttp.proxyPort=8080 -Dhttps.proxyHost=host.domain.com -Dhttps.proxyPort=8080 -DproxySet=true -DproxyUser=user -DproxyPassword=password dokka:dokka
+```

--- a/core/src/main/kotlin/Kotlin/ExternalDocumentationLinkResolver.kt
+++ b/core/src/main/kotlin/Kotlin/ExternalDocumentationLinkResolver.kt
@@ -46,6 +46,16 @@ class ExternalDocumentationLinkResolver @Inject constructor(
         connection.connectTimeout = timeout
         connection.readTimeout = timeout
 
+        // Add proxy basic authentication when proxyUser, proxyPassword is set and proxySet is true
+        val systemSettings = System.getProperties()
+        if (systemSettings.getValue("proxySet").toString() == "true"
+                && systemSettings.getValue("proxyUser").toString().isNotEmpty()
+                && systemSettings.getValue("proxyPassword").toString().isNotEmpty()) {
+            val encoder = sun.misc.BASE64Encoder()
+            val encodedUserPwd = encoder.encode((systemSettings.getValue("proxyUser").toString() + ":" + systemSettings.getValue("proxyPassword").toString()).toByteArray())
+            connection.setRequestProperty("Proxy-Authorization","Basic $encodedUserPwd")
+        }
+
         when (connection) {
             is HttpURLConnection -> {
                 return when (connection.responseCode) {


### PR DESCRIPTION
Dokka is great plugin unfortunatelly can't be used in corporates behind proxy therefore proxy support with basic authentication has been added using system properties below

-Dhttp.proxyHost=host.domain.com
-Dhttp.proxyPort=8080
-Dhttps.proxyHost=host.domain.com
-Dhttps.proxyPort=8080
-DproxySet=true
-DproxyUser=user
-DproxyPassword=password

if proxySet is true and proxyUser with proxyPassword is set then basic proxy authentication is added