### PR TITLE
Rebundle the compiler to make possible to add kotlinx.coroutines to dependencies

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -8,6 +8,9 @@ plugins {
 dependencies {
     api(project(":coreDependencies", configuration = "shadow"))
 
+    val coroutines_version: String by project
+    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version")
+
     val kotlin_version: String by project
     implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version")
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlin_version")

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -9,9 +9,9 @@ dependencies {
     api(project(":coreDependencies", configuration = "shadow"))
 
     val kotlin_version: String by project
-    api("org.jetbrains.kotlin:kotlin-compiler:$kotlin_version")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version")
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlin_version")
+
     implementation("com.google.code.gson:gson:2.8.5")
     implementation("org.jsoup:jsoup:1.12.1")
 

--- a/coreDependencies/build.gradle.kts
+++ b/coreDependencies/build.gradle.kts
@@ -53,7 +53,6 @@ tasks {
         exclude("inspectionDescriptions/**")
         exclude("intentionDescriptions/**")
         exclude("tips/**")
-        exclude("messages/**")
         exclude("src/**")
         exclude("**/*.kotlin_metadata")
         exclude("**/*.kotlin_builtins")

--- a/coreDependencies/build.gradle.kts
+++ b/coreDependencies/build.gradle.kts
@@ -21,12 +21,19 @@ fun intellijCoreAnalysis() = zipTree(intellijCore.singleFile).matching {
 dependencies {
     val idea_version: String by project
     intellijCore("com.jetbrains.intellij.idea:intellij-core:$idea_version")
+
     val kotlin_plugin_version: String by project
     implementation(intellijCoreAnalysis())
     implementation("org.jetbrains.kotlin:kotlin-plugin-ij193:$kotlin_plugin_version") {
         //TODO: parametrize ij version after 1.3.70
         isTransitive = false
     }
+
+    val kotlin_version: String by project
+    implementation("org.jetbrains.kotlin:kotlin-compiler:$kotlin_version") {
+        because("it contains old version of kotlinx.coroutines and possibly other libraries and needs to be repackaged")
+    }
+
     implementation("org.jetbrains:markdown:0.1.41") {
         because("it's published only on bintray")
     }
@@ -50,6 +57,7 @@ tasks {
         exclude("src/**")
         exclude("**/*.kotlin_metadata")
         exclude("**/*.kotlin_builtins")
+        exclude("kotlinx/coroutines/**")
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,7 @@ kotlin_plugin_version=1.4-M2-eap-63
 idea_version=193.6494.35
 language_version=1.4
 
+coroutines_version=1.3.7-1.4-M2
+
 # Code style
 kotlin.code.style=official

--- a/integration-tests/gradle-integration-tests/build.gradle.kts
+++ b/integration-tests/gradle-integration-tests/build.gradle.kts
@@ -1,5 +1,12 @@
-val dokkaPlugin: Configuration by configurations.creating
-val dokkaCore: Configuration by configurations.creating
+fun Configuration.setMetadata() {
+    attributes.attribute(
+        org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE,
+        project.objects.named(org.gradle.api.attributes.Usage::class.java, "java-runtime")
+    )
+}
+
+val dokkaPlugin: Configuration by configurations.creating { setMetadata() }
+val dokkaCore: Configuration by configurations.creating { setMetadata() }
 val kotlinGradle: Configuration by configurations.creating
 
 repositories {

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/main.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/main.kt
@@ -21,6 +21,10 @@ open class DokkaPlugin : Plugin<Project> {
         val dokkaRuntimeConfiguration = addConfiguration(project)
         val pluginsConfiguration = project.configurations.create("dokkaPlugins").apply {
             dependencies.add(project.dependencies.create("org.jetbrains.dokka:dokka-base:${DokkaVersion.version}"))
+            attributes.attribute(
+                org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE,
+                project.objects.named(org.gradle.api.attributes.Usage::class.java, "java-runtime")
+            )
         }
         addDokkaTasks(project, dokkaRuntimeConfiguration, pluginsConfiguration, DokkaTask::class.java)
         addDokkaCollectorTasks(project, DokkaCollectorTask::class.java)


### PR DESCRIPTION
Making one completely independent change in the codebase, I wanted to use flow api from `kotlinx.coroutines`. I was sure that we have a dependency on it defined somewhere, as we are using coroutines extensively in renderers. Then I realized that some newer functions were missing and some others which are definitely stable were marked as experimental. This suggested that we were using some older coroutines version and it needs updating. I went through all of the modules and was not able to find any place where we specify the coroutines version. After further investigation, it turned out that the old version of coroutines is bundled together with a kotlin compiler artifact, which is a transitive dependency of every Dokka plugin through the core module.

This is serious, as it means that no matter what version of `kotlinx.coroutines` is specified by plugin creator, due to how gradle sorts classpath, the old version bundled with compiler will be always preferred. As it affects all plugins, I tried to fix it asap.

After a few hours of different approaches and reading sources of gradle, I realized that it is not possible to provide any solution that would be transparent for plugin creators and would assure that the correct version is always preferred both during compilation and runtime.

I really don't like the idea of bundling such big dependency as kotlin compiler, but here it was necessary.