### PR TITLE
AnalysisExtensions

### DIFF
--- a/core/src/main/kotlin/CoreExtensions.kt
+++ b/core/src/main/kotlin/CoreExtensions.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.dokka
 
+import org.jetbrains.dokka.analysis.AnalysisTransformer
 import org.jetbrains.dokka.pages.MarkdownToContentConverter
 import org.jetbrains.dokka.pages.PageNode
 import org.jetbrains.dokka.plugability.DokkaContext
@@ -29,6 +30,7 @@ object CoreExtensions {
     val rendererFactory by coreExtension<(FileWriter, LocationProvider, DokkaContext) -> Renderer>()
     val locationProviderFactory by coreExtension<(root: PageNode, DokkaConfiguration, DokkaContext) -> LocationProvider>()
     val fileExtension by coreExtension<String>()
+    val analysis by coreExtension<AnalysisTransformer>()
 
     private fun <T: Any> coreExtension() = object {
         operator fun provideDelegate(thisRef: CoreExtensions, property: KProperty<*>): Lazy<ExtensionPoint<T>> =

--- a/core/src/main/kotlin/analysis/AnalysisTransformer.kt
+++ b/core/src/main/kotlin/analysis/AnalysisTransformer.kt
@@ -1,0 +1,11 @@
+package org.jetbrains.dokka.analysis
+
+import org.jetbrains.dokka.EnvironmentAndFacade
+import org.jetbrains.dokka.pages.PlatformData
+
+/**
+ * [AnalysisTransformer] allows to map over
+ */
+interface AnalysisTransformer {
+    fun transform(platformToEnv: Map<PlatformData, EnvironmentAndFacade>): Map<PlatformData, EnvironmentAndFacade>
+}

--- a/core/src/main/kotlin/analysis/DefaultAnalysisTransformer.kt
+++ b/core/src/main/kotlin/analysis/DefaultAnalysisTransformer.kt
@@ -1,0 +1,12 @@
+package org.jetbrains.dokka.analysis
+
+import org.jetbrains.dokka.EnvironmentAndFacade
+import org.jetbrains.dokka.pages.PlatformData
+
+/**
+ * The [DefaultAnalysisTransformer] solely returns the value of the parameter in [transform] unchanged
+ */
+object DefaultAnalysisTransformer : AnalysisTransformer {
+    override fun transform(platformToEnv: Map<PlatformData, EnvironmentAndFacade>): Map<PlatformData, EnvironmentAndFacade> =
+        platformToEnv
+}

--- a/core/src/main/kotlin/plugability/DefaultExtensions.kt
+++ b/core/src/main/kotlin/plugability/DefaultExtensions.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.dokka.plugability
 
 import org.jetbrains.dokka.CoreExtensions
+import org.jetbrains.dokka.analysis.DefaultAnalysisTransformer
 import org.jetbrains.dokka.pages.DefaultMarkdownToContentConverter
 import org.jetbrains.dokka.renderers.HtmlRenderer
 import org.jetbrains.dokka.resolvers.DefaultLocationProvider
@@ -19,6 +20,7 @@ object DefaultExtensions : DokkaExtensionHandler {
             CoreExtensions.rendererFactory -> ::HtmlRenderer
             CoreExtensions.locationProviderFactory -> ::DefaultLocationProvider
             CoreExtensions.fileExtension -> ".html"
+            CoreExtensions.analysis -> DefaultAnalysisTransformer
             else -> null
         }.let { listOfNotNull(it) as List<T> }
 }

--- a/core/src/test/kotlin/markdown/ParserTest.kt
+++ b/core/src/test/kotlin/markdown/ParserTest.kt
@@ -1,8 +1,8 @@
 package org.jetbrains.dokka.tests
 
+import org.jetbrains.dokka.markdown.parseMarkdown
+import org.jetbrains.dokka.markdown.toTestString
 import org.junit.Test
-import org.jetbrains.dokka.toTestString
-import org.jetbrains.dokka.parseMarkdown
 import org.junit.Ignore
 
 @Ignore public class ParserTest {


### PR DESCRIPTION
AnalysisExtensions allow plugin Devs to manipulate ResolutionFacade, which currently 
`DokkaResolutionFacade`.
We may want to consider refactoring `org.jetbrains.dokka.EnvironmentAndFacade` so it allows
Any given ResolutionFacade. I am open to feedback on any matter. If you have questions about the code feel free to ask.