### PR TITLE
add hexo format

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ Dokka supports the following command line arguments:
   * `markdown` - markdown structured as `html`, Java classes are translated to Kotlin
     * `gfm` - GitHub flavored markdown
     * `jekyll` - Jekyll compatible markdown 
+    * `hexo` - [Hexo](https://hexo.io/) compatible markdown 
   * `kotlin-website*` - internal format used for documentation on [kotlinlang.org](https://kotlinlang.org)
 
 ### Platforms<a name="platforms"></a>

--- a/core/src/main/kotlin/Formats/HexoFormatService.kt
+++ b/core/src/main/kotlin/Formats/HexoFormatService.kt
@@ -1,0 +1,47 @@
+package org.jetbrains.dokka.Formats
+
+import com.google.inject.Inject
+import com.google.inject.name.Named
+import org.jetbrains.dokka.*
+import org.jetbrains.dokka.Utilities.impliedPlatformsName
+
+open class HexoOutputBuilder(
+    to: StringBuilder,
+    location: Location,
+    generator: NodeLocationAwareGenerator,
+    languageService: LanguageService,
+    extension: String,
+    impliedPlatforms: List<String>
+) : GFMOutputBuilder(to, location, generator, languageService, extension, impliedPlatforms) {
+
+    override fun appendNodes(nodes: Iterable<DocumentationNode>) {
+        to.appendln("---")
+        appendFrontMatter(nodes, to)
+        to.appendln("---")
+        to.appendln("")
+        super.appendNodes(nodes)
+    }
+
+    protected open fun appendFrontMatter(nodes: Iterable<DocumentationNode>, to: StringBuilder) {
+        to.appendln("title: ${getPageTitle(nodes)}")
+        to.appendln("layout: api")
+    }
+}
+
+open class HexoFormatService(
+    generator: NodeLocationAwareGenerator,
+    signatureGenerator: LanguageService,
+    linkExtension: String,
+    impliedPlatforms: List<String>
+) : GFMFormatService(generator, signatureGenerator, linkExtension, impliedPlatforms) {
+
+    @Inject
+    constructor(
+        generator: NodeLocationAwareGenerator,
+        signatureGenerator: LanguageService,
+        @Named(impliedPlatformsName) impliedPlatforms: List<String>
+    ) : this(generator, signatureGenerator, "html", impliedPlatforms)
+
+    override fun createOutputBuilder(to: StringBuilder, location: Location): FormattedOutputBuilder =
+        HexoOutputBuilder(to, location, generator, languageService, extension, impliedPlatforms)
+}

--- a/core/src/main/kotlin/Formats/StandardFormats.kt
+++ b/core/src/main/kotlin/Formats/StandardFormats.kt
@@ -64,3 +64,7 @@ class MarkdownFormatDescriptor : KotlinFormatDescriptorBase() {
 class GFMFormatDescriptor : KotlinFormatDescriptorBase() {
     override val formatServiceClass = GFMFormatService::class
 }
+
+class HexoFormatDescriptor : KotlinFormatDescriptorBase() {
+    override val formatServiceClass = HexoFormatService::class
+}

--- a/core/src/main/resources/dokka/format/hexo.properties
+++ b/core/src/main/resources/dokka/format/hexo.properties
@@ -1,0 +1,2 @@
+class=org.jetbrains.dokka.Formats.HexoFormatDescriptor
+description=Produces documentation in Hexo format


### PR DESCRIPTION
Support Hexo compatible markdown. Hexo is another static blog framework just like Jekyll, see https://hexo.io/