### PR TITLE
Add anchors for markdown

### DIFF
--- a/plugins/gfm/src/main/kotlin/GfmPlugin.kt
+++ b/plugins/gfm/src/main/kotlin/GfmPlugin.kt
@@ -205,6 +205,7 @@ open class CommonmarkRenderer(
                 val builder = StringBuilder()
                 it.children.forEach {
                     builder.append("| ")
+                    builder.append("<a name=\"${it.dci.dri.first()}\"></a>")
                     builder.append(
                         buildString { it.build(this, pageContext) }.replace(
                             Regex("#+ "),


### PR DESCRIPTION
Works well while serving `dokka-example` with `markserv`
 