### PR TITLE
Exclude kotlin_metadata and kotlin_builtins

### DIFF
--- a/coreDependencies/build.gradle.kts
+++ b/coreDependencies/build.gradle.kts
@@ -45,6 +45,8 @@ tasks {
         exclude("tips/**")
         exclude("messages/**")
         exclude("src/**")
+        exclude("**/*.kotlin_metadata")
+        exclude("**/*.kotlin_builtins")
     }
 }
 


### PR DESCRIPTION
 Exclude kotlin_metadata and kotlin_builtins from coreDependencies to fix IntelliJ symbol resolution