### PR TITLE
Support GFM code-block and code-inline markdown rendering

### DIFF
--- a/plugins/gfm/src/main/kotlin/GfmPlugin.kt
+++ b/plugins/gfm/src/main/kotlin/GfmPlugin.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.dokka.gfm
 
 import org.jetbrains.dokka.CoreExtensions
-import org.jetbrains.dokka.DokkaConfiguration.DokkaSourceSet
 import org.jetbrains.dokka.DokkaException
 import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.base.renderers.DefaultRenderer
@@ -308,6 +307,18 @@ open class CommonmarkRenderer(
 
             buildParagraph()
         }
+    }
+
+    override fun StringBuilder.buildCodeBlock(code: ContentCodeBlock, pageContext: ContentPage) {
+        append("```${if(code.language.isEmpty()) "kotlin" else code.language}\n")
+        code.children.forEach { buildContentNode(it, pageContext) }
+        append("\n```")
+    }
+
+    override fun StringBuilder.buildCodeInline(code: ContentCodeInline, pageContext: ContentPage) {
+        append('`')
+        code.children.forEach { buildContentNode(it, pageContext) }
+        append('`')
     }
 
     private fun decorators(styles: Set<Style>) = buildString {

--- a/plugins/gfm/src/test/kotlin/renderers/gfm/SimpleElementsTest.kt
+++ b/plugins/gfm/src/test/kotlin/renderers/gfm/SimpleElementsTest.kt
@@ -4,6 +4,7 @@ import org.jetbrains.dokka.gfm.CommonmarkRenderer
 import org.junit.jupiter.api.Test
 import renderers.testPage
 import org.jetbrains.dokka.links.DRI
+import org.jetbrains.dokka.model.properties.PropertyContainer
 import org.jetbrains.dokka.pages.*
 import renderers.RawTestPage
 
@@ -80,6 +81,64 @@ class SimpleElementsTest : GfmRenderingOnlyTestBase() {
         )
         val page = RawTestPage(content = image)
         val expect = "//[testPage](test-page.md)\n\n![This is a google logo](https://www.google.pl/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png)"
+        CommonmarkRenderer(context).render(page)
+        assert(renderedContent == expect)
+    }
+
+    @Test
+    fun codeBlock() {
+        val codeBlock = ContentCodeBlock(
+            children = listOf(
+                ContentText(
+                    text = "println(\"Hello\")",
+                    dci = DCI(setOf(DRI.topLevel), ContentKind.Source),
+                    sourceSets = emptySet(),
+                    style = emptySet(),
+                    extra = PropertyContainer.empty()
+                )
+            ),
+            language = "kotlin",
+            dci = DCI(setOf(DRI.topLevel), ContentKind.Main),
+            sourceSets = emptySet(),
+            style = emptySet()
+        )
+        val page = RawTestPage(content = codeBlock)
+        val expect =
+            """
+            |//[testPage](test-page.md)
+            |
+            |```kotlin
+            |println("Hello")
+            |```
+            """.trimMargin()
+        CommonmarkRenderer(context).render(page)
+        assert(renderedContent == expect)
+    }
+
+    @Test
+    fun codeInline() {
+        val codeBlock = ContentCodeInline(
+            children = listOf(
+                ContentText(
+                    text = "println(\"Hello\")",
+                    dci = DCI(setOf(DRI.topLevel), ContentKind.Source),
+                    sourceSets = emptySet(),
+                    style = emptySet(),
+                    extra = PropertyContainer.empty()
+                )
+            ),
+            language = "kotlin",
+            dci = DCI(setOf(DRI.topLevel), ContentKind.Main),
+            sourceSets = emptySet(),
+            style = emptySet()
+        )
+        val page = RawTestPage(content = codeBlock)
+        val expect =
+            """
+            |//[testPage](test-page.md)
+            |
+            |`println("Hello")`
+            """.trimMargin()
         CommonmarkRenderer(context).render(page)
         assert(renderedContent == expect)
     }


### PR DESCRIPTION
This PR enhances GFM markdown rendering for code block (wrapped by tripple backtick) and code inline (wrapped by single backtick) markdown.
