### PR TITLE
Don't create filenames that conflict with Windows reserved filenames.

### DIFF
--- a/core/src/main/kotlin/Locations/Location.kt
+++ b/core/src/main/kotlin/Locations/Location.kt
@@ -43,10 +43,12 @@ fun relativePathToNode(qualifiedName: List<String>, hasMembers: Boolean): String
 
 fun relativePathToNode(node: DocumentationNode) = relativePathToNode(node.path.map { it.name }, node.members.any())
 
+private val reservedFilenames = setOf("index", "con", "aux", "lst", "prn", "nul", "eof", "inp", "out")
+
 fun identifierToFilename(path: String): String {
     val escaped = path.replace('<', '-').replace('>', '-')
     val lowercase = escaped.replace("[A-Z]".toRegex()) { matchResult -> "-" + matchResult.value.toLowerCase() }
-    return if (lowercase == "index") "--index--" else lowercase
+    return if (lowercase in reservedFilenames) "--$lowercase--" else lowercase
 }
 
 fun NodeLocationAwareGenerator.relativePathToLocation(owner: DocumentationNode, node: DocumentationNode): String {


### PR DESCRIPTION
A project that has classes/members whose names match any of the [windows reserved filenames](https://superuser.com/a/613335) can cause Dokka to omit documentation for that member, sometimes with cryptic log messages such as:

```
java.io.IOException: The device is not connected
```

This PR attempts to address that issue by blacklisting the Windows-reserved filenames in the `identifierToFilename` function.

A minimalist test project exists [here](https://github.com/drmoose/dokka-windows-example). The latest release tries to create a file `prn.html` for the example class, which fails on Windows. With this PR, that file is called `--prn--.html`, which is allowed.

```kotlin
/** An example class to trigger the filename bug */
data class Example(
    /** gps satellite ID number */
    val prn: Int)
```
