### PR TITLE
Includes, SourceLinks, Samples

### DIFF
--- a/core/src/main/kotlin/DokkaGenerator.kt
+++ b/core/src/main/kotlin/DokkaGenerator.kt
@@ -164,7 +164,7 @@ class DokkaGenerator(
 
     }
 
-    private class DokkaMessageCollector(private val logger: DokkaLogger) : MessageCollector {
+    class DokkaMessageCollector(private val logger: DokkaLogger) : MessageCollector {
         override fun clear() {
             seenErrors = false
         }

--- a/core/src/main/kotlin/pages/ContentNodes.kt
+++ b/core/src/main/kotlin/pages/ContentNodes.kt
@@ -30,7 +30,7 @@ data class ContentBreakLine(
     override val dci: DCI = DCI(emptySet(), ContentKind.Empty),
     override val style: Set<Style> = emptySet(),
     override val extra: PropertyContainer<ContentNode> = PropertyContainer.empty()
-): ContentNode {
+) : ContentNode {
     override fun withNewExtras(newExtras: PropertyContainer<ContentNode>): ContentNode = copy(extra = newExtras)
 }
 
@@ -163,17 +163,20 @@ data class PlatformHintedContent(
 
 /** All extras */
 interface Extra
+
 interface Style
 interface Kind
 
 enum class ContentKind : Kind {
+
     Comment, Constructors, Functions, Parameters, Properties, Classlikes, Packages, Symbol, Sample, Main, BriefComment,
-    Empty, TypeAliases;
+    Empty, Source, TypeAliases;
 
-    companion object{
-        private val platformTagged = setOf(Constructors, Functions, Properties, Classlikes, Packages, TypeAliases)
+    companion object {
+        private val platformTagged =
+            setOf(Constructors, Functions, Properties, Classlikes, Packages, Source, TypeAliases)
 
-        fun shouldBePlatformTagged(kind: Kind) : Boolean = kind in platformTagged
+        fun shouldBePlatformTagged(kind: Kind): Boolean = kind in platformTagged
     }
 }
 

--- a/plugins/base/src/main/kotlin/DokkaBase.kt
+++ b/plugins/base/src/main/kotlin/DokkaBase.kt
@@ -22,6 +22,7 @@ import org.jetbrains.dokka.base.transformers.pages.merger.FallbackPageMergerStra
 import org.jetbrains.dokka.base.transformers.pages.merger.PageMerger
 import org.jetbrains.dokka.base.transformers.pages.merger.PageMergerStrategy
 import org.jetbrains.dokka.base.transformers.pages.merger.SameMethodNamePageMergerStrategy
+import org.jetbrains.dokka.base.transformers.pages.sourcelinks.SourceLinksTransformer
 import org.jetbrains.dokka.base.translators.descriptors.DefaultDescriptorToDocumentableTranslator
 import org.jetbrains.dokka.base.translators.documentables.DefaultDocumentableToPageTranslator
 import org.jetbrains.dokka.base.translators.psi.DefaultPsiToDocumentableTranslator
@@ -125,6 +126,10 @@ class DokkaBase : DokkaPlugin() {
 
     val rootCreator by extending {
         htmlPreprocessors with RootCreator
+    }
+
+    val sourceLinksTransformer by extending {
+        htmlPreprocessors providing ::SourceLinksTransformer order { after(rootCreator) }
     }
 
     val navigationPageInstaller by extending {

--- a/plugins/base/src/main/kotlin/DokkaBase.kt
+++ b/plugins/base/src/main/kotlin/DokkaBase.kt
@@ -22,6 +22,8 @@ import org.jetbrains.dokka.base.transformers.pages.merger.FallbackPageMergerStra
 import org.jetbrains.dokka.base.transformers.pages.merger.PageMerger
 import org.jetbrains.dokka.base.transformers.pages.merger.PageMergerStrategy
 import org.jetbrains.dokka.base.transformers.pages.merger.SameMethodNamePageMergerStrategy
+import org.jetbrains.dokka.base.transformers.pages.samples.DefaultSamplesTransformer
+import org.jetbrains.dokka.base.transformers.pages.samples.SamplesTransformer
 import org.jetbrains.dokka.base.transformers.pages.sourcelinks.SourceLinksTransformer
 import org.jetbrains.dokka.base.translators.descriptors.DefaultDescriptorToDocumentableTranslator
 import org.jetbrains.dokka.base.translators.documentables.DefaultDocumentableToPageTranslator
@@ -37,6 +39,7 @@ class DokkaBase : DokkaPlugin() {
     val externalLocationProviderFactory by extensionPoint<ExternalLocationProviderFactory>()
     val outputWriter by extensionPoint<OutputWriter>()
     val htmlPreprocessors by extensionPoint<PageTransformer>()
+    val samplesTransformer by extensionPoint<SamplesTransformer>()
 
     val descriptorToDocumentableTranslator by extending(isFallback = true) {
         CoreExtensions.descriptorToDocumentableTranslator providing ::DefaultDescriptorToDocumentableTranslator
@@ -126,6 +129,10 @@ class DokkaBase : DokkaPlugin() {
 
     val rootCreator by extending {
         htmlPreprocessors with RootCreator
+    }
+
+    val defaultSamplesTransformer by extending(isFallback = true) {
+        samplesTransformer providing ::DefaultSamplesTransformer
     }
 
     val sourceLinksTransformer by extending {

--- a/plugins/base/src/main/kotlin/DokkaBase.kt
+++ b/plugins/base/src/main/kotlin/DokkaBase.kt
@@ -131,7 +131,7 @@ class DokkaBase : DokkaPlugin() {
         htmlPreprocessors with RootCreator
     }
 
-    val defaultSamplesTransformer by extending(isFallback = true) {
+    val defaultSamplesTransformer by extending {
         samplesTransformer providing ::DefaultSamplesTransformer
     }
 

--- a/plugins/base/src/main/kotlin/DokkaBase.kt
+++ b/plugins/base/src/main/kotlin/DokkaBase.kt
@@ -15,6 +15,7 @@ import org.jetbrains.dokka.base.transformers.documentables.DefaultDocumentableMe
 import org.jetbrains.dokka.base.transformers.documentables.InheritorsExtractorTransformer
 import org.jetbrains.dokka.base.transformers.pages.annotations.DeprecatedStrikethroughTransformer
 import org.jetbrains.dokka.base.transformers.documentables.DocumentableVisibilityFilter
+import org.jetbrains.dokka.base.transformers.documentables.ModuleAndPackageDocumentationTransformer
 import org.jetbrains.dokka.base.transformers.pages.comments.CommentsToContentConverter
 import org.jetbrains.dokka.base.transformers.pages.comments.DocTagToContentConverter
 import org.jetbrains.dokka.base.transformers.pages.merger.FallbackPageMergerStrategy
@@ -54,6 +55,10 @@ class DokkaBase : DokkaPlugin() {
 
     val actualTypealiasAdder by extending {
         CoreExtensions.preMergeDocumentableTransformer with ActualTypealiasAdder()
+    }
+
+    val modulesAndPackagesDocumentation by extending(isFallback = true) {
+        CoreExtensions.preMergeDocumentableTransformer with ModuleAndPackageDocumentationTransformer
     }
 
     val kotlinSignatureProvider by extending(isFallback = true) {

--- a/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
@@ -10,6 +10,7 @@ import org.jetbrains.dokka.pages.*
 import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.plugability.plugin
 import org.jetbrains.dokka.plugability.query
+import org.jetbrains.dokka.plugability.querySingle
 import java.io.File
 
 open class HtmlRenderer(
@@ -18,7 +19,8 @@ open class HtmlRenderer(
 
     private val pageList = mutableListOf<String>()
 
-    override val preprocessors = context.plugin<DokkaBase>().query { htmlPreprocessors }
+    override val preprocessors = context.plugin<DokkaBase>().query { htmlPreprocessors } +
+                                    context.plugin<DokkaBase>().querySingle { samplesTransformer }
 
     override fun FlowContent.wrapGroup(
         node: ContentGroup,

--- a/plugins/base/src/main/kotlin/transformers/documentables/ModuleAndPackageDocumentationTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/ModuleAndPackageDocumentationTransformer.kt
@@ -18,20 +18,31 @@ internal object ModuleAndPackageDocumentationTransformer : PreMergeDocumentableT
             context.configuration.passesConfigurations
                 .map {
                     Pair(it.moduleName, it.platformData) to
-                        it.includes.map { Paths.get(it) }
-                            .filter { Files.exists(it) }
-                            .flatMap {
-                                it.toFile()
-                                    .readText()
-                                    .split(Regex("(\n|^)# (?=(Module|Package))")) // Matches heading with Module/Package to split by
-                                    .filter { it.isNotEmpty() }
-                                    .map { it.split(Regex(" "), 2) } // Matches space between Module/Package and fully qualified name
-                            }.groupBy({ it[0] }, {
-                                it[1].split(Regex("\n"), 2) // Matches new line after fully qualified name
-                                    .let { it[0] to it[1].trim() }
-                            }).mapValues {
-                                it.value.toMap()
-                            }
+                            it.includes.map { Paths.get(it) }
+                                .also {
+                                    it.forEach {
+                                        if (Files.notExists(it))
+                                            context.logger.warn("Not found file under this path ${it.toAbsolutePath()}")
+                                    }
+                                }
+                                .filter { Files.exists(it) }
+                                .flatMap {
+                                    it.toFile()
+                                        .readText()
+                                        .split(Regex("(\n|^)# (?=(Module|Package))")) // Matches heading with Module/Package to split by
+                                        .filter { it.isNotEmpty() }
+                                        .map {
+                                            it.split(
+                                                Regex(" "),
+                                                2
+                                            )
+                                        } // Matches space between Module/Package and fully qualified name
+                                }.groupBy({ it[0] }, {
+                                    it[1].split(Regex("\n"), 2) // Matches new line after fully qualified name
+                                        .let { it[0] to it[1].trim() }
+                                }).mapValues {
+                                    it.value.toMap()
+                                }
                 }.toMap()
 
         return original.map { module ->
@@ -39,8 +50,8 @@ internal object ModuleAndPackageDocumentationTransformer : PreMergeDocumentableT
             val moduleDocumentation =
                 module.platformData.mapNotNull { pd ->
                     val doc = modulesAndPackagesDocumentation[Pair(module.name, pd)]
-                    val facade = context.platforms[pd]?.facade ?:
-                        return@mapNotNull null.also { context.logger.warn("Could not find platform data for ${pd.name}") }
+                    val facade = context.platforms[pd]?.facade
+                        ?: return@mapNotNull null.also { context.logger.warn("Could not find platform data for ${pd.name}") }
                     doc?.get("Module")?.get(module.name)?.run {
                         pd to MarkdownParser(
                             facade,
@@ -52,10 +63,10 @@ internal object ModuleAndPackageDocumentationTransformer : PreMergeDocumentableT
             val packagesDocumentation = module.packages.map {
                 it.name to it.platformData.mapNotNull { pd ->
                     val doc = modulesAndPackagesDocumentation[Pair(module.name, pd)]
-                    val facade = context.platforms[pd]?.facade ?:
-                        return@mapNotNull null.also { context.logger.warn("Could not find platform data for ${pd.name}") }
-                    val descriptor = facade.resolveSession.getPackageFragment(FqName(it.name)) ?:
-                        return@mapNotNull null.also { context.logger.warn("Could not find descriptor for $") }
+                    val facade = context.platforms[pd]?.facade
+                        ?: return@mapNotNull null.also { context.logger.warn("Could not find platform data for ${pd.name}") }
+                    val descriptor = facade.resolveSession.getPackageFragment(FqName(it.name))
+                        ?: return@mapNotNull null.also { context.logger.warn("Could not find descriptor for $") }
                     doc?.get("Package")?.get(it.name)?.run {
                         pd to MarkdownParser(
                             facade,
@@ -68,7 +79,7 @@ internal object ModuleAndPackageDocumentationTransformer : PreMergeDocumentableT
             module.copy(
                 documentation = module.documentation.let { PlatformDependent(it.map + moduleDocumentation) },
                 packages = module.packages.map {
-                    if(packagesDocumentation[it.name] != null)
+                    if (packagesDocumentation[it.name] != null)
                         it.copy(documentation = it.documentation.let { value ->
                             PlatformDependent(value.map + packagesDocumentation[it.name]!!)
                         })

--- a/plugins/base/src/main/kotlin/transformers/documentables/ModuleAndPackageDocumentationTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/ModuleAndPackageDocumentationTransformer.kt
@@ -1,0 +1,81 @@
+package org.jetbrains.dokka.base.transformers.documentables
+
+import org.jetbrains.dokka.model.DModule
+import org.jetbrains.dokka.model.PlatformDependent
+import org.jetbrains.dokka.parsers.MarkdownParser
+import org.jetbrains.dokka.plugability.DokkaContext
+import org.jetbrains.dokka.transformers.documentation.PreMergeDocumentableTransformer
+import org.jetbrains.kotlin.name.FqName
+import java.nio.file.Files
+import java.nio.file.Paths
+
+
+internal object ModuleAndPackageDocumentationTransformer : PreMergeDocumentableTransformer {
+
+    override fun invoke(original: List<DModule>, context: DokkaContext): List<DModule> {
+
+        val modulesAndPackagesDocumentation =
+            context.configuration.passesConfigurations
+                .map {
+                    Pair(it.moduleName, it.platformData) to
+                        it.includes.map { Paths.get(it) }
+                            .filter { Files.exists(it) }
+                            .flatMap {
+                                it.toFile()
+                                    .readText()
+                                    .split(Regex("(\n|^)# (?=(Module|Package))")) // Matches heading with Module/Package to split by
+                                    .filter { it.isNotEmpty() }
+                                    .map { it.split(Regex(" "), 2) } // Matches space between Module/Package and fully qualified name
+                            }.groupBy({ it[0] }, {
+                                it[1].split(Regex("\n"), 2) // Matches new line after fully qualified name
+                                    .let { it[0] to it[1].trim() }
+                            }).mapValues {
+                                it.value.toMap()
+                            }
+                }.toMap()
+
+        return original.map { module ->
+
+            val moduleDocumentation =
+                module.platformData.mapNotNull { pd ->
+                    val doc = modulesAndPackagesDocumentation[Pair(module.name, pd)]
+                    val facade = context.platforms[pd]?.facade ?:
+                        return@mapNotNull null.also { context.logger.warn("Could not find platform data for ${pd.name}") }
+                    doc?.get("Module")?.get(module.name)?.run {
+                        pd to MarkdownParser(
+                            facade,
+                            facade.moduleDescriptor
+                        ).parse(this)
+                    }
+                }.toMap()
+
+            val packagesDocumentation = module.packages.map {
+                it.name to it.platformData.mapNotNull { pd ->
+                    val doc = modulesAndPackagesDocumentation[Pair(module.name, pd)]
+                    val facade = context.platforms[pd]?.facade ?:
+                        return@mapNotNull null.also { context.logger.warn("Could not find platform data for ${pd.name}") }
+                    val descriptor = facade.resolveSession.getPackageFragment(FqName(it.name)) ?:
+                        return@mapNotNull null.also { context.logger.warn("Could not find descriptor for $") }
+                    doc?.get("Package")?.get(it.name)?.run {
+                        pd to MarkdownParser(
+                            facade,
+                            descriptor
+                        ).parse(this)
+                    }
+                }.toMap()
+            }.toMap()
+
+            module.copy(
+                documentation = module.documentation.let { PlatformDependent(it.map + moduleDocumentation) },
+                packages = module.packages.map {
+                    if(packagesDocumentation[it.name] != null)
+                        it.copy(documentation = it.documentation.let { value ->
+                            PlatformDependent(value.map + packagesDocumentation[it.name]!!)
+                        })
+                    else
+                        it
+                }
+            )
+        }
+    }
+}

--- a/plugins/base/src/main/kotlin/transformers/pages/samples/DefaultSamplesTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/pages/samples/DefaultSamplesTransformer.kt
@@ -1,0 +1,38 @@
+package org.jetbrains.dokka.base.transformers.pages.samples
+
+import com.intellij.psi.PsiElement
+import org.jetbrains.dokka.plugability.DokkaContext
+import org.jetbrains.kotlin.idea.kdoc.resolveKDocSampleLink
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtDeclarationWithBody
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.utils.addToStdlib.safeAs
+
+class DefaultSamplesTransformer(context: DokkaContext) : SamplesTransformer(context) {
+
+    override fun processBody(psiElement: PsiElement): String {
+        val text = processSampleBody(psiElement).trim { it == '\n' || it == '\r' }.trimEnd()
+        val lines = text.split("\n")
+        val indent = lines.filter(String::isNotBlank).map { it.takeWhile(Char::isWhitespace).count() }.min() ?: 0
+        return lines.joinToString("\n") { it.drop(indent) }
+    }
+
+    private fun processSampleBody(psiElement: PsiElement): String = when (psiElement) {
+        is KtDeclarationWithBody -> {
+            val bodyExpression = psiElement.bodyExpression
+            when (bodyExpression) {
+                is KtBlockExpression -> bodyExpression.text.removeSurrounding("{", "}")
+                else -> bodyExpression!!.text
+            }
+        }
+        else -> psiElement.text
+    }
+
+    override fun processImports(psiElement: PsiElement): String {
+        val psiFile = psiElement.containingFile
+        return when(val text = psiFile.safeAs<KtFile>()?.importList?.text) {
+            is String -> text
+            else -> ""
+        }
+    }
+}

--- a/plugins/base/src/main/kotlin/transformers/pages/samples/KotlinWebsiteSamplesTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/pages/samples/KotlinWebsiteSamplesTransformer.kt
@@ -1,0 +1,196 @@
+package org.jetbrains.dokka.base.transformers.pages.samples
+
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiWhiteSpace
+import com.intellij.psi.impl.source.tree.LeafPsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import org.jetbrains.dokka.plugability.DokkaContext
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.allChildren
+import org.jetbrains.kotlin.psi.psiUtil.prevLeaf
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
+import org.jetbrains.kotlin.resolve.ImportPath
+import org.jetbrains.kotlin.utils.addToStdlib.safeAs
+import java.io.PrintWriter
+import java.io.StringWriter
+
+// TODO Inspect below class for any bugs. Big chunk of was ripped from 0.10.1
+class KotlinWebsiteSamplesTransformer(context: DokkaContext): SamplesTransformer(context) {
+
+    private class SampleBuilder : KtTreeVisitorVoid() {
+        val builder = StringBuilder()
+        val text: String
+            get() = builder.toString()
+
+        val errors = mutableListOf<ConvertError>()
+
+        data class ConvertError(val e: Exception, val text: String, val loc: String)
+
+        fun KtValueArgument.extractStringArgumentValue() =
+            (getArgumentExpression() as KtStringTemplateExpression)
+                .entries.joinToString("") { it.text }
+
+
+        fun convertAssertPrints(expression: KtCallExpression) {
+            val (argument, commentArgument) = expression.valueArguments
+            builder.apply {
+                append("println(")
+                append(argument.text)
+                append(") // ")
+                append(commentArgument.extractStringArgumentValue())
+            }
+        }
+
+        fun convertAssertTrueFalse(expression: KtCallExpression, expectedResult: Boolean) {
+            val (argument) = expression.valueArguments
+            builder.apply {
+                expression.valueArguments.getOrNull(1)?.let {
+                    append("// ${it.extractStringArgumentValue()}")
+                    val ws = expression.prevLeaf { it is PsiWhiteSpace }
+                    append(ws?.text ?: "\n")
+                }
+                append("println(\"")
+                append(argument.text)
+                append(" is \${")
+                append(argument.text)
+                append("}\") // $expectedResult")
+            }
+        }
+
+        fun convertAssertFails(expression: KtCallExpression) {
+            val valueArguments = expression.valueArguments
+
+            val funcArgument: KtValueArgument
+            val message: KtValueArgument?
+
+            if (valueArguments.size == 1) {
+                message = null
+                funcArgument = valueArguments.first()
+            } else {
+                message = valueArguments.first()
+                funcArgument = valueArguments.last()
+            }
+
+            builder.apply {
+                val argument = funcArgument.extractFunctionalArgumentText()
+                append(argument.lines().joinToString(separator = "\n") { "// $it" })
+                append(" // ")
+                if (message != null) {
+                    append(message.extractStringArgumentValue())
+                }
+                append(" will fail")
+            }
+        }
+
+        private fun KtValueArgument.extractFunctionalArgumentText(): String {
+            return if (getArgumentExpression() is KtLambdaExpression)
+                PsiTreeUtil.findChildOfType(this, KtBlockExpression::class.java)?.text ?: ""
+            else
+                text
+        }
+
+        fun convertAssertFailsWith(expression: KtCallExpression) {
+            val (funcArgument) = expression.valueArguments
+            val (exceptionType) = expression.typeArguments
+            builder.apply {
+                val argument = funcArgument.extractFunctionalArgumentText()
+                append(argument.lines().joinToString(separator = "\n") { "// $it" })
+                append(" // will fail with ")
+                append(exceptionType.text)
+            }
+        }
+
+        override fun visitCallExpression(expression: KtCallExpression) {
+            when (expression.calleeExpression?.text) {
+                "assertPrints" -> convertAssertPrints(expression)
+                "assertTrue" -> convertAssertTrueFalse(expression, expectedResult = true)
+                "assertFalse" -> convertAssertTrueFalse(expression, expectedResult = false)
+                "assertFails" -> convertAssertFails(expression)
+                "assertFailsWith" -> convertAssertFailsWith(expression)
+                else -> super.visitCallExpression(expression)
+            }
+        }
+
+        private fun reportProblemConvertingElement(element: PsiElement, e: Exception) {
+            val text = element.text
+            val document = PsiDocumentManager.getInstance(element.project).getDocument(element.containingFile)
+
+            val lineInfo = if (document != null) {
+                val lineNumber = document.getLineNumber(element.startOffset)
+                "$lineNumber, ${element.startOffset - document.getLineStartOffset(lineNumber)}"
+            } else {
+                "offset: ${element.startOffset}"
+            }
+            errors += ConvertError(e, text, lineInfo)
+        }
+
+        override fun visitElement(element: PsiElement) {
+            if (element is LeafPsiElement)
+                builder.append(element.text)
+
+            element.acceptChildren(object : PsiElementVisitor() {
+                override fun visitElement(element: PsiElement) {
+                    try {
+                        element.accept(this@SampleBuilder)
+                    } catch (e: Exception) {
+                        try {
+                            reportProblemConvertingElement(element, e)
+                        } finally {
+                            builder.append(element.text) //recover
+                        }
+                    }
+                }
+            })
+        }
+
+    }
+
+    private fun PsiElement.buildSampleText(): String {
+        val sampleBuilder = SampleBuilder()
+        this.accept(sampleBuilder)
+
+        sampleBuilder.errors.forEach {
+            val sw = StringWriter()
+            val pw = PrintWriter(sw)
+            it.e.printStackTrace(pw)
+
+            this@KotlinWebsiteSamplesTransformer.context.logger.error("${containingFile.name}: (${it.loc}): Exception thrown while converting \n```\n${it.text}\n```\n$sw")
+        }
+        return sampleBuilder.text
+    }
+
+    val importsToIgnore = arrayOf("samples.*", "samples.Sample").map { ImportPath.fromString(it) }
+
+    override fun processImports(psiElement: PsiElement): String {
+        val psiFile = psiElement.containingFile
+        return when(val text = psiFile.safeAs<KtFile>()?.importList) {
+            is KtImportList -> text.let {
+                it.allChildren.filter {
+                    it !is KtImportDirective || it.importPath !in importsToIgnore
+                }.joinToString(separator = "\n") { it.text }
+            }
+            else -> ""
+        }
+    }
+
+    override fun processBody(psiElement: PsiElement): String {
+        val text = processSampleBody(psiElement).trim { it == '\n' || it == '\r' }.trimEnd()
+        val lines = text.split("\n")
+        val indent = lines.filter(String::isNotBlank).map { it.takeWhile(Char::isWhitespace).count() }.min() ?: 0
+        return lines.joinToString("\n") { it.drop(indent) }
+    }
+
+    private fun processSampleBody(psiElement: PsiElement) = when (psiElement) {
+        is KtDeclarationWithBody -> {
+            val bodyExpression = psiElement.bodyExpression
+            val bodyExpressionText = bodyExpression!!.buildSampleText()
+            when (bodyExpression) {
+                is KtBlockExpression -> bodyExpressionText.removeSurrounding("{", "}")
+                else -> bodyExpressionText
+            }
+        }
+        else -> psiElement.buildSampleText()
+    }
+}

--- a/plugins/base/src/main/kotlin/transformers/pages/samples/SamplesTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/pages/samples/SamplesTransformer.kt
@@ -1,0 +1,102 @@
+package org.jetbrains.dokka.base.transformers.pages.samples
+
+import com.intellij.psi.PsiElement
+import org.jetbrains.dokka.DokkaGenerator
+import org.jetbrains.dokka.EnvironmentAndFacade
+import org.jetbrains.dokka.Platform
+import org.jetbrains.dokka.analysis.AnalysisEnvironment
+import org.jetbrains.dokka.analysis.DokkaResolutionFacade
+import org.jetbrains.dokka.links.DRI
+import org.jetbrains.dokka.model.doc.Sample
+import org.jetbrains.dokka.model.properties.PropertyContainer
+import org.jetbrains.dokka.pages.*
+import org.jetbrains.dokka.plugability.DokkaContext
+import org.jetbrains.dokka.transformers.pages.PageTransformer
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.utils.PathUtil
+import org.jetbrains.kotlin.idea.kdoc.resolveKDocSampleLink
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.DescriptorToSourceUtils
+import org.jetbrains.kotlin.utils.addToStdlib.safeAs
+import java.io.File
+
+abstract class SamplesTransformer(val context: DokkaContext) : PageTransformer {
+
+    abstract fun processBody(psiElement: PsiElement): String
+    abstract fun processImports(psiElement: PsiElement): String
+
+    override fun invoke(input: RootPageNode): RootPageNode {
+
+        val analysis = setUpAnalysis(context)
+
+        return input.transformContentPagesTree { page ->
+            page.documentable?.documentation?.map?.entries?.fold(page) { acc, entry ->
+                entry.value.children.filterIsInstance<Sample>().fold(acc) { acc, sample ->
+                    acc.modified(content = acc.content.addSample(page, entry.key, sample.name, analysis))
+                }
+            } ?: page
+        }
+    }
+
+    private fun setUpAnalysis(context: DokkaContext) = context.configuration.passesConfigurations.map {
+        it.platformData to AnalysisEnvironment(DokkaGenerator.DokkaMessageCollector(context.logger), it.analysisPlatform).run {
+            if (analysisPlatform == Platform.jvm) {
+                addClasspath(PathUtil.getJdkClassesRootsFromCurrentJre())
+            }
+            it.classpath.forEach { addClasspath(File(it)) }
+
+            addSources(it.samples.map { it })
+
+            loadLanguageVersionSettings(it.languageVersion, it.apiVersion)
+
+            val environment = createCoreEnvironment()
+            val (facade, _) = createResolutionFacade(environment)
+            EnvironmentAndFacade(environment, facade)
+        }
+    }.toMap()
+
+    private fun ContentNode.addSample(contentPage: ContentPage, platform: PlatformData, fqName: String, analysis: Map<PlatformData, EnvironmentAndFacade>): ContentNode {
+        val facade = analysis[platform]?.facade ?:
+            return this.also { context.logger.warn("Cannot resolve facade for platform ${platform.name}")}
+        val psiElement = fqNameToPsiElement(facade, fqName) ?:
+            return this.also { context.logger.warn("Cannot find PsiElement corresponding to $fqName") }
+        val imports = processImports(psiElement) // TODO: Process somehow imports. Maybe just attach them at the top of each body
+        val body = processBody(psiElement)
+        val node = platformHintedContentCode(platform, contentPage.dri, body, "kotlin")
+        return this.safeAs<ContentGroup>()?.run { copy(
+            children = children.indexOfFirst { contentNode ->
+                contentNode.safeAs<ContentHeader>()?.children?.firstOrNull()?.safeAs<ContentText>()?.text == "Sample"
+            }.takeIf { it != -1 }?.let { children.apply { this.safeAs<MutableList<ContentNode>>()?.add(it+1, node) } } ?: children.also { context.logger.warn("Not found Sample block in ${contentPage.dri}")}
+        ) } ?: this.also { context.logger.warn("ContentPage ${contentPage.dri} cannot be cast to ContentGroup") }
+    }
+
+    private fun fqNameToPsiElement(resolutionFacade: DokkaResolutionFacade, functionName: String): PsiElement? {
+        val packageName = functionName.takeWhile { it != '.' }
+        val descriptor = resolutionFacade.resolveSession.getPackageFragment(FqName(packageName)) ?:
+            return null.also { context.logger.warn("Cannot find descriptor for package $packageName") }
+        val symbol = resolveKDocSampleLink(BindingContext.EMPTY, resolutionFacade, descriptor, functionName.split(".")).firstOrNull() ?:
+            return null.also { context.logger.warn("Unresolved function $functionName in @sample") }
+        return DescriptorToSourceUtils.descriptorToDeclaration(symbol)
+    }
+
+    private fun platformHintedContentCode(platformData: PlatformData, dri: Set<DRI>, content: String, language: String) =
+        PlatformHintedContent(
+            inner = ContentCode(
+                children = listOf(
+                    ContentText(
+                        text = content,
+                        dci = DCI(dri, ContentKind.BriefComment),
+                        platforms = setOf(platformData),
+                        style = emptySet(),
+                        extra = PropertyContainer.empty()
+                    )
+                ),
+                language = language,
+                extra = PropertyContainer.empty(),
+                dci = DCI(dri, ContentKind.Source),
+                platforms = setOf(platformData),
+                style = emptySet()
+            ),
+            platforms = setOf(platformData)
+        )
+}

--- a/plugins/base/src/main/kotlin/transformers/pages/samples/SamplesTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/pages/samples/SamplesTransformer.kt
@@ -25,7 +25,7 @@ abstract class SamplesTransformer(val context: DokkaContext) : PageTransformer {
     abstract fun processBody(psiElement: PsiElement): String
     abstract fun processImports(psiElement: PsiElement): String
 
-    override fun invoke(input: RootPageNode): RootPageNode {
+    final override fun invoke(input: RootPageNode): RootPageNode {
 
         val analysis = setUpAnalysis(context)
 

--- a/plugins/base/src/main/kotlin/transformers/pages/sourcelinks/SourceLinksTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/pages/sourcelinks/SourceLinksTransformer.kt
@@ -1,0 +1,10 @@
+package org.jetbrains.dokka.base.transformers.pages.sourcelinks
+
+import org.jetbrains.dokka.pages.RootPageNode
+import org.jetbrains.dokka.transformers.pages.PageTransformer
+
+object SourceLinksTransformer : PageTransformer {
+    override fun invoke(input: RootPageNode): RootPageNode {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+}

--- a/plugins/base/src/main/kotlin/transformers/pages/sourcelinks/SourceLinksTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/pages/sourcelinks/SourceLinksTransformer.kt
@@ -2,6 +2,7 @@ package org.jetbrains.dokka.base.transformers.pages.sourcelinks
 
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.dokka.DokkaConfiguration
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.model.DescriptorDocumentableSource
@@ -11,6 +12,8 @@ import org.jetbrains.dokka.pages.*
 import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.transformers.pages.PageTransformer
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptorWithSource
+import org.jetbrains.kotlin.kdoc.psi.api.KDoc
+import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.resolve.source.getPsi
 import org.jetbrains.kotlin.utils.addToStdlib.cast
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs

--- a/plugins/base/src/main/kotlin/transformers/pages/sourcelinks/SourceLinksTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/pages/sourcelinks/SourceLinksTransformer.kt
@@ -20,11 +20,9 @@ import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
 class SourceLinksTransformer(val context: DokkaContext) : PageTransformer {
 
-    private lateinit var sourceLinks: List<SourceLink>
-
     override fun invoke(input: RootPageNode): RootPageNode {
 
-        sourceLinks = context.configuration.passesConfigurations
+        val sourceLinks = context.configuration.passesConfigurations
             .flatMap { it.sourceLinks.map { sl -> SourceLink(sl, it.platformData) } }
 
         return input.transformContentPagesTree { node ->

--- a/plugins/base/src/main/kotlin/transformers/pages/sourcelinks/SourceLinksTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/pages/sourcelinks/SourceLinksTransformer.kt
@@ -1,10 +1,93 @@
 package org.jetbrains.dokka.base.transformers.pages.sourcelinks
 
-import org.jetbrains.dokka.pages.RootPageNode
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiDocumentManager
+import org.jetbrains.dokka.DokkaConfiguration
+import org.jetbrains.dokka.links.DRI
+import org.jetbrains.dokka.model.DescriptorDocumentableSource
+import org.jetbrains.dokka.model.WithExpectActual
+import org.jetbrains.dokka.model.properties.PropertyContainer
+import org.jetbrains.dokka.pages.*
+import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.transformers.pages.PageTransformer
+import org.jetbrains.kotlin.descriptors.DeclarationDescriptorWithSource
+import org.jetbrains.kotlin.resolve.source.getPsi
+import org.jetbrains.kotlin.utils.addToStdlib.cast
+import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
-object SourceLinksTransformer : PageTransformer {
+class SourceLinksTransformer(val context: DokkaContext) : PageTransformer {
+
+    private lateinit var sourceLinks: List<SourceLink>
+
     override fun invoke(input: RootPageNode): RootPageNode {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+
+        sourceLinks = context.configuration.passesConfigurations
+            .flatMap { it.sourceLinks.map { sl -> SourceLink(sl, it.platformData) } }
+
+        return input.transformContentPagesTree { node ->
+            node.documentable.safeAs<WithExpectActual>()?.sources?.map?.entries?.fold(node) { acc, entry ->
+                sourceLinks.find { entry.value.path.contains(it.path) && it.platformData == entry.key }?.run {
+                    acc.modified(
+                        content = acc.content.addSource(
+                            entry.key,
+                            entry.value.cast<DescriptorDocumentableSource>().toLink(this)
+                        )
+                    )
+                } ?: acc
+            } ?: node
+        }
     }
+
+    private fun DescriptorDocumentableSource.toLink(sourceLink: SourceLink): String =
+        sourceLink.url +
+        this.path.split(sourceLink.path)[1] +
+        sourceLink.lineSuffix +
+        "${this.descriptor.cast<DeclarationDescriptorWithSource>().source.getPsi()?.lineNumber() ?: 1}"
+
+    private fun ContentNode.addSource(platformData: PlatformData, address: String?): ContentNode =
+        if (address != null) when (this) {
+            is ContentGroup -> copy(
+                children = children + listOf(platformHintedContentResolvedLink(platformData, dci.dri, address))
+            )
+            else -> ContentGroup(
+                children = listOf(this, platformHintedContentResolvedLink(platformData, dci.dri, address)),
+                extra = this.extra,
+                platforms = this.platforms,
+                dci = this.dci,
+                style = this.style
+            )
+        } else this
+
+    private fun platformHintedContentResolvedLink(platformData: PlatformData, dri: Set<DRI>, address: String) =
+        PlatformHintedContent(
+            inner = ContentResolvedLink(
+                children = listOf(
+                    ContentText(
+                        text = "(source)",
+                        dci = DCI(dri, ContentKind.BriefComment),
+                        platforms = setOf(platformData),
+                        style = emptySet(),
+                        extra = PropertyContainer.empty()
+                    )
+                ),
+                address = address,
+                extra = PropertyContainer.empty(),
+                dci = DCI(dri, ContentKind.Source),
+                platforms = setOf(platformData),
+                style = emptySet()
+            ),
+            platforms = setOf(platformData)
+        )
+
+    private fun PsiElement.lineNumber(): Int? {
+        val doc = PsiDocumentManager.getInstance(project).getDocument(containingFile)
+        // IJ uses 0-based line-numbers; external source browsers use 1-based
+        return doc?.getLineNumber(textRange.startOffset)?.plus(1)
+    }
+}
+
+data class SourceLink(val path: String, val url: String, val lineSuffix: String?, val platformData: PlatformData) {
+    constructor(sourceLinkDefinition: DokkaConfiguration.SourceLinkDefinition, platformData: PlatformData) : this(
+        sourceLinkDefinition.path, sourceLinkDefinition.url, sourceLinkDefinition.lineSuffix, platformData
+    )
 }

--- a/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
@@ -7,9 +7,6 @@ import org.jetbrains.dokka.base.translators.documentables.PageContentBuilder.Doc
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.model.*
 import org.jetbrains.dokka.model.doc.*
-import org.jetbrains.dokka.model.DFunction
-import org.jetbrains.dokka.model.doc.Property
-import org.jetbrains.dokka.model.doc.TagWrapper
 import org.jetbrains.dokka.model.properties.WithExtraProperties
 import org.jetbrains.dokka.pages.*
 import org.jetbrains.dokka.utilities.DokkaLogger
@@ -78,9 +75,8 @@ open class DefaultPageCreator(
     protected open fun contentForPackage(p: DPackage) = contentBuilder.contentFor(p) {
         group(p.dri, p.platformData.toSet(), ContentKind.Packages) {
             header(1) { text("Package ${p.name}") }
-            +contentForComments(p)
         }
-        header(1) { text("Package ${p.name}") }
+        +contentForComments(p)
         +contentForScope(p, p.dri, p.platformData)
         block("Type aliases", 2, ContentKind.TypeAliases, p.typealiases, p.platformData.toSet()) {
             link(it.name, it.dri)

--- a/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
@@ -7,6 +7,9 @@ import org.jetbrains.dokka.base.translators.documentables.PageContentBuilder.Doc
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.model.*
 import org.jetbrains.dokka.model.doc.*
+import org.jetbrains.dokka.model.DFunction
+import org.jetbrains.dokka.model.doc.Property
+import org.jetbrains.dokka.model.doc.TagWrapper
 import org.jetbrains.dokka.model.properties.WithExtraProperties
 import org.jetbrains.dokka.pages.*
 import org.jetbrains.dokka.utilities.DokkaLogger

--- a/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
@@ -64,6 +64,7 @@ open class DefaultPageCreator(
 
     protected open fun contentForModule(m: DModule) = contentBuilder.contentFor(m) {
         header(1) { text(m.name) }
+        +contentForComments(m)
         block("Packages", 2, ContentKind.Packages, m.packages, m.platformData.toSet()) {
             link(it.name, it.dri)
         }
@@ -74,7 +75,9 @@ open class DefaultPageCreator(
     protected open fun contentForPackage(p: DPackage) = contentBuilder.contentFor(p) {
         group(p.dri, p.platformData.toSet(), ContentKind.Packages) {
             header(1) { text("Package ${p.name}") }
+            +contentForComments(p)
         }
+        header(1) { text("Package ${p.name}") }
         +contentForScope(p, p.dri, p.platformData)
         block("Type aliases", 2, ContentKind.TypeAliases, p.typealiases, p.platformData.toSet()) {
             link(it.name, it.dri)

--- a/plugins/base/src/test/kotlin/renderers/RenderingOnlyTestBase.kt
+++ b/plugins/base/src/test/kotlin/renderers/RenderingOnlyTestBase.kt
@@ -1,5 +1,6 @@
 package renderers
 
+import org.jetbrains.dokka.DokkaConfigurationImpl
 import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.base.renderers.html.RootCreator
 import org.jetbrains.dokka.base.resolvers.external.DokkaExternalLocationProviderFactory
@@ -9,6 +10,7 @@ import org.jetbrains.dokka.base.resolvers.local.LocationProvider
 import org.jetbrains.dokka.base.resolvers.local.LocationProviderFactory
 import org.jetbrains.dokka.base.signatures.KotlinSignatureProvider
 import org.jetbrains.dokka.base.transformers.pages.comments.CommentsToContentConverter
+import org.jetbrains.dokka.base.transformers.pages.samples.DefaultSamplesTransformer
 import org.jetbrains.dokka.base.translators.documentables.PageContentBuilder
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.model.Documentable
@@ -28,9 +30,11 @@ abstract class RenderingOnlyTestBase {
     val context = MockContext(
         DokkaBase().outputWriter to { _ -> files },
         DokkaBase().locationProviderFactory to ::DefaultLocationProviderFactory,
+        DokkaBase().samplesTransformer to ::DefaultSamplesTransformer,
         DokkaBase().htmlPreprocessors to { _ -> RootCreator },
         DokkaBase().externalLocationProviderFactory to { _ -> ::JavadocExternalLocationProviderFactory },
-        DokkaBase().externalLocationProviderFactory to { _ -> ::DokkaExternalLocationProviderFactory }
+        DokkaBase().externalLocationProviderFactory to { _ -> ::DokkaExternalLocationProviderFactory },
+        testConfiguration = DokkaConfigurationImpl("", "", false, null, emptyList(), emptyList(), emptyList())
     )
 
     protected val renderedContent: Element by lazy {


### PR DESCRIPTION
Handles configuration inputs: Includes, SourceLinks, Samples.

Please look into the EP for Samples. I don't know if I got it right.

I also think the API for Samples (actually annotations type aliases) should be included in dokka. Right now I have seen them losely attached to stdlib.

#747