### PR TITLE
Fix configuration for suppressing obvious functions

### DIFF
--- a/docs/src/doc/docs/user_guide/cli/usage.md
+++ b/docs/src/doc/docs/user_guide/cli/usage.md
@@ -20,6 +20,7 @@ Dokka supports the following command line arguments:
   * `-globalPackageOptions` - per package options added to all source sets
   * `-globalLinks` - external documentation links added to all source sets
   * `-globalSrcLink` - source links added to all source sets
+  * `-noSuppressObviousFunctions` - don't suppress obvious functions like default `toString` or `equals`
   * `-sourceSet` - (repeatable) - configuration for a single source set. Following this argument, you can pass other arguments:
     * `-sourceSetName` - source set name as a part of source set ID when declaring dependent source sets
     * `-displayName` - source set name displayed in the generated documentation

--- a/docs/src/doc/docs/user_guide/gradle/usage.md
+++ b/docs/src/doc/docs/user_guide/gradle/usage.md
@@ -89,6 +89,10 @@ dokkaHtml {
     // to enable package-list caching
     // When this is set to default, caches are stored in $USER_HOME/.cache/dokka
     cacheRoot.set(file("default"))
+
+    // Suppress obvious functions like default toString or equals. Defaults to true
+    suppressObviousFunctions.set(false)
+    
     dokkaSourceSets {
         configureEach { // Or source set name, for single-platform the default source sets are `main` and `test`
 

--- a/docs/src/doc/docs/user_guide/maven/usage.md
+++ b/docs/src/doc/docs/user_guide/maven/usage.md
@@ -84,7 +84,10 @@ The available configuration options are shown below:
         <samples>
             <dir>src/test/samples</dir>
         </samples>
-        
+
+        <!-- Suppress obvious functions like default toString or equals. Defaults to true -->
+        <suppressObviousFunctions>false</suppressObviousFunctions>
+
         <!-- Used for linking to JDK, default: 6 -->
         <jdkVersion>6</jdkVersion>
 

--- a/integration-tests/gradle/projects/it-basic/build.gradle.kts
+++ b/integration-tests/gradle/projects/it-basic/build.gradle.kts
@@ -48,5 +48,7 @@ tasks.withType<DokkaTask> {
             kotlinSourceSet(kotlin.sourceSets["test"])
         }
     }
+    suppressObviousFunctions.set(false)
+
     pluginsMapConfiguration.set(mapOf(DokkaBase::class.qualifiedName to """{ "customStyleSheets": ["${file("customResources/logo-styles.css")}", "${file("customResources/custom-style-to-add.css")}"], "customAssets" : ["${file("customResources/custom-resource.svg")}"] }"""))
 }

--- a/integration-tests/maven/projects/it-maven/pom.xml
+++ b/integration-tests/maven/projects/it-maven/pom.xml
@@ -124,6 +124,8 @@
                     <!-- Disable linking to online JDK documentation -->
                     <noJdkLink>false</noJdkLink>
 
+                    <suppressObviousFunctions>false</suppressObviousFunctions>
+
                     <!-- Allows to customize documentation generation options on a per-package basis -->
                     <perPackageOptions>
                         <packageOptions>

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/AbstractDokkaTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/AbstractDokkaTask.kt
@@ -44,6 +44,10 @@ abstract class AbstractDokkaTask : DefaultTask() {
         .safeConvention(DokkaDefaults.failOnWarning)
 
     @Input
+    val suppressObviousFunctions: Property<Boolean> = project.objects.safeProperty<Boolean>()
+        .safeConvention(DokkaDefaults.suppressObviousFunctions)
+
+    @Input
     val offlineMode: Property<Boolean> = project.objects.safeProperty<Boolean>()
         .safeConvention(DokkaDefaults.offlineMode)
 

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaTask.kt
@@ -42,6 +42,7 @@ abstract class DokkaTask : AbstractDokkaTask() {
             failOnWarning = failOnWarning.getSafe(),
             sourceSets = unsuppressedSourceSets.build(),
             pluginsConfiguration = buildPluginsConfiguration(),
-            pluginsClasspath = plugins.resolve().toList()
+            pluginsClasspath = plugins.resolve().toList(),
+            suppressObviousFunctions = suppressObviousFunctions.getSafe(),
         )
 }

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaTaskPartial.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaTaskPartial.kt
@@ -44,7 +44,8 @@ abstract class DokkaTaskPartial : AbstractDokkaTask() {
             sourceSets = unsuppressedSourceSets.build(),
             pluginsConfiguration = buildPluginsConfiguration(),
             pluginsClasspath = plugins.resolve().toList(),
-            delayTemplateSubstitution = true
+            delayTemplateSubstitution = true,
+            suppressObviousFunctions = suppressObviousFunctions.getSafe(),
         )
     }
 }

--- a/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
+++ b/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
@@ -118,9 +118,6 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
     var reportUndocumented: Boolean = DokkaDefaults.reportUndocumented
 
     @Parameter
-    var impliedPlatforms: List<String> = emptyList()
-
-    @Parameter
     var perPackageOptions: List<PackageOptions> = emptyList()
 
     @Parameter
@@ -158,6 +155,9 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
 
     @Parameter
     var failOnWarning: Boolean = DokkaDefaults.failOnWarning
+
+    @Parameter
+    var suppressObviousFunctions: Boolean = DokkaDefaults.suppressObviousFunctions
 
     @Parameter
     var dokkaPlugins: List<Dependency> = emptyList()
@@ -216,7 +216,7 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
             noStdlibLink = noStdlibLink,
             noJdkLink = noJdkLink,
             suppressedFiles = suppressedFiles.map(::File).toSet(),
-            analysisPlatform = if (platform.isNotEmpty()) Platform.fromString(platform) else Platform.DEFAULT
+            analysisPlatform = if (platform.isNotEmpty()) Platform.fromString(platform) else Platform.DEFAULT,
         ).let {
             it.copy(
                 externalDocumentationLinks = defaultLinks(it) + it.externalDocumentationLinks
@@ -247,6 +247,7 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
             pluginsConfiguration = pluginsConfiguration.toMutableList(),
             modules = emptyList(),
             failOnWarning = failOnWarning,
+            suppressObviousFunctions = suppressObviousFunctions,
         )
 
         val gen = DokkaGenerator(configuration, logger)
@@ -270,8 +271,10 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
             servers = session!!.request.servers
             mirrors = session!!.request.mirrors
             proxies = session!!.request.proxies
-            artifact = DefaultArtifact(groupId, artifactId, version, "compile", "jar", null,
-                    DefaultArtifactHandler("jar"))
+            artifact = DefaultArtifact(
+                groupId, artifactId, version, "compile", "jar", null,
+                DefaultArtifactHandler("jar")
+            )
         }
 
         log.debug("Resolving $groupId:$artifactId:$version ...")

--- a/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
+++ b/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
@@ -156,7 +156,7 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
     @Parameter
     var failOnWarning: Boolean = DokkaDefaults.failOnWarning
 
-    @Parameter
+    @Parameter(defaultValue = "${DokkaDefaults.suppressObviousFunctions}")
     var suppressObviousFunctions: Boolean = DokkaDefaults.suppressObviousFunctions
 
     @Parameter


### PR DESCRIPTION
I am wondering whether or not this should be in sourceset configuration. Technically you could have some sourcesets that you would like to show those functions....

@kamildoleglo ?