### PR TITLE
Mitigate issue `Couldn't get delegate for class`

### DIFF
--- a/plugins/base/src/test/kotlin/translators/Bug1341.kt
+++ b/plugins/base/src/test/kotlin/translators/Bug1341.kt
@@ -2,7 +2,6 @@ package translators
 
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.testApi.testRunner.AbstractCoreTest
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 

--- a/plugins/base/src/test/kotlin/translators/Bug1341.kt
+++ b/plugins/base/src/test/kotlin/translators/Bug1341.kt
@@ -1,0 +1,62 @@
+package translators
+
+import org.jetbrains.dokka.links.DRI
+import org.jetbrains.dokka.testApi.testRunner.AbstractCoreTest
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class Bug1341 : AbstractCoreTest() {
+    @Test
+    fun `reproduce bug #1341`() {
+        val configuration = dokkaConfiguration {
+            sourceSets {
+                sourceSet {
+                    sourceRoots = listOf("src")
+                    analysisPlatform = "jvm"
+                }
+            }
+        }
+
+        testInline(
+            """
+            /src/com/sample/OtherClass.kt
+            package com.sample
+            /**
+             * @suppress
+             */
+            class OtherClass internal constructor() {
+                @kotlin.annotation.Retention(AnnotationRetention.SOURCE)
+                @IntDef(ELEM_1, ELEM_2, ELEM_3)
+                internal annotation class CustomAnnotation
+
+                companion object {
+                    const val ELEM_1 = 1
+                    const val ELEM_2 = -1
+                    const val ELEM_3 = 0
+                }
+            }
+            
+            /src/com/sample/ClassUsingAnnotation.java
+            package com.sample
+            import static sample.OtherClass.ELEM_1;
+
+            /**
+             * @suppress
+             */
+            public class ClassUsingAnnotation {
+
+                @OtherClass.CustomAnnotation
+                public int doSomething() {
+                    return ELEM_1;
+                }
+            }
+            """.trimIndent(),
+            configuration
+        ) {
+            this.documentablesMergingStage = { module ->
+                assertEquals(DRI("com.sample"), module.packages.single().dri)
+            }
+        }
+    }
+}

--- a/plugins/base/src/test/kotlin/translators/Bug1341.kt
+++ b/plugins/base/src/test/kotlin/translators/Bug1341.kt
@@ -22,33 +22,16 @@ class Bug1341 : AbstractCoreTest() {
             """
             /src/com/sample/OtherClass.kt
             package com.sample
-            /**
-             * @suppress
-             */
             class OtherClass internal constructor() {
-                @kotlin.annotation.Retention(AnnotationRetention.SOURCE)
-                @IntDef(ELEM_1, ELEM_2, ELEM_3)
                 internal annotation class CustomAnnotation
-
-                companion object {
-                    const val ELEM_1 = 1
-                    const val ELEM_2 = -1
-                    const val ELEM_3 = 0
-                }
             }
             
             /src/com/sample/ClassUsingAnnotation.java
             package com.sample
-            import static sample.OtherClass.ELEM_1;
-
-            /**
-             * @suppress
-             */
             public class ClassUsingAnnotation {
-
                 @OtherClass.CustomAnnotation
                 public int doSomething() {
-                    return ELEM_1;
+                    return 1;
                 }
             }
             """.trimIndent(),


### PR DESCRIPTION
Closes #1341

This is just a temporary workaround to mitigate the effect of this bug. A new ticket for the light classes subsystem will be created and tracked afterwards.

Shall track: https://youtrack.jetbrains.com/issue/KT-41234