### PR TITLE
Use maven directly to download additional dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/org/jetbrains/SetupMaven.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/SetupMaven.kt
@@ -17,9 +17,6 @@ open class SetupMaven : Sync() {
     @get:Input
     var mavenPluginToolsVersion = "3.5.2"
 
-    @get:Input
-    var aetherVersion = "1.1.0"
-
     @get:Internal
     val mavenBuildDir = "${project.buildDir}/maven"
 

--- a/runners/maven-plugin/build.gradle.kts
+++ b/runners/maven-plugin/build.gradle.kts
@@ -11,13 +11,6 @@ dependencies {
     implementation("org.apache.maven.plugin-tools:maven-plugin-annotations:${setupMaven.mavenPluginToolsVersion}")
     implementation("org.apache.maven:maven-archiver:2.5")
     implementation(kotlin("stdlib-jdk8"))
-    implementation("org.eclipse.aether:aether-api:${setupMaven.aetherVersion}")
-    implementation("org.eclipse.aether:aether-spi:${setupMaven.aetherVersion}")
-    implementation("org.eclipse.aether:aether-impl:${setupMaven.aetherVersion}")
-    implementation("org.eclipse.aether:aether-connector-basic:${setupMaven.aetherVersion}")
-    implementation("org.eclipse.aether:aether-transport-file:${setupMaven.aetherVersion}")
-    implementation("org.eclipse.aether:aether-transport-http:${setupMaven.aetherVersion}")
-    implementation("org.apache.maven:maven-aether-provider:3.3.3")
 }
 
 tasks.named<Delete>("clean") {

--- a/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
+++ b/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
@@ -53,16 +53,16 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
 
     /**
      * The current build session instance. This is used for
-     * for dependency resolver API calls via repositorySystem.
+     * dependency resolver API calls via repositorySystem.
      */
     @Parameter(defaultValue = "\${session}", required = true, readonly = true)
     protected var session: MavenSession? = null
 
     @Component
-    private var repositorySystem: RepositorySystem? = null;
+    private var repositorySystem: RepositorySystem? = null
 
     @Component
-    private var resolutionErrorHandler: ResolutionErrorHandler? = null;
+    private var resolutionErrorHandler: ResolutionErrorHandler? = null
 
     class PackageOptions : DokkaConfiguration.PackageOptions {
         @Parameter
@@ -260,24 +260,25 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
         version: String
     ): List<File> {
 
-        val request = ArtifactResolutionRequest()
-        request.isResolveRoot = true
-        request.isResolveTransitively = true
-        request.localRepository = session!!.localRepository
-        request.remoteRepositories = mavenProject!!.pluginArtifactRepositories
-        request.isOffline = session!!.isOffline
-        request.isForceUpdate = session!!.request.isUpdateSnapshots
-        request.servers = session!!.request.servers
-        request.mirrors = session!!.request.mirrors
-        request.proxies = session!!.request.proxies
-        request.artifact = DefaultArtifact(groupId, artifactId, version, "compile", "jar", null,
-                DefaultArtifactHandler("jar"))
+        val request = ArtifactResolutionRequest().apply {
+            isResolveRoot = true
+            isResolveTransitively = true
+            localRepository = session!!.localRepository
+            remoteRepositories = mavenProject!!.pluginArtifactRepositories
+            isOffline = session!!.isOffline
+            isForceUpdate = session!!.request.isUpdateSnapshots
+            servers = session!!.request.servers
+            mirrors = session!!.request.mirrors
+            proxies = session!!.request.proxies
+            artifact = DefaultArtifact(groupId, artifactId, version, "compile", "jar", null,
+                    DefaultArtifactHandler("jar"))
+        }
 
         log.debug("Resolving $groupId:$artifactId:$version ...")
 
         val result: ArtifactResolutionResult = repositorySystem!!.resolve(request)
-        resolutionErrorHandler!!.throwErrors(request, result);
-        return result.artifacts.stream().map { it.file }.collect(Collectors.toList())
+        resolutionErrorHandler!!.throwErrors(request, result)
+        return result.artifacts.map { it.file }
     }
 
     private val dokkaVersion: String by lazy {


### PR DESCRIPTION
Use maven instead of aether to resolve additional dependencies. Aether is still used, but now indirectly by maven. Using maven directly allows to reuse all the configurations like repositories, mirrors, proxies and the local repository.

This fixes #1625 . A local test showed, that the additional dependencies like dokka-base, javadoc-plugin (and their dependencies) are downloaded correctly. If they are in the local repository already, now download is done again. This probably fixes #1408 as well.

**Note**: I've changed the code to only consider remote plugin repositories for downloading these artifacts, as this seems more correct - dokka-base/javadoc-plugin are in fact plugin dependencies and not project dependencies. This could be easily changed back, see comment.

I then removed the now unneeded aether dependencies. This seems to fix #1626. At least, if running maven with wagon-logging enabled, the httpclient logs are showing up now. I didn't test whether the TTL config is actually applied though. I assume, that one of these aether dependencies provided another plexus component for "org.sonatype.aether.RepositorySystem" which was picked up by maven in general and replaced the already existing component - thus maven didn't use anymore its bundled httpclient but the httpclient provided through transitive dependencies of aether.

~**Note:** I was not able to do a full test of my use case: dokka-maven-plugin by default fetches e.g. dokka-base with the same version - on master 1.4.10.2-SNAPSHOT. That would mean, I need to publish these already into my local repo - thus the download would not be tried again, because it's already in my local repository. So I temporarily changed this to download the stable version 1.4.10.2 for dokka-base/javadoc-plugin instead. With that setting, I could test and see, that these additional artifacts are downloaded into the correct local maven repo. However, these stable versions don't seem to be compatible anymore with the current master (java.lang.NoSuchMethodError: 'org.jetbrains.dokka.plugability.ExtensionPoint org.jetbrains.dokka.CoreExtensions.getPreMergeDocumentableTransformer()'), so I actually never fully executed dokka-maven-plugin...~ [Updated: see comment below]
