### PR TITLE
Remove redundant types

### DIFF
--- a/core/src/main/kotlin/model/WithChildren.kt
+++ b/core/src/main/kotlin/model/WithChildren.kt
@@ -23,6 +23,11 @@ inline fun <reified T> WithChildren<WithChildren<*>>.firstMemberOfType(): T wher
     return withDescendants().filterIsInstance<T>().first()
 }
 
+inline fun <reified T> WithChildren<WithChildren<*>>.firstMemberOfType(
+    predicate: (T) -> Boolean
+): T where T : WithChildren<*> = withDescendants().filterIsInstance<T>().first(predicate)
+
+
 inline fun <reified T> WithChildren<WithChildren<*>>.firstMemberOfTypeOrNull(): T? where T : WithChildren<*> {
     return withDescendants().filterIsInstance<T>().firstOrNull()
 }
@@ -66,7 +71,7 @@ fun <T> T.dfs(predicate: (T) -> Boolean): T? where T : WithChildren<T> = if (pre
     children.asSequence().mapNotNull { it.dfs(predicate) }.firstOrNull()
 }
 
-fun <T: WithChildren<T>> T.asPrintableTree(
+fun <T : WithChildren<T>> T.asPrintableTree(
     nodeNameBuilder: Appendable.(T) -> Unit = { append(it.toString()) }
 ): String {
     fun Appendable.append(element: T, ownPrefix: String, childPrefix: String) {

--- a/core/src/main/kotlin/model/WithChildren.kt
+++ b/core/src/main/kotlin/model/WithChildren.kt
@@ -65,3 +65,25 @@ fun <T> T.dfs(predicate: (T) -> Boolean): T? where T : WithChildren<T> = if (pre
 } else {
     children.asSequence().mapNotNull { it.dfs(predicate) }.firstOrNull()
 }
+
+fun <T: WithChildren<T>> T.asPrintableTree(
+    nodeNameBuilder: Appendable.(T) -> Unit = { append(it.toString()) }
+): String {
+    fun Appendable.append(element: T, ownPrefix: String, childPrefix: String) {
+        append(ownPrefix)
+        nodeNameBuilder(element)
+        appendLine()
+        element.children.takeIf(Collection<*>::isNotEmpty)?.also { children ->
+            val newOwnPrefix = childPrefix + '\u251c' + '\u2500' + ' '
+            val lastOwnPrefix = childPrefix + '\u2514' + '\u2500' + ' '
+            val newChildPrefix = childPrefix + '\u2502' + ' ' + ' '
+            val lastChildPrefix = childPrefix + ' ' + ' ' + ' '
+            children.forEachIndexed { n, e ->
+                if (n != children.lastIndex) append(e, newOwnPrefix, newChildPrefix)
+                else append(e, lastOwnPrefix, lastChildPrefix)
+            }
+        }
+    }
+
+    return buildString { append(this@asPrintableTree, "", "") }
+}

--- a/plugins/base/src/main/kotlin/signatures/KotlinSignatureProvider.kt
+++ b/plugins/base/src/main/kotlin/signatures/KotlinSignatureProvider.kt
@@ -155,7 +155,7 @@ class KotlinSignatureProvider(ctcc: CommentsToContentConverter, logger: DokkaLog
             }
             link(c.name!!, c.dri)
             if (c is WithGenerics) {
-                list(c.generics, prefix = "<", suffix = "> ") {
+                list(c.generics, prefix = "<", suffix = ">") {
                     +buildSignature(it)
                 }
             }
@@ -292,8 +292,8 @@ class KotlinSignatureProvider(ctcc: CommentsToContentConverter, logger: DokkaLog
         t.sourceSets.map {
             contentBuilder.contentFor(t, styles = t.stylesIfDeprecated(it), sourceSets = setOf(it)) {
                 link(t.name, t.dri.withTargetToDeclaration())
-                list(t.bounds, prefix = " : ") {
-                    signatureForProjection(it)
+                list(t.nontrivialBounds, prefix = " : ") { bound ->
+                    signatureForProjection(bound)
                 }
             }
         }
@@ -374,6 +374,9 @@ private fun PrimitiveJavaType.translateToKotlin() = TypeConstructor(
     dri = dri,
     projections = emptyList()
 )
+
+private val DTypeParameter.nontrivialBounds: List<Bound>
+    get() = bounds.filterNot { it is Nullable && it.inner.driOrNull == DriOfAny  }
 
 val TypeConstructor.function
     get() = modifier == FunctionModifiers.FUNCTION || modifier == FunctionModifiers.EXTENSION

--- a/plugins/base/src/main/kotlin/translators/descriptors/DefaultDescriptorToDocumentableTranslator.kt
+++ b/plugins/base/src/main/kotlin/translators/descriptors/DefaultDescriptorToDocumentableTranslator.kt
@@ -614,16 +614,13 @@ private class DokkaDescriptorVisitor(
     private fun TypeProjection.toProjection(): Projection =
         if (isStarProjection) Star else formPossiblyVariant()
 
-    private fun TypeProjection.formPossiblyVariant(): Projection = type.fromPossiblyNullable().let {
+    private fun TypeProjection.formPossiblyVariant(): Projection = type.toBound().let {
         when (projectionKind) {
             org.jetbrains.kotlin.types.Variance.INVARIANT -> it
             org.jetbrains.kotlin.types.Variance.IN_VARIANCE -> Variance(Variance.Kind.In, it)
             org.jetbrains.kotlin.types.Variance.OUT_VARIANCE -> Variance(Variance.Kind.Out, it)
         }
     }
-
-    private fun KotlinType.fromPossiblyNullable(): Bound =
-        toBound().let { if (isMarkedNullable) Nullable(it) else it }
 
     private fun DeclarationDescriptor.getDocumentation() = findKDoc().let {
         MarkdownParser(resolutionFacade, this, logger).parseFromKDocTag(it)

--- a/plugins/base/src/test/kotlin/basic/FailOnWarningTest.kt
+++ b/plugins/base/src/test/kotlin/basic/FailOnWarningTest.kt
@@ -1,12 +1,12 @@
 package basic
 
 import org.jetbrains.dokka.DokkaException
+import org.jetbrains.dokka.testApi.logger.TestLogger
 import org.jetbrains.dokka.testApi.testRunner.AbstractCoreTest
 import org.jetbrains.dokka.utilities.DokkaConsoleLogger
 import org.jetbrains.dokka.utilities.DokkaLogger
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.jetbrains.dokka.testApi.logger.TestLogger
 
 class FailOnWarningTest : AbstractCoreTest() {
 
@@ -62,7 +62,6 @@ class FailOnWarningTest : AbstractCoreTest() {
 
     @Test
     fun `does not throw if now warning or error was emitted`() {
-        logger = TestLogger(ZeroErrorOrWarningCountDokkaLogger())
 
         val configuration = dokkaConfiguration {
             failOnWarning = true
@@ -78,7 +77,9 @@ class FailOnWarningTest : AbstractCoreTest() {
             """
                 |/src/main/kotlin
                 |package sample
-                """.trimIndent(), configuration
+                """.trimIndent(),
+            configuration,
+            loggerForTest = TestLogger(ZeroErrorOrWarningCountDokkaLogger())
         ) {
             /* We expect no Exception */
         }

--- a/plugins/base/src/test/kotlin/signatures/ObviousTypeSkippingTest.kt
+++ b/plugins/base/src/test/kotlin/signatures/ObviousTypeSkippingTest.kt
@@ -1,0 +1,195 @@
+package signatures
+
+import matchers.content.assertNode
+import matchers.content.hasExactText
+import org.jetbrains.dokka.model.firstMemberOfType
+import org.jetbrains.dokka.pages.*
+import org.jetbrains.dokka.testApi.logger.FilteringLogger
+import org.jetbrains.dokka.testApi.logger.TestLogger
+import org.jetbrains.dokka.testApi.testRunner.AbstractCoreTest
+import org.jetbrains.dokka.utilities.DokkaConsoleLogger
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import kotlin.reflect.KClass
+
+class ObviousTypeSkippingTest : AbstractCoreTest(
+    logger = TestLogger(FilteringLogger(minLevel = FilteringLogger.Level.Warn, DokkaConsoleLogger))
+) {
+
+    private fun source(signature: String) =
+        """
+            |/src/test.kt
+            |package example
+            |
+            | $signature
+            """.trimIndent()
+
+    private val configuration = dokkaConfiguration {
+        sourceSets {
+            sourceSet {
+                sourceRoots = listOf("src")
+                classpath = listOfNotNull(jvmStdlibPath)
+            }
+        }
+    }
+
+    companion object TestDataSources {
+        @JvmStatic
+        fun `run tests for obvious types omitting`() = listOf(
+            forFunction("fun underTest(): Int = 5", "fun underTest(): Int"),
+            forFunction("fun underTest() = 5", "fun underTest(): Int"),
+            forFunction("fun underTest() {}", "fun underTest()"),
+            forFunction("fun underTest() = println(6)", "fun underTest()"),
+            forFunction("fun underTest(): Unit = println(6)", "fun underTest()"),
+            forFunction("fun underTest(): Unit? = if (true) println(6) else null", "fun underTest(): Unit?"),
+            forFunction("fun underTest() = if (true) println(6) else null", "fun underTest(): Unit?"),
+            forFunction("fun underTest(): Any = if (true) 7 else true", "fun underTest(): Any"),
+            forFunction("fun underTest() = if (true) 7 else true", "fun underTest(): Any"),
+            forFunction("fun underTest(): Any? = if (true) 7 else (null as String?)", "fun underTest(): Any?"),
+            forFunction("fun underTest() = if (true) 7 else (null as String?)", "fun underTest(): Any?"),
+            forFunction("fun underTest(arg: Int) {}", "fun underTest(arg: Int)"),
+            forFunction("fun underTest(arg: Unit) {}", "fun underTest(arg: Unit)"),
+            forFunction("fun <T: Iterable<Any>> underTest(arg: T) {}", "fun <T : Iterable<Any>> underTest(arg: T)"),
+            forFunction("fun <T: Iterable<Any?>> underTest(arg: T) {}", "fun <T : Iterable<Any?>> underTest(arg: T)"),
+            forFunction("fun <T> underTest(arg: T) {}", "fun <T> underTest(arg: T)"),
+            forFunction("fun <T: Any> underTest(arg: T) {}", "fun <T : Any> underTest(arg: T)"),
+            forFunction("fun <T: Any?> underTest(arg: T) {}", "fun <T> underTest(arg: T)"),
+            forProperty("val underTest: Int = 5", "val underTest: Int"),
+            forProperty("val underTest = 5", "val underTest: Int"),
+            forProperty("val underTest: Unit = println(5)", "val underTest: Unit"),
+            forProperty("val underTest = println(5)", "val underTest: Unit"),
+            forProperty("val underTest: Unit? = if (true) println(5) else null", "val underTest: Unit?"),
+            forProperty("val underTest = if (true) println(5) else null", "val underTest: Unit?"),
+            forProperty("val underTest: Any = if (true) println(5) else 5", "val underTest: Any"),
+            forProperty("val underTest = if (true) println(5) else 5", "val underTest: Any"),
+            forFunction("fun <T: Iterable<Any>> T.underTest() {}", "fun <T : Iterable<Any>> T.underTest()"),
+            forFunction("fun <T: Iterable<Any?>> T.underTest() {}", "fun <T : Iterable<Any?>> T.underTest()"),
+            forFunction("fun <T: Iterable<Any?>?> T.underTest() {}", "fun <T : Iterable<Any?>?> T.underTest()"),
+            forFunction("fun <T: Any> T.underTest() {}", "fun <T : Any> T.underTest()"),
+            forFunction("fun <T: Any?> T.underTest() {}", "fun <T> T.underTest()"),
+            forFunction("fun <T> T.underTest() {}", "fun <T> T.underTest()"),
+            forClass("class Testable<T: Any>", "class Testable<T : Any>"),
+            forClass("class Testable<T: Any?>", "class Testable<T>"),
+            forClass("class Testable<T: Any?>(t: T)", "class Testable<T>(t: T)"),
+            forClass("class Testable<T>", "class Testable<T>"),
+            forClass("class Testable(butWhy: Unit)", "class Testable(butWhy: Unit)"),
+            forMethod("class Testable { fun underTest(): Int = 5 }", "fun underTest(): Int"),
+            forMethod("class Testable { fun underTest() = 5 }", "fun underTest(): Int"),
+            forMethod("class Testable { fun underTest() {} }", "fun underTest()"),
+            forMethod("class Testable { fun underTest() = println(6) }", "fun underTest()"),
+            forMethod("class Testable { fun underTest(): Unit = println(6) }", "fun underTest()"),
+            forMethod(
+                "class Testable { fun underTest(): Unit? = if (true) println(6) else null }",
+                "fun underTest(): Unit?"
+            ),
+            forClassProperty("class Testable { val underTest: Unit = println(5) }", "val underTest: Unit"),
+            forClassProperty("class Testable { val underTest = println(5) }", "val underTest: Unit"),
+            forClassProperty(
+                "class Testable { val underTest: Unit? = if (true) println(5) else null }",
+                "val underTest: Unit?"
+            ),
+            forClassProperty(
+                "class Testable { val underTest = if (true) println(5) else null }",
+                "val underTest: Unit?"
+            ),
+            forClassProperty(
+                "class Testable { val underTest: Any = if (true) println(5) else 5 }",
+                "val underTest: Any"
+            ),
+            forClassProperty("class Testable { val underTest = if (true) println(5) else 5 }", "val underTest: Any"),
+        )
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource
+    fun `run tests for obvious types omitting`(testData: TestData) {
+        val (codeFragment, expectedSignature, placesToTest) = testData
+        testInline(
+            query = source(codeFragment),
+            configuration = configuration
+        ) {
+            pagesTransformationStage = { root ->
+                placesToTest.forEach { place ->
+                    try {
+                        when (place) {
+                            is OnOwnPage ->
+                                root.firstMemberOfType<ContentPage> { it.name == place.name }.content
+                                    .firstMemberOfType<ContentGroup> { it.dci.kind == ContentKind.Symbol }
+                                    .assertNode { hasExactText(expectedSignature) }
+                            is OnParentPage ->
+                                root.firstMemberOfType<ContentPage> {
+                                    place.pageType.isInstance(it) && (place.parentName.isNullOrBlank() || place.parentName == it.name)
+                                }
+                                    .content
+                                    .firstMemberOfType<ContentGroup> {
+                                        it.dci.kind == place.section && (place.selfName.isNullOrBlank() ||
+                                                it.dci.dri.toString().contains(place.selfName))
+                                    }
+                                    .firstMemberOfType<ContentGroup> { it.dci.kind == ContentKind.Symbol }
+                                    .assertNode { hasExactText(expectedSignature) }
+                        }
+                    } catch (e: Throwable) {
+                        logger.warn("$testData") // Because gradle has serious problem rendering custom test names
+                        throw e
+                    }
+                }
+            }
+        }
+    }
+
+}
+
+sealed class Place
+data class OnOwnPage(val name: String) : Place()
+data class OnParentPage(
+    val pageType: KClass<out ContentPage>,
+    val section: Kind,
+    val parentName: String? = null,
+    val selfName: String? = null
+) : Place()
+
+data class TestData(
+    val codeFragment: String,
+    val expectedSignature: String,
+    val placesToTest: Iterable<Place>
+) {
+    constructor(codeFragment: String, expectedSignature: String, vararg placesToTest: Place)
+            : this(codeFragment, expectedSignature, placesToTest.asIterable())
+
+    override fun toString() = "[code = \"$codeFragment\"]"
+}
+
+private fun forFunction(codeFragment: String, expectedSignature: String, functionName: String = "underTest") =
+    TestData(
+        codeFragment,
+        expectedSignature,
+        OnParentPage(PackagePageNode::class, ContentKind.Functions),
+        OnOwnPage(functionName)
+    )
+
+private fun forMethod(
+    codeFragment: String,
+    expectedSignature: String,
+    functionName: String = "underTest",
+    className: String = "Testable"
+) =
+    TestData(
+        codeFragment,
+        expectedSignature,
+        OnParentPage(ClasslikePageNode::class, ContentKind.Functions, className, functionName),
+        OnOwnPage(functionName)
+    )
+
+private fun forProperty(codeFragment: String, expectedSignature: String) =
+    TestData(codeFragment, expectedSignature, OnParentPage(PackagePageNode::class, ContentKind.Properties))
+
+private fun forClassProperty(codeFragment: String, expectedSignature: String, className: String = "Testable") =
+    TestData(codeFragment, expectedSignature, OnParentPage(ClasslikePageNode::class, ContentKind.Properties, className))
+
+private fun forClass(codeFragment: String, expectedSignature: String, className: String = "Testable") =
+    TestData(
+        codeFragment,
+        expectedSignature,
+        OnParentPage(PackagePageNode::class, ContentKind.Classlikes),
+        OnOwnPage(className)
+    )

--- a/plugins/base/src/test/kotlin/signatures/SignatureTest.kt
+++ b/plugins/base/src/test/kotlin/signatures/SignatureTest.kt
@@ -176,7 +176,7 @@ class SignatureTest : AbstractCoreTest() {
         ) {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example/simple-fun.html").firstSignature().match(
-                    "fun <", A("T"), " : ", A("Any"), "?> ", A("simpleFun"), "(): ",
+                    "fun <", A("T"), "> ", A("simpleFun"), "(): ",
                     A("T"), Span()
                 )
             }

--- a/test-tools/src/main/kotlin/matchers/content/ContentMatchersDsl.kt
+++ b/test-tools/src/main/kotlin/matchers/content/ContentMatchersDsl.kt
@@ -30,12 +30,14 @@ class ContentMatcherBuilder<T : ContentComposite> @PublishedApi internal constru
     internal val children = mutableListOf<MatcherElement>()
     internal val assertions = mutableListOf<T.() -> Unit>()
 
-    fun build() = CompositeMatcher(kclass, children) { assertions.forEach { it() } }
+    fun build() = CompositeMatcher(kclass, childrenOrSkip()) { assertions.forEach { it() } }
 
     // part of DSL that cannot be defined as an extension
     operator fun String.unaryPlus() {
         children += TextMatcher(this)
     }
+
+    private fun childrenOrSkip() = if (children.isEmpty() && assertions.isNotEmpty()) listOf(Anything) else children
 }
 
 fun <T : ContentComposite> ContentMatcherBuilder<T>.check(assertion: T.() -> Unit) {

--- a/test-tools/src/main/kotlin/matchers/content/ContentMatchersDsl.kt
+++ b/test-tools/src/main/kotlin/matchers/content/ContentMatchersDsl.kt
@@ -3,6 +3,8 @@ package matchers.content
 import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.isEqualTo
+import assertk.assertions.matches
+import org.jetbrains.dokka.model.withDescendants
 import org.jetbrains.dokka.pages.*
 import org.jetbrains.dokka.test.tools.matchers.content.*
 import kotlin.reflect.KClass
@@ -38,6 +40,21 @@ class ContentMatcherBuilder<T : ContentComposite> @PublishedApi internal constru
 
 fun <T : ContentComposite> ContentMatcherBuilder<T>.check(assertion: T.() -> Unit) {
     assertions += assertion
+}
+
+private val ContentComposite.extractedText
+    get() = withDescendants().filterIsInstance<ContentText>().joinToString(separator = "") { it.text }
+
+fun <T : ContentComposite> ContentMatcherBuilder<T>.hasExactText(expected: String) {
+    assertions += {
+        assertThat(this::extractedText).isEqualTo(expected)
+    }
+}
+
+fun <T : ContentComposite> ContentMatcherBuilder<T>.textMatches(pattern: Regex) {
+    assertions += {
+        assertThat(this::extractedText).matches(pattern)
+    }
 }
 
 inline fun <reified S : ContentComposite> ContentMatcherBuilder<*>.composite(

--- a/testApi/src/main/kotlin/testApi/logger/TestLogger.kt
+++ b/testApi/src/main/kotlin/testApi/logger/TestLogger.kt
@@ -46,3 +46,34 @@ class TestLogger(private val logger: DokkaLogger) : DokkaLogger {
         logger.error(message)
     }
 }
+
+class FilteringLogger(
+    private val minLevel: Level,
+    private val downstream: DokkaLogger
+) : DokkaLogger {
+    enum class Level { Debug, Info, Progress, Warn, Error }
+
+    override var warningsCount: Int by downstream::warningsCount
+
+    override var errorsCount by downstream::errorsCount
+
+    override fun debug(message: String) {
+        if (minLevel <= Level.Debug) downstream.debug(message)
+    }
+
+    override fun info(message: String) {
+        if (minLevel <= Level.Info) downstream.info(message)
+    }
+
+    override fun progress(message: String) {
+        if (minLevel <= Level.Progress) downstream.progress(message)
+    }
+
+    override fun warn(message: String) {
+        if (minLevel <= Level.Warn) downstream.warn(message)
+    }
+
+    override fun error(message: String) {
+        if (minLevel <= Level.Error) downstream.error(message)
+    }
+}


### PR DESCRIPTION
Closes #1201 
This solves the trivial issue of redundant type information being displayed. Although while testing it I've found some nasty problems with signatures. Fix for those problems was embarrassingly easy, but I spent long hours trying to find a root cause. To prevent that in the future I've added an unreasonable number of tests for such a small fix.

Also, I've added a few utils for easier testing and easier debugging, that I cannot believe we had not had till now.