### PR TITLE
Exclude top-level const val from generated getters

### DIFF
--- a/plugins/javadoc/src/test/kotlin/org/jetbrains/dokka/javadoc/JavadocClasslikeTemplateMapTest.kt
+++ b/plugins/javadoc/src/test/kotlin/org/jetbrains/dokka/javadoc/JavadocClasslikeTemplateMapTest.kt
@@ -316,6 +316,33 @@ internal class JavadocClasslikeTemplateMapTest : AbstractJavadocTemplateMapTest(
         }
     }
 
+    @Test
+    fun `class with top-level const`() {
+        dualTestTemplateMapInline(
+            kotlin =
+                """
+                /src/Test.kt
+                package com.test.package0
+                
+                const val TEST_VAL = "test"
+                """,
+            java =
+                """
+                /src/com/test/package0/TestKt.java
+                package com.test.package0;
+                
+                public final class TestKt {
+                    public static final String TEST_VAL = "test"; 
+                }
+                """
+        ) {
+            val map = singlePageOfType<JavadocClasslikePageNode>().templateMap
+            val properties = assertIsInstance<List<*>>(map["properties"])
+            val property = assertIsInstance<Map<String, Any?>>(properties.first())
+            assertEquals("public final static <a href=https://docs.oracle.com/javase/8/docs/api/java/lang/String.html>String</a> <a href=TestKt.html#TEST_VAL>TEST_VAL</a>", "${property["modifiers"]} ${property["signature"]}")
+        }
+    }
+
     private fun assertParameterNode(node: Map<String, Any?>, expectedName: String, expectedType: String, expectedDescription: String){
         assertEquals(expectedName, node["name"])
         assertEquals(expectedType, node["type"])

--- a/plugins/kotlin-as-java/src/test/kotlin/KotlinAsJavaPluginTest.kt
+++ b/plugins/kotlin-as-java/src/test/kotlin/KotlinAsJavaPluginTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 import matchers.content.*
 import org.jetbrains.dokka.DokkaConfiguration
 import org.jetbrains.dokka.jdk
+import org.junit.Assert
 import signatures.renderedContent
 import signatures.signature
 import utils.A
@@ -369,6 +370,37 @@ class KotlinAsJavaPluginTest : AbstractCoreTest() {
                     "final ", A("Integer"), A("someFun"), "(", A("Map"), "<", A("String"),
                     ", ", A("Integer"), ">", A("xd"), ")", Span()
                 )
+            }
+        }
+    }
+
+    @Test
+    fun `const in top level`() {
+        val writerPlugin = TestOutputWriterPlugin()
+        val configuration = dokkaConfiguration {
+            sourceSets {
+                sourceSet {
+                    sourceRoots = listOf("src/")
+                    externalDocumentationLinks = listOf(
+                        DokkaConfiguration.ExternalDocumentationLink.jdk(8),
+                        stdlibExternalDocumentationLink
+                    )
+                }
+            }
+        }
+        testInline(
+            """
+            |/src/main/kotlin/kotlinAsJavaPlugin/Test.kt
+            |package kotlinAsJavaPlugin
+            |
+            |const val FIRST = "String"
+        """.trimMargin(),
+            configuration,
+            pluginOverrides = listOf(writerPlugin),
+            cleanupOutput = true
+        ) {
+            renderingStage = { _, _ ->
+                Assert.assertNull(writerPlugin.writer.contents["root/kotlinAsJavaPlugin/-test-kt/get-f-i-r-s-t.html"])
             }
         }
     }


### PR DESCRIPTION
This fixes #1624 