### PR TITLE
Preserve newlines in javadoc code blocks

### DIFF
--- a/core/src/main/kotlin/Java/JavadocParser.kt
+++ b/core/src/main/kotlin/Java/JavadocParser.kt
@@ -76,10 +76,15 @@ class JavadocParser(private val refGraph: NodeReferenceGraph,
             append(ContentText(node.text()))
         } else if (node is Element) {
             val childBlock = createBlock(node)
-            node.childNodes().forEach {
-                childBlock.convertHtmlNode(it)
+            if (childBlock is ContentBlockCode) {
+                append(childBlock)
+                childBlock.append(ContentText(node.text()))
+            } else {
+                node.childNodes().forEach {
+                    childBlock.convertHtmlNode(it)
+                }
+                append(childBlock)
             }
-            append(childBlock)
         }
     }
 


### PR DESCRIPTION
This fixes #158 by using JSoup's `node.text()` directly on the "pre" tag.
Before this change the code went another node down the tree and used the `.text()` method on the TextNode leaf which would not preserve newlines.