### PR TITLE
Adapt to jdk 10+ package info changes

### DIFF
--- a/core/src/main/kotlin/Kotlin/DocumentationBuilder.kt
+++ b/core/src/main/kotlin/Kotlin/DocumentationBuilder.kt
@@ -73,8 +73,19 @@ class DocumentationOptions(val outputDir: String,
 
     val defaultLinks = run {
         val links = mutableListOf<ExternalDocumentationLink>()
-        if (!noJdkLink)
-            links += ExternalDocumentationLink.Builder("https://docs.oracle.com/javase/$jdkVersion/docs/api/").build()
+        if (!noJdkLink) {
+            val docLink = if (jdkVersion > 10) {
+                "https://docs.oracle.com/en/java/javase/$jdkVersion/docs/api/"
+            } else {
+                "https://docs.oracle.com/javase/$jdkVersion/docs/api/"
+            }
+            val packageList = if (jdkVersion > 9) {
+                "$docLink/element-list"
+            } else {
+                "$docLink/package-list"
+            }
+            links += ExternalDocumentationLink.Builder(docLink, packageList).build()
+        }
 
         if (!noStdlibLink)
             links += ExternalDocumentationLink.Builder("https://kotlinlang.org/api/latest/jvm/stdlib/").build()


### PR DESCRIPTION
For jdk 11+, look at /en/java/javase instead of /javase
For jdk 10+, look at element-list instead of package-list,
and parse the module out to generate the correct class link.

Fixes #416
Might also fix #294