### PR TITLE
Improve JSON parsing for CLI

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -3,12 +3,14 @@ import org.jetbrains.configureBintrayPublication
 plugins {
     `maven-publish`
     id("com.jfrog.bintray")
+    kotlin("plugin.serialization")
 }
 
 dependencies {
     api(project("dependencies", configuration = "shadow"))
 
     implementation(kotlin("reflect"))
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.20.0-1.4-M3")
     implementation("com.google.code.gson:gson:2.8.5")
     implementation("org.jsoup:jsoup:1.12.1")
 

--- a/core/src/main/kotlin/configuration.kt
+++ b/core/src/main/kotlin/configuration.kt
@@ -5,6 +5,7 @@ package org.jetbrains.dokka
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UnstableDefault
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonConfiguration
 import java.io.File
 import java.net.URL
 
@@ -26,7 +27,7 @@ object DokkaDefaults {
     val analysisPlatform: Platform = Platform.DEFAULT
     const val suppress: Boolean = false
 
-    const val displayName = "JVM"
+    const val sourceSetDisplayName = "JVM"
     const val sourceSetName = "main"
 }
 
@@ -62,8 +63,9 @@ data class DokkaSourceSetID(
 }
 
 @OptIn(UnstableDefault::class)
-fun DokkaConfigurationImpl(json: String): DokkaConfigurationImpl {
-    return Json.parse(DokkaConfigurationImpl.serializer(), json)
+fun DokkaConfigurationImpl(input: String): DokkaConfigurationImpl {
+    val json = Json(JsonConfiguration.Default.copy(ignoreUnknownKeys = true))
+    return json.parse(DokkaConfigurationImpl.serializer(), input)
 }
 
 interface DokkaConfiguration {

--- a/core/src/main/kotlin/configuration.kt
+++ b/core/src/main/kotlin/configuration.kt
@@ -2,9 +2,10 @@
 
 package org.jetbrains.dokka
 
-import com.google.gson.Gson
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UnstableDefault
+import kotlinx.serialization.json.Json
 import java.io.File
-import java.io.Serializable
 import java.net.URL
 
 object DokkaDefaults {
@@ -24,6 +25,9 @@ object DokkaDefaults {
     const val noJdkLink: Boolean = false
     val analysisPlatform: Platform = Platform.DEFAULT
     const val suppress: Boolean = false
+
+    const val displayName = "JVM"
+    const val sourceSetName = "main"
 }
 
 enum class Platform(val key: String) {
@@ -47,21 +51,19 @@ enum class Platform(val key: String) {
     }
 }
 
+@Serializable
 data class DokkaSourceSetID(
     val moduleName: String,
     val sourceSetName: String
-) : Serializable {
+) {
     override fun toString(): String {
         return "$moduleName/$sourceSetName"
     }
 }
 
+@OptIn(UnstableDefault::class)
 fun DokkaConfigurationImpl(json: String): DokkaConfigurationImpl {
-    return Gson().fromJson(json, DokkaConfigurationImpl::class.java)
-}
-
-fun DokkaConfiguration.toJson(): String {
-    return Gson().toJson(this)
+    return Json.parse(DokkaConfigurationImpl.serializer(), json)
 }
 
 interface DokkaConfiguration {

--- a/core/src/main/kotlin/defaultConfiguration.kt
+++ b/core/src/main/kotlin/defaultConfiguration.kt
@@ -1,57 +1,62 @@
 package org.jetbrains.dokka
 
+import kotlinx.serialization.*
 import org.jetbrains.dokka.DokkaConfiguration.DokkaSourceSet
 import java.io.File
 import java.net.URL
-import java.io.Serializable
 
+@Serializable
 data class DokkaConfigurationImpl(
-    override val outputDir: String,
-    override val cacheRoot: String?,
-    override val offlineMode: Boolean,
-    override val sourceSets: List<DokkaSourceSetImpl>,
-    override val pluginsClasspath: List<File>,
-    override val pluginsConfiguration: Map<String, String>,
-    override val modules: List<DokkaModuleDescriptionImpl>,
-    override val failOnWarning: Boolean
+    override val outputDir: String = DokkaDefaults.outputDir,
+    override val cacheRoot: String? = DokkaDefaults.cacheRoot,
+    override val offlineMode: Boolean = DokkaDefaults.offlineMode,
+    override val sourceSets: List<DokkaSourceSetImpl> = emptyList(),
+    override val pluginsClasspath: List<@Serializable(with = FileSerializer::class) File> = emptyList(),
+    override val pluginsConfiguration: Map<String, String> = emptyMap(),
+    override val modules: List<DokkaModuleDescriptionImpl> = emptyList(),
+    override val failOnWarning: Boolean = DokkaDefaults.failOnWarning
 ) : DokkaConfiguration
 
+@Serializable
 data class DokkaSourceSetImpl(
     override val moduleDisplayName: String,
-    override val displayName: String,
+    override val displayName: String = DokkaDefaults.displayName,
     override val sourceSetID: DokkaSourceSetID,
-    override val classpath: List<String>,
+    override val classpath: List<String> = emptyList(),
     override val sourceRoots: List<SourceRootImpl>,
-    override val dependentSourceSets: Set<DokkaSourceSetID>,
-    override val samples: List<String>,
-    override val includes: List<String>,
-    override val includeNonPublic: Boolean,
-    override val includeRootPackage: Boolean,
-    override val reportUndocumented: Boolean,
-    override val skipEmptyPackages: Boolean,
-    override val skipDeprecated: Boolean,
-    override val jdkVersion: Int,
-    override val sourceLinks: List<SourceLinkDefinitionImpl>,
-    override val perPackageOptions: List<PackageOptionsImpl>,
-    override var externalDocumentationLinks: List<ExternalDocumentationLinkImpl>,
-    override val languageVersion: String?,
-    override val apiVersion: String?,
-    override val noStdlibLink: Boolean,
-    override val noJdkLink: Boolean,
-    override val suppressedFiles: List<String>,
-    override val analysisPlatform: Platform
+    override val dependentSourceSets: Set<DokkaSourceSetID> = emptySet(),
+    override val samples: List<String> = emptyList(),
+    override val includes: List<String> = emptyList(),
+    override val includeNonPublic: Boolean = DokkaDefaults.includeNonPublic,
+    override val includeRootPackage: Boolean = DokkaDefaults.includeRootPackage,
+    override val reportUndocumented: Boolean = DokkaDefaults.reportUndocumented,
+    override val skipEmptyPackages: Boolean = DokkaDefaults.skipEmptyPackages,
+    override val skipDeprecated: Boolean = DokkaDefaults.skipDeprecated,
+    override val jdkVersion: Int = DokkaDefaults.jdkVersion,
+    override val sourceLinks: List<SourceLinkDefinitionImpl> = emptyList(),
+    override val perPackageOptions: List<PackageOptionsImpl> = emptyList(),
+    override var externalDocumentationLinks: List<ExternalDocumentationLinkImpl> = emptyList(),
+    override val languageVersion: String? = null,
+    override val apiVersion: String? = null,
+    override val noStdlibLink: Boolean = DokkaDefaults.noStdlibLink,
+    override val noJdkLink: Boolean = DokkaDefaults.noJdkLink,
+    override val suppressedFiles: List<String> = emptyList(),
+    override val analysisPlatform: Platform = DokkaDefaults.analysisPlatform
 ) : DokkaSourceSet
 
+@Serializable
 data class DokkaModuleDescriptionImpl(
     override val name: String,
     override val path: String,
     override val docFile: String
 ) : DokkaConfiguration.DokkaModuleDescription
 
+@Serializable
 data class SourceRootImpl(
     override val path: String
 ) : DokkaConfiguration.SourceRoot
 
+@Serializable
 data class SourceLinkDefinitionImpl(
     override val path: String,
     override val url: String,
@@ -68,6 +73,7 @@ data class SourceLinkDefinitionImpl(
     }
 }
 
+@Serializable
 data class PackageOptionsImpl(
     override val prefix: String,
     override val includeNonPublic: Boolean,
@@ -76,8 +82,28 @@ data class PackageOptionsImpl(
     override val suppress: Boolean
 ) : DokkaConfiguration.PackageOptions
 
-
+@Serializable
 data class ExternalDocumentationLinkImpl(
-    override val url: URL,
-    override val packageListUrl: URL
-) : DokkaConfiguration.ExternalDocumentationLink, Serializable
+    @Serializable(with = URLSerializer::class) override val url: URL,
+    @Serializable(with = URLSerializer::class) override val packageListUrl: URL
+) : DokkaConfiguration.ExternalDocumentationLink
+
+private object FileSerializer : KSerializer<File> {
+    override val descriptor: SerialDescriptor = PrimitiveDescriptor("File", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: File) {
+        encoder.encodeString(value.path)
+    }
+
+    override fun deserialize(decoder: Decoder): File = File(decoder.decodeString())
+}
+
+private object URLSerializer : KSerializer<URL> {
+    override val descriptor: SerialDescriptor = PrimitiveDescriptor("URL", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: URL) {
+        encoder.encodeString(value.toString())
+    }
+
+    override fun deserialize(decoder: Decoder): URL = URL(decoder.decodeString())
+}

--- a/core/src/main/kotlin/defaultConfiguration.kt
+++ b/core/src/main/kotlin/defaultConfiguration.kt
@@ -20,7 +20,7 @@ data class DokkaConfigurationImpl(
 @Serializable
 data class DokkaSourceSetImpl(
     override val moduleDisplayName: String,
-    override val displayName: String = DokkaDefaults.displayName,
+    override val displayName: String = DokkaDefaults.sourceSetDisplayName,
     override val sourceSetID: DokkaSourceSetID,
     override val classpath: List<String> = emptyList(),
     override val sourceRoots: List<SourceRootImpl>,

--- a/runners/cli/src/main/kotlin/cli/main.kt
+++ b/runners/cli/src/main/kotlin/cli/main.kt
@@ -129,7 +129,7 @@ private fun parseSourceSet(args: Array<String>): DokkaConfiguration.DokkaSourceS
     val sourceSetDisplayName by parser.option(
         ArgType.String,
         description = "Displayed name of the source set"
-    ).default("JVM")
+    ).default(DokkaDefaults.displayName)
 
     val classpath by parser.option(
         ArgType.String,

--- a/runners/cli/src/main/kotlin/cli/main.kt
+++ b/runners/cli/src/main/kotlin/cli/main.kt
@@ -129,7 +129,7 @@ private fun parseSourceSet(args: Array<String>): DokkaConfiguration.DokkaSourceS
     val sourceSetDisplayName by parser.option(
         ArgType.String,
         description = "Displayed name of the source set"
-    ).default(DokkaDefaults.displayName)
+    ).default(DokkaDefaults.sourceSetDisplayName)
 
     val classpath by parser.option(
         ArgType.String,

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,6 +27,7 @@ pluginManagement {
     val kotlin_version: String by settings
     plugins {
         id("org.jetbrains.kotlin.jvm") version kotlin_version
+        id("org.jetbrains.kotlin.plugin.serialization") version kotlin_version
         id("com.github.johnrengelman.shadow") version "5.2.0"
         id("com.jfrog.bintray") version "1.8.5"
         id("com.gradle.plugin-publish") version "0.12.0"


### PR DESCRIPTION
Currently one has to provide *every* field when using the JSON CLI option. This CL use the kotlinx/serialization library to provide defaults and improve parsing.