### PR TITLE
Move plugin version management to buildSrc/build.gradle.kts

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -2,12 +2,36 @@ plugins {
     `kotlin-dsl`
 }
 
-repositories {
-    mavenCentral()
-    jcenter()
+/**
+ * These plugins are added to the buildscript classpath, so subprojects can refer to the plugin in the plugins block
+ * by using the [PluginDependenciesSpec.id] function, without the need to also call [PluginDependencySpec.version].
+ */
+val pluginVersions = setOf(
+  "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5",
+  "com.github.jengelman.gradle.plugins:shadow:5.2.0",
+  "com.gradle.publish:plugin-publish-plugin:0.12.0"
+).map {
+    dependencies.implementation(it) ?: throw NullPointerException("Plugin dependency must not be null!")
 }
 
-dependencies {
-    implementation("com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4")
-    implementation("com.github.jengelman.gradle.plugins:shadow:2.0.4")
+repositories {
+    exclusiveContent {
+        forRepository {
+            gradlePluginPortal()
+        }
+        filter {
+            pluginVersions.forEach { includeVersion(it.group!!, it.name, it.version!!) }
+        }
+    }
+    jcenter()
+    maven("https://dl.bintray.com/kotlin/kotlin-eap/") {
+        content {
+            includeGroupByRegex("^org\\.jetbrains\\.(anko|dokka|kotlin|kotlinx)(\\..+)?$")
+        }
+    }
+    maven("https://dl.bintray.com/kotlin/kotlin-dev/") {
+        content {
+            includeGroupByRegex("^org\\.jetbrains\\.(anko|dokka|intellij|kotlin|kotlinx)(\\..+)?$")
+        }
+    }
 }

--- a/buildSrc/buildSrc/build.gradle.kts
+++ b/buildSrc/buildSrc/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+  `kotlin-dsl`
+}
+repositories.jcenter()
+sourceSets.main {
+  /**
+   * The classes that are included here are compiled a second time,
+   * so they are available on the classpath of `${rootProject.projectDir}/buildSrc/build.gradle.kts`.
+   */
+  java {
+    setSrcDirs(setOf(projectDir.parentFile.resolve("src/main/kotlin")))
+    exclude("org/jetbrains/publication.kt")
+    exclude("org/jetbrains/ValidatePublications.kt")
+  }
+}

--- a/runners/gradle-plugin/build.gradle.kts
+++ b/runners/gradle-plugin/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.dokkaVersion
 
 plugins {
     `java-gradle-plugin`
-    id("com.gradle.plugin-publish") version "0.10.1"
+    id("com.gradle.plugin-publish")
 }
 
 repositories {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,17 +26,6 @@ include("integration-tests:maven")
 pluginManagement {
     val kotlin_version: String by settings
     plugins {
-        id("org.jetbrains.kotlin.jvm") version kotlin_version
-        id("com.github.johnrengelman.shadow") version "5.2.0"
-        id("com.jfrog.bintray") version "1.8.5"
-        id("com.gradle.plugin-publish") version "0.12.0"
-    }
-
-    repositories {
-        maven("https://dl.bintray.com/kotlin/kotlin-eap/")
-        maven("https://dl.bintray.com/kotlin/kotlin-dev/")
-        mavenCentral()
-        jcenter()
-        gradlePluginPortal()
+        kotlin("jvm").version(kotlin_version)
     }
 }


### PR DESCRIPTION
While researching a similar issue, I recently came across https://github.com/gradle/gradle/issues/11090#issuecomment-666249417 (cc @sellmair ) about how the `pluginManagement{}` block in `settings.gradle.kts` can't access logic defined in `buildSrc`.

So I thought I'd share how I'm trying to solve that problem in some of my projects. Just in case this could be useful for this project, too.

There are two parts to this solution:

---

There is a second `buildSrc` project inside the existing `buildSrc` project. It only contains a short `build.gradle.kts` script and just compiles the sources of the first `buildSrc` project one additional time, so those classes are on the classpath of `buildSrc/build.gradle.kts`.

At the moment this is not utilized in this pull request, but you could then add build logic to `buildSrc/src/main/kotlin` that can be reused in the buildscript of `buildSrc` for e.g. plugin version management.

This may sound like a hack, but in my experience this works pretty reliably.

---

The plugin versions are defined in `buildSrc/build.gradle.kts` as `dependencies.implementation("‹…›")` instead of using the `pluginManagement{}` block in `settings.gradle.kts`.

This gets rid of version inconsistencies like https://github.com/Kotlin/dokka/blob/b19ce3c7622666bd638baf2f840e898bb00efd90/settings.gradle.kts#L31 vs https://github.com/Kotlin/dokka/blob/b19ce3c7622666bd638baf2f840e898bb00efd90/buildSrc/build.gradle.kts#L11 Both are now defined in one location.

Also subprojects can then no longer declare conflicting plugin versions like https://github.com/Kotlin/dokka/blob/b19ce3c7622666bd638baf2f840e898bb00efd90/settings.gradle.kts#L32 and https://github.com/Kotlin/dokka/blob/b19ce3c7622666bd638baf2f840e898bb00efd90/runners/gradle-plugin/build.gradle.kts#L6 because Gradle will issue a warning: `Plugin request for plugin already on the classpath must not include a version`.