### PR TITLE
Update packaging structure, fix testAPI publication, simplify dependencies handling in plugins

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -7,28 +7,18 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":coreDependencies", configuration = "shadow"))
+    api(project(":coreDependencies", configuration = "shadow"))
 
     val kotlin_version: String by project
-    implementation("org.jetbrains.kotlin:kotlin-compiler:$kotlin_version")
-    implementation("org.jetbrains.kotlin:kotlin-script-runtime:$kotlin_version")
+    api("org.jetbrains.kotlin:kotlin-compiler:$kotlin_version")
+    implementation("org.jetbrains.kotlinx:kotlinx-html-jvm:0.6.10")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version")
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlin_version")
     implementation("org.jsoup:jsoup:1.12.1")
     implementation("com.google.code.gson:gson:2.8.5")
-    implementation("org.jetbrains:markdown:0.1.41")
-    implementation("org.jetbrains.kotlinx:kotlinx-html-jvm:0.6.10")
 
     testImplementation(project(":testApi"))
     testImplementation("junit:junit:4.13")
-}
-
-tasks {
-    shadowJar {
-        val dokka_version: String by project
-        archiveFileName.set("dokka-core-$dokka_version.jar")
-        archiveClassifier.set("")
-    }
 }
 
 val sourceJar by tasks.registering(Jar::class) {
@@ -40,7 +30,7 @@ publishing {
     publications {
         register<MavenPublication>("dokkaCore") {
             artifactId = "dokka-core"
-            project.shadow.component(this)
+            from(components["java"])
             artifact(sourceJar.get())
         }
     }

--- a/coreDependencies/build.gradle.kts
+++ b/coreDependencies/build.gradle.kts
@@ -1,6 +1,9 @@
+import org.jetbrains.configureBintrayPublication
+
 plugins {
     id("com.github.johnrengelman.shadow")
     `maven-publish`
+    id("com.jfrog.bintray")
 }
 
 val intellijCore: Configuration by configurations.creating
@@ -24,6 +27,9 @@ dependencies {
         //TODO: parametrize ij version after 1.3.70
         isTransitive = false
     }
+    implementation("org.jetbrains:markdown:0.1.41") {
+        because("it's published only on bintray")
+    }
 }
 
 tasks {
@@ -41,3 +47,14 @@ tasks {
         exclude("src/**")
     }
 }
+
+publishing {
+    publications {
+        register<MavenPublication>("dokkaCoreDependencies") {
+            artifactId = "dokka-core-dependencies"
+            project.shadow.component(this)
+        }
+    }
+}
+
+configureBintrayPublication("dokkaCoreDependencies")

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -6,6 +6,10 @@ subprojects {
     dependencies {
         compileOnly(project(":core"))
         compileOnly(kotlin("stdlib-jdk8"))
+//        compileOnly(project(":coreDependencies", configuration = "shadow")) // uncomment if IntelliJ does not recognize pacakges from IntelliJ
+
         testImplementation(project(":testApi"))
+        testImplementation(kotlin("stdlib-jdk8"))
+        testImplementation("junit:junit:4.13")
     }
 }

--- a/plugins/kotlin-as-java/build.gradle.kts
+++ b/plugins/kotlin-as-java/build.gradle.kts
@@ -6,12 +6,3 @@ publishing {
         }
     }
 }
-
-dependencies {
-    implementation(kotlin("stdlib-jdk8"))
-    compileOnly(project(":coreDependencies", configuration = "shadow"))
-    testImplementation(project(":core"))
-    testImplementation(project(":coreDependencies", configuration = "shadow"))
-    testImplementation(project(":testApi"))
-    testImplementation("junit:junit:4.13")
-}

--- a/testApi/build.gradle.kts
+++ b/testApi/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":core"))
+    api(project(":core"))
     implementation("junit:junit:4.13") // TODO: remove dependency to junit
     implementation(kotlin("stdlib"))
 }
@@ -20,7 +20,7 @@ publishing {
     publications {
         register<MavenPublication>("dokkaTestAPI") {
             artifactId = "dokka-test-api"
-            components["java"]
+            from(components["java"])
             artifact(sourceJar.get())
         }
     }


### PR DESCRIPTION
Fixes #627

This commit removes repackaging `dokka-core` with all its dependencies by creating a publication for those dependencies. Moreover it moves `kotlinx-markdown` dependency to `coreDependencies` as this library is only present in Kotlin Bintray repository. TestAPI now publishes correctly