### PR TITLE
Fix rendering of comment tables

### DIFF
--- a/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
@@ -527,8 +527,8 @@ open class HtmlRenderer(
         pageContext: ContentPage,
         sourceSetRestriction: Set<DisplaySourceSet>?
     ) {
-        when (node.dci.kind) {
-            ContentKind.Comment -> buildDefaultTable(node, pageContext, sourceSetRestriction)
+        when {
+            node.style.contains(CommentTable) -> buildDefaultTable(node, pageContext, sourceSetRestriction)
             else -> div(classes = "table") {
                 node.extra.extraHtmlAttributes().forEach { attributes[it.extraKey] = it.extraValue }
                 node.children.forEach {


### PR DESCRIPTION
There were changes of kind inheritance and tables coming from comments no longer have `ContentKind.Comment`, instead they have specific style `CommentTable` which is not checked in `HtmlRenderer` and due to that, tables in comments are parsed like blocks. This PR should fix that