### PR TITLE
Include fallback monospace font in style.css

### DIFF
--- a/plugins/base/src/main/resources/dokka/styles/style.css
+++ b/plugins/base/src/main/resources/dokka/styles/style.css
@@ -243,7 +243,7 @@ code.paragraph {
     font-weight: bold;
     position: relative;
     line-height: 24px;
-    font-family: JetBrains Mono, Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal;
+    font-family: JetBrains Mono, Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal, monospace;
     font-size: 14px;
     min-height: 43px;
 }
@@ -427,14 +427,14 @@ td:first-child {
 
 .keyword {
     color: black;
-    font-family: JetBrains Mono, Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal;
+    font-family: JetBrains Mono, Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal, monospace;
     font-size: 12px;
 }
 
 .identifier {
     color: darkblue;
     font-size: 12px;
-    font-family: JetBrains Mono, Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal;
+    font-family: JetBrains Mono, Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal, monospace;
 }
 
 .brief {


### PR DESCRIPTION
Fallback to a monospace font on systems without any of the listed concrete
fonts. (This includes a very large number of Linux systems.) Otherwise they
will fall back to the system default, which is almost certainly proportional.