### PR TITLE
Wrap superclasses in Javadoc

### DIFF
--- a/plugins/javadoc/src/main/kotlin/javadoc/signatures/JavadocSignatureProvider.kt
+++ b/plugins/javadoc/src/main/kotlin/javadoc/signatures/JavadocSignatureProvider.kt
@@ -70,7 +70,7 @@ class JavadocSignatureProvider(ctcc: CommentsToContentConverter, logger: DokkaLo
                 if (c is WithSupertypes) {
                     c.supertypes.map { (p, dris) ->
                         val (classes, interfaces) = dris.partition { it.kind == JavaClassKindTypes.CLASS }
-                        list(classes, prefix = " extends ", sourceSets = setOf(p)) {
+                        list(classes, prefix = "extends ", sourceSets = setOf(p)) {
                             link(it.dri.sureClassNames, it.dri, sourceSets = setOf(p))
                         }
                         list(interfaces, prefix = " implements ", sourceSets = setOf(p)){

--- a/plugins/javadoc/src/main/resources/static_res/dokka-javadoc-stylesheet.css
+++ b/plugins/javadoc/src/main/resources/static_res/dokka-javadoc-stylesheet.css
@@ -1,0 +1,6 @@
+pre.wrap-overflow {
+    overflow-x: auto;
+    white-space: pre-wrap;
+    white-space: -moz-pre-wrap;
+    word-wrap: break-word;
+}

--- a/plugins/javadoc/src/main/resources/views/class.korte
+++ b/plugins/javadoc/src/main/resources/views/class.korte
@@ -32,10 +32,10 @@
                     </dl>
                     {% endif %}
                     <hr>
-                    <pre>
+                    <pre class="wrap-overflow">
 {% if signature.annotations != null %}{{ signature.annotations|raw }} {% endif %}
 {{ signature.modifiers }} <span class="typeNameLabel">{{ signature.signatureWithoutModifiers|raw }}</span>
-{% if signature.supertypes != null %}{{signature.supertypes|raw}} {% endif %}
+{% if signature.supertypes != null %}{{signature.supertypes|raw}}{% endif %}
                     </pre>
                     <div class="block">{{ classlikeDocumentation|raw }}</div>
                 </li>

--- a/plugins/javadoc/src/main/resources/views/components/head.korte
+++ b/plugins/javadoc/src/main/resources/views/components/head.korte
@@ -3,6 +3,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="dc.created" content="2020-03-25">
     <link rel="stylesheet" type="text/css" href="{{ pathToRoot }}stylesheet.css" title="Style">
+    <link rel="stylesheet" type="text/css" href="{{ pathToRoot }}dokka-javadoc-stylesheet.css" title="Style">
     <link rel="stylesheet" type="text/css" href="{{ pathToRoot }}jquery/jquery-ui.css" title="Style">
     <script type="text/javascript" src="{{ pathToRoot }}jquery/jquery-3.3.1.js"></script>
     <script type="text/javascript" src="{{ pathToRoot }}jquery/jquery-migrate-3.0.1.js"></script>


### PR DESCRIPTION
This is quite sad since the bug is also present in javadoc (even for Java 14), so using custom styles in the only option here
![image](https://user-images.githubusercontent.com/15652452/87940028-3a96f480-ca99-11ea-8e43-6a47f3d0f602.png)
