### PR TITLE
Escape multimodule paths on windows

### DIFF
--- a/plugins/all-module-page/src/main/kotlin/templates/DirectiveBasedTemplateProcessing.kt
+++ b/plugins/all-module-page/src/main/kotlin/templates/DirectiveBasedTemplateProcessing.kt
@@ -156,8 +156,8 @@ class DirectiveBasedTemplateProcessingStrategy(private val context: DokkaContext
             return
         }
 
-        val modulePath = context.configuration.outputDir.absolutePath.split("/")
-        val contextPath = fileContext.absolutePath.split("/")
+        val modulePath = context.configuration.outputDir.absolutePath.split(File.separator)
+        val contextPath = fileContext.absolutePath.split(File.separator)
         val commonPathElements = modulePath.zip(contextPath)
             .takeWhile { (a, b) -> a == b }.count()
 

--- a/plugins/all-module-page/src/main/kotlin/templates/PathToRootSubstitutor.kt
+++ b/plugins/all-module-page/src/main/kotlin/templates/PathToRootSubstitutor.kt
@@ -1,16 +1,14 @@
 package org.jetbrains.dokka.allModulesPage.templates
 
-import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.base.templating.PathToRootSubstitutionCommand
 import org.jetbrains.dokka.base.templating.SubstitutionCommand
 import org.jetbrains.dokka.plugability.DokkaContext
-import org.jetbrains.dokka.plugability.query
-import java.nio.file.Path
+import java.io.File
 
 class PathToRootSubstitutor(private val dokkaContext: DokkaContext) : Substitutor {
     override fun trySubstitute(context: TemplatingContext<SubstitutionCommand>, match: MatchResult): String? =
         if (context.command is PathToRootSubstitutionCommand) {
-            context.output.toPath().parent.relativize(dokkaContext.configuration.outputDir.toPath()).toString() + "/"
+            context.output.toPath().parent.relativize(dokkaContext.configuration.outputDir.toPath()).toString().split(File.separator).joinToString(separator = "/", postfix = "/") { it }
         } else null
 
 }

--- a/plugins/base/src/main/kotlin/templating/Command.kt
+++ b/plugins/base/src/main/kotlin/templating/Command.kt
@@ -1,13 +1,11 @@
 package org.jetbrains.dokka.base.templating
 
-import com.fasterxml.jackson.annotation.JsonSubTypes
-import com.fasterxml.jackson.annotation.JsonSubTypes.Type
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS
 
-@JsonTypeInfo(use= CLASS)
+@JsonTypeInfo(use = CLASS)
 interface Command
 
-abstract class SubstitutionCommand: Command {
+abstract class SubstitutionCommand : Command {
     abstract val pattern: String
 }


### PR DESCRIPTION
Paths changed from absolute to more relative:
```
<a href="../../../kotlinx-serialization-core/kotlinx-serialization-core/kotlinx.serialization/index.html">serializer</a>
```

Also `pathToRoot` is now correct