### PR TITLE
Use types that are serializable by Gradle's configuration cache

### DIFF
--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/AbstractDokkaTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/AbstractDokkaTask.kt
@@ -6,7 +6,6 @@ import groovy.lang.Closure
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.Task
-import org.gradle.api.artifacts.Configuration
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
@@ -19,7 +18,6 @@ import org.jetbrains.dokka.plugability.ConfigurableBlock
 import org.jetbrains.dokka.plugability.DokkaPlugin
 import java.io.File
 import java.util.function.BiConsumer
-import kotlin.reflect.KClass
 import kotlin.reflect.full.createInstance
 
 abstract class AbstractDokkaTask : DefaultTask() {
@@ -68,10 +66,10 @@ abstract class AbstractDokkaTask : DefaultTask() {
     }
 
     @Classpath
-    val plugins: Configuration = project.maybeCreateDokkaPluginConfiguration(name)
+    val plugins: Set<File> = project.maybeCreateDokkaPluginConfiguration(name).files
 
     @Classpath
-    val runtime: Configuration = project.maybeCreateDokkaRuntimeConfiguration(name)
+    val runtime: Set<File> = project.maybeCreateDokkaRuntimeConfiguration(name).files
 
     final override fun doFirst(action: Action<in Task>): Task = super.doFirst(action)
 

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/dokkaBootstrapFactory.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/dokkaBootstrapFactory.kt
@@ -2,13 +2,12 @@
 
 package org.jetbrains.dokka.gradle
 
-import org.gradle.api.artifacts.Configuration
 import org.jetbrains.dokka.DokkaBootstrap
+import java.io.File
 import java.net.URLClassLoader
 import kotlin.reflect.KClass
 
-fun DokkaBootstrap(configuration: Configuration, bootstrapClass: KClass<out DokkaBootstrap>): DokkaBootstrap {
-    val runtimeJars = configuration.resolve()
+fun DokkaBootstrap(runtimeJars: Set<File>, bootstrapClass: KClass<out DokkaBootstrap>): DokkaBootstrap {
     val runtimeClassLoader = URLClassLoader(
         runtimeJars.map { it.toURI().toURL() }.toTypedArray(),
         ClassLoader.getSystemClassLoader().parent


### PR DESCRIPTION
`org.gradle.api.artifacts.Configuration` is not serializable by Gradle's configuration cache. This replaces it with `Set<File>` which should be (I had a little trouble testing to see if I was successful since the build I'm using fails when using Gradle's composite build feature that would help me verify).

This is the warning that should be resolved:
![image](https://user-images.githubusercontent.com/170028/111751316-744e2280-88e8-11eb-95e3-066c3bdaf34a.png)
