### PR TITLE
Remove `documentationFileName` from documentation as it is no longer …

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,10 @@ For documenting Gradle multi-module projects, you can use `dokka${format}Multimo
 ```kotlin
 tasks.dokkaHtmlMultiModule.configure {
     outputDirectory.set(buildDir.resolve("dokkaCustomMultiModuleOutput"))
-    documentationFileName.set("README.md")
 }
 ```
 
-`DokkaMultiModule` depends on all Dokka tasks in the subprojects, runs them, and creates a toplevel page (based on the `documentationFile`)
+`DokkaMultiModule` depends on all Dokka tasks in the subprojects, runs them, and creates a toplevel page
 with links to all generated (sub)documentations
 
 ### Using the Maven plugin

--- a/docs/src/doc/docs/user_guide/gradle/usage.md
+++ b/docs/src/doc/docs/user_guide/gradle/usage.md
@@ -308,11 +308,10 @@ For documenting Gradle multi-module projects, you can use `dokka${format}MultiMo
 ```kotlin
 tasks.dokkaHtmlMultiModule.configure {
     outputDirectory.set(buildDir.resolve("dokkaCustomMultiModuleOutput"))
-    documentationFileName.set("README.md")
 }
 ```
 
-`DokkaMultiModule` depends on all Dokka tasks in the subprojects, runs them, and creates a toplevel page (based on the `documentationFile`)
+`DokkaMultiModule` depends on all Dokka tasks in the subprojects, runs them, and creates a toplevel page
 with links to all generated (sub)documentations
 
 ## Example project


### PR DESCRIPTION
…valid

This option on multimodule was removed in 02ccae10e3f717c330dae5d87b49a0e72f798905

At some point we should consider bringing it back with proper, sourceset dependent content, thats why i am not closing the issue #1530