### PR TITLE
Navigation pane improvements

### DIFF
--- a/plugins/base/src/main/kotlin/renderers/html/htmlPreprocessors.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/htmlPreprocessors.kt
@@ -49,17 +49,14 @@ object NavigationPageInstaller : PageTransformer {
             page.navigableChildren()
         )
 
-    private fun ContentPage.navigableChildren(): List<NavigationNode> {
-        if (this !is ClasslikePageNode) {
-            return children.filterIsInstance<ContentPage>()
-                .map { visit(it) }
-        } else if (documentable is DEnum) {
-            return children.filter { it is ContentPage && it.documentable is DEnumEntry }
-                .map { visit(it as ContentPage) }
-        }
-
-        return emptyList()
-    }
+    private fun ContentPage.navigableChildren(): List<NavigationNode> =
+        when {
+            this !is ClasslikePageNode ->
+                children.filterIsInstance<ContentPage>().map { visit(it) }
+            documentable is DEnum ->
+                children.filter { it is ContentPage && it.documentable is DEnumEntry }.map { visit(it as ContentPage) }
+            else -> emptyList()
+        }.sortedBy { it.name.toLowerCase() }
 }
 
 object ResourceInstaller : PageTransformer {

--- a/plugins/base/src/main/resources/dokka/styles/style.css
+++ b/plugins/base/src/main/resources/dokka/styles/style.css
@@ -829,6 +829,13 @@ td.content {
 
 .platform-hinted > .content:not([data-active]),
 .tabs-section-body > *:not([data-active]) {
+    display: none;
+}
+
+/*Work around an issue: https://github.com/JetBrains/kotlin-playground/issues/91*/
+.platform-hinted[data-togglable="Samples"] > .content:not([data-active]),
+.tabs-section-body > *[data-togglable="Samples"]:not([data-active]) {
+    display: block !important;
     visibility: hidden;
     height: 0;
     position: fixed;


### PR DESCRIPTION
Small PR for low-hanging fruits like sorting in navigation pane on left and improving performance of CSS. 
I'd CSS to make it to RC.

You can check if samples still work on stdlib: `/kotlin-stdlib/kotlin-stdlib/kotlin.sequences/as-sequence.html`
I havn't found any sample that is in tab so here is a screen for our project:


![Jul-23-2020 10-10-50](https://user-images.githubusercontent.com/15652452/88264883-d52b4980-cccc-11ea-9f03-65cb6309609a.gif)
