### PR TITLE
Set aether authn when getting artifacts

### DIFF
--- a/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
+++ b/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
@@ -279,7 +279,7 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
                     "repo",
                     "default",
                     it.url
-                ).build()
+                ).setAuthentication( it.authentication ).build()
             )
         }
         val node: DependencyNode = repoSystem.collectDependencies(session, collectRequest).root


### PR DESCRIPTION
When getting artifacts via aether for the plugins classpath,
set authentication on the remote repositories.

Without this, dokka fails if remote repositories require authentication.