### PR TITLE
Update pom file to use 'compile' instead of 'runtime'

### DIFF
--- a/buildSrc/src/main/groovy/org/jetbrains/CorrectShadowPublishing.groovy
+++ b/buildSrc/src/main/groovy/org/jetbrains/CorrectShadowPublishing.groovy
@@ -35,5 +35,5 @@ private static void addDependency(Node dependenciesNode, dep) {
     dependencyNode.appendNode('groupId', dep.group)
     dependencyNode.appendNode('artifactId', dep.name)
     dependencyNode.appendNode('version', dep.version)
-    dependencyNode.appendNode('scope', 'runtime')
+    dependencyNode.appendNode('scope', 'compile')
 }


### PR DESCRIPTION
This addresses Gradle 5.0 compatibility and fixes https://github.com/Kotlin/dokka/issues/388