### PR TITLE
Fix javadoc rendering

### DIFF
--- a/integration-tests/maven/src/integrationTest/kotlin/org/jetbrains/dokka/it/maven/MavenIntegrationTest.kt
+++ b/integration-tests/maven/src/integrationTest/kotlin/org/jetbrains/dokka/it/maven/MavenIntegrationTest.kt
@@ -2,6 +2,7 @@ package org.jetbrains.dokka.it.maven
 
 import org.jetbrains.dokka.it.AbstractIntegrationTest
 import org.jetbrains.dokka.it.awaitProcessResult
+import org.jetbrains.dokka.it.ProcessResult
 import java.io.File
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -26,10 +27,84 @@ class MavenIntegrationTest : AbstractIntegrationTest() {
     }
 
     @Test
-    fun run() {
+    fun `dokka dokka`() {
         val result = ProcessBuilder().directory(projectDir)
             .command(mavenBinaryFile.absolutePath, "dokka:dokka", "-U", "-e").start().awaitProcessResult()
 
+        diagnosticAsserts(result)
+
+        val dokkaOutputDir = File(projectDir, "output")
+        assertTrue(dokkaOutputDir.isDirectory, "Missing dokka output directory")
+
+        val imagesDir = File(dokkaOutputDir, "images")
+        assertTrue(imagesDir.isDirectory, "Missing images directory")
+
+        val scriptsDir = File(dokkaOutputDir, "scripts")
+        assertTrue(scriptsDir.isDirectory, "Missing scripts directory")
+
+        val stylesDir = File(dokkaOutputDir, "styles")
+        assertTrue(stylesDir.isDirectory, "Missing styles directory")
+
+        val navigationHtml = File(dokkaOutputDir, "navigation.html")
+        assertTrue(navigationHtml.isFile, "Missing navigation.html")
+
+        projectDir.allHtmlFiles().forEach { file ->
+            assertContainsNoErrorClass(file)
+            assertNoUnresolvedLInks(file)
+        }
+    }
+
+    @Test
+    fun `dokka javadoc`() {
+        val result = ProcessBuilder().directory(projectDir)
+            .command(mavenBinaryFile.absolutePath, "dokka:javadoc", "-U", "-e").start().awaitProcessResult()
+
+        diagnosticAsserts(result)
+
+        val dokkaOutputDir = File(projectDir, "output")
+        assertTrue(dokkaOutputDir.isDirectory, "Missing dokka output directory")
+
+        val scriptsDir = File(dokkaOutputDir, "jquery")
+        assertTrue(scriptsDir.isDirectory, "Missing jquery directory")
+
+        val stylesDir = File(dokkaOutputDir, "resources")
+        assertTrue(stylesDir.isDirectory, "Missing resources directory")
+
+        projectDir.allHtmlFiles().forEach { file ->
+            assertContainsNoErrorClass(file)
+            assertNoUnresolvedLInks(file)
+        }
+    }
+
+    @Test
+    fun `dokka javadocJar`() {
+        val result = ProcessBuilder().directory(projectDir)
+            .command(mavenBinaryFile.absolutePath, "dokka:javadocJar", "-U", "-e").start().awaitProcessResult()
+
+        diagnosticAsserts(result)
+
+        val dokkaOutputDir = File(projectDir, "output")
+        assertTrue(dokkaOutputDir.isDirectory, "Missing dokka output directory")
+
+        val scriptsDir = File(dokkaOutputDir, "jquery")
+        assertTrue(scriptsDir.isDirectory, "Missing jquery directory")
+
+        val stylesDir = File(dokkaOutputDir, "resources")
+        assertTrue(stylesDir.isDirectory, "Missing resources directory")
+
+        val dokkaTargetDir = File(projectDir, "target")
+        assertTrue(dokkaOutputDir.isDirectory, "Missing dokka target directory")
+
+        val jarFile = File(dokkaTargetDir, "it-maven-1.0-SNAPSHOT-javadoc.jar")
+        assertTrue(jarFile.isFile, "Missing dokka jar file")
+
+        projectDir.allHtmlFiles().forEach { file ->
+            assertContainsNoErrorClass(file)
+            assertNoUnresolvedLInks(file)
+        }
+    }
+
+    private fun diagnosticAsserts(result: ProcessResult) {
         assertEquals(0, result.exitCode, "Expected exitCode 0 (Success)")
 
         val extensionLoadedRegex = Regex("""Extension: org\.jetbrains\.dokka\.base\.DokkaBase""")
@@ -53,26 +128,5 @@ class MavenIntegrationTest : AbstractIntegrationTest() {
             amountOfUndocumentedJavaReports > 0,
             "Expected at least one report of undocumented java code (found $amountOfUndocumentedJavaReports)"
         )
-
-        val dokkaOutputDir = File(projectDir, "output")
-        assertTrue(dokkaOutputDir.isDirectory, "Missing dokka output directory")
-
-        val imagesDir = File(dokkaOutputDir, "images")
-        assertTrue(imagesDir.isDirectory, "Missing images directory")
-
-        val scriptsDir = File(dokkaOutputDir, "scripts")
-        assertTrue(scriptsDir.isDirectory, "Missing scripts directory")
-
-        val stylesDir = File(dokkaOutputDir, "styles")
-        assertTrue(stylesDir.isDirectory, "Missing styles directory")
-
-        val navigationHtml = File(dokkaOutputDir, "navigation.html")
-        assertTrue(navigationHtml.isFile, "Missing navigation.html")
-
-        projectDir.allHtmlFiles().forEach { file ->
-            assertContainsNoErrorClass(file)
-            assertNoUnresolvedLInks(file)
-        }
-
     }
 }

--- a/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
+++ b/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
@@ -166,7 +166,7 @@ abstract class AbstractDokkaMojo : AbstractMojo() {
     var failOnWarning: Boolean = DokkaDefaults.failOnWarning
 
     @Parameter
-    var dokkaPlugins: List<Dependency> = emptyList()
+    open var dokkaPlugins: List<Dependency> = emptyList()
 
     protected abstract fun getOutDir(): String
 
@@ -243,7 +243,7 @@ abstract class AbstractDokkaMojo : AbstractMojo() {
                 if (sourceSet.moduleDisplayName.isEmpty()) logger.warn("Not specified module name. It can result in unexpected behaviour while including documentation for module")
             },
             pluginsClasspath = getArtifactByAether("org.jetbrains.dokka", "dokka-base", dokkaVersion) +
-                    dokkaPlugins.map { getArtifactByAether(it.groupId, it.artifactId, it.version) }.flatten(),
+                    dokkaPlugins.map { getArtifactByAether(it.groupId, it.artifactId, it.version ?: dokkaVersion) }.flatten(),
             pluginsConfiguration = mutableMapOf(), //TODO implement as it is in Gradle
             modules = emptyList(),
             failOnWarning = failOnWarning
@@ -332,6 +332,9 @@ class DokkaMojo : AbstractDokkaMojo() {
 class DokkaJavadocMojo : AbstractDokkaMojo() {
     @Parameter(required = true, defaultValue = "\${project.basedir}/target/dokkaJavadoc")
     var outputDir: String = ""
+
+    override var dokkaPlugins = super.dokkaPlugins + javadocDependency
+
     override fun getOutDir() = outputDir
 }
 
@@ -389,6 +392,8 @@ class DokkaJavadocJarMojo : AbstractDokkaMojo() {
 
     override fun getOutDir() = outputDir
 
+    override var dokkaPlugins = super.dokkaPlugins + javadocDependency
+
     override fun execute() {
         super.execute()
         if (!File(outputDir).exists()) {
@@ -414,4 +419,9 @@ class DokkaJavadocJarMojo : AbstractDokkaMojo() {
 
         return javadocJar
     }
+}
+
+private val javadocDependency = Dependency().apply {
+    groupId = "org.jetbrains.dokka"
+    artifactId = "javadoc-plugin"
 }

--- a/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
+++ b/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
@@ -52,7 +52,7 @@ class ExternalDocumentationLinkBuilder : DokkaConfiguration.ExternalDocumentatio
     override var packageListUrl: URL? = null
 }
 
-abstract class AbstractDokkaMojo : AbstractMojo() {
+abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependency>) : AbstractMojo() {
     class SourceRoot : DokkaConfiguration.SourceRoot {
         @Parameter(required = true)
         override var path: String = ""
@@ -166,7 +166,8 @@ abstract class AbstractDokkaMojo : AbstractMojo() {
     var failOnWarning: Boolean = DokkaDefaults.failOnWarning
 
     @Parameter
-    open var dokkaPlugins: List<Dependency> = emptyList()
+    var dokkaPlugins: List<Dependency> = emptyList()
+        get() = field + defaultDokkaPlugins
 
     protected abstract fun getOutDir(): String
 
@@ -315,7 +316,7 @@ abstract class AbstractDokkaMojo : AbstractMojo() {
     requiresDependencyResolution = ResolutionScope.COMPILE,
     requiresProject = true
 )
-class DokkaMojo : AbstractDokkaMojo() {
+class DokkaMojo : AbstractDokkaMojo(emptyList()) {
     @Parameter(required = true, defaultValue = "\${project.basedir}/target/dokka")
     var outputDir: String = ""
 
@@ -329,11 +330,9 @@ class DokkaMojo : AbstractDokkaMojo() {
     requiresDependencyResolution = ResolutionScope.COMPILE,
     requiresProject = true
 )
-class DokkaJavadocMojo : AbstractDokkaMojo() {
+class DokkaJavadocMojo : AbstractDokkaMojo(listOf(javadocDependency)) {
     @Parameter(required = true, defaultValue = "\${project.basedir}/target/dokkaJavadoc")
     var outputDir: String = ""
-
-    override var dokkaPlugins = super.dokkaPlugins + javadocDependency
 
     override fun getOutDir() = outputDir
 }
@@ -345,7 +344,7 @@ class DokkaJavadocMojo : AbstractDokkaMojo() {
     requiresDependencyResolution = ResolutionScope.COMPILE,
     requiresProject = true
 )
-class DokkaJavadocJarMojo : AbstractDokkaMojo() {
+class DokkaJavadocJarMojo : AbstractDokkaMojo(listOf(javadocDependency)) {
     @Parameter(required = true, defaultValue = "\${project.basedir}/target/dokkaJavadocJar")
     var outputDir: String = ""
 
@@ -391,8 +390,6 @@ class DokkaJavadocJarMojo : AbstractDokkaMojo() {
     private var jarArchiver: JarArchiver? = null
 
     override fun getOutDir() = outputDir
-
-    override var dokkaPlugins = super.dokkaPlugins + javadocDependency
 
     override fun execute() {
         super.execute()


### PR DESCRIPTION
Tested on https://github.com/Kotlin/kotlin-examples/tree/master/maven/dokka-maven-example

Remember to change version of `dokka.version` property to `0.11.0-SNAPSHOT` or whatever version of `0.11.0` you're using. Moreover, add following plugin repositories

```xml
<pluginRepository>
    <id>jcenter-dokka</id>
    <name>JCenterDokka</name>
    <url>https://dl.bintray.com/kotlin/kotlin-dev/</url>
    <releases>
        <enabled>true</enabled>
    </releases>
</pluginRepository>
<pluginRepository>
    <id>jcenter-md</id>
    <name>JCenterMd</name>
    <url>https://dl.bintray.com/jetbrains/markdown/</url>
    <releases>
        <enabled>true</enabled>
    </releases>
</pluginRepository>   
```