### PR TITLE
Implement display of Java default constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ Inside the `dokka` tag you can create another tags named `<passconfig/>` that su
 
 ### Using the Command Line
 
-To run Dokka from the command line, download the [Dokka jar](https://github.com/Kotlin/dokka/releases/download/0.10.0/dokka-fatjar.jar).
+To run Dokka from the command line, download the [Dokka jar](https://github.com/Kotlin/dokka/releases/download/0.10.0/dokka-fatjar-0.10.0.jar).
 To generate documentation, run the following command:
 
     java -jar dokka-fatjar.jar <arguments>

--- a/core/src/test/kotlin/model/KotlinAsJavaTest.kt
+++ b/core/src/test/kotlin/model/KotlinAsJavaTest.kt
@@ -16,9 +16,8 @@ class KotlinAsJavaTest {
             val facadeClass = pkg.members.single { it.name == "FunctionKt" }
             assertEquals(NodeKind.Class, facadeClass.kind)
 
-            val fn = facadeClass.members.single()
+            val fn = facadeClass.members.single { it.kind == NodeKind.Function}
             assertEquals("fn", fn.name)
-            assertEquals(NodeKind.Function, fn.kind)
         }
     }
 


### PR DESCRIPTION
PsiClass does not include methods which are not present in the text
of the code. So when there are no constructors in a java class this
represents a class that only has a default constructor. The fix is
to create one for documentation.