### PR TITLE
Resolved problems with android multiflavors documentation shadowing

### DIFF
--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaTask.kt
@@ -200,7 +200,7 @@ open class DokkaTask : DefaultTask() {
 
         if (disableAutoconfiguration) return userConfig
 
-        val baseConfig = configExtractor.extractConfiguration(userConfig.name, userConfig.androidVariant)
+        val baseConfig = configExtractor.extractConfiguration(userConfig.name, userConfig.androidVariants)
             ?.let { mergeUserConfigurationAndPlatformData(userConfig, it) }
                 ?: if (this.isMultiplatformProject()) {
                     if (outputDiagnosticInfo)
@@ -217,7 +217,7 @@ open class DokkaTask : DefaultTask() {
                 subProjects.toProjects().fold(baseConfig) { config, subProject ->
                     mergeUserConfigurationAndPlatformData(
                         config,
-                        ConfigurationExtractor(subProject).extractConfiguration(config.name, config.androidVariant)!!
+                        ConfigurationExtractor(subProject).extractConfiguration(config.name, config.androidVariants)!!
                     )
                 }
             } catch(e: NullPointerException) {

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/configurationImplementations.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/configurationImplementations.kt
@@ -51,7 +51,7 @@ open class GradlePassConfigurationImpl(@Transient val name: String = ""): PassCo
     @Input override var targets: List<String> = emptyList()
     @Input @Optional override var sinceKotlin: String? = null
     @Transient var collectKotlinTasks: (() -> List<Any?>?)? = null
-    @Input @Optional @Transient var androidVariant: String? = null
+    @Input @Optional @Transient var androidVariants: List<String?> = listOf(null)
 
     fun kotlinTasks(taskSupplier: Callable<List<Any>>) {
         collectKotlinTasks = { taskSupplier.call() }

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/configurationImplementations.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/configurationImplementations.kt
@@ -51,7 +51,7 @@ open class GradlePassConfigurationImpl(@Transient val name: String = ""): PassCo
     @Input override var targets: List<String> = emptyList()
     @Input @Optional override var sinceKotlin: String? = null
     @Transient var collectKotlinTasks: (() -> List<Any?>?)? = null
-    @Input @Optional @Transient var androidVariants: List<String?> = listOf(null)
+    @Input @Optional @Transient var androidVariants: List<String> = emptyList()
 
     fun kotlinTasks(taskSupplier: Callable<List<Any>>) {
         collectKotlinTasks = { taskSupplier.call() }


### PR DESCRIPTION
The problem was with generating documentation for multiflavored android project. 
From now it will generate documentation for all stated flavors through dokka task's parameter.

Note it will actually squash JDocs / KDocs of all classes / methods that share same name. For convenient results pass single flavor that you want to generate documentation of.