### PR TITLE
Fix multiline links in javadoc and wrong linebreaking of <pre> bodies

### DIFF
--- a/plugins/base/src/test/kotlin/translators/JavadocParserTest.kt
+++ b/plugins/base/src/test/kotlin/translators/JavadocParserTest.kt
@@ -114,6 +114,14 @@ class JavadocParserTest : AbstractCoreTest() {
             | * not fall within the indicated ranges; for example, a date may be
             | * specified as January 32 and is interpreted as meaning February 1.
             | *
+            | * <pre class="prettyprint">
+            | * class MyFragment extends Fragment {
+            | *   public MyFragment() {
+            | *     super(R.layout.fragment_main);
+            | *   }
+            | * }
+            | * </pre>
+            |
             | * @author  James Gosling
             | * @author  Arthur van Hoff
             | * @author  Alan Liu
@@ -178,4 +186,19 @@ class JavadocParserTest : AbstractCoreTest() {
             assertEquals(expectedText.trim(), preTagContent.body.trim())
         }
     }
+
+    @Test
+    fun `correctly parsed code block with curly braces (which PSI has problem with)`() {
+        performJavadocTest { module ->
+            val dateDescription = module.descriptionOf("Date2")!!
+            val preTagContent = dateDescription.childrenOfType<Pre>()[1].firstChildOfType<Text>()
+            val expectedText = """class MyFragment extends Fragment {
+  public MyFragment() {
+    super(R.layout.fragment_main);
+  }
+}""".trimIndent()
+            assertEquals(expectedText.trim(), preTagContent.body.trim())
+        }
+    }
+
 }

--- a/plugins/javadoc/src/test/kotlin/org/jetbrains/dokka/javadoc/AbstractJavadocTemplateMapTest.kt
+++ b/plugins/javadoc/src/test/kotlin/org/jetbrains/dokka/javadoc/AbstractJavadocTemplateMapTest.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.dokka.javadoc
 
-import org.jetbrains.dokka.DokkaConfigurationImpl
-import org.jetbrains.dokka.ExternalDocumentationLink
+import org.jetbrains.dokka.*
 import org.jetbrains.dokka.javadoc.pages.JavadocPageNode
 import org.jetbrains.dokka.javadoc.renderer.JavadocContentToTemplateMapTranslator
 import org.jetbrains.dokka.javadoc.JavadocPlugin
@@ -19,8 +18,8 @@ internal abstract class AbstractJavadocTemplateMapTest : AbstractCoreTest() {
                 sourceRoots = listOf("src")
                 analysisPlatform = "jvm"
                 externalDocumentationLinks = listOf(
-                    ExternalDocumentationLink("https://docs.oracle.com/javase/8/docs/api/"),
-                    ExternalDocumentationLink("https://kotlinlang.org/api/latest/jvm/stdlib/")
+                    DokkaConfiguration.ExternalDocumentationLink.jdk(8),
+                    DokkaConfiguration.ExternalDocumentationLink.kotlinStdlib()
                 )
             }
         }

--- a/plugins/javadoc/src/test/kotlin/org/jetbrains/dokka/javadoc/location/JavadocLinkingTest.kt
+++ b/plugins/javadoc/src/test/kotlin/org/jetbrains/dokka/javadoc/location/JavadocLinkingTest.kt
@@ -1,0 +1,68 @@
+package org.jetbrains.dokka.javadoc.location
+
+import org.jetbrains.dokka.ExternalDocumentationLink
+import org.jetbrains.dokka.model.doc.DocumentationLink
+import org.jetbrains.dokka.model.doc.Text
+import org.jetbrains.dokka.testApi.testRunner.AbstractCoreTest
+import org.jetbrains.dokka.utilities.cast
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class JavadocLinkingTest : AbstractCoreTest() {
+
+    @Test
+    fun `linebroken link`() {
+        fun externalLink(link: String) = ExternalDocumentationLink(link)
+
+        val config = dokkaConfiguration {
+            sourceSets {
+                sourceSet {
+                    sourceRoots = listOf("jvmSrc/")
+                    externalDocumentationLinks = listOf(
+                        externalLink("https://docs.oracle.com/javase/8/docs/api/"),
+                        externalLink("https://kotlinlang.org/api/latest/jvm/stdlib/")
+                    )
+                    analysisPlatform = "jvm"
+                }
+            }
+        }
+        testInline(
+            """
+            |/jvmSrc/javadoc/test/SomeClass.kt
+            |
+            |package example
+            |
+            |class SomeClass {
+            |    fun someFun(x: Int): Int = 1
+            |}
+            |/jvmSrc/javadoc/test/SomeJavaDocExample.java
+            |
+            |package example;
+            |
+            |/**
+            | * Here comes some comment
+            | *
+            | * {@link example.SomeClass#someFun(int) someName(ads,
+            | * dsa)}
+            | *
+            | * longer comment
+            | */
+            |public class SomeJavaDocExample {
+            |    public void someFunc(int integer, Object object) {
+            |    }
+            |}
+        """.trimIndent(),
+            config,
+            cleanupOutput = false
+        ) {
+            documentablesMergingStage = {
+                it.packages.single().classlikes.single { it.name == "SomeJavaDocExample" }.documentation.values.single().children.single().children.single {
+                    it is DocumentationLink
+                }.children.single().cast<Text>().body.run {
+                    assertEquals("someName(ads, dsa)", this)
+                }
+            }
+        }
+    }
+
+}

--- a/plugins/javadoc/src/test/kotlin/org/jetbrains/dokka/javadoc/location/JavadocLinkingTest.kt
+++ b/plugins/javadoc/src/test/kotlin/org/jetbrains/dokka/javadoc/location/JavadocLinkingTest.kt
@@ -1,26 +1,27 @@
 package org.jetbrains.dokka.javadoc.location
 
-import org.jetbrains.dokka.ExternalDocumentationLink
+import org.jetbrains.dokka.DokkaConfiguration
+import org.jetbrains.dokka.jdk
+import org.jetbrains.dokka.kotlinStdlib
 import org.jetbrains.dokka.model.doc.DocumentationLink
 import org.jetbrains.dokka.model.doc.Text
 import org.jetbrains.dokka.testApi.testRunner.AbstractCoreTest
 import org.jetbrains.dokka.utilities.cast
 import org.junit.jupiter.api.Test
+import utils.TestOutputWriterPlugin
 import kotlin.test.assertEquals
 
 class JavadocLinkingTest : AbstractCoreTest() {
 
     @Test
-    fun `linebroken link`() {
-        fun externalLink(link: String) = ExternalDocumentationLink(link)
-
+    fun lineBrokenLink() {
         val config = dokkaConfiguration {
             sourceSets {
                 sourceSet {
                     sourceRoots = listOf("jvmSrc/")
                     externalDocumentationLinks = listOf(
-                        externalLink("https://docs.oracle.com/javase/8/docs/api/"),
-                        externalLink("https://kotlinlang.org/api/latest/jvm/stdlib/")
+                        DokkaConfiguration.ExternalDocumentationLink.jdk(8),
+                        DokkaConfiguration.ExternalDocumentationLink.kotlinStdlib(),
                     )
                     analysisPlatform = "jvm"
                 }
@@ -35,6 +36,7 @@ class JavadocLinkingTest : AbstractCoreTest() {
             |class SomeClass {
             |    fun someFun(x: Int): Int = 1
             |}
+            |
             |/jvmSrc/javadoc/test/SomeJavaDocExample.java
             |
             |package example;
@@ -51,18 +53,22 @@ class JavadocLinkingTest : AbstractCoreTest() {
             |    public void someFunc(int integer, Object object) {
             |    }
             |}
-        """.trimIndent(),
+        """.trimMargin(),
             config,
-            cleanupOutput = false
+            pluginOverrides = listOf(TestOutputWriterPlugin())
         ) {
             documentablesMergingStage = {
-                it.packages.single().classlikes.single { it.name == "SomeJavaDocExample" }.documentation.values.single().children.single().children.single {
-                    it is DocumentationLink
-                }.children.single().cast<Text>().body.run {
-                    assertEquals("someName(ads, dsa)", this)
-                }
+                it.packages.single()
+                    .classlikes.single { classlike -> classlike.name == "SomeJavaDocExample" }
+                    .documentation.values.single()
+                    .children.single()
+                    .children.single()
+                    .children.single {
+                        it is DocumentationLink
+                    }.children.filterIsInstance<Text>().single { it.body.contains("someName") }.cast<Text>().body.run {
+                        assertEquals("someName(ads, dsa)", this)
+                    }
             }
         }
     }
-
 }

--- a/plugins/javadoc/src/test/kotlin/org/jetbrains/dokka/javadoc/location/JavadocLocationTest.kt
+++ b/plugins/javadoc/src/test/kotlin/org/jetbrains/dokka/javadoc/location/JavadocLocationTest.kt
@@ -1,11 +1,9 @@
 package org.jetbrains.dokka.javadoc.location
 
+import org.jetbrains.dokka.*
 import org.jetbrains.dokka.javadoc.pages.JavadocClasslikePageNode
 import org.jetbrains.dokka.javadoc.pages.JavadocPackagePageNode
 import org.jetbrains.dokka.javadoc.renderer.JavadocContentToHtmlTranslator
-import org.jetbrains.dokka.DokkaConfiguration
-import org.jetbrains.dokka.ExternalDocumentationLink
-import org.jetbrains.dokka.ExternalDocumentationLinkImpl
 import org.jetbrains.dokka.javadoc.JavadocPlugin
 import org.jetbrains.dokka.model.firstChildOfType
 import org.jetbrains.dokka.pages.RootPageNode
@@ -19,16 +17,14 @@ import org.junit.jupiter.api.Assertions.assertEquals
 class JavadocLocationTest : AbstractCoreTest() {
 
     private fun locationTestInline(testHandler: (RootPageNode, DokkaContext) -> Unit) {
-        fun externalLink(link: String) = ExternalDocumentationLink(link)
-
         val config = dokkaConfiguration {
             format = "javadoc"
             sourceSets {
                 sourceSet {
                     sourceRoots = listOf("jvmSrc/")
                     externalDocumentationLinks = listOf(
-                        externalLink("https://docs.oracle.com/javase/8/docs/api/"),
-                        externalLink("https://kotlinlang.org/api/latest/jvm/stdlib/")
+                        DokkaConfiguration.ExternalDocumentationLink.jdk(8),
+                        DokkaConfiguration.ExternalDocumentationLink.kotlinStdlib()
                     )
                     analysisPlatform = "jvm"
                 }


### PR DESCRIPTION
I decided to do that in one PR, because fixes implementation depends on same code sections

#### Multiline links

```
/**
 * Here comes some comment
 *
 * {@link example.SomeClassToLink#someFunc(int, Object) someName(ads,
 * dsa)}
 *
 * longer comment
 */
public class SomeJavaDocExample {
}
```

![obraz](https://user-images.githubusercontent.com/32793002/94783144-8be22f00-03cc-11eb-8db9-487931a4303d.png)

#### Pre tags bodies formatting

```
/**
 * <pre class="prettyprint">
 * class MyFragment extends Fragment {
 *   public MyFragment() {
 *     super(R.layout.fragment_main);
 *   }
 * }
 * </pre>
 */
```

![obraz](https://user-images.githubusercontent.com/32793002/94805399-9ca29d00-03ec-11eb-8a86-e35542535d3b.png)
