### PR TITLE
Divergent comments fix

### DIFF
--- a/plugins/base/src/main/kotlin/DokkaBase.kt
+++ b/plugins/base/src/main/kotlin/DokkaBase.kt
@@ -21,16 +21,13 @@ import org.jetbrains.dokka.base.transformers.pages.merger.PageMerger
 import org.jetbrains.dokka.base.transformers.pages.merger.PageMergerStrategy
 import org.jetbrains.dokka.base.transformers.pages.merger.SameMethodNamePageMergerStrategy
 import org.jetbrains.dokka.base.transformers.pages.samples.DefaultSamplesTransformer
-import org.jetbrains.dokka.base.transformers.pages.samples.SamplesTransformer
 import org.jetbrains.dokka.base.transformers.pages.sourcelinks.SourceLinksTransformer
 import org.jetbrains.dokka.base.translators.descriptors.DefaultDescriptorToDocumentableTranslator
 import org.jetbrains.dokka.base.translators.documentables.DefaultDocumentableToPageTranslator
 import org.jetbrains.dokka.base.translators.documentables.PageContentBuilder
 import org.jetbrains.dokka.base.translators.psi.DefaultPsiToDocumentableTranslator
-import org.jetbrains.dokka.pages.ContentDivergentGroup
 import org.jetbrains.dokka.plugability.DokkaPlugin
 import org.jetbrains.dokka.transformers.pages.PageTransformer
-import org.jetbrains.kotlin.descriptors.PackageFragmentDescriptor
 
 class DokkaBase : DokkaPlugin() {
     val pageMergerStrategy by extensionPoint<PageMergerStrategy>()
@@ -40,7 +37,6 @@ class DokkaBase : DokkaPlugin() {
     val externalLocationProviderFactory by extensionPoint<ExternalLocationProviderFactory>()
     val outputWriter by extensionPoint<OutputWriter>()
     val htmlPreprocessors by extensionPoint<PageTransformer>()
-    val samplesTransformer by extensionPoint<SamplesTransformer>()
 
     val descriptorToDocumentableTranslator by extending {
         CoreExtensions.sourceToDocumentableTranslator with DefaultDescriptorToDocumentableTranslator
@@ -133,7 +129,9 @@ class DokkaBase : DokkaPlugin() {
     }
 
     val defaultSamplesTransformer by extending {
-        samplesTransformer providing ::DefaultSamplesTransformer
+        CoreExtensions.pageTransformer providing ::DefaultSamplesTransformer order {
+            before(pageMerger)
+        }
     }
 
     val sourceLinksTransformer by extending {

--- a/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
@@ -27,8 +27,7 @@ open class HtmlRenderer(
 
     private val pageList = mutableListOf<String>()
 
-    override val preprocessors = context.plugin<DokkaBase>().query { htmlPreprocessors } +
-            context.plugin<DokkaBase>().querySingle { samplesTransformer }
+    override val preprocessors = context.plugin<DokkaBase>().query { htmlPreprocessors }
 
     override fun FlowContent.wrapGroup(
         node: ContentGroup,

--- a/plugins/base/src/test/kotlin/renderers/RenderingOnlyTestBase.kt
+++ b/plugins/base/src/test/kotlin/renderers/RenderingOnlyTestBase.kt
@@ -32,7 +32,6 @@ abstract class RenderingOnlyTestBase {
     val context = MockContext(
         DokkaBase().outputWriter to { _ -> files },
         DokkaBase().locationProviderFactory to ::DefaultLocationProviderFactory,
-        DokkaBase().samplesTransformer to ::DefaultSamplesTransformer,
         DokkaBase().htmlPreprocessors to { _ -> RootCreator },
         DokkaBase().externalLocationProviderFactory to { _ -> ::JavadocExternalLocationProviderFactory },
         DokkaBase().externalLocationProviderFactory to { _ -> ::DokkaExternalLocationProviderFactory },


### PR DESCRIPTION
I decided to drop the `SamplesTransformer` `ExternsionPoint` since it is yet another `PageTransformer`, but this way we can control proper plugins ordering, which is crucial for samples to be correctly interpolated,  before PageMerge.