### PR TITLE
Change annotation name to qualified name.

### DIFF
--- a/core/src/main/kotlin/Java/JavaPsiDocumentationBuilder.kt
+++ b/core/src/main/kotlin/Java/JavaPsiDocumentationBuilder.kt
@@ -275,7 +275,7 @@ class JavaPsiDocumentationBuilder : JavaDocumentationBuilder {
     }
 
     fun PsiAnnotation.build(): DocumentationNode {
-        val node = DocumentationNode(nameReferenceElement?.text ?: "<?>", Content.Empty, NodeKind.Annotation)
+        val node = DocumentationNode(nameReferenceElement?.qualifiedName ?: "<?>", Content.Empty, NodeKind.Annotation)
         parameterList.attributes.forEach {
             val parameter = DocumentationNode(it.name ?: "value", Content.Empty, NodeKind.Parameter)
             val value = it.value

--- a/core/src/main/kotlin/Kotlin/DocumentationBuilder.kt
+++ b/core/src/main/kotlin/Kotlin/DocumentationBuilder.kt
@@ -763,7 +763,7 @@ class DocumentationBuilder
         if (annotationClass == null || ErrorUtils.isError(annotationClass)) {
             return null
         }
-        val node = DocumentationNode(annotationClass.name.asString(), Content.Empty, NodeKind.Annotation)
+        val node = DocumentationNode(annotationClass.fqNameSafe.asString(), Content.Empty, NodeKind.Annotation)
         allValueArguments.forEach { (name, value) ->
             val valueNode = value.toDocumentationNode()
             if (valueNode != null) {


### PR DESCRIPTION
Annotation name is the simple name. It wouldn't distinguish the annotation Which has used the same name. So I think it should use the qualified name.