### PR TITLE
Fix a bug with inserting template commands instead of link text

### DIFF
--- a/plugins/base/src/test/kotlin/renderers/html/BasicTest.kt
+++ b/plugins/base/src/test/kotlin/renderers/html/BasicTest.kt
@@ -1,0 +1,20 @@
+package renderers.html
+
+import org.jetbrains.dokka.base.renderers.html.HtmlRenderer
+import org.jetbrains.dokka.links.DRI
+import org.junit.jupiter.api.Test
+import renderers.testPage
+import utils.Span
+import utils.match
+
+class BasicTest : HtmlRenderingOnlyTestBase() {
+    @Test
+    fun `unresolved DRI link should render as text`() {
+        val page = testPage {
+            link("linkText", DRI("nonexistentPackage", "nonexistentClass"))
+        }
+
+        HtmlRenderer(context).render(page)
+        renderedContent.match(Span("linkText"))
+    }
+}

--- a/plugins/base/src/test/kotlin/renderers/html/HtmlRenderingOnlyTestBase.kt
+++ b/plugins/base/src/test/kotlin/renderers/html/HtmlRenderingOnlyTestBase.kt
@@ -62,26 +62,3 @@ abstract class HtmlRenderingOnlyTestBase : RenderingOnlyTestBase<Element>() {
             .dropWhile { !it.contains("""<div id="content">""") }
             .joinToString(separator = "") { it.trim() }
 }
-
-fun Element.match(vararg matchers: Any): Unit =
-    childNodes()
-        .filter { it !is TextNode || it.text().isNotBlank() }
-        .let { it.drop(it.size - matchers.size) }
-        .zip(matchers)
-        .forEach { (n, m) -> m.accepts(n) }
-
-open class Tag(val name: String, vararg val matchers: Any)
-class Div(vararg matchers: Any) : Tag("div", *matchers)
-class P(vararg matchers: Any) : Tag("p", *matchers)
-class Span(vararg matchers: Any) : Tag("span", *matchers)
-
-private fun Any.accepts(n: Node) {
-    when (this) {
-        is String -> assert(n is TextNode && n.text().trim() == this.trim()) { "\"$this\" expected but found: $n" }
-        is Tag -> {
-            assert(n is Element && n.tagName() == name) { "Tag $name expected but found: $n" }
-            if (n is Element && matchers.isNotEmpty()) n.match(*matchers)
-        }
-        else -> throw IllegalArgumentException("$this is not proper matcher")
-    }
-}


### PR DESCRIPTION
Some test methods were dropped intentionally, as using them can lead to subtle bugs. The same methods are available in the base-test-utils module