### PR TITLE
Remove dokka context from creating analysis

### DIFF
--- a/kotlin-analysis/src/main/kotlin/org/jetbrains/dokka/analysis/EnvironmentAndFacade.kt
+++ b/kotlin-analysis/src/main/kotlin/org/jetbrains/dokka/analysis/EnvironmentAndFacade.kt
@@ -10,7 +10,7 @@ import java.io.File
 
 internal fun createEnvironmentAndFacade(
     logger: DokkaLogger,
-    configuration: DokkaConfiguration,
+    sourceSets: List<DokkaConfiguration.DokkaSourceSet>,
     sourceSet: DokkaConfiguration.DokkaSourceSet
 ): EnvironmentAndFacade =
     AnalysisEnvironment(DokkaMessageCollector(logger), sourceSet.analysisPlatform).run {
@@ -20,7 +20,7 @@ internal fun createEnvironmentAndFacade(
         sourceSet.classpath.forEach(::addClasspath)
 
         addSources(
-            (sourceSet.sourceRoots + configuration.sourceSets.filter { it.sourceSetID in sourceSet.dependentSourceSets }
+            (sourceSet.sourceRoots + sourceSets.filter { it.sourceSetID in sourceSet.dependentSourceSets }
                 .flatMap { it.sourceRoots })
         )
 

--- a/kotlin-analysis/src/main/kotlin/org/jetbrains/dokka/analysis/KotlinAnalysis.kt
+++ b/kotlin-analysis/src/main/kotlin/org/jetbrains/dokka/analysis/KotlinAnalysis.kt
@@ -6,18 +6,24 @@ import org.jetbrains.dokka.DokkaConfiguration.DokkaSourceSet
 import org.jetbrains.dokka.DokkaSourceSetID
 import org.jetbrains.dokka.model.SourceSetDependent
 import org.jetbrains.dokka.plugability.DokkaContext
+import org.jetbrains.dokka.utilities.DokkaLogger
 
-fun KotlinAnalysis(context: DokkaContext): KotlinAnalysis {
-    val environments = context.configuration.sourceSets.associateWith { sourceSet ->
+fun KotlinAnalysis(sourceSets: List<DokkaSourceSet>, logger: DokkaLogger): KotlinAnalysis {
+    val environments = sourceSets.associateWith { sourceSet ->
         createEnvironmentAndFacade(
-            logger = context.logger,
-            configuration = context.configuration,
+            logger = logger,
+            sourceSets = sourceSets,
             sourceSet = sourceSet
         )
     }
 
     return KotlinAnalysisImpl(environments)
 }
+
+@Deprecated(message = "Construct using list of DokkaSourceSets and logger",
+    replaceWith = ReplaceWith("KotlinAnalysis(context.configuration.sourceSets, context.logger)")
+)
+fun KotlinAnalysis(context: DokkaContext): KotlinAnalysis = KotlinAnalysis(context.configuration.sourceSets, context.logger)
 
 interface KotlinAnalysis : SourceSetDependent<EnvironmentAndFacade> {
     override fun get(key: DokkaSourceSet): EnvironmentAndFacade

--- a/plugins/base/src/main/kotlin/DokkaBase.kt
+++ b/plugins/base/src/main/kotlin/DokkaBase.kt
@@ -152,7 +152,7 @@ class DokkaBase : DokkaPlugin() {
 
 
     val defaultKotlinAnalysis by extending {
-        kotlinAnalysis providing { ctx -> KotlinAnalysis(ctx) }
+        kotlinAnalysis providing { ctx -> KotlinAnalysis(ctx.configuration.sourceSets, ctx.logger) }
     }
 
     val locationProvider by extending {


### PR DESCRIPTION
If someone uses just the dokka-analysis should not be forced into creating a dokka context only to pass configuration, sourcesets and logger