### PR TITLE
 Add type safe counterparts to Closure taking methods on Gradle DokkaTask

### DIFF
--- a/runners/gradle-integration-tests/build.gradle
+++ b/runners/gradle-integration-tests/build.gradle
@@ -56,4 +56,5 @@ testClasses.dependsOn createClasspathManifest
 
 test {
     systemProperty "android.licenses.overwrite", project.findProperty("android.licenses.overwrite") ?: ""
+    inputs.dir(file('testData'))
 }

--- a/runners/gradle-integration-tests/src/test/kotlin/org/jetbrains/dokka/gradle/TypeSafeConfigurationTest.kt
+++ b/runners/gradle-integration-tests/src/test/kotlin/org/jetbrains/dokka/gradle/TypeSafeConfigurationTest.kt
@@ -1,10 +1,8 @@
 package org.jetbrains.dokka.gradle
 
-import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
-import kotlin.test.assertEquals
 
 @RunWith(Parameterized::class)
 class TypeSafeConfigurationTest(private val testCase: TestCase) : AbstractDokkaGradleTest() {
@@ -25,14 +23,14 @@ class TypeSafeConfigurationTest(private val testCase: TestCase) : AbstractDokkaG
 
     @Test
     fun test() {
-        testDataFolder.resolve("typeSafeConfiguration").toFile().copyRecursively(testProjectDir.root)
+
+        testDataFolder.resolve("typeSafeConfiguration").toFile()
+                .copyRecursively(testProjectDir.root)
+
         configure(
                 testCase.gradleVersion,
                 testCase.kotlinVersion,
                 arguments = arrayOf("help", "-s")
-        ).build().apply {
-            println(output)
-            assertEquals(TaskOutcome.SUCCESS, task(":help")?.outcome)
-        }
+        ).build()
     }
 }

--- a/runners/gradle-integration-tests/src/test/kotlin/org/jetbrains/dokka/gradle/TypeSafeConfigurationTest.kt
+++ b/runners/gradle-integration-tests/src/test/kotlin/org/jetbrains/dokka/gradle/TypeSafeConfigurationTest.kt
@@ -1,0 +1,38 @@
+package org.jetbrains.dokka.gradle
+
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import kotlin.test.assertEquals
+
+@RunWith(Parameterized::class)
+class TypeSafeConfigurationTest(private val testCase: TestCase) : AbstractDokkaGradleTest() {
+
+    data class TestCase(val gradleVersion: String, val kotlinVersion: String) {
+        override fun toString(): String = "Gradle $gradleVersion and Kotlin $kotlinVersion"
+    }
+
+    companion object {
+        @Parameterized.Parameters(name = "{0}")
+        @JvmStatic
+        fun testCases() = listOf(
+                TestCase("4.0", "1.1.2"),
+                TestCase("4.5", "1.2.20"),
+                TestCase("4.10.1", "1.2.60")
+        )
+    }
+
+    @Test
+    fun test() {
+        testDataFolder.resolve("typeSafeConfiguration").toFile().copyRecursively(testProjectDir.root)
+        configure(
+                testCase.gradleVersion,
+                testCase.kotlinVersion,
+                arguments = arrayOf("help", "-s")
+        ).build().apply {
+            println(output)
+            assertEquals(TaskOutcome.SUCCESS, task(":help")?.outcome)
+        }
+    }
+}

--- a/runners/gradle-integration-tests/testData/typeSafeConfiguration/build.gradle
+++ b/runners/gradle-integration-tests/testData/typeSafeConfiguration/build.gradle
@@ -21,64 +21,64 @@ plugins {
 apply plugin: 'kotlin'
 
 @CompileStatic
-def configureDokkaTypeSafely(Project project) {
-    project.tasks.withType(DokkaTask) { DokkaTask dokka ->
-        dokka.with {
-            moduleName = "some String"
-            outputFormat = "some String"
-            outputDirectory = "some String"
-            classpath = Collections.singleton(file("someClassDir"))
-            includes = Collections.emptyList()
-            linkMappings = new ArrayList<LinkMapping>()
-            samples = Collections.emptyList()
-            jdkVersion = 6
-            sourceDirs = Collections.<File>emptyList()
-            sourceRoots = new ArrayList<SourceRoot>()
-            dokkaFatJar = file("some File")
-            includeNonPublic = false
-            skipDeprecated = false
-            skipEmptyPackages = true
-            reportUndocumented = true
-            perPackageOptions = new ArrayList<PackageOptions>()
-            impliedPlatforms = Collections.<String>emptyList()
-            externalDocumentationLinks = new ArrayList<DokkaConfiguration.ExternalDocumentationLink>()
-            noStdlibLink = false
-            cacheRoot = null as String
-            languageVersion = null as String
-            apiVersion = null as String
-            kotlinTasks(new Callable<List<Object>>() {
-                @Override
-                List<Object> call() {
-                    return defaultKotlinTasks()
-                }
-            })
-            linkMapping(new Action<LinkMapping>() {
-                @Override
-                void execute(LinkMapping mapping) {
-                    mapping.dir = "some String"
-                    mapping.url = "some String"
-                }
-            })
-            sourceRoot(new Action<SourceRoot>() {
-                @Override
-                void execute(SourceRoot sourceRoot) {
-                    sourceRoot.path = "some String"
-                }
-            })
-            packageOptions(new Action<PackageOptions>() {
-                @Override
-                void execute(PackageOptions packageOptions) {
-                    packageOptions.prefix = "some String"
-                }
-            })
-            externalDocumentationLink(new Action<DokkaConfiguration.ExternalDocumentationLink.Builder>() {
-                @Override
-                void execute(DokkaConfiguration.ExternalDocumentationLink.Builder builder) {
-                    builder.url = uri("some URI").toURL()
-                }
-            })
-        }
+def configureDokkaTypeSafely(DokkaTask dokka) {
+    dokka.with {
+        moduleName = "some String"
+        outputFormat = "some String"
+        outputDirectory = "some String"
+        classpath = Collections.singleton(file("someClassDir"))
+        includes = Collections.emptyList()
+        linkMappings = new ArrayList<LinkMapping>()
+        samples = Collections.emptyList()
+        jdkVersion = 6
+        sourceDirs = Collections.<File>emptyList()
+        sourceRoots = new ArrayList<SourceRoot>()
+        dokkaFatJar = file("some File")
+        includeNonPublic = false
+        skipDeprecated = false
+        skipEmptyPackages = true
+        reportUndocumented = true
+        perPackageOptions = new ArrayList<PackageOptions>()
+        impliedPlatforms = Collections.<String>emptyList()
+        externalDocumentationLinks = new ArrayList<DokkaConfiguration.ExternalDocumentationLink>()
+        noStdlibLink = false
+        cacheRoot = null as String
+        languageVersion = null as String
+        apiVersion = null as String
+        kotlinTasks(new Callable<List<Object>>() {
+            @Override
+            List<Object> call() {
+                return defaultKotlinTasks()
+            }
+        })
+        linkMapping(new Action<LinkMapping>() {
+            @Override
+            void execute(LinkMapping mapping) {
+                mapping.dir = "some String"
+                mapping.url = "some String"
+            }
+        })
+        sourceRoot(new Action<SourceRoot>() {
+            @Override
+            void execute(SourceRoot sourceRoot) {
+                sourceRoot.path = "some String"
+            }
+        })
+        packageOptions(new Action<PackageOptions>() {
+            @Override
+            void execute(PackageOptions packageOptions) {
+                packageOptions.prefix = "some String"
+            }
+        })
+        externalDocumentationLink(new Action<DokkaConfiguration.ExternalDocumentationLink.Builder>() {
+            @Override
+            void execute(DokkaConfiguration.ExternalDocumentationLink.Builder builder) {
+                builder.url = uri("some URI").toURL()
+            }
+        })
     }
 }
 
-configureDokkaTypeSafely(project)
+project.tasks.withType(DokkaTask) { dokka ->
+    configureDokkaTypeSafely(dokka)
+}

--- a/runners/gradle-integration-tests/testData/typeSafeConfiguration/build.gradle
+++ b/runners/gradle-integration-tests/testData/typeSafeConfiguration/build.gradle
@@ -46,6 +46,37 @@ def configureDokkaTypeSafely(Project project) {
             cacheRoot = null as String
             languageVersion = null as String
             apiVersion = null as String
+            kotlinTasks(new Callable<List<Object>>() {
+                @Override
+                List<Object> call() {
+                    return defaultKotlinTasks()
+                }
+            })
+            linkMapping(new Action<LinkMapping>() {
+                @Override
+                void execute(LinkMapping mapping) {
+                    mapping.dir = "some String"
+                    mapping.url = "some String"
+                }
+            })
+            sourceRoot(new Action<SourceRoot>() {
+                @Override
+                void execute(SourceRoot sourceRoot) {
+                    sourceRoot.path = "some String"
+                }
+            })
+            packageOptions(new Action<PackageOptions>() {
+                @Override
+                void execute(PackageOptions packageOptions) {
+                    packageOptions.prefix = "some String"
+                }
+            })
+            externalDocumentationLink(new Action<DokkaConfiguration.ExternalDocumentationLink.Builder>() {
+                @Override
+                void execute(DokkaConfiguration.ExternalDocumentationLink.Builder builder) {
+                    builder.url = uri("some URI").toURL()
+                }
+            })
         }
     }
 }

--- a/runners/gradle-integration-tests/testData/typeSafeConfiguration/build.gradle
+++ b/runners/gradle-integration-tests/testData/typeSafeConfiguration/build.gradle
@@ -1,0 +1,53 @@
+import org.jetbrains.dokka.*
+import org.jetbrains.dokka.gradle.*
+import org.jetbrains.kotlin.gradle.tasks.*
+
+import groovy.transform.CompileStatic
+import java.util.concurrent.Callable
+
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$test_kotlin_version"
+    }
+}
+
+plugins {
+    id 'org.jetbrains.dokka'
+}
+
+apply plugin: 'kotlin'
+
+@CompileStatic
+def configureDokkaTypeSafely(Project project) {
+    project.tasks.withType(DokkaTask) { DokkaTask dokka ->
+        dokka.with {
+            moduleName = "some String"
+            outputFormat = "some String"
+            outputDirectory = "some String"
+            classpath = Collections.singleton(file("someClassDir"))
+            includes = Collections.emptyList()
+            linkMappings = new ArrayList<LinkMapping>()
+            samples = Collections.emptyList()
+            jdkVersion = 6
+            sourceDirs = Collections.<File> emptyList()
+            sourceRoots = new ArrayList<SourceRoot>()
+            dokkaFatJar = file("some File")
+            includeNonPublic = false
+            skipDeprecated = false
+            skipEmptyPackages = true
+            reportUndocumented = true
+            perPackageOptions = new ArrayList<PackageOptions>()
+            impliedPlatforms = Collections.<String>emptyList()
+            externalDocumentationLinks = new ArrayList<DokkaConfiguration.ExternalDocumentationLink>()
+            noStdlibLink = false
+            cacheRoot = null as String
+            languageVersion = null as String
+            apiVersion = null as String
+        }
+    }
+}
+
+configureDokkaTypeSafely(project)

--- a/runners/gradle-integration-tests/testData/typeSafeConfiguration/build.gradle
+++ b/runners/gradle-integration-tests/testData/typeSafeConfiguration/build.gradle
@@ -32,7 +32,7 @@ def configureDokkaTypeSafely(Project project) {
             linkMappings = new ArrayList<LinkMapping>()
             samples = Collections.emptyList()
             jdkVersion = 6
-            sourceDirs = Collections.<File> emptyList()
+            sourceDirs = Collections.<File>emptyList()
             sourceRoots = new ArrayList<SourceRoot>()
             dokkaFatJar = file("some File")
             includeNonPublic = false

--- a/runners/gradle-integration-tests/testData/typeSafeConfiguration/settings.gradle
+++ b/runners/gradle-integration-tests/testData/typeSafeConfiguration/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "type-safe-configuration"


### PR DESCRIPTION
This allows build logic written in statically compiled languages to configure dokka without struggling with Groovy Closures and reflection.

This will benefit Gradle Kotlin DSL scripts, see #196, but it also applies to all statically compiled languages. For example, a Gradle plugin written in Java and integrating Dokka will be much easier to write.

The added test uses Groovy's `@CompileStatic` to assert type safe configuration compiles cleanly.

I just saw #357 when creating that PR, thought I'll open this one anyway.