### PR TITLE
Applying Javadoc plugin breaks MathjaxPlugin

### DIFF
--- a/plugins/mathjax/build.gradle.kts
+++ b/plugins/mathjax/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.registerDokkaArtifactPublication
 dependencies {
     testImplementation("org.jsoup:jsoup:1.12.1")
     testImplementation(project(":plugins:base"))
+    testImplementation(project(":plugins:javadoc"))
     testImplementation(project(":plugins:base:test-utils"))
     testImplementation(project(":test-tools"))
     testImplementation(kotlin("test-junit"))

--- a/plugins/mathjax/src/test/kotlin/MathjaxPluginTest.kt
+++ b/plugins/mathjax/src/test/kotlin/MathjaxPluginTest.kt
@@ -1,5 +1,6 @@
 package mathjaxTest
 
+import org.jetbrains.dokka.javadoc.JavadocPlugin
 import org.jetbrains.dokka.mathjax.LIB_PATH
 import org.jetbrains.dokka.mathjax.MathjaxPlugin
 import org.jetbrains.dokka.testApi.testRunner.AbstractCoreTest
@@ -58,22 +59,22 @@ class MathjaxPluginTest : AbstractCoreTest() {
             |/src/main/kotlin/test/Test.kt
             |package example
             | /**
-            | * @usesMathJax
-            | *
-            | * \(\alpha_{out} = \alpha_{dst}\)
-            | * \(C_{out} = C_{dst}\)
-            | */
+            |  * Some text here
+            |  * \(\alpha_{out} = \alpha_{dst}\)
+            |  * \(C_{out} = C_{dst}\)
+            |  * @usesMathJax
+            |  */
             | fun test(): String = ""
             """.trimIndent()
         val writerPlugin = TestOutputWriterPlugin()
         testInline(
             source,
             configuration,
-            pluginOverrides = listOf(writerPlugin, MathjaxPlugin())
+            pluginOverrides = listOf(writerPlugin, MathjaxPlugin(), JavadocPlugin())
         ) {
             renderingStage = {
                     _, _ -> Jsoup
-                .parse(writerPlugin.writer.contents["root/example/test.html"])
+                .parse(writerPlugin.writer.contents["example/TestKt.html"])
                 .head()
                 .select("link, script")
                 .let {


### PR DESCRIPTION
From the investigation, it seems that apply Javadoc plugin causes
documentable?.documentation?.values to drop all the CustomTagWrapper
type elements, which means mathjax never applies. Updated existing test
to validate it.

Here is the html output after test modification https://jsfiddle.net/1gyz6k4x/