### PR TITLE
Add filtering stategies extension point and fixed constructors in Kotlin-as-Java

### DIFF
--- a/plugins/base/src/main/kotlin/DokkaBase.kt
+++ b/plugins/base/src/main/kotlin/DokkaBase.kt
@@ -23,7 +23,9 @@ import org.jetbrains.dokka.base.transformers.pages.merger.*
 import org.jetbrains.dokka.base.transformers.pages.samples.DefaultSamplesTransformer
 import org.jetbrains.dokka.base.transformers.pages.sourcelinks.SourceLinksTransformer
 import org.jetbrains.dokka.base.translators.descriptors.DefaultDescriptorToDocumentableTranslator
+import org.jetbrains.dokka.base.translators.documentables.DefaultDocumentableFilteringStrategies
 import org.jetbrains.dokka.base.translators.documentables.DefaultDocumentableToPageTranslator
+import org.jetbrains.dokka.base.translators.documentables.DocumentableFilteringStrategies
 import org.jetbrains.dokka.base.translators.documentables.PageContentBuilder
 import org.jetbrains.dokka.base.translators.psi.DefaultPsiToDocumentableTranslator
 import org.jetbrains.dokka.plugability.DokkaPlugin
@@ -39,7 +41,7 @@ class DokkaBase : DokkaPlugin() {
     val htmlPreprocessors by extensionPoint<PageTransformer>()
     val kotlinAnalysis by extensionPoint<KotlinAnalysis>()
     val tabSortingStrategy by extensionPoint<TabSortingStrategy>()
-
+    val documentableFilteringStrategies by extensionPoint<DocumentableFilteringStrategies>()
 
     val descriptorToDocumentableTranslator by extending {
         CoreExtensions.sourceToDocumentableTranslator providing { ctx ->
@@ -115,7 +117,7 @@ class DokkaBase : DokkaPlugin() {
             DefaultDocumentableToPageTranslator(
                 ctx.single(commentsToContentConverter),
                 ctx.single(signatureProvider),
-                ctx.logger
+                ctx
             )
         }
     }
@@ -228,5 +230,9 @@ class DokkaBase : DokkaPlugin() {
         CoreExtensions.allModulePageCreator providing {
             MultimodulePageCreator(it)
         }
+    }
+
+    val defaultDocumentableFilteringStrategies by extending {
+        documentableFilteringStrategies with DefaultDocumentableFilteringStrategies
     }
 }

--- a/plugins/base/src/main/kotlin/translators/documentables/DefaultDocumentableFilteringStrategies.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DefaultDocumentableFilteringStrategies.kt
@@ -1,0 +1,9 @@
+package org.jetbrains.dokka.base.translators.documentables
+
+import org.jetbrains.dokka.model.DFunction
+import org.jetbrains.dokka.model.PrimaryConstructorExtra
+
+object DefaultDocumentableFilteringStrategies : DocumentableFilteringStrategies {
+    override fun shouldConstructorBeInPage(constructor: DFunction): Boolean =
+        constructor.extra[PrimaryConstructorExtra] == null || constructor.documentation.isNotEmpty()
+}

--- a/plugins/base/src/main/kotlin/translators/documentables/DefaultDocumentableToPageTranslator.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DefaultDocumentableToPageTranslator.kt
@@ -4,14 +4,15 @@ import org.jetbrains.dokka.base.signatures.SignatureProvider
 import org.jetbrains.dokka.base.transformers.pages.comments.CommentsToContentConverter
 import org.jetbrains.dokka.model.DModule
 import org.jetbrains.dokka.pages.ModulePageNode
+import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.transformers.documentation.DocumentableToPageTranslator
 import org.jetbrains.dokka.utilities.DokkaLogger
 
 class DefaultDocumentableToPageTranslator(
     private val commentsToContentConverter: CommentsToContentConverter,
     private val signatureProvider: SignatureProvider,
-    private val logger: DokkaLogger
+    private val context: DokkaContext
 ) : DocumentableToPageTranslator {
     override fun invoke(module: DModule): ModulePageNode =
-        DefaultPageCreator(commentsToContentConverter, signatureProvider, logger).pageForModule(module)
+        DefaultPageCreator(commentsToContentConverter, signatureProvider, context).pageForModule(module)
 }

--- a/plugins/base/src/main/kotlin/translators/documentables/DocumentableFilteringStrategies.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DocumentableFilteringStrategies.kt
@@ -1,0 +1,7 @@
+package org.jetbrains.dokka.base.translators.documentables
+
+import org.jetbrains.dokka.model.DFunction
+
+interface DocumentableFilteringStrategies {
+    fun shouldConstructorBeInPage(constructor: DFunction): Boolean
+}

--- a/plugins/base/src/test/kotlin/transformerBuilders/PageTransformerBuilderTest.kt
+++ b/plugins/base/src/test/kotlin/transformerBuilders/PageTransformerBuilderTest.kt
@@ -1,9 +1,7 @@
 package transformerBuilders;
 
 import org.jetbrains.dokka.CoreExtensions
-import org.jetbrains.dokka.pages.PageNode
-import org.jetbrains.dokka.pages.RendererSpecificResourcePage
-import org.jetbrains.dokka.pages.RenderingStrategy
+import org.jetbrains.dokka.pages.*
 import org.jetbrains.dokka.plugability.DokkaPlugin
 import org.jetbrains.dokka.testApi.testRunner.AbstractCoreTest
 import org.jetbrains.dokka.transformers.pages.PageTransformer
@@ -11,6 +9,7 @@ import org.jetbrains.dokka.transformers.pages.pageMapper
 import org.jetbrains.dokka.transformers.pages.pageScanner
 import org.jetbrains.dokka.transformers.pages.pageStructureTransformer
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
 
 class PageTransformerBuilderTest : AbstractCoreTest() {
 
@@ -132,6 +131,43 @@ class PageTransformerBuilderTest : AbstractCoreTest() {
             }
         }
     }
+
+    @Test
+    fun `kotlin constructors tab should not exist`() {
+        val configuration = dokkaConfiguration {
+            sourceSets {
+                sourceSet {
+                    sourceRoots = listOf("src/")
+                }
+            }
+        }
+        testInline(
+            """
+            |/src/main/kotlin/kotlinAsJavaPlugin/Test.kt
+            |package kotlinAsJavaPlugin
+            |
+            |class Test(val xd: Int)
+        """.trimMargin(),
+            configuration
+        ) {
+            pagesGenerationStage = { root ->
+                val content = root.children
+                    .flatMap { it.children<ContentPage>() }
+                    .map { it.content }.single().children
+                    .filterIsInstance<ContentGroup>()
+                    .single { it.dci.kind == ContentKind.Main }.children
+
+                val constructorTabsCount = content.filter { it is ContentHeader }.flatMap {
+                    it.children.filter { it is ContentText }
+                }.count {
+                    (it as? ContentText)?.text == "Constructors"
+                }
+
+                assertEquals(0, constructorTabsCount)
+            }
+        }
+    }
+
 
     private fun <T> Collection<T>.assertCount(n: Int, prefix: String = "") =
         assert(count() == n) { "${prefix}Expected $n, got ${count()}" }

--- a/plugins/kotlin-as-java/src/main/kotlin/KotlinAsJavaPlugin.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/KotlinAsJavaPlugin.kt
@@ -4,6 +4,7 @@ import org.jetbrains.dokka.CoreExtensions
 import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.kotlinAsJava.signatures.JavaSignatureProvider
 import org.jetbrains.dokka.kotlinAsJava.transformers.KotlinAsJavaDocumentableTransformer
+import org.jetbrains.dokka.kotlinAsJava.translators.KotlinAsJavaDocumentableFilteringStrategies
 import org.jetbrains.dokka.kotlinAsJava.translators.KotlinAsJavaDocumentableToPageTranslator
 import org.jetbrains.dokka.plugability.DokkaPlugin
 
@@ -11,19 +12,27 @@ class KotlinAsJavaPlugin : DokkaPlugin() {
     val kotlinAsJavaDocumentableTransformer by extending {
         CoreExtensions.documentableTransformer with KotlinAsJavaDocumentableTransformer()
     }
+
     val javaSignatureProvider by extending {
         val dokkaBasePlugin = plugin<DokkaBase>()
         dokkaBasePlugin.signatureProvider providing { ctx ->
             JavaSignatureProvider(ctx.single(dokkaBasePlugin.commentsToContentConverter), ctx.logger)
         } override dokkaBasePlugin.kotlinSignatureProvider
     }
+
+    val defaultDocumentableFilteringStrategies by extending {
+        val dokkaBasePlugin = plugin<DokkaBase>()
+        dokkaBasePlugin.documentableFilteringStrategies with KotlinAsJavaDocumentableFilteringStrategies override
+                dokkaBasePlugin.defaultDocumentableFilteringStrategies
+    }
+    
     val kotlinAsJavaDocumentableToPageTranslator by extending {
         val dokkaBasePlugin = plugin<DokkaBase>()
         CoreExtensions.documentableToPageTranslator providing { ctx ->
             KotlinAsJavaDocumentableToPageTranslator(
                 ctx.single(dokkaBasePlugin.commentsToContentConverter),
                 ctx.single(dokkaBasePlugin.signatureProvider),
-                ctx.logger
+                ctx
             )
         } override dokkaBasePlugin.documentableToPageTranslator
     }

--- a/plugins/kotlin-as-java/src/main/kotlin/translators/KotlinAsJavaDocumentableFilteringStrategies.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/translators/KotlinAsJavaDocumentableFilteringStrategies.kt
@@ -1,0 +1,8 @@
+package org.jetbrains.dokka.kotlinAsJava.translators
+
+import org.jetbrains.dokka.base.translators.documentables.DocumentableFilteringStrategies
+import org.jetbrains.dokka.model.DFunction
+
+object KotlinAsJavaDocumentableFilteringStrategies : DocumentableFilteringStrategies {
+    override fun shouldConstructorBeInPage(constructor: DFunction) = true
+}

--- a/plugins/kotlin-as-java/src/main/kotlin/translators/KotlinAsJavaDocumentableToPageTranslator.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/translators/KotlinAsJavaDocumentableToPageTranslator.kt
@@ -2,16 +2,16 @@ package org.jetbrains.dokka.kotlinAsJava.translators
 
 import org.jetbrains.dokka.base.signatures.SignatureProvider
 import org.jetbrains.dokka.base.transformers.pages.comments.CommentsToContentConverter
-import org.jetbrains.dokka.transformers.documentation.DocumentableToPageTranslator
 import org.jetbrains.dokka.model.DModule
 import org.jetbrains.dokka.pages.ModulePageNode
-import org.jetbrains.dokka.utilities.DokkaLogger
+import org.jetbrains.dokka.plugability.DokkaContext
+import org.jetbrains.dokka.transformers.documentation.DocumentableToPageTranslator
 
 class KotlinAsJavaDocumentableToPageTranslator(
     private val commentsToContentConverter: CommentsToContentConverter,
     private val signatureProvider: SignatureProvider,
-    private val logger: DokkaLogger
+    private val context: DokkaContext
 ) : DocumentableToPageTranslator {
     override fun invoke(module: DModule): ModulePageNode =
-        KotlinAsJavaPageCreator(commentsToContentConverter, signatureProvider, logger).pageForModule(module)
+        KotlinAsJavaPageCreator(commentsToContentConverter, signatureProvider, context).pageForModule(module)
 }

--- a/plugins/kotlin-as-java/src/main/kotlin/translators/KotlinAsJavaPageCreator.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/translators/KotlinAsJavaPageCreator.kt
@@ -5,12 +5,12 @@ import org.jetbrains.dokka.base.transformers.pages.comments.CommentsToContentCon
 import org.jetbrains.dokka.base.translators.documentables.DefaultPageCreator
 import org.jetbrains.dokka.model.DProperty
 import org.jetbrains.dokka.pages.MemberPageNode
-import org.jetbrains.dokka.utilities.DokkaLogger
+import org.jetbrains.dokka.plugability.DokkaContext
 
 class KotlinAsJavaPageCreator(
     commentsToContentConverter: CommentsToContentConverter,
     signatureProvider: SignatureProvider,
-    logger: DokkaLogger
-) : DefaultPageCreator(commentsToContentConverter, signatureProvider, logger) {
+    context: DokkaContext
+) : DefaultPageCreator(commentsToContentConverter, signatureProvider, context) {
     override fun pageForProperty(p: DProperty): MemberPageNode? = null
 }


### PR DESCRIPTION
Kotlin: consturctor in class declaration signature so no need for tab
![obraz](https://user-images.githubusercontent.com/32793002/92723574-8cf1e480-f369-11ea-8888-c6fbd7fb2092.png)
Kotlin as Java: no constructor in signature so tab is needed
![obraz](https://user-images.githubusercontent.com/32793002/92723726-c88cae80-f369-11ea-8b0b-d7f6c77dd819.png)
