### PR TITLE
Fix plugins configuration in groovy gradle configs

### DIFF
--- a/core/src/main/kotlin/plugability/DokkaPlugin.kt
+++ b/core/src/main/kotlin/plugability/DokkaPlugin.kt
@@ -49,7 +49,7 @@ interface WithUnsafeExtensionSuppression {
 }
 
 interface Configurable {
-    val pluginsConfiguration: Map<String, String>
+    var pluginsConfiguration: Map<String, String>
 }
 
 interface ConfigurableBlock


### PR DESCRIPTION
Currently, we can configure plugins in build.gradle.kts configs using below function 
`inline fun <reified P : DokkaPlugin, reified T : ConfigurableBlock> Configurable.pluginConfiguration(block: T.() -> Unit)`
Unfortunately, using reified types makes it impossible to use in build.gradle, because Groovy cannot cooperate with that function. Therefore, we should allow user somehow pass arguments. As it is not going to be typesafe anymore, we can let user pass parameters, as he would do it in CLI, manually.