### PR TITLE
Replace jcenter with mavenCentral in usage doc

### DIFF
--- a/docs/src/doc/docs/user_guide/gradle/usage.md
+++ b/docs/src/doc/docs/user_guide/gradle/usage.md
@@ -14,7 +14,7 @@ plugins {
 }
 
 repositories {
-    jcenter() // or maven(url="https://dl.bintray.com/kotlin/dokka")
+    mavenCentral()
 }
 ```
 
@@ -23,7 +23,7 @@ settings.gradle.kts:
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        jcenter()
+        mavenCentral()
     }
 }
 ```


### PR DESCRIPTION
I think dokka is fully published to Maven Central now, so it makes sense to update the usage doc.