### PR TITLE
Add parsing of package-info in java sources

### DIFF
--- a/core/test-api/src/main/kotlin/testApi/testRunner/TestRunner.kt
+++ b/core/test-api/src/main/kotlin/testApi/testRunner/TestRunner.kt
@@ -187,7 +187,7 @@ abstract class AbstractCoreTest(
     )
 
     companion object {
-        private val filePathRegex = Regex("""[\n^](/\w+)+(\.\w+)?\s*\n""")
+        private val filePathRegex = Regex("""[\n^](\/[\w|\-]+)+(\.\w+)?\s*\n""")
     }
 }
 

--- a/plugins/base/src/main/kotlin/translators/psi/JavadocParser.kt
+++ b/plugins/base/src/main/kotlin/translators/psi/JavadocParser.kt
@@ -88,8 +88,7 @@ class JavadocParser(
             return if (indexOfSuperClass >= 0) superMethodDocumentation[indexOfSuperClass]
             else superMethodDocumentation.first()
         }
-
-        return null
+        return element.children.firstIsInstanceOrNull<PsiDocComment>()
     }
 
     /**

--- a/plugins/base/src/test/kotlin/translators/DefaultPsiToDocumentableTranslatorTest.kt
+++ b/plugins/base/src/test/kotlin/translators/DefaultPsiToDocumentableTranslatorTest.kt
@@ -1,9 +1,9 @@
 package translators
 
-import org.jetbrains.dokka.model.DModule
-import org.jetbrains.dokka.model.doc.Description
 import org.jetbrains.dokka.model.doc.Text
+import org.jetbrains.dokka.model.firstMemberOfType
 import org.jetbrains.dokka.testApi.testRunner.AbstractCoreTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -22,21 +22,21 @@ class DefaultPsiToDocumentableTranslatorTest : AbstractCoreTest() {
         testInline(
             """
             |/src/main/java/sample/BaseClass1.java
-            |package sample
+            |package sample;
             |public class BaseClass1 {
             |    /** B1 */
             |    void x() { }
             |}
             |
             |/src/main/java/sample/BaseClass2.java
-            |package sample
+            |package sample;
             |public class BaseClass2 extends BaseClass1 {
             |    /** B2 */
             |    void x() { }
             |}
             |
             |/src/main/java/sample/X.java
-            |package sample
+            |package sample;
             |public class X extends BaseClass2 {
             |    void x() { }
             |}
@@ -67,21 +67,21 @@ class DefaultPsiToDocumentableTranslatorTest : AbstractCoreTest() {
         testInline(
             """
             |/src/main/java/sample/BaseClass1.java
-            |package sample
+            |package sample;
             |public class BaseClass1 {
             |    /** B1 */
             |    void x() { }
             |}
             |
             |/src/main/java/sample/Interface1.java
-            |package sample
+            |package sample;
             |public interface Interface1 {
             |    /** I1 */
             |    void x() {}
             |}
             |
             |/src/main/java/sample/X.java
-            |package sample
+            |package sample;
             |public class X extends BaseClass1 implements Interface1 {
             |    void x() { }
             |}
@@ -112,20 +112,20 @@ class DefaultPsiToDocumentableTranslatorTest : AbstractCoreTest() {
         testInline(
             """
             |/src/main/java/sample/BaseClass1.java
-            |package sample
+            |package sample;
             |public class BaseClass1 {
             |    /** B1 */
             |    void x() { }
             |}
             |
             |/src/main/java/sample/BaseClass2.java
-            |package sample
+            |package sample;
             |public class BaseClass2 extends BaseClass1 {
             |    void x() {}
             |}
             |
             |/src/main/java/sample/X.java
-            |package sample
+            |package sample;
             |public class X extends BaseClass2 {
             |    void x() { }
             |}
@@ -137,6 +137,55 @@ class DefaultPsiToDocumentableTranslatorTest : AbstractCoreTest() {
                 assertTrue(
                     "B1" in documentationOfFunctionX,
                     "Expected Documentation \"B1\", found: \"$documentationOfFunctionX\""
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `java package-info package description`() {
+        val configuration = dokkaConfiguration {
+            sourceSets {
+                sourceSet {
+                    sourceRoots = listOf("src/main/java")
+                }
+            }
+        }
+
+        testInline(
+            """
+            |/src/main/java/sample/BaseClass1.java
+            |package sample;
+            |public class BaseClass1 {
+            |    /** B1 */
+            |    void x() { }
+            |}
+            |
+            |/src/main/java/sample/BaseClass2.java
+            |package sample;
+            |public class BaseClass2 extends BaseClass1 {
+            |    void x() {}
+            |}
+            |
+            |/src/main/java/sample/X.java
+            |package sample;
+            |public class X extends BaseClass2 {
+            |    void x() { }
+            |}
+            |
+            |/src/main/java/sample/package-info.java
+            |/**
+            | * Here comes description from package-info
+            | */
+            |package sample;
+            """.trimMargin(),
+            configuration
+        ) {
+            documentablesMergingStage = { module ->
+                val documentationOfPackage = module.packages.single().documentation.values.single().children.single()
+                    .firstMemberOfType<Text>().body
+                assertEquals(
+                    "Here comes description from package-info", documentationOfPackage
                 )
             }
         }


### PR DESCRIPTION
Note this descriptions probably can be easily overwriten with traditional dokka `includes`. The merging of these can be guaranteed by merging #1480 which depends on #1473 


```
/**
 * Here comes my description for package via package-info
 */
package example;
```

![obraz](https://user-images.githubusercontent.com/32793002/94821223-a5ea3480-0401-11eb-8eeb-a89aacaf9dbc.png)
