### PR TITLE
Add better handling of functional types in rendered output

### DIFF
--- a/plugins/base/src/test/kotlin/signatures/FunctionalTypeConstructorsSignatureTest.kt
+++ b/plugins/base/src/test/kotlin/signatures/FunctionalTypeConstructorsSignatureTest.kt
@@ -1,0 +1,260 @@
+package signatures
+
+import org.jetbrains.dokka.DokkaConfiguration
+import org.jetbrains.dokka.jdk
+import org.jetbrains.dokka.testApi.testRunner.AbstractCoreTest
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import utils.A
+import utils.Span
+import utils.TestOutputWriterPlugin
+import utils.match
+
+class FunctionalTypeConstructorsSignatureTest : AbstractCoreTest() {
+    private val configuration = dokkaConfiguration {
+        sourceSets {
+            sourceSet {
+                sourceRoots = listOf("src/")
+                classpath = listOf(commonStdlibPath!!)
+                externalDocumentationLinks = listOf(
+                    stdlibExternalDocumentationLink,
+                    DokkaConfiguration.ExternalDocumentationLink.Companion.jdk(8)
+                )
+            }
+        }
+    }
+
+    fun source(signature: String) =
+        """
+            |/src/main/kotlin/test/Test.kt
+            |package example
+            |
+            | $signature
+            """.trimIndent()
+
+    @Test
+    fun `kotlin normal function`() {
+        val source = source("val nF: Function1<Int, String> = { _ -> \"\" }")
+        val writerPlugin = TestOutputWriterPlugin()
+
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin)
+        ) {
+            renderingStage = { _, _ ->
+                writerPlugin.writer.renderedContent("root/example.html").firstSignature().match(
+                    "val ", A("nF"), ": (", A("Int"), ") -> ", A("String"), Span()
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `kotlin syntactic sugar function`() {
+        val source = source("val nF: (Int) -> String = { _ -> \"\" }")
+        val writerPlugin = TestOutputWriterPlugin()
+
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin)
+        ) {
+            renderingStage = { _, _ ->
+                writerPlugin.writer.renderedContent("root/example.html").firstSignature().match(
+                    "val ", A("nF"), ": (", A("Int"), ") -> ", A("String"), Span()
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `kotlin syntactic sugar extension function`() {
+        val source = source("val nF: Boolean.(Int) -> String = { _ -> \"\" }")
+        val writerPlugin = TestOutputWriterPlugin()
+
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin)
+        ) {
+            renderingStage = { _, _ ->
+                writerPlugin.writer.renderedContent("root/example.html").firstSignature().match(
+                    "val ", A("nF"), ": ", A("Boolean"), ".(", A("Int"), ") -> ", A("String"), Span()
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `kotlin syntactic sugar function with param name`() {
+        val source = source("val nF: (param: Int) -> String = { _ -> \"\" }")
+        val writerPlugin = TestOutputWriterPlugin()
+
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin)
+        ) {
+            renderingStage = { _, _ ->
+                writerPlugin.writer.renderedContent("root/example.html").firstSignature().match(
+                    "val ", A("nF"), ": (param: ", A("Int"), ") -> ", A("String"), Span()
+                )
+            }
+        }
+    }
+
+    @Disabled // Add coroutines on classpath and get proper import
+    @Test
+    fun `kotlin normal suspendable function`() {
+        val source = source("val nF: SuspendFunction1<Int, String> = { _ -> \"\" }")
+        val writerPlugin = TestOutputWriterPlugin()
+
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin)
+        ) {
+            renderingStage = { _, _ ->
+                writerPlugin.writer.renderedContent("root/example.html").firstSignature().match(
+                    "val ", A("nF"), ": suspend (", A("Int"), ") -> ", A("String"), Span()
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `kotlin syntactic sugar suspendable function`() {
+        val source = source("val nF: suspend (Int) -> String = { _ -> \"\" }")
+        val writerPlugin = TestOutputWriterPlugin()
+
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin)
+        ) {
+            renderingStage = { _, _ ->
+                writerPlugin.writer.renderedContent("root/example.html").firstSignature().match(
+                    "val ", A("nF"), ": suspend (", A("Int"), ") -> ", A("String"), Span()
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `kotlin syntactic sugar suspendable extension function`() {
+        val source = source("val nF: suspend Boolean.(Int) -> String = { _ -> \"\" }")
+        val writerPlugin = TestOutputWriterPlugin()
+
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin)
+        ) {
+            renderingStage = { _, _ ->
+                writerPlugin.writer.renderedContent("root/example.html").firstSignature().match(
+                    "val ", A("nF"), ": suspend ", A("Boolean"), ".(", A("Int"), ") -> ", A("String"), Span()
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `kotlin syntactic sugar suspendable function with param name`() {
+        val source = source("val nF: suspend (param: Int) -> String = { _ -> \"\" }")
+        val writerPlugin = TestOutputWriterPlugin()
+
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin)
+        ) {
+            renderingStage = { _, _ ->
+                writerPlugin.writer.renderedContent("root/example.html").firstSignature().match(
+                    "val ", A("nF"), ": suspend (param: ", A("Int"), ") -> ", A("String"), Span()
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `kotlin syntactic sugar suspendable fancy function with param name`() {
+        val source =
+            source("val nF: suspend (param1: suspend Boolean.(param2: List<Int>) -> Boolean) -> String = { _ -> \"\" }")
+        val writerPlugin = TestOutputWriterPlugin()
+
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin)
+        ) {
+            renderingStage = { _, _ ->
+                writerPlugin.writer.renderedContent("root/example.html").firstSignature().match(
+                    "val ",
+                    A("nF"),
+                    ": suspend (param1: suspend",
+                    A("Boolean"),
+                    ".(param2: ",
+                    A("List"),
+                    "<",
+                    A("Int"),
+                    ">) -> ",
+                    A("Boolean"),
+                    ") -> ",
+                    A("String"),
+                    Span()
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `java with java function`() {
+        val source = """
+            |/src/main/kotlin/test/JavaClass.java
+            |package example
+            |
+            |public class JavaClass {
+            |    public java.util.function.Function<Integer, String> javaFunction = null;
+            |}
+        """.trimIndent()
+        val writerPlugin = TestOutputWriterPlugin()
+
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin)
+        ) {
+            renderingStage = { _, _ ->
+                writerPlugin.writer.renderedContent("root/example/-java-class/index.html").signature().last().match(
+                    "open val ", A("javaFunction"), ": (", A("Integer"), ") -> ", A("String"), Span()
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `java with kotlin function`() {
+        val source = """
+            |/src/main/kotlin/test/JavaClass.java
+            |package example
+            |
+            |public class JavaClass {
+            |    public kotlin.jvm.functions.Function1<Integer, String> kotlinFunction = null;
+            |}
+        """.trimIndent()
+        val writerPlugin = TestOutputWriterPlugin()
+
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin)
+        ) {
+            renderingStage = { _, _ ->
+                writerPlugin.writer.renderedContent("root/example/-java-class/index.html").signature().last().match(
+                    "open val ", A("kotlinFunction"), ": (", A("Integer"), ") -> ", A("String"), Span()
+                )
+            }
+        }
+    }
+}

--- a/plugins/kotlin-as-java/src/main/kotlin/converters/KotlinToJavaConverter.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/converters/KotlinToJavaConverter.kt
@@ -188,7 +188,11 @@ private fun Projection.asJava(): Projection = when(this) {
 
 private fun Bound.asJava(): Bound = when(this) {
     is TypeParameter -> copy(dri.possiblyAsJava())
-    is TypeConstructor -> copy(
+    is GenericTypeConstructor -> copy(
+        dri = dri.possiblyAsJava(),
+        projections = projections.map { it.asJava() }
+    )
+    is FunctionalTypeConstructor -> copy(
         dri = dri.possiblyAsJava(),
         projections = projections.map { it.asJava() }
     )
@@ -229,7 +233,7 @@ internal fun DObject.asJava(): DObject = copy(
                 visibility = sourceSets.map {
                     it to JavaVisibility.Public
                 }.toMap(),
-                type = TypeConstructor(dri, emptyList()),
+                type = GenericTypeConstructor(dri, emptyList()),
                 setter = null,
                 getter = null,
                 sourceSets = sourceSets,
@@ -276,7 +280,10 @@ internal fun String.getAsPrimitive(): JvmPrimitiveType? = org.jetbrains.kotlin.b
 
 private fun DRI.partialFqName() = packageName?.let { "$it." } + classNames
 private fun DRI.possiblyAsJava() = this.partialFqName().mapToJava()?.toDRI(this) ?: this
-private fun TypeConstructor.possiblyAsJava() = copy(dri = this.dri.possiblyAsJava())
+private fun TypeConstructor.possiblyAsJava() = when(this) {
+    is GenericTypeConstructor -> copy(dri = this.dri.possiblyAsJava())
+    is FunctionalTypeConstructor -> copy(dri = this.dri.possiblyAsJava())
+}
 
 private fun String.mapToJava(): ClassId? =
     JavaToKotlinClassMap.mapKotlinToJava(FqName(this).toUnsafe())


### PR DESCRIPTION
260 lines are just tests

```kotlin
val n1: Function1<Int, String> = { _ -> "" }
val n2: (Int) -> String = { _ -> "" }
val n3: Boolean.(Int) -> String = { _ -> "" }
val n4: (param: Int) -> String = { _ -> "" }
val n5: suspend (Int) -> String = { _ -> "" }
val n6: suspend Boolean.(Int) -> String = { _ -> "" }
val n7: suspend (param: Int) -> String = { _ -> "" }
val n8: suspend (param1: suspend Boolean.(param2: List<Int>) -> Boolean) -> String = { _ -> "" }
```

![obraz](https://user-images.githubusercontent.com/32793002/93475092-82e75d00-f8f8-11ea-8347-2dc63b1dff9b.png)
