### PR TITLE
Return types links in inner classes with generic parents

### DIFF
--- a/plugins/base/src/main/kotlin/translators/descriptors/DefaultDescriptorToDocumentableTranslator.kt
+++ b/plugins/base/src/main/kotlin/translators/descriptors/DefaultDescriptorToDocumentableTranslator.kt
@@ -101,8 +101,7 @@ private class DokkaDescriptorVisitor(
         descriptor: PackageFragmentDescriptor,
         parent: DRIWithPlatformInfo
     ): DPackage {
-        val name = descriptor.fqName.asString().takeUnless { it.isBlank() } ?:
-            "[${sourceSet.sourceSetName} root]"// TODO: error-prone, find a better way to do it
+        val name = descriptor.fqName.asString().takeUnless { it.isBlank() } ?: fallbackPackageName()
         val driWithPlatform = DRI(packageName = name).withEmptyInfo()
         val scope = descriptor.getMemberScope()
 
@@ -544,7 +543,7 @@ private class DokkaDescriptorVisitor(
         is DynamicType -> Dynamic
         else -> when (val ctor = constructor.declarationDescriptor) {
             is TypeParameterDescriptor -> OtherParameter(
-                declarationDRI = DRI.from(ctor.containingDeclaration),
+                declarationDRI = DRI.from(ctor.containingDeclaration).withPackageFallbackTo(fallbackPackageName()),
                 name = ctor.name.asString()
             )
             else -> TypeConstructor(
@@ -694,4 +693,14 @@ private class DokkaDescriptorVisitor(
 
     private fun ConstantsEnumValue.fullEnumEntryName() =
         "${this.enumClassId.relativeClassName.asString()}.${this.enumEntryName.identifier}"
+
+    private fun fallbackPackageName(): String = "[${sourceSet.sourceSetName} root]"// TODO: error-prone, find a better way to do it
+}
+
+private fun DRI.withPackageFallbackTo(fallbackPackage: String): DRI {
+    return if(packageName.isNullOrBlank()){
+        copy(packageName = fallbackPackage)
+    } else {
+        this
+    }
 }

--- a/plugins/base/src/test/kotlin/markdown/LinkTest.kt
+++ b/plugins/base/src/test/kotlin/markdown/LinkTest.kt
@@ -51,14 +51,14 @@ class LinkTest : AbstractCoreTest() {
         val configuration = dokkaConfiguration {
             passes {
                 pass {
-                    sourceRoots = listOf("src/main/kotlin/parser")
+                    sourceRoots = listOf("src/main/kotlin")
                 }
             }
         }
+        //This does not contain a package to check for situation when the package has to be artificially generated
         testInline(
             """
             |/src/main/kotlin/parser/Test.kt
-            |package parser
             |
             |class Outer<OUTER> {
             |   inner class Inner<INNER> {
@@ -73,7 +73,8 @@ class LinkTest : AbstractCoreTest() {
                 val innerClass = root.children.first { it is ClasslikePageNode }
                 val foo = innerClass.children.first { it.name == "foo" } as MemberPageNode
 
-                assertNotNull(foo.content.dfs { it is ContentDRILink && it.address.toString() == "parser/Outer///PointingToDeclaration/" } )
+                assertEquals(root.dri.first().toString(), "[main root]/Outer///PointingToDeclaration/")
+                assertNotNull(foo.content.dfs { it is ContentDRILink && it.address.toString() == root.dri.first().toString() } )
             }
         }
     }

--- a/plugins/base/src/test/kotlin/renderers/RenderingOnlyTestBase.kt
+++ b/plugins/base/src/test/kotlin/renderers/RenderingOnlyTestBase.kt
@@ -113,20 +113,3 @@ internal object EmptyCommentConverter : CommentsToContentConverter {
         extras: PropertyContainer<ContentNode>
     ): List<ContentNode> = emptyList()
 }
-
-internal object EmptyLocationProviderFactory: LocationProviderFactory {
-    override fun getLocationProvider(pageNode: RootPageNode) = object : LocationProvider {
-        override fun resolve(dri: DRI, sourceSets: List<SourceSetData>, context: PageNode?): String = ""
-
-        override fun resolve(node: PageNode, context: PageNode?, skipExtension: Boolean): String = node.name
-
-        override fun resolveRoot(node: PageNode): String {
-            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-        }
-
-        override fun ancestors(node: PageNode): List<PageNode> {
-            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-        }
-
-    }
-}

--- a/plugins/base/src/test/kotlin/renderers/html/SourceSetDependentHintTest.kt
+++ b/plugins/base/src/test/kotlin/renderers/html/SourceSetDependentHintTest.kt
@@ -101,7 +101,6 @@ class SourceSetDependentHintTest : RenderingOnlyTestBase() {
         }
 
         HtmlRenderer(context).render(page)
-        println(renderedContent)
         renderedContent.match(Div(Div("ab")))
     }
 


### PR DESCRIPTION
The issue was that given a class without a package:
```
class Sample<S>{
    inner class SampleInner {
        fun foo(): S = TODO()
    }
}
```

We would generate package name from a sourceRoot, but while creating a DRI for `foo`'s return type, the package would be empty. Then the location provider wouldn't be able to give a correct value so we end up with an empty `href` on frontend. 