### PR TITLE
Show anchors icon only on hover

### DIFF
--- a/plugins/base/src/main/resources/dokka/styles/style.css
+++ b/plugins/base/src/main/resources/dokka/styles/style.css
@@ -734,8 +734,15 @@ td.content {
     color: var(--hover-link-color);
 }
 
+.main-subrow:hover .anchor-icon {
+    opacity: 1;
+    transition: 0.2s;
+}
+
 .main-subrow .anchor-icon {
     padding: 0 8px;
+    opacity: 0;
+    transition: 0.2s 0.5s;
 }
 
 .main-subrow .anchor-icon > svg path {


### PR DESCRIPTION
I think this was described in https://github.com/Kotlin/dokka/issues/998

Please use AWS to check if delays are fine for you. We can increase delay (even to the same level that is in copy icons == 1.2s), but that would result in multiple icons being rendered at the same time. Imo 0.5s is a decent point