### PR TITLE
Add processing of annotations to typealiases

### DIFF
--- a/plugins/base/src/main/kotlin/signatures/KotlinSignatureProvider.kt
+++ b/plugins/base/src/main/kotlin/signatures/KotlinSignatureProvider.kt
@@ -273,14 +273,15 @@ class KotlinSignatureProvider(ctcc: CommentsToContentConverter, logger: DokkaLog
 
     private fun signature(t: DTypeAlias) =
         t.sourceSets.map {
-            contentBuilder.contentFor(t, styles = t.stylesIfDeprecated(it), sourceSets = setOf(it)) {
+            contentBuilder.contentFor(t, sourceSets = setOf(it)) {
                 t.underlyingType.entries.groupBy({ it.value }, { it.key }).map { (type, platforms) ->
                     +contentBuilder.contentFor(
                         t,
                         ContentKind.Symbol,
-                        setOf(TextStyle.Monospace),
+                        setOf(TextStyle.Monospace) + t.stylesIfDeprecated(it),
                         sourceSets = platforms.toSet()
                     ) {
+                        annotationsBlock(t)
                         text(t.visibility[it]?.takeIf { it !in ignoredVisibilities }?.name?.let { "$it " } ?: "")
                         processExtraModifiers(t)
                         text("typealias ")

--- a/plugins/base/src/main/kotlin/transformers/documentables/DeprecatedDocumentableFilterTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/DeprecatedDocumentableFilterTransformer.kt
@@ -57,6 +57,10 @@ class DeprecatedDocumentableFilterTransformer(val context: DokkaContext) : PreMe
                     modified = modified || listModified
                     list
                 }
+                val typeAliases = filterTypeAliases(pckg.typealiases).let { (listModified, list) ->
+                    modified = modified || listModified
+                    list
+                }
                 when {
                     !modified -> pckg
                     else -> {
@@ -64,7 +68,8 @@ class DeprecatedDocumentableFilterTransformer(val context: DokkaContext) : PreMe
                         pckg.copy(
                             functions = functions,
                             properties = properties,
-                            classlikes = classlikes
+                            classlikes = classlikes,
+                            typealiases = typeAliases
                         )
                     }
                 }
@@ -93,6 +98,11 @@ class DeprecatedDocumentableFilterTransformer(val context: DokkaContext) : PreMe
                     properties = filterProperties(entry.properties).second,
                     classlikes = filterClasslikes(entry.classlikes).second,
                 )
+            }
+
+        private fun filterTypeAliases(typeAliases: List<DTypeAlias>) =
+            typeAliases.filter { it.isAllowedInPackage() }.let {
+                Pair(typeAliases.size != it.size, it)
             }
 
         private fun filterClasslikes(

--- a/plugins/base/src/main/kotlin/translators/descriptors/DefaultDescriptorToDocumentableTranslator.kt
+++ b/plugins/base/src/main/kotlin/translators/descriptors/DefaultDescriptorToDocumentableTranslator.kt
@@ -510,7 +510,7 @@ private class DokkaDescriptorVisitor(
             sources = descriptor.createSources(),
             sourceSets = setOf(sourceSet),
             isExpectActual = (isExpect || isActual),
-            extra = PropertyContainer.withAll<DFunction>(
+            extra = PropertyContainer.withAll(
                 descriptor.additionalExtras().toSourceSetDependent().toAdditionalModifiers(),
                 descriptor.getAnnotations().toSourceSetDependent().toAnnotations()
             )
@@ -528,7 +528,10 @@ private class DokkaDescriptorVisitor(
                 visibility = visibility.toDokkaVisibility().toSourceSetDependent(),
                 documentation = resolveDescriptorData(),
                 sourceSets = setOf(sourceSet),
-                generics = descriptor.declaredTypeParameters.map { it.toVariantTypeParameter() }
+                generics = descriptor.declaredTypeParameters.map { it.toVariantTypeParameter() },
+                extra = PropertyContainer.withAll(
+                    descriptor.getAnnotations().toSourceSetDependent().toAnnotations()
+                )
             )
         }
 

--- a/plugins/base/src/test/kotlin/signatures/SignatureTest.kt
+++ b/plugins/base/src/test/kotlin/signatures/SignatureTest.kt
@@ -401,6 +401,40 @@ class SignatureTest : AbstractCoreTest() {
     }
 
     @Test
+    fun `plain typealias of plain class with annotation`() {
+
+        val writerPlugin = TestOutputWriterPlugin()
+
+        testInline(
+            """
+                |/src/main/kotlin/common/Test.kt
+                |package example
+                |
+                |@MustBeDocumented
+                |@Target(AnnotationTarget.TYPEALIAS)
+                |annotation class SomeAnnotation
+                |
+                |@SomeAnnotation
+                |typealias PlainTypealias = Int
+                |
+            """.trimMargin(),
+            configuration,
+            pluginOverrides = listOf(writerPlugin)
+        ) {
+            renderingStage = { _, _ ->
+                writerPlugin.writer.renderedContent("root/example/index.html").signature().first().match(
+                    Div(
+                        Div(
+                            "@", A("SomeAnnotation"), "()"
+                        )
+                    ),
+                    "typealias ", A("PlainTypealias"), " = ", A("Int"), Span()
+                )
+            }
+        }
+    }
+
+    @Test
     fun `plain typealias of generic class`() {
 
         val writerPlugin = TestOutputWriterPlugin()


### PR DESCRIPTION
By mistake, we forgot to process annotations for `typealiases` completetly.

Also fixes reported bug with not deprecating them.

```kotlin
@MustBeDocumented
@Target(AnnotationTarget.TYPEALIAS)
annotation class SomeAnnotation

@SomeAnnotation
@Deprecated(
    message = "Replace with ImageRequest.",
    replaceWith = ReplaceWith("ImageRequest", "coil.request.ImageRequest")
)
typealias GetRequest = Int
```

![obraz](https://user-images.githubusercontent.com/32793002/93487799-ee83f700-f905-11ea-9fc7-33609fc9fb32.png)
