### PR TITLE
Platform dependant comments

### DIFF
--- a/core/src/main/kotlin/pages/ContentNodes.kt
+++ b/core/src/main/kotlin/pages/ContentNodes.kt
@@ -171,7 +171,7 @@ interface Kind
 enum class ContentKind : Kind {
 
     Comment, Constructors, Functions, Parameters, Properties, Classlikes, Packages, Symbol, Sample, Main, BriefComment,
-    Empty, Source, TypeAliases, Cover, Inheritors;
+    Empty, Source, TypeAliases, Cover, Inheritors, PlatformDependantHint;
 
     companion object {
         private val platformTagged =
@@ -183,6 +183,10 @@ enum class ContentKind : Kind {
 
 enum class TextStyle : Style {
     Bold, Italic, Strong, Strikethrough, Paragraph, Block, Monospace, Indented
+}
+
+enum class ContentStyle : Style {
+    KeyValue
 }
 
 object CommentTable: Style

--- a/core/src/main/resources/dokka/styles/style.css
+++ b/core/src/main/resources/dokka/styles/style.css
@@ -89,6 +89,7 @@
     box-sizing: border-box;
     font-weight: bold;
     white-space: pre;
+    flex-wrap: wrap;
 }
 
 #nav-submenu > .sideMenuPart {
@@ -214,10 +215,9 @@ td:first-child {
 }
 
 .brief {
-    width: 40vw;
-    white-space: nowrap;
+    white-space: pre-wrap;
     overflow: hidden;
-    text-overflow: ellipsis;
+    padding-top: 24px;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -424,6 +424,7 @@ footer {
     flex-direction: row;
     align-items: flex-start;
     justify-content: flex-end;
+    height: 24px;
 }
 
 .platform-tags > .platform-tag {
@@ -462,7 +463,7 @@ td.content {
     flex-direction: column;
 }
 
-.title > a {
+.title-row > a {
     text-decoration: none;
     font-style: normal;
     font-weight: 600;
@@ -470,7 +471,7 @@ td.content {
     color: #282E34;
 }
 
-.title > a:hover {
+.title-row > a:hover {
     color: #5B5DEF;
 }
 
@@ -536,7 +537,6 @@ td.content {
 .table {
     display: flex;
     flex-direction: column;
-    flex-direction: column;
 }
 
 .table-row {
@@ -547,42 +547,29 @@ td.content {
     padding: 16px 24px 16px 24px;
 }
 
-.table-row > .main-subrow {
-    height: 24px;
+.platform-dependant-row {
     display: grid;
-    grid-template-columns: 310px auto auto;
+    padding-top: 8px;
 }
 
-.table-row > .signature-subrow {
+.title-row {
     display: grid;
-    grid-template-columns: 310px auto;
+    grid-template-columns: auto auto 7em;
+    width: 100%;
 }
 
-.main-subrow > .title {
-    order: 1;
+.keyValue {
+    display: grid;
 }
 
-.main-subrow > .brief {
-    order: 2;
-}
+@media print, screen and (min-width: 960px) {
+    .keyValue {
+        grid-template-columns: 20% auto;
+    }
 
-.main-subrow > .platform-tags {
-    grid-column-start: 3;
-}
-
-.main-subrow > * {
-    order: 4;
-}
-
-.signature-subrow > .signatures {
-    grid-column-start: 2;
-    display: flex;
-    flex-direction: column;
-    margin-top: 5px;
-}
-
-.signature-subrow > * {
-    order: 4;
+    .title-row {
+        grid-template-columns: 20% auto 7em;
+    }
 }
 
 @media print, screen and (max-width: 960px) {
@@ -640,7 +627,7 @@ td.content {
 
 @media print, screen and (max-width: 480px) {
     body {
-        padding: 15px;
+        padding-right: 15px;
     }
 
     header ul {

--- a/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
@@ -128,22 +128,32 @@ open class HtmlRenderer(
             ?.let {
                 div(classes = "table-row") {
                     it.filter { it.dci.kind != ContentKind.Symbol }.takeIf { it.isNotEmpty() }?.let {
-                        div("main-subrow") {
+                        div("main-subrow ${node.style.joinToString { it.toString().decapitalize() }}") {
                             it.filter { platformRestriction == null || platformRestriction in it.platforms }
                                 .forEach {
                                     when(it.dci.kind){
-                                        ContentKind.Main -> div("title") {
-                                            it.build(this, pageContext, platformRestriction)
+                                        ContentKind.PlatformDependantHint -> {
+                                            div("platform-dependant-row keyValue"){
+                                                div()
+                                                div("title"){
+                                                    it.build(this, pageContext, platformRestriction)
+                                                }
+                                            }
                                         }
-                                        ContentKind.BriefComment, ContentKind.Comment -> div("brief") {
-                                            it.build(this, pageContext, platformRestriction)
+                                        ContentKind.Main -> {
+                                            div("title-row"){
+                                                it.build(this, pageContext, platformRestriction)
+                                                div()
+                                                if (ContentKind.shouldBePlatformTagged(node.dci.kind) && node.platforms.size == 1) {
+                                                    createPlatformTags(node)
+                                                } else {
+                                                    div()
+                                                }
+                                            }
                                         }
                                         else -> div { it.build(this, pageContext, platformRestriction) }
                                     }
                                 }
-                            if (ContentKind.shouldBePlatformTagged(node.dci.kind) && node.platforms.size == 1) {
-                                createPlatformTags(node)
-                            }
                         }
                     }
                     it.filter { it.dci.kind == ContentKind.Symbol }.takeIf { it.isNotEmpty() }?.let {

--- a/plugins/base/src/main/kotlin/signatures/KotlinSignatureProvider.kt
+++ b/plugins/base/src/main/kotlin/signatures/KotlinSignatureProvider.kt
@@ -31,7 +31,9 @@ class KotlinSignatureProvider(ctcc: CommentsToContentConverter, logger: DokkaLog
         )
     }
 
-    private fun signature(e: DEnumEntry) = contentBuilder.contentFor(e, ContentKind.Symbol, setOf(TextStyle.Monospace))
+    private fun signature(e: DEnumEntry) = contentBuilder.contentFor(e, ContentKind.Symbol, setOf(TextStyle.Monospace)){
+        link(e.name, e.dri)
+    }
 
     private fun actualTypealiasedSignature(dri: DRI, name: String, aliasedTypes: PlatformDependent<Bound>) =
         aliasedTypes.entries.groupBy({ it.value }, { it.key }).map { (bound, platforms) ->


### PR DESCRIPTION
Comments look like this:
![image](https://user-images.githubusercontent.com/15652452/81824564-e837d580-9535-11ea-8e25-56b8cff0a153.png)

Also some changes are related to the fact, that i wanted dokka to be the same as on figma (so the platform dependant tabs are brought down, and have more horizontal space)

On the 'mobile' or lower resolution screens it looks like this:
![image](https://user-images.githubusercontent.com/15652452/81825554-14a02180-9537-11ea-9465-92e667c1088b.png)
