### PR TITLE
Add a basic mathjax test

### DIFF
--- a/plugins/mathjax/build.gradle.kts
+++ b/plugins/mathjax/build.gradle.kts
@@ -1,5 +1,14 @@
 import org.jetbrains.registerDokkaArtifactPublication
 
+dependencies {
+    testImplementation("org.jsoup:jsoup:1.12.1")
+    testImplementation(project(":plugins:base"))
+    testImplementation(project(":plugins:base:test-utils"))
+    testImplementation(project(":test-tools"))
+    testImplementation(kotlin("test-junit"))
+    testImplementation(project(":kotlin-analysis"))
+}
+
 registerDokkaArtifactPublication("mathjaxPlugin") {
     artifactId = "mathjax-plugin"
 }

--- a/plugins/mathjax/src/main/kotlin/MathjaxPlugin.kt
+++ b/plugins/mathjax/src/main/kotlin/MathjaxPlugin.kt
@@ -15,7 +15,7 @@ class MathjaxPlugin : DokkaPlugin() {
 }
 
 private const val ANNOTATION = "usesMathJax"
-private const val LIB_PATH = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js?config=TeX-AMS_SVG&latest"
+internal const val LIB_PATH = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js?config=TeX-AMS_SVG&latest"
 
 object MathjaxTransformer : PageTransformer {
     override fun invoke(input: RootPageNode) = input.transformContentPagesTree {

--- a/plugins/mathjax/src/test/kotlin/MathjaxPluginTest.kt
+++ b/plugins/mathjax/src/test/kotlin/MathjaxPluginTest.kt
@@ -1,5 +1,6 @@
 package mathjaxTest
 
+import org.jetbrains.dokka.mathjax.LIB_PATH
 import org.jetbrains.dokka.mathjax.MathjaxPlugin
 import org.jetbrains.dokka.testApi.testRunner.AbstractCoreTest
 import org.jsoup.Jsoup
@@ -8,7 +9,7 @@ import utils.TestOutputWriterPlugin
 
 class MathjaxPluginTest : AbstractCoreTest() {
     @Test
-    fun basicMathjaxTest() {
+    fun noMathjaxTest() {
         val configuration = dokkaConfiguration {
             sourceSets {
                 sourceSet {
@@ -21,11 +22,9 @@ class MathjaxPluginTest : AbstractCoreTest() {
             |/src/main/kotlin/test/Test.kt
             |package example
             | /**
-            | * {@usesMathJax}
-            | *
-            | * <p>\(\alpha_{out} = \alpha_{dst}\)</p>
-            | * <p>\(C_{out} = C_{dst}\)</p>
+            | * Just a regular kdoc
             | */
+            | fun test(): String = ""
             """.trimIndent()
         val writerPlugin = TestOutputWriterPlugin()
         testInline(
@@ -35,19 +34,18 @@ class MathjaxPluginTest : AbstractCoreTest() {
         ) {
             renderingStage = {
                     _, _ -> Jsoup
-                .parse(writerPlugin.writer.contents["root/example.html"])
+                .parse(writerPlugin.writer.contents["root/example/test.html"])
                 .head()
                 .select("link, script")
                 .let {
-                    val link = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js?config=TeX-AMS_SVG&latest"
-                    assert(it.`is`("[href=$link], [src=$link]"))
+                    assert(!it.`is`("[href=$LIB_PATH], [src=$LIB_PATH]"))
                 }
             }
         }
     }
 
     @Test
-    fun basicNoMathjaxTest() {
+    fun usingMathjaxTest() {
         val configuration = dokkaConfiguration {
             sourceSets {
                 sourceSet {
@@ -60,9 +58,12 @@ class MathjaxPluginTest : AbstractCoreTest() {
             |/src/main/kotlin/test/Test.kt
             |package example
             | /**
-            | * <p>\(\alpha_{out} = \alpha_{dst}\)</p>
-            | * <p>\(C_{out} = C_{dst}\)</p>
+            | * @usesMathJax
+            | *
+            | * \(\alpha_{out} = \alpha_{dst}\)
+            | * \(C_{out} = C_{dst}\)
             | */
+            | fun test(): String = ""
             """.trimIndent()
         val writerPlugin = TestOutputWriterPlugin()
         testInline(
@@ -72,12 +73,11 @@ class MathjaxPluginTest : AbstractCoreTest() {
         ) {
             renderingStage = {
                     _, _ -> Jsoup
-                .parse(writerPlugin.writer.contents["root/example.html"])
+                .parse(writerPlugin.writer.contents["root/example/test.html"])
                 .head()
                 .select("link, script")
                 .let {
-                    val link = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js?config=TeX-AMS_SVG&latest"
-                    assert(!it.`is`("[href=$link], [src=$link]"))
+                    assert(it.`is`("[href=$LIB_PATH], [src=$LIB_PATH]"))
                 }
             }
         }

--- a/plugins/mathjax/src/test/kotlin/MathjaxPluginTest.kt
+++ b/plugins/mathjax/src/test/kotlin/MathjaxPluginTest.kt
@@ -1,0 +1,85 @@
+package mathjaxTest
+
+import org.jetbrains.dokka.mathjax.MathjaxPlugin
+import org.jetbrains.dokka.testApi.testRunner.AbstractCoreTest
+import org.jsoup.Jsoup
+import org.junit.jupiter.api.Test
+import utils.TestOutputWriterPlugin
+
+class MathjaxPluginTest : AbstractCoreTest() {
+    @Test
+    fun basicMathjaxTest() {
+        val configuration = dokkaConfiguration {
+            sourceSets {
+                sourceSet {
+                    sourceRoots = listOf("src/main/kotlin/test/Test.kt")
+                }
+            }
+        }
+        val source =
+            """
+            |/src/main/kotlin/test/Test.kt
+            |package example
+            | /**
+            | * {@usesMathJax}
+            | *
+            | * <p>\(\alpha_{out} = \alpha_{dst}\)</p>
+            | * <p>\(C_{out} = C_{dst}\)</p>
+            | */
+            """.trimIndent()
+        val writerPlugin = TestOutputWriterPlugin()
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin, MathjaxPlugin())
+        ) {
+            renderingStage = {
+                    _, _ -> Jsoup
+                .parse(writerPlugin.writer.contents["root/example.html"])
+                .head()
+                .select("link, script")
+                .let {
+                    val link = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js?config=TeX-AMS_SVG&latest"
+                    assert(it.`is`("[href=$link], [src=$link]"))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun basicNoMathjaxTest() {
+        val configuration = dokkaConfiguration {
+            sourceSets {
+                sourceSet {
+                    sourceRoots = listOf("src/main/kotlin/test/Test.kt")
+                }
+            }
+        }
+        val source =
+            """
+            |/src/main/kotlin/test/Test.kt
+            |package example
+            | /**
+            | * <p>\(\alpha_{out} = \alpha_{dst}\)</p>
+            | * <p>\(C_{out} = C_{dst}\)</p>
+            | */
+            """.trimIndent()
+        val writerPlugin = TestOutputWriterPlugin()
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin, MathjaxPlugin())
+        ) {
+            renderingStage = {
+                    _, _ -> Jsoup
+                .parse(writerPlugin.writer.contents["root/example.html"])
+                .head()
+                .select("link, script")
+                .let {
+                    val link = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js?config=TeX-AMS_SVG&latest"
+                    assert(!it.`is`("[href=$link], [src=$link]"))
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
A simple tests that seems to show that MathjaxPlugin does not work. It does not seem insert the additional script resources.