### PR TITLE
Fix descriptor visiting, add test for DRI clash on JS

### DIFF
--- a/core/src/main/kotlin/transformers/descriptors/DefaultDescriptorToDocumentationTranslator.kt
+++ b/core/src/main/kotlin/transformers/descriptors/DefaultDescriptorToDocumentationTranslator.kt
@@ -81,7 +81,7 @@ open class DokkaDescriptorVisitor(
 
     fun enumDescriptor(descriptor: ClassDescriptor, parent: DRIWithPlatformInfo): Enum {
         val driWithPlatform = parent.dri.withClass(descriptor.name.asString()).withEmptyInfo()
-        val scope = descriptor.getMemberScope(emptyList())
+        val scope = descriptor.unsubstitutedMemberScope
         val descriptorData = descriptor.takeUnless { it.isExpect }?.resolveClassDescriptionData()
 
         return Enum(
@@ -105,7 +105,7 @@ open class DokkaDescriptorVisitor(
 
     fun classDescriptor(descriptor: ClassDescriptor, parent: DRIWithPlatformInfo): Class {
         val driWithPlatform = parent.dri.withClass(descriptor.name.asString()).withEmptyInfo()
-        val scope = descriptor.getMemberScope(emptyList())
+        val scope = descriptor.unsubstitutedMemberScope
         val descriptorData = descriptor.takeUnless { it.isExpect }?.resolveClassDescriptionData()
         val expected = descriptor.takeIf { it.isExpect }?.resolveClassDescriptionData()
         val actual = listOfNotNull(descriptorData)


### PR DESCRIPTION
After creating the test reproducing the DRI clash, I found a bug in the `DefaultDescriptorToDocumentationTranslator`, which this commit fixes. The bug was present when running the tests but not when using dokka on an external project. I have no idea how it worked, as debugging showed that the same code from AbstractClassDescriptor runs in both cases and the code contains an assert, which had to (and did) fail. Probably the error messages are being suppressed somehow. `getMemberScope()` requires a list of type substitutions which size is being compared to the type constructor's parameters count. I suppose we don't want to substitute the type parameters and get the unsubstituted member scope instead