### PR TITLE
Fix double backticks in MarkdownFormat

### DIFF
--- a/core/src/main/kotlin/Formats/MarkdownFormatService.kt
+++ b/core/src/main/kotlin/Formats/MarkdownFormatService.kt
@@ -100,7 +100,15 @@ open class MarkdownOutputBuilder(to: StringBuilder,
         val codeBlockStart = to.length
         maxBackticksInCodeBlock = 0
 
-        wrapIfNotEmpty("`", "`", body, checkEndsWith = true)
+        val startLength = to.length
+        val backtick = "`"
+        wrapIfNotEmpty(backtick, backtick, body, checkEndsWith = true)
+        // The body() itself could have backticks. Double backticks like `` could
+        // result in wrong markdown. Sanitize if that is the case.
+        val prefixEndIdx = startLength + backtick.length
+        if (to.startsWith(backtick, prefixEndIdx)) {
+            to.replace(startLength, prefixEndIdx + backtick.length, "")
+        }
 
         if (maxBackticksInCodeBlock > 0) {
             val extraBackticks = "`".repeat(maxBackticksInCodeBlock)

--- a/core/src/test/kotlin/format/MarkdownFormatTest.kt
+++ b/core/src/test/kotlin/format/MarkdownFormatTest.kt
@@ -2,7 +2,6 @@ package org.jetbrains.dokka.tests
 
 import org.jetbrains.dokka.*
 import org.jetbrains.dokka.Generation.DocumentationMerger
-import org.junit.Ignore
 import org.junit.Test
 
 abstract class BaseMarkdownFormatTest(val analysisPlatform: Platform): FileGeneratorTestCase() {

--- a/core/src/test/kotlin/format/MarkdownFormatTest.kt
+++ b/core/src/test/kotlin/format/MarkdownFormatTest.kt
@@ -2,6 +2,7 @@ package org.jetbrains.dokka.tests
 
 import org.jetbrains.dokka.*
 import org.jetbrains.dokka.Generation.DocumentationMerger
+import org.junit.Ignore
 import org.junit.Test
 
 abstract class BaseMarkdownFormatTest(val analysisPlatform: Platform): FileGeneratorTestCase() {
@@ -508,6 +509,16 @@ class JVMMarkdownFormatTest: BaseMarkdownFormatTest(Platform.jvm) {
     @Test
     fun javaCodeLiteralTags() {
         verifyJavaMarkdownNode("javaCodeLiteralTags", defaultModelConfig)
+    }
+
+    @Test
+    fun javaLinkTag() {
+        verifyJavaMarkdownNode("javaLinkTag", defaultModelConfig)
+    }
+
+    @Test
+    fun javaLinkTagWithLabel() {
+        verifyJavaMarkdownNode("javaLinkTagWithLabel", defaultModelConfig)
     }
 
     @Test

--- a/core/testdata/format/javaLinkTag.md
+++ b/core/testdata/format/javaLinkTag.md
@@ -1,0 +1,16 @@
+[test](../../index.md) / [Foo](./index.md)
+
+# Foo
+
+`protected open class Foo`
+
+Call [`#bar()`](bar.md) to do the job.
+
+### Constructors
+
+| [&lt;init&gt;](-init-.md) | Call [`#bar()`](bar.md) to do the job.`Foo()` |
+
+### Functions
+
+| [bar](bar.md) | `open fun bar(): Unit` |
+

--- a/core/testdata/format/javaLinkTagWithLabel.md
+++ b/core/testdata/format/javaLinkTagWithLabel.md
@@ -1,0 +1,16 @@
+[test](../../index.md) / [Foo](./index.md)
+
+# Foo
+
+`protected open class Foo`
+
+Call [`this wonderful method`](bar.md) to do the job.
+
+### Constructors
+
+| [&lt;init&gt;](-init-.md) | Call [`this wonderful method`](bar.md) to do the job.`Foo()` |
+
+### Functions
+
+| [bar](bar.md) | `open fun bar(): Unit` |
+


### PR DESCRIPTION
Fixes #848 

The main problem here was that double backticks for links would break markdown formatting. For example:

``[`bar`](bar.md)

But if you have a space between the backticks, it's fine. Example;
` `[`bar`](bar.md)

Instead of adding a redundant space, I sanitize the double backtick so it becomes:
[`bar`](bar.md)