### PR TITLE
Always show protected members

### DIFF
--- a/plugins/base/src/main/kotlin/transformers/documentables/DocumentableVisibilityFilterTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/DocumentableVisibilityFilterTransformer.kt
@@ -20,8 +20,10 @@ class DocumentableVisibilityFilterTransformer(val context: DokkaContext) : PreMe
     ) {
         fun Visibility.isAllowedInPackage(packageName: String?) = when (this) {
             is JavaVisibility.Public,
+            is JavaVisibility.Protected,
             is JavaVisibility.Default,
-            is KotlinVisibility.Public -> true
+            is KotlinVisibility.Public,
+            is KotlinVisibility.Protected -> true
             else -> packageName != null
                     && packageOptions.firstOrNull { packageName.startsWith(it.prefix) }?.includeNonPublic
                     ?: globalOptions.includeNonPublic

--- a/plugins/base/src/main/kotlin/transformers/documentables/ReportUndocumentedTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/ReportUndocumentedTransformer.kt
@@ -140,15 +140,10 @@ internal class ReportUndocumentedTransformer : DocumentableTransformer {
 
     private fun isPrivateOrInternalApi(documentable: Documentable, sourceSet: DokkaSourceSet): Boolean {
         return when (documentable.safeAs<WithVisibility>()?.visibility?.get(sourceSet)) {
-            KotlinVisibility.Public -> false
-            KotlinVisibility.Private -> true
-            KotlinVisibility.Protected -> true
-            KotlinVisibility.Internal -> true
-            JavaVisibility.Public -> false
-            JavaVisibility.Private -> true
-            JavaVisibility.Protected -> true
-            JavaVisibility.Default -> true
+            KotlinVisibility.Public, KotlinVisibility.Protected -> false
+            JavaVisibility.Public, JavaVisibility.Protected -> false
             null -> false
+            else -> true
         }
     }
 


### PR DESCRIPTION
They are part of the public API and should always be shown.

Fixes #434