### PR TITLE
Follow Javadoc file path convention

### DIFF
--- a/plugins/javadoc/src/main/kotlin/javadoc/location/JavadocLocationProvider.kt
+++ b/plugins/javadoc/src/main/kotlin/javadoc/location/JavadocLocationProvider.kt
@@ -18,7 +18,10 @@ class JavadocLocationProvider(pageRoot: RootPageNode, dokkaContext: DokkaContext
 
     private val pathIndex = IdentityHashMap<PageNode, List<String>>().apply {
         fun registerPath(page: PageNode, prefix: List<String> = emptyList()) {
-            val newPrefix = prefix + page.takeIf { it is JavadocPackagePageNode }?.name.orEmpty()
+            val packagePath = page.takeIf { it is JavadocPackagePageNode }?.name.orEmpty()
+                .replace(".", "/")
+            val newPathPrefix = prefix + packagePath
+
             val path = (prefix + when (page) {
                 is AllClassesPage -> listOf("allclasses")
                 is TreeViewPage -> if (page.classes == null)
@@ -28,14 +31,14 @@ class JavadocLocationProvider(pageRoot: RootPageNode, dokkaContext: DokkaContext
                 is ContentPage -> if (page.dri.isNotEmpty() && page.dri.first().classNames != null)
                     listOfNotNull(page.dri.first().classNames)
                 else if (page is JavadocPackagePageNode)
-                    listOf(page.name, "package-summary")
+                    listOf(packagePath, "package-summary")
                 else
                     listOf("index")
                 else -> emptyList()
             }).filterNot { it.isEmpty() }
 
             put(page, path)
-            page.children.forEach { registerPath(it, newPrefix) }
+            page.children.forEach { registerPath(it, newPathPrefix) }
 
         }
         put(pageRoot, listOf("index"))

--- a/plugins/javadoc/src/test/kotlin/javadoc/location/JavadocLocationTest.kt
+++ b/plugins/javadoc/src/test/kotlin/javadoc/location/JavadocLocationTest.kt
@@ -37,8 +37,8 @@ class JavadocTest : AbstractCoreTest() {
         }
         testInline(
             """
-            |/jvmSrc/javadoc/Test.kt
-            |package javadoc
+            |/jvmSrc/javadoc/test/Test.kt
+            |package javadoc.test
             |import java.io.Serializable
             |class Test<A>() : Serializable, Cloneable {
             |   fun test() {}
@@ -120,9 +120,27 @@ class JavadocTest : AbstractCoreTest() {
         }
     }
 
-    private fun htmlTranslator(rootPageNode: RootPageNode, dokkaContext: DokkaContext) = JavadocContentToHtmlTranslator(
-        dokkaContext.plugin<JavadocPlugin>().querySingle { locationProviderFactory }
-            .getLocationProvider(rootPageNode),
-        dokkaContext
-    )
+    @Test
+    fun `resolved package path`() {
+
+        locationTestInline { rootPageNode, dokkaContext ->
+            val locationProvider = dokkaContext.plugin<JavadocPlugin>().querySingle { locationProviderFactory }
+                .getLocationProvider(rootPageNode)
+            val packageNode = rootPageNode.firstChildOfType<JavadocPackagePageNode>()
+            val packagePath = locationProvider.resolve(packageNode)
+
+            assertEquals("javadoc/test/package-summary", packagePath)
+        }
+    }
+
+    private fun htmlTranslator(rootPageNode: RootPageNode, dokkaContext: DokkaContext): JavadocContentToHtmlTranslator {
+        val locationProvider = dokkaContext.plugin<JavadocPlugin>().querySingle { locationProviderFactory }
+            .getLocationProvider(rootPageNode)
+        return htmlTranslator(dokkaContext, locationProvider)
+    }
+
+    private fun htmlTranslator(
+        dokkaContext: DokkaContext,
+        locationProvider: JavadocLocationProvider
+    ) = JavadocContentToHtmlTranslator(locationProvider, dokkaContext)
 }


### PR DESCRIPTION
Cherry pick of `f98c791d8b893ad6d171c5a65ebcad025342895d`, PR just for integration tests