### PR TITLE
Ignore samples.Sample import when generating runnable samples

### DIFF
--- a/core/src/main/kotlin/Samples/KotlinWebsiteSampleProcessingService.kt
+++ b/core/src/main/kotlin/Samples/KotlinWebsiteSampleProcessingService.kt
@@ -165,7 +165,7 @@ open class KotlinWebsiteSampleProcessingService
         return sampleBuilder.text
     }
 
-    val importsToIgnore = arrayOf("samples.*").map { ImportPath.fromString(it) }
+    val importsToIgnore = arrayOf("samples.*", "samples.Sample").map { ImportPath.fromString(it) }
 
     override fun processImports(psiElement: PsiElement): ContentBlockCode {
         val psiFile = psiElement.containingFile


### PR DESCRIPTION
Some of the runnable samples for the Kotlin standard library fail to run on the website, because the `import samples.Sample` leaks through from the Kotlin project onto the website and cannot be found there.

Affected are for example https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/with-index.html and https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/as-reversed.html .

This pull request fixes that by not only ignoring imports of `samples.*` but also `samples.Sample`.