### PR TITLE
Fix nested monospace spans in signature

### DIFF
--- a/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
@@ -34,7 +34,6 @@ open class HtmlRenderer(
             node.dci.kind == ContentKind.BriefComment -> div("brief $additionalClasses") { childrenCallback() }
             node.style.contains(TextStyle.Paragraph) -> p(additionalClasses) { childrenCallback() }
             node.style.contains(TextStyle.Block) -> div(additionalClasses) { childrenCallback() }
-            additionalClasses.isNotBlank() -> span(additionalClasses) { childrenCallback() }
             else -> childrenCallback()
         }
     }

--- a/plugins/base/src/main/kotlin/signatures/KotlinSignatureProvider.kt
+++ b/plugins/base/src/main/kotlin/signatures/KotlinSignatureProvider.kt
@@ -77,7 +77,7 @@ class KotlinSignatureProvider(ctcc: CommentsToContentConverter, logger: DokkaLog
         }
     }
 
-    private fun signature(t: TypeParameter) = contentBuilder.contentFor(t, ContentKind.Main) {
+    private fun signature(t: TypeParameter) = contentBuilder.contentFor(t) {
         link(t.name, t.dri)
         list(t.bounds, prefix = " : ") {
             signatureForProjection(it)

--- a/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
@@ -61,9 +61,7 @@ open class DefaultPageCreator(
         block("Types", 2, ContentKind.Classlikes, s.classlikes, platformData.toSet()) {
             link(it.name.orEmpty(), it.dri)
             group {
-                group(kind = ContentKind.Symbol) {
-                    +buildSignature(it)
-                }
+                +buildSignature(it)
                 group(kind = ContentKind.BriefComment) {
                     text(it.briefDocumentation())
                 }
@@ -72,9 +70,8 @@ open class DefaultPageCreator(
         block("Functions", 2, ContentKind.Functions, s.functions, platformData.toSet()) {
             link(it.name, it.dri)
             group {
-                group(kind = ContentKind.Symbol) {
-                    +buildSignature(it)
-                }
+                +buildSignature(it)
+
                 group(kind = ContentKind.BriefComment) {
                     text(it.briefDocumentation())
                 }
@@ -91,18 +88,16 @@ open class DefaultPageCreator(
 
     protected open fun contentForClasslike(c: Classlike) = contentBuilder.contentFor(c) {
         header(1) { text(c.name.orEmpty()) }
-        group(kind = ContentKind.Symbol) {
-            +buildSignature(c)
-        }
+        +buildSignature(c)
+
         +contentForComments(c) { it !is Property }
 
         if (c is WithConstructors) {
             block("Constructors", 2, ContentKind.Constructors, c.constructors, c.platformData.toSet()) {
                 link(it.name, it.dri)
                 group {
-                    group(kind = ContentKind.Symbol) {
-                        +buildSignature(it)
-                    }
+                    +buildSignature(it)
+
                     group(kind = ContentKind.BriefComment) {
                         text(it.briefDocumentation())
                     }

--- a/plugins/kotlin-as-java/src/main/kotlin/signatures/JavaSignatureProvider.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/signatures/JavaSignatureProvider.kt
@@ -10,7 +10,7 @@ import org.jetbrains.dokka.model.Enum
 import org.jetbrains.dokka.model.Function
 import org.jetbrains.dokka.pages.ContentKind
 import org.jetbrains.dokka.pages.ContentNode
-import org.jetbrains.dokka.pages.PlatformData
+import org.jetbrains.dokka.pages.TextStyle
 import org.jetbrains.dokka.utilities.DokkaLogger
 
 class JavaSignatureProvider(ctcc: CommentsToContentConverter, logger: DokkaLogger) : SignatureProvider {
@@ -30,7 +30,7 @@ class JavaSignatureProvider(ctcc: CommentsToContentConverter, logger: DokkaLogge
         )
     }
 
-    private fun signature(c: Classlike) = contentBuilder.contentFor(c, ContentKind.Symbol) {
+    private fun signature(c: Classlike) = contentBuilder.contentFor(c, ContentKind.Symbol, setOf(TextStyle.Monospace)) {
         platformText(c.visibility) { (it.takeIf { it !in ignoredVisibilities }?.name ?: "") + " " }
 
         if (c is Class) {
@@ -59,7 +59,7 @@ class JavaSignatureProvider(ctcc: CommentsToContentConverter, logger: DokkaLogge
         }
     }
 
-    private fun signature(f: Function) = contentBuilder.contentFor(f, ContentKind.Symbol) {
+    private fun signature(f: Function) = contentBuilder.contentFor(f, ContentKind.Symbol, setOf(TextStyle.Monospace)) {
         text(f.modifier.takeIf { it !in ignoredModifiers }?.name.orEmpty() + " ")
         val returnType = f.type
         signatureForProjection(returnType)
@@ -77,7 +77,7 @@ class JavaSignatureProvider(ctcc: CommentsToContentConverter, logger: DokkaLogge
         text(")")
     }
 
-    private fun signature(t: TypeParameter) = contentBuilder.contentFor(t, ContentKind.Symbol) {
+    private fun signature(t: TypeParameter) = contentBuilder.contentFor(t) {
         text(t.name.substringAfterLast("."))
         list(t.bounds, prefix = " extends ") {
             signatureForProjection(it)


### PR DESCRIPTION
This commit fixes this:
![image](https://user-images.githubusercontent.com/9080183/76450904-df5c4380-63ce-11ea-8ed3-dd8df81a70e2.png)
to look like this:
![image](https://user-images.githubusercontent.com/9080183/76450976-fdc23f00-63ce-11ea-881f-5ad23b277572.png)

