### PR TITLE
Relative paths fix

### DIFF
--- a/runners/cli/src/main/kotlin/cli/main.kt
+++ b/runners/cli/src/main/kotlin/cli/main.kt
@@ -246,7 +246,7 @@ private fun parseSourceSet(args: Array<String>): DokkaConfiguration.DokkaSourceS
 }
 
 object ArgTypeFile : ArgType<File>(true) {
-    override fun convert(value: kotlin.String, name: kotlin.String): File = File(value)
+    override fun convert(value: kotlin.String, name: kotlin.String): File = Paths.get(value).toRealPath().toFile()
     override val description: kotlin.String
         get() = "{ String that points to file path }"
 }


### PR DESCRIPTION
I don't know why, the previous solution was correctly resolving the file, but during serialization it used to lose sometimes correct location (while debuggin I observed `File` serializes to its path, which in case it was provided as relative path, it is serialized to one, which caused trouble while deserialization)

Of course I could change it to be `File(value).toAbsoulteFile()`, but I have more trust in `Paths` since it cooperates well on different OSes