### PR TITLE
fix fatjar argument parsing

### DIFF
--- a/runners/cli/src/main/kotlin/cli/main.kt
+++ b/runners/cli/src/main/kotlin/cli/main.kt
@@ -36,10 +36,10 @@ class DokkaArguments {
     var classpath: String = ""
 
     @set:Argument(value = "nodeprecated", description = "Exclude deprecated members from documentation")
-    var nodeprecated: Boolean = false
+    var nodeprecated: String = "false"
 
     @set:Argument(value = "jdkVersion", description = "Version of JDK to use for linking to JDK JavaDoc")
-    var jdkVersion: Int = 6
+    var jdkVersion: String = "6"
 
     @set:Argument(value = "impliedPlatforms", description = "List of implied platforms (comma-separated)")
     var impliedPlatforms: String = ""
@@ -51,10 +51,10 @@ class DokkaArguments {
     var links: String = ""
 
     @set:Argument(value = "noStdlibLink", description = "Disable documentation link to stdlib")
-    var noStdlibLink: Boolean = false
+    var noStdlibLink: String = "false"
 
     @set:Argument(value = "noJdkLink", description = "Disable documentation link to jdk")
-    var noJdkLink: Boolean = false
+    var noJdkLink: String = "false"
 
     @set:Argument(value = "cacheRoot", description = "Path to cache folder, or 'default' to use ~/.cache/dokka, if not provided caching is disabled")
     var cacheRoot: String? = null
@@ -66,7 +66,7 @@ class DokkaArguments {
     var apiVersion: String? = null
 
     @set:Argument(value = "collectInheritedExtensionsFromLibraries", description = "Search for applicable extensions in libraries")
-    var collectInheritedExtensionsFromLibraries: Boolean = false
+    var collectInheritedExtensionsFromLibraries: String = "false"
 
 }
 
@@ -114,18 +114,18 @@ object MainKt {
         val documentationOptions = DocumentationOptions(
             arguments.outputDir.let { if (it.endsWith('/')) it else it + '/' },
             arguments.outputFormat,
-            skipDeprecated = arguments.nodeprecated,
+            skipDeprecated = arguments.nodeprecated.toBoolean(),
             sourceLinks = sourceLinks,
             impliedPlatforms = arguments.impliedPlatforms.split(','),
             perPackageOptions = parsePerPackageOptions(arguments.packageOptions),
-            jdkVersion = arguments.jdkVersion,
+            jdkVersion = arguments.jdkVersion.toInt(),
             externalDocumentationLinks = parseLinks(arguments.links),
-            noStdlibLink = arguments.noStdlibLink,
+            noStdlibLink = arguments.noStdlibLink.toBoolean(),
             cacheRoot = arguments.cacheRoot,
             languageVersion = arguments.languageVersion,
             apiVersion = arguments.apiVersion,
-            collectInheritedExtensionsFromLibraries = arguments.collectInheritedExtensionsFromLibraries,
-            noJdkLink = arguments.noJdkLink
+            collectInheritedExtensionsFromLibraries = arguments.collectInheritedExtensionsFromLibraries.toBoolean(),
+            noJdkLink = arguments.noJdkLink.toBoolean()
         )
 
         val generator = DokkaGenerator(


### PR DESCRIPTION
Using the fatjar with a `-jdkVersion 8` argument will cause an exception now: 

````raw
Exception in thread "main" java.lang.IllegalArgumentException: Could not find constructor in class int that takes a string
        at com.sampullara.cli.Args.setProperty(Args.java:351)
        at com.sampullara.cli.Args.processProperty(Args.java:163)
        at com.sampullara.cli.Args.parse(Args.java:55)
        at org.jetbrains.dokka.MainKt.main(main.kt:172)
Caused by: java.lang.NoSuchMethodException: int.<init>(java.lang.String)
        at java.lang.Class.getConstructor0(Class.java:3082)
        at java.lang.Class.getDeclaredConstructor(Class.java:2178)
        at com.sampullara.cli.Args.createValue(Args.java:408)
        at com.sampullara.cli.Args.getValue(Args.java:401)
        at com.sampullara.cli.Args.setProperty(Args.java:346)
        ... 3 more
````

So I changed the types of all the properties in DokkaArguments to String to fix this bug.