### PR TITLE
Set cursor value to pointer for various buttons

### DIFF
--- a/plugins/base/frontend/src/main/components/search/search.scss
+++ b/plugins/base/frontend/src/main/components/search/search.scss
@@ -3,6 +3,7 @@
     border: none;
     fill: #637282;
     background: #F4F4F4;
+    cursor: pointer;
 
     &:focus {
       outline: none;

--- a/plugins/base/src/main/resources/dokka/styles/style.css
+++ b/plugins/base/src/main/resources/dokka/styles/style.css
@@ -225,6 +225,7 @@ code.paragraph {
     display: flex;
     justify-content: flex-end;
     padding-right: 24px;
+    cursor: pointer;
 }
 
 .strikethrough {
@@ -245,6 +246,10 @@ code.paragraph {
     font-weight: bold;
     position: relative;
     line-height: 24px;
+}
+
+.copy-icon {
+    cursor: pointer;
 }
 
 .symbol span.copy-icon path {


### PR DESCRIPTION
This PR sets `cursor` style value to `pointer` for following buttons:
- Navigation drop-downs button
- Copy button
- Search button