### PR TITLE
Minor style fixes for gfm signatures

### DIFF
--- a/plugins/base/src/main/kotlin/renderers/DefaultRenderer.kt
+++ b/plugins/base/src/main/kotlin/renderers/DefaultRenderer.kt
@@ -175,7 +175,7 @@ abstract class DefaultRenderer<T>(
         pageContext: ContentPage,
         beforeTransformer: (ContentDivergentInstance, ContentPage, DokkaSourceSet) -> String,
         afterTransformer: (ContentDivergentInstance, ContentPage, DokkaSourceSet) -> String
-    ): Map<SerializedInstanceWithSource, List<InstanceWithSource>> =
+    ): Map<SerializedBeforeAndAfter, List<InstanceWithSource>> =
         children.flatMap { instance ->
             instance.sourceSets.map { sourceSet ->
                 Pair(instance, sourceSet) to Pair(
@@ -184,12 +184,12 @@ abstract class DefaultRenderer<T>(
                 )
             }
         }.groupBy(
-            Pair<Pair<ContentDivergentInstance, DokkaSourceSet>, Pair<String, String>>::second,
-            Pair<Pair<ContentDivergentInstance, DokkaSourceSet>, Pair<String, String>>::first
+            Pair<InstanceWithSource, SerializedBeforeAndAfter>::second,
+            Pair<InstanceWithSource, SerializedBeforeAndAfter>::first
         )
 }
 
-internal typealias SerializedInstanceWithSource = Pair<String, String>
+internal typealias SerializedBeforeAndAfter = Pair<String, String>
 internal typealias InstanceWithSource = Pair<ContentDivergentInstance, DokkaSourceSet>
 
 fun ContentPage.sourceSets() = this.content.sourceSets

--- a/plugins/gfm/src/main/kotlin/GfmPlugin.kt
+++ b/plugins/gfm/src/main/kotlin/GfmPlugin.kt
@@ -145,11 +145,9 @@ open class CommonmarkRenderer(
             }.groupBy(Pair<DokkaSourceSet, String>::second, Pair<DokkaSourceSet, String>::first)
 
             distinct.filter { it.key.isNotBlank() }.forEach { (text, platforms) ->
-                append(
-                    platforms.joinToString(
-                        prefix = " [",
-                        postfix = "] $text "
-                    ) { it.displayName })
+                append(" ")
+                buildSourceSetTags(platforms.toSet())
+                append(" $text ")
                 buildNewLine()
             }
         }
@@ -255,7 +253,7 @@ open class CommonmarkRenderer(
         distinct.values.forEach { entry ->
             val (instance, sourceSets) = entry.getInstanceAndSourceSets()
 
-            append(sourceSets.joinToString(prefix = "[", postfix = "]") { it.displayName })
+            buildSourceSetTags(sourceSets)
             buildNewLine()
             instance.before?.let {
                 append("Brief description")
@@ -270,7 +268,7 @@ open class CommonmarkRenderer(
                 .values.forEach { innerEntry ->
                     val (innerInstance, innerSourceSets) = innerEntry.getInstanceAndSourceSets()
                     if(sourceSets.size > 1) {
-                        append(innerSourceSets.joinToString(prefix = "[", postfix = "]") { it.displayName })
+                        buildSourceSetTags(innerSourceSets)
                         buildNewLine()
                     }
                     innerInstance.divergent.build(this@buildDivergent, pageContext, setOf(innerSourceSets.first())) // It's workaround to render content only once
@@ -327,6 +325,9 @@ open class CommonmarkRenderer(
     private fun String.withEntersAsHtml(): String = replace("\n", "<br>")
 
     private fun List<Pair<ContentDivergentInstance, DokkaSourceSet>>.getInstanceAndSourceSets() = this.let { Pair(it.first().first, it.map { it.second }.toSet()) }
+
+    private fun StringBuilder.buildSourceSetTags(sourceSets: Set<DokkaSourceSet>) =
+        append(sourceSets.joinToString(prefix = "[", postfix = "]") { it.displayName })
 }
 
 class MarkdownLocationProviderFactory(val context: DokkaContext) : LocationProviderFactory {

--- a/plugins/gfm/src/test/kotlin/renderers/gfm/DivergentTest.kt
+++ b/plugins/gfm/src/test/kotlin/renderers/gfm/DivergentTest.kt
@@ -44,7 +44,7 @@ class DivergentTest : GfmRenderingOnlyTestBase() {
                 }
             }
         }
-        val expect = "//[testPage](test-page.md)\n\n#### [root/js]  \n##### Content  \na  \n"
+        val expect = "//[testPage](test-page.md)\n\n[js]  \nContent  \na  \n\n\n"
         CommonmarkRenderer(context).render(page)
         assert(renderedContent == expect)
     }
@@ -60,7 +60,7 @@ class DivergentTest : GfmRenderingOnlyTestBase() {
                 }
             }
         }
-        val expect = "//[testPage](test-page.md)\n\n#### [root/js]  \n##### Content  \na  \n"
+        val expect = "//[testPage](test-page.md)\n\n[js]  \nContent  \na  \n\n\n"
         CommonmarkRenderer(context).render(page)
         assert(renderedContent == expect)
     }
@@ -86,7 +86,7 @@ class DivergentTest : GfmRenderingOnlyTestBase() {
                 }
             }
         }
-        val expect = "//[testPage](test-page.md)\n\n#### [root/js, root/jvm, root/native]  \n##### Content  \n###### [root/js]  \na  \n###### [root/jvm]  \nb  \n###### [root/native]  \nc  \n"
+        val expect = "//[testPage](test-page.md)\n\n[js, jvm, native]  \nContent  \n[js]  \na  \n[jvm]  \nb  \n[native]  \nc  \n\n\n"
         CommonmarkRenderer(context).render(page)
         assert(renderedContent == expect)
     }
@@ -112,7 +112,7 @@ class DivergentTest : GfmRenderingOnlyTestBase() {
                 }
             }
         }
-        val expect = "//[testPage](test-page.md)\n\n#### [root/js]  \n##### Content  \na  \nb  \nc  \n"
+        val expect = "//[testPage](test-page.md)\n\n[js]  \nContent  \na  \nb  \nc  \n\n\n"
         CommonmarkRenderer(context).render(page)
         assert(renderedContent == expect)
     }
@@ -148,7 +148,7 @@ class DivergentTest : GfmRenderingOnlyTestBase() {
                 }
             }
         }
-        val expect = "//[testPage](test-page.md)\n\n#### [root/native, root/js, root/jvm]  \n##### Content  \n###### [root/native]  \na  \n###### [root/js]  \nb  \n###### [root/jvm]  \nc  \n###### [root/js]  \nd  \n###### [root/native]  \ne  \n"
+        val expect = "//[testPage](test-page.md)\n\n[native, js, jvm]  \nContent  \n[native]  \na  \n[js]  \nb  \n[jvm]  \nc  \n[js]  \nd  \n[native]  \ne  \n\n\n"
         CommonmarkRenderer(context).render(page)
         assert(renderedContent == expect)
     }
@@ -196,7 +196,7 @@ class DivergentTest : GfmRenderingOnlyTestBase() {
                 }
             }
         }
-        val expect = "//[testPage](test-page.md)\n\n#### [root/native]  \n##### Content  \na  \n##### More info  \na+  \n#### [root/js]  \n##### Content  \nb  \nd  \n##### More info  \nbd+  \n#### [root/jvm]  \n##### Content  \nc  \n#### [root/native]  \n##### Content  \ne  \n##### More info  \ne+  \n"
+        val expect = "//[testPage](test-page.md)\n\n[native]  \nContent  \na  \nMore info  \na+  \n\n\n[js]  \nContent  \nb  \nd  \nMore info  \nbd+  \n\n\n[jvm]  \nContent  \nc  \n\n\n[native]  \nContent  \ne  \nMore info  \ne+  \n\n\n"
         CommonmarkRenderer(context).render(page)
         assert(renderedContent == expect)
     }
@@ -223,7 +223,7 @@ class DivergentTest : GfmRenderingOnlyTestBase() {
                 }
             }
         }
-        val expect = "//[testPage](test-page.md)\n\n#### [root/native]  \n##### Brief description  \nab-  \n##### Content  \na  \nb  \n"
+        val expect = "//[testPage](test-page.md)\n\n[native]  \nBrief description  \nab-  \nContent  \na  \nb  \n\n\n"
         CommonmarkRenderer(context).render(page)
         assert(renderedContent == expect)
     }
@@ -250,7 +250,7 @@ class DivergentTest : GfmRenderingOnlyTestBase() {
                 }
             }
         }
-        val expect = "//[testPage](test-page.md)\n\n#### [root/native]  \n##### Content  \na  \nb  \n##### More info  \nab+  \n"
+        val expect = "//[testPage](test-page.md)\n\n[native]  \nContent  \na  \nb  \nMore info  \nab+  \n\n\n"
         CommonmarkRenderer(context).render(page)
         assert(renderedContent == expect)
     }
@@ -283,7 +283,7 @@ class DivergentTest : GfmRenderingOnlyTestBase() {
                 }
             }
         }
-        val expect = "//[testPage](test-page.md)\n\n#### [root/native]  \n##### Brief description  \nab-  \n##### Content  \na  \nb  \n##### More info  \nab+  \n"
+        val expect = "//[testPage](test-page.md)\n\n[native]  \nBrief description  \nab-  \nContent  \na  \nb  \nMore info  \nab+  \n\n\n"
         CommonmarkRenderer(context).render(page)
         assert(renderedContent == expect)
     }
@@ -316,7 +316,7 @@ class DivergentTest : GfmRenderingOnlyTestBase() {
                 }
             }
         }
-        val expect = "//[testPage](test-page.md)\n\n#### [root/native]  \n##### Brief description  \na-  \n##### Content  \na  \n##### More info  \nab+  \n#### [root/native]  \n##### Brief description  \nb-  \n##### Content  \nb  \n##### More info  \nab+  \n"
+        val expect = "//[testPage](test-page.md)\n\n[native]  \nBrief description  \na-  \nContent  \na  \nMore info  \nab+  \n\n\n[native]  \nBrief description  \nb-  \nContent  \nb  \nMore info  \nab+  \n\n\n"
         CommonmarkRenderer(context).render(page)
         assert(renderedContent == expect)
     }
@@ -367,7 +367,7 @@ class DivergentTest : GfmRenderingOnlyTestBase() {
                 }
             }
         }
-        val expect = "//[testPage](test-page.md)\n\n#### [root/native]  \n##### Content  \na  \n##### More info  \na+  \n#### [root/js, root/jvm]  \n##### Content  \n###### [root/js]  \nb  \n###### [root/jvm]  \nc  \n###### [root/js]  \nd  \n##### More info  \nbd+  \n#### [root/native]  \n##### Content  \ne  \n##### More info  \ne+  \n"
+        val expect = "//[testPage](test-page.md)\n\n[native]  \nContent  \na  \nMore info  \na+  \n\n\n[js, jvm]  \nContent  \n[js]  \nb  \n[jvm]  \nc  \n[js]  \nd  \nMore info  \nbd+  \n\n\n[native]  \nContent  \ne  \nMore info  \ne+  \n\n\n"
         CommonmarkRenderer(context).render(page)
         assert(renderedContent == expect)
     }

--- a/plugins/gfm/src/test/kotlin/renderers/gfm/SourceSetDependentHintTest.kt
+++ b/plugins/gfm/src/test/kotlin/renderers/gfm/SourceSetDependentHintTest.kt
@@ -44,7 +44,7 @@ class SourceSetDependentHintTest : GfmRenderingOnlyTestBase() {
         }
 
         CommonmarkRenderer(context).render(page)
-        assert(renderedContent == "//[testPage](test-page.md)\n\n [root/pl1, root/pl2, root/pl3] abc  \n   \n")
+        assert(renderedContent == "//[testPage](test-page.md)\n\n [pl1, pl2, pl3] abc  \n   \n")
     }
 
     @Test
@@ -58,7 +58,7 @@ class SourceSetDependentHintTest : GfmRenderingOnlyTestBase() {
         }
 
         CommonmarkRenderer(context).render(page)
-        assert(renderedContent == "//[testPage](test-page.md)\n\n [root/pl1] a  \n   \n [root/pl2] b  \n   \n [root/pl3] c  \n   \n")
+        assert(renderedContent == "//[testPage](test-page.md)\n\n [pl1] a  \n   \n [pl2] b  \n   \n [pl3] c  \n   \n")
     }
 
     @Test
@@ -72,7 +72,7 @@ class SourceSetDependentHintTest : GfmRenderingOnlyTestBase() {
         }
 
         CommonmarkRenderer(context).render(page)
-        assert(renderedContent == "//[testPage](test-page.md)\n\n [root/pl1] ab  \n   \n [root/pl2] bc  \n   \n")
+        assert(renderedContent == "//[testPage](test-page.md)\n\n [pl1] ab  \n   \n [pl2] bc  \n   \n")
     }
 
     @Test
@@ -86,7 +86,7 @@ class SourceSetDependentHintTest : GfmRenderingOnlyTestBase() {
         }
 
         CommonmarkRenderer(context).render(page)
-        assert(renderedContent == "//[testPage](test-page.md)\n\n [root/pl1, root/pl2] ab  \n   \n")
+        assert(renderedContent == "//[testPage](test-page.md)\n\n [pl1, pl2] ab  \n   \n")
     }
 
     @Test
@@ -102,7 +102,7 @@ class SourceSetDependentHintTest : GfmRenderingOnlyTestBase() {
         }
 
         CommonmarkRenderer(context).render(page)
-        assert(renderedContent == "//[testPage](test-page.md)\n\n [root/pl1] ab  \n  \n   \n [root/pl2] a  \nb  \n   \n")
+        assert(renderedContent == "//[testPage](test-page.md)\n\n [pl1] ab  \n  \n   \n [pl2] a  \nb  \n   \n")
     }
 
     @Test
@@ -118,7 +118,7 @@ class SourceSetDependentHintTest : GfmRenderingOnlyTestBase() {
         }
 
         CommonmarkRenderer(context).render(page)
-        assert(renderedContent == "//[testPage](test-page.md)\n\n [root/pl1, root/pl2] ab   \n")
+        assert(renderedContent == "//[testPage](test-page.md)\n\n [pl1, pl2] ab   \n")
     }
 
     @Test
@@ -132,6 +132,6 @@ class SourceSetDependentHintTest : GfmRenderingOnlyTestBase() {
         }
 
         CommonmarkRenderer(context).render(page)
-        assert(renderedContent == "//[testPage](test-page.md)\n\n [root/pl1, root/pl2] a  \n   \n [root/pl3] b  \n   \n")
+        assert(renderedContent == "//[testPage](test-page.md)\n\n [pl1, pl2] a  \n   \n [pl3] b  \n   \n")
     }
 }


### PR DESCRIPTION
What have been fixed:
- headers inside tables are now omitted
- styles are now properly rendered
- signatures in divergent now render only once
- some minor fixes