### PR TITLE
Missing generics on class #834

### DIFF
--- a/core/src/main/kotlin/model/Documentable.kt
+++ b/core/src/main/kotlin/model/Documentable.kt
@@ -263,9 +263,10 @@ data class DAnnotation(
     override val visibility: SourceSetDependent<Visibility>,
     override val companion: DObject?,
     override val constructors: List<DFunction>,
+    override val generics: List<DTypeParameter>,
     override val sourceSets: List<SourceSetData>,
     override val extra: PropertyContainer<DAnnotation> = PropertyContainer.empty()
-) : DClasslike(), WithCompanion, WithConstructors, WithExtraProperties<DAnnotation> {
+) : DClasslike(), WithCompanion, WithConstructors, WithExtraProperties<DAnnotation>, WithGenerics {
     override val children: List<Documentable>
         get() = (functions + properties + classlikes + constructors) as List<Documentable>
 
@@ -344,7 +345,7 @@ data class DTypeAlias(
 
 sealed class Projection
 sealed class Bound : Projection()
-data class OtherParameter(val name: String) : Bound()
+data class OtherParameter(val declarationDRI: DRI, val name: String) : Bound()
 object Star : Projection()
 data class TypeConstructor(
     val dri: DRI,

--- a/plugins/base/src/main/kotlin/transformers/documentables/DefaultDocumentableMerger.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/DefaultDocumentableMerger.kt
@@ -175,7 +175,8 @@ fun DAnnotation.mergeWith(other: DAnnotation): DAnnotation = copy(
     expectPresentInSet = expectPresentInSet ?: other.expectPresentInSet,
     sources = sources+ other.sources,
     visibility = visibility + other.visibility,
-    sourceSets = sourceSets + other.sourceSets
+    sourceSets = sourceSets + other.sourceSets,
+    generics = merge(generics + other.generics, DTypeParameter::mergeWith)
 ).mergeExtras(this, other)
 
 fun DParameter.mergeWith(other: DParameter): DParameter = copy(

--- a/plugins/base/src/main/kotlin/transformers/documentables/DocumentableVisibilityFilter.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/DocumentableVisibilityFilter.kt
@@ -265,6 +265,7 @@ internal class DocumentableVisibilityFilter(val context: DokkaContext) : PreMerg
                                 visibility.filtered(filteredPlatforms),
                                 companion,
                                 constructors,
+                                generics,
                                 filteredPlatforms,
                                 extra
                             )

--- a/plugins/base/src/main/kotlin/translators/psi/DefaultPsiToDocumentableTranslator.kt
+++ b/plugins/base/src/main/kotlin/translators/psi/DefaultPsiToDocumentableTranslator.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.psi.*
 import com.intellij.psi.impl.source.PsiClassReferenceType
 import org.jetbrains.dokka.links.DRI
+import org.jetbrains.dokka.links.nextTarget
 import org.jetbrains.dokka.links.withClass
 import org.jetbrains.dokka.model.*
 import org.jetbrains.dokka.model.properties.PropertyContainer
@@ -159,6 +160,7 @@ object DefaultPsiToDocumentableTranslator : SourceToDocumentableTranslator {
                         visibility,
                         null,
                         constructors.map { parseFunction(it, true) },
+                        mapTypeParameters(dri),
                         listOf(sourceSetData),
                         PropertyContainer.empty<DAnnotation>() + annotations.toList().toExtra()
                     )
@@ -238,9 +240,9 @@ object DefaultPsiToDocumentableTranslator : SourceToDocumentableTranslator {
                 dri,
                 if (isConstructor) "<init>" else psi.name,
                 isConstructor,
-                psi.parameterList.parameters.mapIndexed { index, psiParameter ->
+                psi.parameterList.parameters.map { psiParameter ->
                     DParameter(
-                        dri.copy(target = index + 1),
+                        dri.copy(target = dri.target.nextTarget()),
                         psiParameter.name,
                         javadocParser.parseDocumentation(psiParameter).toPlatformDependant(),
                         null,
@@ -321,9 +323,9 @@ object DefaultPsiToDocumentableTranslator : SourceToDocumentableTranslator {
                 if (bounds.isEmpty()) emptyList() else bounds.mapNotNull {
                     (it as? PsiClassType)?.let { classType -> Nullable(getBound(classType)) }
                 }
-            return typeParameters.mapIndexed { index, type ->
+            return typeParameters.map { type ->
                 DTypeParameter(
-                    dri.copy(genericTarget = index),
+                    dri.copy(target = dri.target.nextTarget()),
                     type.name.orEmpty(),
                     javadocParser.parseDocumentation(type).toPlatformDependant(),
                     null,

--- a/plugins/base/src/test/kotlin/markdown/LinkTest.kt
+++ b/plugins/base/src/test/kotlin/markdown/LinkTest.kt
@@ -1,10 +1,12 @@
 package markdown
 
+import org.jetbrains.dokka.pages.ClasslikePageNode
 import org.jetbrains.dokka.pages.ContentDRILink
 import org.jetbrains.dokka.pages.MemberPageNode
 import org.jetbrains.dokka.pages.dfs
 import org.jetbrains.dokka.testApi.testRunner.AbstractCoreTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 
 class LinkTest : AbstractCoreTest() {
@@ -36,10 +38,42 @@ class LinkTest : AbstractCoreTest() {
                     .dfs { node -> node is ContentDRILink }
                     .let {
                         assertEquals(
-                            "parser//test/#java.lang.ClassLoader//",
+                            "parser//test/#java.lang.ClassLoader/PointingToDeclaration/",
                             (it as ContentDRILink).address.toString()
                         )
                     }
+            }
+        }
+    }
+
+    @Test
+    fun returnTypeShouldHaveLinkToOuterClassFromInner() {
+        val configuration = dokkaConfiguration {
+            passes {
+                pass {
+                    sourceRoots = listOf("src/main/kotlin/parser")
+                }
+            }
+        }
+        testInline(
+            """
+            |/src/main/kotlin/parser/Test.kt
+            |package parser
+            |
+            |class Outer<OUTER> {
+            |   inner class Inner<INNER> {
+            |       fun foo(): OUTER = TODO()
+            |   }
+            |}
+        """.trimMargin(),
+            configuration
+        ) {
+            renderingStage = { rootPageNode, _ ->
+                val root = rootPageNode.children.single().children.single() as ClasslikePageNode
+                val innerClass = root.children.first { it is ClasslikePageNode }
+                val foo = innerClass.children.first { it.name == "foo" } as MemberPageNode
+
+                assertNotNull(foo.content.dfs { it is ContentDRILink && it.address.toString() == "parser/Outer///PointingToDeclaration/" } )
             }
         }
     }

--- a/plugins/base/src/test/kotlin/model/JavaTest.kt
+++ b/plugins/base/src/test/kotlin/model/JavaTest.kt
@@ -394,7 +394,6 @@ class JavaTest : AbstractModelTest("/src/main/kotlin/java/Test.java", "java") {
         }
     }
 
-    @Disabled("reenable after fixing subtypes")
     @Test
     fun inheritorLinks() {
         inlineModelTest(

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -14,7 +14,6 @@ subprojects {
 
     tasks.test {
         useJUnitPlatform()
-        ignoreFailures = true
         testLogging {
             events("passed", "skipped", "failed")
         }

--- a/plugins/kotlin-as-java/src/main/kotlin/converters/KotlinToJavaConverter.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/converters/KotlinToJavaConverter.kt
@@ -1,12 +1,13 @@
 package org.jetbrains.dokka.kotlinAsJava.converters
 
+import org.jetbrains.dokka.links.*
 import org.jetbrains.dokka.links.Callable
-import org.jetbrains.dokka.links.DRI
-import org.jetbrains.dokka.links.withClass
 import org.jetbrains.dokka.model.*
 import org.jetbrains.dokka.model.DAnnotation
 import org.jetbrains.dokka.model.DEnum
 import org.jetbrains.dokka.model.DFunction
+import org.jetbrains.dokka.model.Nullable
+import org.jetbrains.dokka.model.TypeConstructor
 import org.jetbrains.dokka.model.properties.PropertyContainer
 import org.jetbrains.kotlin.builtins.jvm.JavaToKotlinClassMap
 import org.jetbrains.kotlin.name.ClassId
@@ -243,7 +244,7 @@ internal fun ClassId.toDRI(dri: DRI?): DRI = DRI(
     classNames = classNames(),
     callable = dri?.callable,//?.asJava(), TODO: check this
     extra = null,
-    target = null
+    target = PointingToDeclaration
 )
 
 private fun PropertyContainer<out Documentable>.mergeAdditionalModifiers(second: Set<ExtraModifiers>) =

--- a/plugins/kotlin-as-java/src/main/kotlin/signatures/JavaSignatureProvider.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/signatures/JavaSignatureProvider.kt
@@ -92,7 +92,7 @@ class JavaSignatureProvider(ctcc: CommentsToContentConverter, logger: DokkaLogge
 
 
     private fun PageContentBuilder.DocumentableContentBuilder.signatureForProjection(p: Projection): Unit = when (p) {
-        is OtherParameter -> text(p.name)
+        is OtherParameter -> link(p.name, p.declarationDRI)
 
         is TypeConstructor -> group {
             link(p.dri.classNames.orEmpty(), p.dri)


### PR DESCRIPTION
- Added displaying generics on classes
- Added generics to Annotations
- Removed inherited types from inner classes (now there are only types that are declared by the inner class and not inherited from parent), just like it is in code
- Refactored DRI Target to use a sealed class instead of `int?`
- Added a reference to a point of declaration for types. So in case of:
```
class Outer<T> {
    inner class Inner<G> {
        fun foo(): T = { TODO() }
    }
}
```
While user is on Inner class, link on the T return type forwards to Outer class.