### PR TITLE
Make Gradle tasks cacheable

### DIFF
--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/AbstractDokkaTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/AbstractDokkaTask.kt
@@ -14,7 +14,7 @@ import org.jetbrains.dokka.plugability.Configurable
 
 
 abstract class AbstractDokkaTask : DefaultTask(), Configurable {
-    @Input
+    @Internal
     var outputDirectory: String = defaultDokkaOutputDirectory().absolutePath
 
     @Input

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaMultimoduleTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaMultimoduleTask.kt
@@ -3,10 +3,12 @@ package org.jetbrains.dokka.gradle
 import com.google.gson.GsonBuilder
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.JavaBasePlugin.DOCUMENTATION_GROUP
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.jetbrains.dokka.plugability.Configurable
 
+@CacheableTask
 open class DokkaMultimoduleTask : AbstractDokkaTask(), Configurable {
 
     @Input

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaTask.kt
@@ -18,6 +18,7 @@ import org.jetbrains.dokka.gradle.ConfigurationExtractor.PlatformData
 import java.io.File
 import java.util.concurrent.Callable
 
+@CacheableTask
 open class DokkaTask : AbstractDokkaTask() {
     private val ANDROID_REFERENCE_URL = Builder("https://developer.android.com/reference/").build()
     private val configExtractor = ConfigurationExtractor(project)
@@ -165,9 +166,9 @@ open class DokkaTask : AbstractDokkaTask() {
     internal fun getConfigurationOrThrow(): GradleDokkaConfigurationImpl {
         return getConfigurationOrNull() ?: throw DokkaException(
             """
-                No source sets to document found. 
+                No source sets to document found.
                 Make source to configure at least one source set e.g.
-                
+
                 dokka {
                     dokkaSourceSets {
                         create("commonMain") {
@@ -273,6 +274,7 @@ open class DokkaTask : AbstractDokkaTask() {
 
     // Needed for Gradle incremental build
     @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
     fun getInputFiles(): FileCollection = configuredDokkaSourceSets.let { config ->
         project.files(config.flatMap { it.sourceRoots }.map { project.fileTree(File(it.path)) }) +
                 project.files(config.flatMap { it.includes }) +

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/configurationImplementations.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/configurationImplementations.kt
@@ -6,6 +6,7 @@ import com.android.build.gradle.api.AndroidSourceSet
 import groovy.lang.Closure
 import org.gradle.api.Action
 import org.gradle.api.Project
+import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
@@ -38,7 +39,7 @@ open class GradleDokkaSourceSet constructor(
     @Transient @get:Internal internal val project: Project
 ) : DokkaSourceSet {
 
-    @Input
+    @Classpath
     @Optional
     override var classpath: List<String> = emptyList()
 


### PR DESCRIPTION
adds support for Gradle local and remote caching.

addresses https://github.com/Kotlin/dokka/issues/453

supersedes #830 