### PR TITLE
Adds possibility to configure plugins

### DIFF
--- a/core/src/main/kotlin/configuration.kt
+++ b/core/src/main/kotlin/configuration.kt
@@ -33,6 +33,7 @@ interface DokkaConfiguration {
     val passesConfigurations: List<PassConfiguration>
     val impliedPlatforms: List<String>
     val pluginsClasspath: List<File>
+    val pluginsConfiguration: Map<String, String>
 
     interface PassConfiguration {
         val moduleName: String
@@ -100,3 +101,5 @@ interface DokkaConfiguration {
         }
     }
 }
+
+

--- a/core/src/main/kotlin/defaultConfiguration.kt
+++ b/core/src/main/kotlin/defaultConfiguration.kt
@@ -10,7 +10,8 @@ data class DokkaConfigurationImpl(
     override val cacheRoot: String?,
     override val impliedPlatforms: List<String>,
     override val passesConfigurations: List<PassConfigurationImpl>,
-    override var pluginsClasspath: List<File>
+    override val pluginsClasspath: List<File>,
+    override val pluginsConfiguration: Map<String, String>
 ) : DokkaConfiguration
 
 data class PassConfigurationImpl (

--- a/runners/cli/src/main/kotlin/cli/main.kt
+++ b/runners/cli/src/main/kotlin/cli/main.kt
@@ -54,6 +54,8 @@ open class GlobalArguments(parser: DokkaArgumentsParser) : DokkaConfiguration {
     ) {
         Arguments(parser).also { if(it.moduleName.isEmpty()) DokkaConsoleLogger.warn("Not specified module name. It can result in unexpected behaviour while including documentation for module") }
     }
+
+    override val pluginsConfiguration: Map<String, String> = mutableMapOf()
 }
 
 class Arguments(val parser: DokkaArgumentsParser) : DokkaConfiguration.PassConfiguration {

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/configurationImplementations.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/configurationImplementations.kt
@@ -125,6 +125,7 @@ class GradleDokkaConfigurationImpl: DokkaConfiguration {
     override var impliedPlatforms: List<String> = emptyList()
     override var passesConfigurations: List<GradlePassConfigurationImpl> = emptyList()
     override var pluginsClasspath: List<File> = emptyList()
+    override var pluginsConfiguration: Map<String, String> = mutableMapOf()
 }
 
 class GradlePackageOptionsImpl: PackageOptions, Serializable {

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/main.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/main.kt
@@ -48,7 +48,7 @@ open class DokkaPlugin : Plugin<Project> {
             task.multiplatform = project.container(GradlePassConfigurationImpl::class.java)
             task.configuration = GradlePassConfigurationImpl()
             task.dokkaRuntime = runtimeConfiguration
-            task.pluginsConfiguration = pluginsConfiguration
+            task.pluginsConfig = pluginsConfiguration
             task.outputDirectory = File(project.buildDir, DOKKA_TASK_NAME).absolutePath
         }
     }

--- a/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
+++ b/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
@@ -249,7 +249,8 @@ abstract class AbstractDokkaMojo : AbstractMojo() {
             },
             generateIndexPages = generateIndexPages,
             pluginsClasspath = getArtifactByAether("org.jetbrains.dokka", "dokka-base", dokkaVersion) +
-                    dokkaPlugins.map { getArtifactByAether(it.groupId, it.artifactId, it.version) }.flatten()
+                    dokkaPlugins.map { getArtifactByAether(it.groupId, it.artifactId, it.version) }.flatten(),
+            pluginsConfiguration = mutableMapOf() //TODO implement as it is in Gradle
         )
 
         val gen = DokkaGenerator(configuration, logger)

--- a/testApi/src/main/kotlin/testApi/testRunner/TestRunner.kt
+++ b/testApi/src/main/kotlin/testApi/testRunner/TestRunner.kt
@@ -140,6 +140,7 @@ abstract class AbstractCoreTest {
         var generateIndexPages: Boolean = true
         var cacheRoot: String? = null
         var pluginsClasspath: List<File> = emptyList()
+        var pluginsConfigurations: Map<String, String> = emptyMap()
         private val passesConfigurations = mutableListOf<PassConfigurationImpl>()
         fun build() = DokkaConfigurationImpl(
             outputDir = outputDir,
@@ -148,7 +149,8 @@ abstract class AbstractCoreTest {
             cacheRoot = cacheRoot,
             impliedPlatforms = emptyList(),
             passesConfigurations = passesConfigurations,
-            pluginsClasspath = pluginsClasspath
+            pluginsClasspath = pluginsClasspath,
+            pluginsConfiguration = pluginsConfigurations
         )
 
         fun passes(block: Passes.() -> Unit) {


### PR DESCRIPTION
#638 
We have to be explicite with:
1. context
2. Dokka Plugin Type
3. Dokka Plugin Container Type

### 1. context

All the configuration for plugin is set up in context. We cannot obtain passed configs without context.
What's more it cannot be implicit in `DokkaPlugin()` because the context is nullable there, and probably will be null at the time of accessing the property, cause it's injected later. Also, we will probably feed configuration to Extensions, not `DokkaPlugin()` itself

### 2. Dokka Plugin Type

It is crucial to distinct plugins. Unfortunatel, delegate's `thisRef` will most of the time be other that parent `DokkaPlugin()`

### 3. Dokka Plugin Container Type

This is the most tricky part that probably could be skipped, but I spend few hours on research and have not found anything satisfying me. We need this type to know what type we want to project to. I really would like to couple Dokka Plugin Type and Dokka Plugin Container Type, but cannot obtain via generics Dokka Plugin Container Type from Dokka Plugin Type.

Edit: Actually we can have only Dokka Plugin Container Type, because these two types are not coupled in any way but logical structure. What is more we get rid of problem where somebody passes Dokka Plugin Type with wrong Dokka Plugin Container Type, which can lead to problems with casting.

Example config for Mathjax Transformer

Declaration:
```kotlin
class MathjaxPluginConfig : ConfigurableBlock {
    var property1: Int = 0
    var property2: String = "param"
    var property3: List<Int> = listOf(1, 2)
}
```

Usage
```kotlin
val configInstance by configuration<MathjaxPlugin, MathjaxPluginConfig>(context)
println(configInstance.property1) // 1
```

In build.gradle.kts

```gradle
import org.jetbrains.dokka.mathjax.MathjaxPlugin
import org.jetbrains.dokka.mathjax.MathjaxPluginConfig
import org.jetbrains.dokka.plugability.pluginConfiguration

buildscript {
    repositories {
        mavenLocal()
    }

    dependencies {
        classpath("org.jetbrains.dokka:mathjax-plugin:0.11.0-SNAPSHOT")
    }
}

tasks {
    val dokka by getting(DokkaTask::class) {
            pluginConfiguration<MathjaxPlugin, MathjaxPluginConfig> { // type-safe, this: MathjaxPluginConfig
                property1 = 1
                property2 = "new param"
                property3 = listOf(1, 2, 3)
        }
    }
}
```