### PR TITLE
Declaring some build dependencies

### DIFF
--- a/runners/gradle-plugin/build.gradle
+++ b/runners/gradle-plugin/build.gradle
@@ -45,6 +45,7 @@ task sourceJar(type: Jar) {
 }
 
 processResources {
+    inputs.property("dokka_version", dokka_version)
     eachFile {
         if (it.name == "org.jetbrains.dokka.properties") {
             it.filter { line ->

--- a/runners/gradle-plugin/build.gradle
+++ b/runners/gradle-plugin/build.gradle
@@ -72,6 +72,27 @@ publishing {
             }
 
             project.shadow.component(publication)
+            publication.pom { pom ->
+                // Add dokka-fatjar as a runtime dependency.
+                // This is a workaround until the Shadow jar can put project dependencies into the .pom: https://github.com/johnrengelman/shadow/commit/da82b37522b349aff414f571d2037682acd84f27
+                pom.withXml { xml ->
+                    def node = xml.asNode()
+                    def deps = null
+                    node.children().each { child ->
+                        if (child.name().toString() == "dependencies") {
+                            deps = child
+                        }
+                    }
+                    if (deps == null) {
+                        deps = node.appendNode("dependencies")
+                    }
+                    def dep = deps.appendNode("dependency")
+                    dep.appendNode("groupId", "org.jetbrains.dokka")
+                    dep.appendNode("artifactId", "dokka-fatjar")
+                    dep.appendNode("version", dokka_version)
+                    dep.appendNode("scope", "runtime")
+                }
+            }
         }
     }
 }

--- a/runners/maven-plugin/build.gradle
+++ b/runners/maven-plugin/build.gradle
@@ -59,6 +59,9 @@ sourceSets.main.resources {
 
 task generatePom() {
     inputs.file(new File(projectDir, "pom.tpl.xml"))
+    inputs.property("dokka_version", dokka_version)
+    inputs.property("maven_version", maven_version)
+    inputs.property("maven_plugin_tools_version", maven_plugin_tools_version)
     outputs.file(new File(mavenBuildDir, "pom.xml"))
     doLast {
         final pomTemplate = new File(projectDir, "pom.tpl.xml")


### PR DESCRIPTION
To make it more convenient to build Dokka from source and use the result in another build