### PR TITLE
Add hexo format

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,3 +456,25 @@ Basically, given the `documentation` as a model, we do this:
 
 Dokka is built with Gradle. To build it, use `./gradlew build`.
 Alternatively, open the project directory in IntelliJ IDEA and use the IDE to build and run Dokka.
+
+Here's how to import and configure Dokka in IntelliJ IDEA:
+ * Select "Open" from the IDEA welcome screen, or File > Open if a project is
+  already open
+* Select the directory with your clone of Dokka
+  * Note: IDEA may have an error after the project is initally opened; it is OK
+    to ignore this as the next step will address this error
+* After IDEA opens the project, select File > New > Module from existing sources
+  and select the `build.gradle` file from the root directory of your Dokka clone
+* Use the default options and select "OK"
+* After Dokka is loaded into IDEA, open the Gradle tool window (View > Tool
+  Windows > Gradle) and click on the top left "Refresh all Gradle projects"
+  button
+* Verify the following project settings.  In File > Settings > Build, Execution,
+  Deployment > Build Tools > Gradle > Runner:
+  * Ensure "Delegate IDE build/run actions to gradle" is checked
+  * "Gradle Test Runner" should be selected in the "Run tests using" drop-down
+    menu
+* Note: After closing and re-opening the project, IDEA may give an error
+  message: "Error Loading Project: Cannot load 3 modules".  Open up the details
+  of the error, and click "Remove Selected", as these module `.iml` files are
+  safe to remove.

--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ Dokka supports the following command line arguments:
   * `markdown` - Markdown structured as `html`
     * `gfm` - GitHub flavored markdown  
     * `jekyll` - Jekyll compatible markdown 
+    * `hexo` - [Hexo](https://hexo.io/) compatible markdown 
   * `kotlin-website*` - internal format used for documentation on [kotlinlang.org](https://kotlinlang.org)
 
 ### Platforms<a name="platforms"></a>

--- a/README.md
+++ b/README.md
@@ -252,8 +252,8 @@ The available configuration options are shown below:
         <!-- List of '.md' files with package and module docs -->
         <!-- http://kotlinlang.org/docs/reference/kotlin-doc.html#module-and-package-documentation -->
         <includes>
-            <file>packages.md</file>
-            <file>extra.md</file>
+            <include>packages.md</include>
+            <include>extra.md</include>
         </includes>
         
         <!-- List of sample roots -->

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ dokka {
     impliedPlatforms = ["JVM"] // See platforms section of documentation 
     
     // Manual adding files to classpath
-    // This property not overrides classpath collected from kotlinTasks but appends to it
+    // This property doesn't override classpath collected from kotlinTasks but appends to it
     classpath = [new File("$buildDir/other.jar")]
 
     // By default, sourceRoots is taken from kotlinTasks, following roots will be appended to it

--- a/core/src/main/kotlin/Formats/HexoFormatService.kt
+++ b/core/src/main/kotlin/Formats/HexoFormatService.kt
@@ -1,0 +1,47 @@
+package org.jetbrains.dokka.Formats
+
+import com.google.inject.Inject
+import com.google.inject.name.Named
+import org.jetbrains.dokka.*
+import org.jetbrains.dokka.Utilities.impliedPlatformsName
+
+open class HexoOutputBuilder(
+    to: StringBuilder,
+    location: Location,
+    generator: NodeLocationAwareGenerator,
+    languageService: LanguageService,
+    extension: String,
+    impliedPlatforms: List<String>
+) : GFMOutputBuilder(to, location, generator, languageService, extension, impliedPlatforms) {
+
+    override fun appendNodes(nodes: Iterable<DocumentationNode>) {
+        to.appendln("---")
+        appendFrontMatter(nodes, to)
+        to.appendln("---")
+        to.appendln("")
+        super.appendNodes(nodes)
+    }
+
+    protected open fun appendFrontMatter(nodes: Iterable<DocumentationNode>, to: StringBuilder) {
+        to.appendln("title: ${getPageTitle(nodes)}")
+        to.appendln("layout: api")
+    }
+}
+
+open class HexoFormatService(
+    generator: NodeLocationAwareGenerator,
+    signatureGenerator: LanguageService,
+    linkExtension: String,
+    impliedPlatforms: List<String>
+) : GFMFormatService(generator, signatureGenerator, linkExtension, impliedPlatforms) {
+
+    @Inject
+    constructor(
+        generator: NodeLocationAwareGenerator,
+        signatureGenerator: LanguageService,
+        @Named(impliedPlatformsName) impliedPlatforms: List<String>
+    ) : this(generator, signatureGenerator, "html", impliedPlatforms)
+
+    override fun createOutputBuilder(to: StringBuilder, location: Location): FormattedOutputBuilder =
+        HexoOutputBuilder(to, location, generator, languageService, extension, impliedPlatforms)
+}

--- a/core/src/main/kotlin/Formats/StandardFormats.kt
+++ b/core/src/main/kotlin/Formats/StandardFormats.kt
@@ -64,3 +64,7 @@ class MarkdownFormatDescriptor : KotlinFormatDescriptorBase() {
 class GFMFormatDescriptor : KotlinFormatDescriptorBase() {
     override val formatServiceClass = GFMFormatService::class
 }
+
+class HexoFormatDescriptor : KotlinFormatDescriptorBase() {
+    override val formatServiceClass = HexoFormatService::class
+}

--- a/core/src/main/resources/dokka/format/hexo.properties
+++ b/core/src/main/resources/dokka/format/hexo.properties
@@ -1,0 +1,2 @@
+class=org.jetbrains.dokka.Formats.HexoFormatDescriptor
+description=Produces documentation in Hexo format


### PR DESCRIPTION
Support [Hexo](https://hexo.io/) compatible markdown. Hexo is another static blog framework just like Jekyll, see https://hexo.io/