### PR TITLE
Remove unnecessary grouping in Java Signature Provider that caused si…

### DIFF
--- a/plugins/kotlin-as-java/src/main/kotlin/signatures/JavaSignatureProvider.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/signatures/JavaSignatureProvider.kt
@@ -121,22 +121,19 @@ class JavaSignatureProvider(ctcc: CommentsToContentConverter, logger: DokkaLogge
                 val returnType = f.type
                 signatureForProjection(returnType)
                 text(nbsp.toString())
-                group {
-                    link(f.name, f.dri)
-                    list(f.generics, prefix = "<", suffix = ">") {
-                        +buildSignature(it)
-                    }
-                    text("(")
-                    list(f.parameters) {
-                        annotationsInline(it)
-                        text(it.modifiers()[it]?.toSignatureString() ?: "")
-                        signatureForProjection(it.type)
-                        text(nbsp.toString())
-                        link(it.name!!, it.dri)
-                    }
-                    text(")")
+                link(f.name, f.dri)
+                list(f.generics, prefix = "<", suffix = ">") {
+                    +buildSignature(it)
                 }
-
+                text("(")
+                list(f.parameters) {
+                    annotationsInline(it)
+                    text(it.modifiers()[it]?.toSignatureString() ?: "")
+                    signatureForProjection(it.type)
+                    text(nbsp.toString())
+                    link(it.name!!, it.dri)
+                }
+                text(")")
             }
         }
 

--- a/plugins/kotlin-as-java/src/test/kotlin/KotlinAsJavaPluginTest.kt
+++ b/plugins/kotlin-as-java/src/test/kotlin/KotlinAsJavaPluginTest.kt
@@ -172,12 +172,10 @@ class KotlinAsJavaPluginTest : AbstractCoreTest() {
                                             +" String"
                                         }
                                     }
-                                    group {
-                                        link {
-                                            +"getPublicProperty"
-                                        }
-                                        +"()"
+                                    link {
+                                        +"getPublicProperty"
                                     }
+                                    +"()"
                                 }
                             }
                         }


### PR DESCRIPTION
…gnature to be in 2 lines

I guess that was a leftover from the previous attempt at using java signature provider for javadoc