### PR TITLE
Add dokka to GitHub link

### DIFF
--- a/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
@@ -777,8 +777,9 @@ open class HtmlRenderer(
                             }
                             span { text("© 2020 Copyright") }
                             span("pull-right") {
-                                span { text("Sponsored and developed by dokka") }
+                                span { text("Sponsored and developed by ") }
                                 a(href = "https://github.com/Kotlin/dokka") {
+                                    span { text("dokka") }
                                     span(classes = "padded-icon")
                                 }
                             }

--- a/plugins/base/src/main/resources/dokka/styles/style.css
+++ b/plugins/base/src/main/resources/dokka/styles/style.css
@@ -1109,6 +1109,10 @@ td.content {
     padding: 0 16px;
 }
 
+.footer a {
+    color: var(--breadcrumb-font-color);
+}
+
 .footer .padded-icon {
     padding-left: 0.5em;
 }


### PR DESCRIPTION
I just discovered a dokka website in a friends pet project.
At the bottom right I saw this nice `Sponsored and developed by dokka ->` text.
I wanted to press at `dokka` but realized that only the arrow is clickable.
![Geist_1607084524165](https://user-images.githubusercontent.com/10229883/101163330-c28a2f00-3633-11eb-8625-14d00d84683d.gif)

I guess it is a common pattern that "a text" is also linkend in such cases.
Therefore I moved the "dokka" text into the anchor as well. At least I hope so 😁 
I have never used `kotlinx.html` nor found a good documentation :( 
So I basically copied the `span` `text` thingy into the anchor tag. I hope this is working 😁 .
If not, sorry. Please guide me how to do it correctly 😇
