### PR TITLE
Remove stack overflow error

### DIFF
--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaTask.kt
@@ -90,7 +90,12 @@ open class DokkaTask : DefaultTask() {
         return try {
             configuration!!.resolve()
         } catch (e: Exception) {
-            project.parent?.let { tryResolveFatJar(configuration) } ?: throw e
+            // Unless I'm missing something, this retries the resolution but I
+            // don't see what could make it succeed after a retry if it fail the first time.
+            // project.parent?.let { tryResolveFatJar(configuration) } ?: throw e
+            
+            // Instead, rethrow the exception which will contain detail about why the resolution failed.
+            throw e
         }
     }
 


### PR DESCRIPTION
See https://github.com/Kotlin/dokka/issues/512#issuecomment-539737596

I'm not sure I understand the previous code so please tell me if I'm missing something. 

This error happened during development. I usually publish to mavenLocal:

```
./gradlew publishToMavenLocal
```

Then I add the mavenLocal repo to my other project buildscript but I didn't think it was mandatory to add to the project repositories as well. 

This PR lets the exception fall through.  It'll contain more actionable information such as:

```
* What went wrong:
Execution failed for task ':lib:dokka'.
> Could not resolve all files for configuration ':lib:dokka:dokkaRuntime'.
   > Could not resolve org.jetbrains.dokka:dokka-fatjar:0.10.0-SNAPSHOT.
     Required by:
         project :lib

```
Hopefully, that'll give a better hint at what's going wrong.

