### PR TITLE
Do not begin filenames with minus (-)

### DIFF
--- a/core/src/main/kotlin/Locations/Location.kt
+++ b/core/src/main/kotlin/Locations/Location.kt
@@ -45,7 +45,8 @@ fun relativePathToNode(node: DocumentationNode) = relativePathToNode(node.path.m
 
 fun identifierToFilename(path: String): String {
     val escaped = path.replace('<', '-').replace('>', '-')
-    val lowercase = escaped.replace("[A-Z]".toRegex()) { matchResult -> "-" + matchResult.value.toLowerCase() }
+    val lowercaseFirst = escaped.replace("^[A-Z]".toRegex()) { matchResult -> matchResult.value.toLowerCase() }
+    val lowercase = lowercaseFirst.replace("[A-Z]".toRegex()) { matchResult -> "-" + matchResult.value.toLowerCase() }
     return if (lowercase == "index") "--index--" else lowercase
 }
 


### PR DESCRIPTION
Filenames are converted to lowercase, e.g., by replacing "A" to "-a". So "LongClassExampleFactory" will be "-long-class-example-factory". IMHO It should be "long-class-example-factory" without the minus (-) at the first character.

This pull request fixes this.