### PR TITLE
Stdlib npe fix

### DIFF
--- a/plugins/base/src/main/kotlin/translators/descriptors/DefaultDescriptorToDocumentableTranslator.kt
+++ b/plugins/base/src/main/kotlin/translators/descriptors/DefaultDescriptorToDocumentableTranslator.kt
@@ -217,8 +217,8 @@ open class DokkaDescriptorVisitor( // TODO: close this class and make it private
             },
             sources = actual,
             getter = descriptor.accessors.filterIsInstance<PropertyGetterDescriptor>().singleOrNull()?.let {
-                visitPropertyAccessorDescriptor(it, descriptor, dri)
-            }!!,
+               visitPropertyAccessorDescriptor(it, descriptor, dri)
+            },
             setter = descriptor.accessors.filterIsInstance<PropertySetterDescriptor>().singleOrNull()?.let {
                 visitPropertyAccessorDescriptor(it, descriptor, dri)
             },


### PR DESCRIPTION
JavaPropertyDescriptor has no accessors, so I've altered descriptorToDocumentableTranslator to work with them. 