### PR TITLE
Fix vararg signatures

### DIFF
--- a/plugins/base/src/main/kotlin/translators/descriptors/DefaultDescriptorToDocumentableTranslator.kt
+++ b/plugins/base/src/main/kotlin/translators/descriptors/DefaultDescriptorToDocumentableTranslator.kt
@@ -543,7 +543,7 @@ private class DokkaDescriptorVisitor(
         DParameter(
             dri = parent.dri.copy(target = PointingToCallableParameters(index)),
             name = descriptor.name.asString(),
-            type = descriptor.type.toBound(),
+            type = descriptor.varargElementType?.toBound() ?: descriptor.type.toBound(),
             expectPresentInSet = null,
             documentation = descriptor.resolveDescriptorData(),
             sourceSets = setOf(sourceSet),

--- a/plugins/base/src/test/kotlin/signatures/SignatureTest.kt
+++ b/plugins/base/src/test/kotlin/signatures/SignatureTest.kt
@@ -179,6 +179,24 @@ class SignatureTest : AbstractCoreTest() {
     }
 
     @Test
+    fun `fun with vararg`() {
+        val source = source("fun simpleFun(vararg params: Int): Unit")
+        val writerPlugin = TestOutputWriterPlugin()
+
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin)
+        ) {
+            renderingStage = { _, _ ->
+                writerPlugin.writer.renderedContent("root/example/simple-fun.html").firstSignature().match(
+                    "fun ", A("simpleFun"), "(vararg params: ", A("Int"), ")", Span()
+                )
+            }
+        }
+    }
+
+    @Test
     fun `class with no supertype`() {
         val source = source("class SimpleClass")
         val writerPlugin = TestOutputWriterPlugin()


### PR DESCRIPTION
```
fun foo(vararg params: Int) { }
```

![obraz](https://user-images.githubusercontent.com/32793002/94696303-2ee86980-0337-11eb-8729-98b9582f2547.png)
