### PR TITLE
Only apply KasJ plugin if using Javadoc format

### DIFF
--- a/plugins/javadoc/src/main/kotlin/javadoc/JavadocPlugin.kt
+++ b/plugins/javadoc/src/main/kotlin/javadoc/JavadocPlugin.kt
@@ -7,6 +7,7 @@ import javadoc.signatures.JavadocSignatureProvider
 import org.jetbrains.dokka.CoreExtensions
 import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.kotlinAsJava.KotlinAsJavaPlugin
+import org.jetbrains.dokka.kotlinAsJava.KotlinAsJavaPlugin.Companion.JAVADOC_FORMAT
 import org.jetbrains.dokka.plugability.DokkaPlugin
 import org.jetbrains.dokka.plugability.querySingle
 
@@ -20,7 +21,7 @@ class JavadocPlugin : DokkaPlugin() {
     val dokkaJavadocPlugin by extending {
         (CoreExtensions.renderer
                 providing { ctx -> KorteJavadocRenderer(dokkaBasePlugin.querySingle { outputWriter }, ctx, "views") }
-                applyIf { format == javadocFormat }
+                applyIf { format == JAVADOC_FORMAT }
                 override dokkaBasePlugin.htmlRenderer)
     }
 
@@ -31,13 +32,13 @@ class JavadocPlugin : DokkaPlugin() {
                 dokkaBasePlugin.querySingle { signatureProvider },
                 context.logger
             )
-        } override dokkaBasePlugin.documentableToPageTranslator applyIf { format == javadocFormat }
+        } override dokkaBasePlugin.documentableToPageTranslator applyIf { format == JAVADOC_FORMAT }
     }
 
     val javadocLocationProviderFactory by extending {
         locationProviderFactory providing { context ->
             JavadocLocationProviderFactory(context)
-        } applyIf { format == javadocFormat }
+        } applyIf { format == JAVADOC_FORMAT }
     }
 
     val javadocSignatureProvider by extending {
@@ -48,11 +49,6 @@ class JavadocPlugin : DokkaPlugin() {
                     dokkaBasePlugin.commentsToContentConverter
                 ), ctx.logger
             )
-        } override kotinAsJavaPlugin.javaSignatureProvider applyIf { format == javadocFormat }
-    }
-
-    companion object {
-        private val javadocFormat = "javadoc"
+        } override kotinAsJavaPlugin.javaSignatureProvider applyIf { format == JAVADOC_FORMAT }
     }
 }
-

--- a/plugins/javadoc/src/main/kotlin/javadoc/JavadocPlugin.kt
+++ b/plugins/javadoc/src/main/kotlin/javadoc/JavadocPlugin.kt
@@ -22,7 +22,7 @@ class JavadocPlugin : DokkaPlugin() {
         (CoreExtensions.renderer
                 providing { ctx -> KorteJavadocRenderer(dokkaBasePlugin.querySingle { outputWriter }, ctx, "views") }
                 applyIf { format == JAVADOC_FORMAT }
-                override dokkaBasePlugin.htmlRenderer)
+                override kotinAsJavaPlugin.htmlRenderer)
     }
 
     val pageTranslator by extending {

--- a/plugins/kotlin-as-java/src/main/kotlin/KotlinAsJavaPlugin.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/KotlinAsJavaPlugin.kt
@@ -2,11 +2,15 @@ package org.jetbrains.dokka.kotlinAsJava
 
 import org.jetbrains.dokka.CoreExtensions
 import org.jetbrains.dokka.base.DokkaBase
+import org.jetbrains.dokka.base.renderers.html.HtmlRenderer
 import org.jetbrains.dokka.kotlinAsJava.signatures.JavaSignatureProvider
 import org.jetbrains.dokka.kotlinAsJava.transformers.KotlinAsJavaDocumentableTransformer
 import org.jetbrains.dokka.plugability.DokkaPlugin
 
 class KotlinAsJavaPlugin : DokkaPlugin() {
+    val htmlRenderer by extending {
+        CoreExtensions.renderer providing ::HtmlRenderer applyIf { format == JAVADOC_FORMAT }
+    }
     val kotlinAsJavaDocumentableToPageTranslator by extending {
         (CoreExtensions.documentableTransformer
                 with KotlinAsJavaDocumentableTransformer()

--- a/plugins/kotlin-as-java/src/main/kotlin/KotlinAsJavaPlugin.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/KotlinAsJavaPlugin.kt
@@ -8,12 +8,18 @@ import org.jetbrains.dokka.plugability.DokkaPlugin
 
 class KotlinAsJavaPlugin : DokkaPlugin() {
     val kotlinAsJavaDocumentableToPageTranslator by extending {
-        CoreExtensions.documentableTransformer with KotlinAsJavaDocumentableTransformer()
+        (CoreExtensions.documentableTransformer
+                with KotlinAsJavaDocumentableTransformer()
+                applyIf { format == JAVADOC_FORMAT })
     }
     val javaSignatureProvider by extending {
         val dokkaBasePlugin = plugin<DokkaBase>()
         dokkaBasePlugin.signatureProvider providing { ctx ->
             JavaSignatureProvider(ctx.single(dokkaBasePlugin.commentsToContentConverter), ctx.logger)
-        } override dokkaBasePlugin.kotlinSignatureProvider
+        } override dokkaBasePlugin.kotlinSignatureProvider applyIf { format == JAVADOC_FORMAT }
+    }
+
+    companion object {
+        const val JAVADOC_FORMAT = "javadoc"
     }
 }

--- a/plugins/kotlin-as-java/src/test/kotlin/KotlinAsJavaPluginTest.kt
+++ b/plugins/kotlin-as-java/src/test/kotlin/KotlinAsJavaPluginTest.kt
@@ -10,6 +10,7 @@ class KotlinAsJavaPluginTest : AbstractCoreTest() {
     @Test
     fun topLevelTest() {
         val configuration = dokkaConfiguration {
+            format = "javadoc"
             sourceSets {
                 sourceSet {
                     sourceRoots = listOf("src/")
@@ -48,6 +49,7 @@ class KotlinAsJavaPluginTest : AbstractCoreTest() {
     @Test
     fun topLevelWithClassTest() {
         val configuration = dokkaConfiguration {
+            format = "javadoc"
             sourceSets {
                 sourceSet {
                     sourceRoots = listOf("src/")
@@ -89,6 +91,7 @@ class KotlinAsJavaPluginTest : AbstractCoreTest() {
     @Test
     fun kotlinAndJavaTest() {
         val configuration = dokkaConfiguration {
+            format = "javadoc"
             sourceSets {
                 sourceSet {
                     sourceRoots = listOf("src/")


### PR DESCRIPTION
Currently, you can't generate Javadoc and Kdoc from the same JAR. Since the Javadoc plugin applies the KasJ plugin, Kdoc will end up having snippets with Java code instead of Kotlin.