### PR TITLE
Make Gradle plugin use `api` instead of `implementation` for core

### DIFF
--- a/runners/gradle-plugin/build.gradle.kts
+++ b/runners/gradle-plugin/build.gradle.kts
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-    implementation(project(":core"))
+    api(project(":core"))
     compileOnly("com.fasterxml.jackson.core:jackson-annotations:2.11.1")
     compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin")
     compileOnly("com.android.tools.build:gradle:4.0.1")


### PR DESCRIPTION
Fixes #1724