### PR TITLE
Samples CSS fix

### DIFF
--- a/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
@@ -64,7 +64,7 @@ open class HtmlRenderer(
                 node.extra.extraHtmlAttributes().forEach { attributes[it.extraKey] = it.extraValue }
                 childrenCallback()
             }
-            node.dci.kind in setOf(ContentKind.Symbol, ContentKind.Sample) -> div("symbol $additionalClasses") {
+            node.dci.kind in setOf(ContentKind.Symbol) -> div("symbol $additionalClasses") {
                 childrenCallback()
                 if (node.hasStyle(TextStyle.Monospace)) copyButton()
             }
@@ -543,8 +543,11 @@ open class HtmlRenderer(
         code: ContentCode,
         pageContext: ContentPage
     ) {
-        code(code.style.joinToString(" ") { it.toString().toLowerCase() }) {
-            code.children.forEach { buildContentNode(it, pageContext) }
+        div("sample-container") {
+            code(code.style.joinToString(" ") { it.toString().toLowerCase() }) {
+                attributes["theme"] = "idea"
+                code.children.forEach { buildContentNode(it, pageContext) }
+            }
         }
     }
 

--- a/plugins/base/src/main/resources/dokka/styles/style.css
+++ b/plugins/base/src/main/resources/dokka/styles/style.css
@@ -212,6 +212,11 @@
     font-family: monospace;
 }
 
+.sample-container {
+    display: flex;
+    flex-direction: column;
+}
+
 code.paragraph {
     display: block;
 }


### PR DESCRIPTION
Still TODO:

-  Code is shrinked before unfolding
- On Firefox div of sample is bigger than sample-container