### PR TITLE
Escape urls in anchors

### DIFF
--- a/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/BasicGradleIntegrationTest.kt
+++ b/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/BasicGradleIntegrationTest.kt
@@ -104,6 +104,14 @@ class BasicGradleIntegrationTest(override val versions: BuildVersions) : Abstrac
             },
             "Expected `SampleJavaClass` source link to GitHub"
         )
+
+        val anchorsShouldNotHaveHashes = "data-name=\".*#.*\"".toRegex()
+        assertTrue(
+            allHtmlFiles().all { file ->
+                !anchorsShouldNotHaveHashes.containsMatchIn(file.readText())
+            },
+            "Anchors should not have hashes inside"
+        )
     }
 
     private fun File.assertJavadocOutputDir() {

--- a/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
@@ -21,6 +21,7 @@ import org.jetbrains.dokka.plugability.plugin
 import org.jetbrains.dokka.plugability.query
 import org.jetbrains.dokka.plugability.querySingle
 import org.jetbrains.dokka.utilities.htmlEscape
+import org.jetbrains.dokka.utilities.urlEncoded
 import java.io.File
 import java.net.URI
 
@@ -365,7 +366,7 @@ open class HtmlRenderer(
             .filter { sourceSetRestriction == null || it.sourceSets.any { s -> s in sourceSetRestriction } }
             .takeIf { it.isNotEmpty() }
             ?.let {
-                val anchorName = node.dci.dri.first().toString()
+                val anchorName = node.dci.dri.first().anchor
                 withAnchor(anchorName) {
                     div(classes = "table-row") {
                         if (!style.contains(MultimoduleTable)) {
@@ -498,7 +499,7 @@ open class HtmlRenderer(
 
 
     override fun FlowContent.buildHeader(level: Int, node: ContentHeader, content: FlowContent.() -> Unit) {
-        val anchor = node.extra[SimpleAttr.SimpleAttrKey("anchor")]?.extraValue
+        val anchor = node.extra[SimpleAttr.SimpleAttrKey("anchor")]?.extraValue?.urlEncoded()
         val classes = node.style.joinToString { it.toString() }.toLowerCase()
         when (level) {
             1 -> h1(classes = classes) { withAnchor(anchor, content) }
@@ -759,3 +760,6 @@ private val PageNode.isNavigable: Boolean
     get() = this !is RendererSpecificPage || strategy != RenderingStrategy.DoNothing
 
 fun PropertyContainer<ContentNode>.extraHtmlAttributes() = allOfType<SimpleAttr>()
+
+private val DRI.anchor: String
+    get() = toString().urlEncoded()

--- a/plugins/base/src/main/kotlin/resolvers/local/DokkaLocationProvider.kt
+++ b/plugins/base/src/main/kotlin/resolvers/local/DokkaLocationProvider.kt
@@ -8,6 +8,7 @@ import org.jetbrains.dokka.model.DisplaySourceSet
 import org.jetbrains.dokka.model.withDescendants
 import org.jetbrains.dokka.pages.*
 import org.jetbrains.dokka.plugability.DokkaContext
+import org.jetbrains.dokka.utilities.urlEncoded
 import java.util.*
 
 open class DokkaLocationProvider(
@@ -68,7 +69,7 @@ open class DokkaLocationProvider(
 
     private fun getLocalLocation(dri: Pair<DRI, DisplaySourceSet?>, context: PageNode?): String? =
         pagesIndex[dri]?.let { resolve(it, context) }
-            ?: anchorsIndex[dri]?.let { resolve(it, context) + "#${dri.first}" }
+            ?: anchorsIndex[dri]?.let { resolve(it, context) + "#${dri.first.toString().urlEncoded()}" }
 
 
     override fun pathToRoot(from: PageNode): String =

--- a/plugins/base/src/main/resources/dokka/scripts/platformContentHandler.js
+++ b/plugins/base/src/main/resources/dokka/scripts/platformContentHandler.js
@@ -57,15 +57,14 @@ function handleAnchor() {
         if (element) {
             let tab = searchForTab(element)
             if (tab) {
-                let found = document.querySelector('.tabs-section > .section-tab[data-togglable="' + tab.getAttribute("data-togglable") + '"]')
                 toggleSections(tab)
-                const content = element.nextElementSibling
-                if(content){
-                    content.classList.add('anchor-highlight')
-                    highlightedAnchor = content
-                }
-                element.scrollIntoView({behavior: "smooth"})
             }
+            const content = element.nextElementSibling
+            if(content){
+                content.classList.add('anchor-highlight')
+                highlightedAnchor = content
+            }
+            element.scrollIntoView({behavior: "smooth"})
         }
     }
 }


### PR DESCRIPTION
Complete escape of the anchors since they are arbitrary values.

Anchors change from:
```
https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-json/kotlinx-serialization-json/kotlinx.serialization.json/-json-builder/index.html#kotlinx.serialization.json/JsonBuilder/isLenient/#/PointingToDeclaration/
```
To:
```
http://localhost:63342/kotlinx.serialization/build/dokka/htmlMultiModule/kotlinx-serialization-json/kotlinx-serialization-json/kotlinx.serialization.json/-json-builder/index.html#kotlinx.serialization.json%2FJsonBuilder%2FisLenient%2F%23%2FPointingToDeclaration%2F
```