### PR TITLE
Option to Suppress annotations

### DIFF
--- a/core/src/main/kotlin/configuration.kt
+++ b/core/src/main/kotlin/configuration.kt
@@ -135,6 +135,7 @@ interface DokkaConfiguration : Serializable {
         val noStdlibLink: Boolean
         val noJdkLink: Boolean
         val suppressedFiles: Set<File>
+        val suppressedAnnotations: Set<String>
         val analysisPlatform: Platform
     }
 

--- a/core/src/main/kotlin/defaultConfiguration.kt
+++ b/core/src/main/kotlin/defaultConfiguration.kt
@@ -49,6 +49,7 @@ data class DokkaSourceSetImpl(
     override val noStdlibLink: Boolean = DokkaDefaults.noStdlibLink,
     override val noJdkLink: Boolean = DokkaDefaults.noJdkLink,
     override val suppressedFiles: Set<File> = emptySet(),
+    override val suppressedAnnotations: Set<String> = emptySet(),
     override val analysisPlatform: Platform = DokkaDefaults.analysisPlatform,
 ) : DokkaSourceSet
 

--- a/core/test-api/src/main/kotlin/testApi/testRunner/TestDokkaConfigurationBuilder.kt
+++ b/core/test-api/src/main/kotlin/testApi/testRunner/TestDokkaConfigurationBuilder.kt
@@ -96,6 +96,7 @@ class DokkaSourceSetBuilder(
     var noStdlibLink: Boolean = false,
     var noJdkLink: Boolean = false,
     var suppressedFiles: List<String> = emptyList(),
+    var suppressedAnnotations: List<String> = emptyList(),
     var analysisPlatform: String = "jvm",
     var perPackageOptions: List<PackageOptionsImpl> = emptyList(),
     var externalDocumentationLinks: List<ExternalDocumentationLinkImpl> = emptyList(),
@@ -122,6 +123,7 @@ class DokkaSourceSetBuilder(
         noStdlibLink = noStdlibLink,
         noJdkLink = noJdkLink,
         suppressedFiles = suppressedFiles.map(::File).toSet(),
+        suppressedAnnotations = suppressedAnnotations.toSet(),
         analysisPlatform = Platform.fromString(analysisPlatform)
     )
 }
@@ -147,6 +149,7 @@ val defaultSourceSet = DokkaSourceSetImpl(
     noStdlibLink = false,
     noJdkLink = false,
     suppressedFiles = emptySet(),
+    suppressedAnnotations = emptySet(),
     analysisPlatform = Platform.DEFAULT
 )
 

--- a/plugins/base/src/main/kotlin/DokkaBase.kt
+++ b/plugins/base/src/main/kotlin/DokkaBase.kt
@@ -4,12 +4,13 @@ package org.jetbrains.dokka.base
 
 import org.jetbrains.dokka.CoreExtensions
 import org.jetbrains.dokka.analysis.KotlinAnalysis
+import org.jetbrains.dokka.base.generation.SingleModuleGeneration
 import org.jetbrains.dokka.base.renderers.*
 import org.jetbrains.dokka.base.renderers.html.*
 import org.jetbrains.dokka.base.renderers.html.command.consumers.PathToRootConsumer
 import org.jetbrains.dokka.base.renderers.html.command.consumers.ResolveLinkConsumer
-import org.jetbrains.dokka.base.resolvers.external.ExternalLocationProviderFactory
 import org.jetbrains.dokka.base.resolvers.external.DefaultExternalLocationProviderFactory
+import org.jetbrains.dokka.base.resolvers.external.ExternalLocationProviderFactory
 import org.jetbrains.dokka.base.resolvers.external.javadoc.JavadocExternalLocationProviderFactory
 import org.jetbrains.dokka.base.resolvers.local.DokkaLocationProviderFactory
 import org.jetbrains.dokka.base.resolvers.local.LocationProviderFactory
@@ -27,7 +28,6 @@ import org.jetbrains.dokka.base.transformers.pages.sourcelinks.SourceLinksTransf
 import org.jetbrains.dokka.base.translators.descriptors.DefaultDescriptorToDocumentableTranslator
 import org.jetbrains.dokka.base.translators.documentables.DefaultDocumentableToPageTranslator
 import org.jetbrains.dokka.base.translators.psi.DefaultPsiToDocumentableTranslator
-import org.jetbrains.dokka.base.generation.SingleModuleGeneration
 import org.jetbrains.dokka.plugability.DokkaPlugin
 import org.jetbrains.dokka.transformers.documentation.PreMergeDocumentableTransformer
 import org.jetbrains.dokka.transformers.pages.PageTransformer
@@ -82,6 +82,10 @@ class DokkaBase : DokkaPlugin() {
         preMergeDocumentableTransformer providing ::ObviousFunctionsDocumentableFilterTransformer
     }
 
+    val suppressedAnnotationsVisibilityFilter by extending {
+        preMergeDocumentableTransformer providing ::SuppressedAnnotationsDocumentaryFilterTransformer
+    }
+
     val inheritedEntriesVisbilityFilter by extending {
         preMergeDocumentableTransformer providing ::InheritedEntriesDocumentableFilterTransformer
     }
@@ -95,6 +99,7 @@ class DokkaBase : DokkaPlugin() {
                 suppressedBySuppressTagDocumentableFilter,
                 obviousFunctionsVisbilityFilter,
                 inheritedEntriesVisbilityFilter,
+                suppressedAnnotationsVisibilityFilter
             )
         }
     }

--- a/plugins/base/src/main/kotlin/transformers/documentables/SuppressedAnnotationsDocumentaryFilterTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/SuppressedAnnotationsDocumentaryFilterTransformer.kt
@@ -1,0 +1,15 @@
+package org.jetbrains.dokka.base.transformers.documentables
+
+import org.jetbrains.dokka.model.Documentable
+import org.jetbrains.dokka.model.properties.WithExtraProperties
+import org.jetbrains.dokka.plugability.DokkaContext
+import org.jetbrains.dokka.transformers.documentation.sourceSet
+import org.jetbrains.dokka.utilities.cast
+
+class SuppressedAnnotationsDocumentaryFilterTransformer(context: DokkaContext) :
+    SuppressedByConditionDocumentableFilterTransformer(context) {
+    override fun shouldBeSuppressed(d: Documentable): Boolean {
+        if (d !is WithExtraProperties<*>) return false
+        return d.cast<WithExtraProperties<out Documentable>>().hasOneOfAnnotations(sourceSet(d).suppressedAnnotations)
+    }
+}

--- a/plugins/base/src/main/kotlin/transformers/documentables/utils.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/utils.kt
@@ -1,13 +1,29 @@
 package org.jetbrains.dokka.base.transformers.documentables
 
+import org.jetbrains.dokka.links.PointingToDeclaration
 import org.jetbrains.dokka.model.Annotations
 import org.jetbrains.dokka.model.Documentable
 import org.jetbrains.dokka.model.ExceptionInSupertypes
-import org.jetbrains.dokka.model.WithSupertypes
 import org.jetbrains.dokka.model.properties.WithExtraProperties
 
 fun <T> T.isDeprecated() where T : WithExtraProperties<out Documentable> =
     deprecatedAnnotation != null
+
+fun <T> T.hasOneOfAnnotations(fqNames: Set<String>) where T : WithExtraProperties<out Documentable> =
+    extra[Annotations]?.let { annotations ->
+        (annotations.directAnnotations + annotations.fileLevelAnnotations).values.flatten().any {
+            if (it.dri.target != PointingToDeclaration) return@any false
+            if (it.dri.classNames.isNullOrEmpty()) return@any false
+
+            val fqName = buildString {
+                if (!it.dri.packageName.isNullOrEmpty())
+                    append(it.dri.packageName!!.trim('.'))
+                append(".${it.dri.classNames}")
+            }
+
+            fqName in fqNames
+        }
+    } ?: false
 
 val <T> T.deprecatedAnnotation where T : WithExtraProperties<out Documentable>
     get() = extra[Annotations]?.let { annotations ->

--- a/plugins/base/src/test/kotlin/filter/AnnotationFilterTest.kt
+++ b/plugins/base/src/test/kotlin/filter/AnnotationFilterTest.kt
@@ -1,0 +1,131 @@
+package filter
+
+import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class AnnotationFilterTest : BaseAbstractTest() {
+    @Test
+    fun `function with empty global suppressAnnotations`() {
+        val configuration = dokkaConfiguration {
+            sourceSets {
+                sourceSet {
+                    sourceRoots = listOf("src/main/kotlin/basic/Test.kt")
+                }
+            }
+        }
+
+        testInline(
+            """
+            |/src/main/kotlin/basic/Test.kt
+            |package example
+            |
+            |fun testFunction() { }
+            |
+            |
+            |
+        """.trimMargin(),
+            configuration
+        ) {
+            preMergeDocumentablesTransformationStage = {
+                Assertions.assertTrue(
+                    it.first().packages.first().functions.size == 1
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `annotated function with empty global suppressAnnotations`() {
+        val configuration = dokkaConfiguration {
+            sourceSets {
+                sourceSet {
+                    sourceRoots = listOf("src/main/kotlin/basic/Test.kt")
+                }
+            }
+        }
+
+        testInline(
+            """
+            |/src/main/kotlin/basic/Test.kt
+            |package example
+            |
+            |@Deprecated("dep")
+            |fun testFunction() { }
+            |
+            |
+        """.trimMargin(),
+            configuration
+        ) {
+            preMergeDocumentablesTransformationStage = {
+                Assertions.assertTrue(
+                    it.first().packages.first().functions.size == 1
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `qualified name annotated function with used global suppressAnnotations`() {
+        val configuration = dokkaConfiguration {
+            sourceSets {
+                sourceSet {
+                    suppressedAnnotations = listOf("kotlin.ExperimentalStdlibApi")
+                    sourceRoots = listOf("src/main/kotlin/basic/Test.kt")
+                }
+            }
+        }
+
+        testInline(
+            """
+            |/src/main/kotlin/basic/Test.kt
+            |package example
+            |
+            |@kotlin.ExperimentalStdlibApi
+            |fun testFunction() { }
+            |
+            |
+        """.trimMargin(),
+            configuration
+        ) {
+            preMergeDocumentablesTransformationStage = {
+                Assertions.assertTrue(
+                    it.first().packages.first().functions.size == 0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `import annotated function with used global suppressAnnotations`() {
+        val configuration = dokkaConfiguration {
+            sourceSets {
+                sourceSet {
+                    suppressedAnnotations = listOf("kotlin.ExperimentalStdlibApi")
+                    sourceRoots = listOf("src/main/kotlin/basic/Test.kt")
+                }
+            }
+        }
+
+        testInline(
+            """
+            |/src/main/kotlin/basic/Test.kt
+            |package example
+            |
+            |import kotlin.ExperimentalStdlibApi
+            |
+            |@ExperimentalStdlibApi
+            |fun testFunction() { }
+            |
+            |
+        """.trimMargin(),
+            configuration
+        ) {
+            preMergeDocumentablesTransformationStage = {
+                Assertions.assertTrue(
+                    it.first().packages.first().functions.size == 0
+                )
+            }
+        }
+    }
+}

--- a/runners/cli/src/main/kotlin/cli/main.kt
+++ b/runners/cli/src/main/kotlin/cli/main.kt
@@ -4,7 +4,7 @@ import kotlinx.cli.*
 import org.jetbrains.dokka.DokkaConfiguration.ExternalDocumentationLink
 import org.jetbrains.dokka.utilities.DokkaConsoleLogger
 import org.jetbrains.dokka.utilities.cast
-import java.io.*
+import java.io.File
 import java.net.MalformedURLException
 import java.net.URL
 import java.nio.file.Paths
@@ -74,7 +74,7 @@ class GlobalArguments(args: Array<String>) : DokkaConfiguration {
         description = "Document generated or obvious functions like default `toString` or `equals`"
     ).default(!DokkaDefaults.suppressObviousFunctions)
 
-    override val suppressObviousFunctions: Boolean by lazy{ !noSuppressObviousFunctions }
+    override val suppressObviousFunctions: Boolean by lazy { !noSuppressObviousFunctions }
 
     private val _includes by parser.option(
         ArgTypeFile,
@@ -221,6 +221,11 @@ private fun parseSourceSet(moduleName: String, args: Array<String>): DokkaConfig
         description = "Paths to files to be suppressed (allows many paths separated by the semicolon `;`)"
     ).delimiter(";")
 
+    val suppressedAnnotations by parser.option(
+        ArgType.String,
+        description = "Fully qualified names of annotations to suppress (allows many names separated by the semicolon `;`)"
+    ).delimiter(";")
+
     val analysisPlatform: Platform by parser.option(
         ArgTypePlatform,
         description = "Platform for analysis"
@@ -268,6 +273,7 @@ private fun parseSourceSet(moduleName: String, args: Array<String>): DokkaConfig
         override val noStdlibLink = noStdlibLink
         override val noJdkLink = noJdkLink
         override val suppressedFiles = suppressedFiles.toMutableSet()
+        override val suppressedAnnotations: Set<String> = suppressedAnnotations.toSet()
     }
 }
 

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/GradleDokkaSourceSetBuilder.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/GradleDokkaSourceSetBuilder.kt
@@ -3,7 +3,9 @@
 package org.jetbrains.dokka.gradle
 
 import groovy.lang.Closure
-import org.gradle.api.*
+import org.gradle.api.Action
+import org.gradle.api.NamedDomainObjectFactory
+import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
@@ -112,6 +114,10 @@ open class GradleDokkaSourceSetBuilder(
 
     @InputFiles
     val suppressedFiles: ConfigurableFileCollection = project.files()
+
+    @Input
+    val suppressedAnnotations: SetProperty<String> = project.objects.setProperty<String>()
+        .convention(emptySet())
 
     @Input
     @Optional

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/toDokkaSourceSetImpl.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/toDokkaSourceSetImpl.kt
@@ -25,6 +25,7 @@ internal fun GradleDokkaSourceSetBuilder.toDokkaSourceSetImpl(): DokkaSourceSetI
     noStdlibLink = noStdlibLink.getSafe(),
     noJdkLink = noJdkLink.getSafe(),
     suppressedFiles = suppressedFilesWithDefaults(),
+    suppressedAnnotations = suppressedAnnotations.getSafe(),
     analysisPlatform = platform.getSafe()
 )
 

--- a/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/GradleDokkaSourceSetBuilderTest.kt
+++ b/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/GradleDokkaSourceSetBuilderTest.kt
@@ -425,6 +425,19 @@ class GradleDokkaSourceSetBuilderTest {
     }
 
     @Test
+    fun suppressedAnnotations() {
+        val sourceSet = GradleDokkaSourceSetBuilder("", project)
+        assertTrue(sourceSet.build().suppressedAnnotations.isEmpty(), "Expected no suppressed annotations by default")
+
+        sourceSet.suppressedAnnotations.set(setOf("kotlin.ExperimentalStdlibApi"))
+
+        assertEquals(
+            setOf("kotlin.ExperimentalStdlibApi"), sourceSet.build().suppressedAnnotations,
+            "Expected all suppressed annotations to be present after build"
+        )
+    }
+
+    @Test
     fun suppressedFilesByDefault() {
         val sourceSet = GradleDokkaSourceSetBuilder("", project)
         assertTrue(sourceSet.build().suppressedFiles.isEmpty(), "Expected no suppressed files by default")

--- a/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
+++ b/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
@@ -22,7 +22,6 @@ import org.jetbrains.dokka.*
 import org.jetbrains.dokka.DokkaConfiguration.ExternalDocumentationLink
 import java.io.File
 import java.net.URL
-import java.util.stream.Collectors
 
 class SourceLinkMapItem {
     @Parameter(name = "path", required = true)
@@ -148,6 +147,9 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
     var suppressedFiles: List<String> = emptyList()
 
     @Parameter
+    var suppressedAnnotations: List<String> = emptyList()
+
+    @Parameter
     var platform: String = ""
 
     @Parameter
@@ -219,6 +221,7 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
             noStdlibLink = noStdlibLink,
             noJdkLink = noJdkLink,
             suppressedFiles = suppressedFiles.map(::File).toSet(),
+            suppressedAnnotations = suppressedAnnotations.toSet(),
             analysisPlatform = if (platform.isNotEmpty()) Platform.fromString(platform) else Platform.DEFAULT,
         ).let {
             it.copy(


### PR DESCRIPTION
Fixes #1861.

I did this in the base plugin rather than a separate plugin since it fits with things like `supressedFiles` and `skipDeprecated`, and it seemed like overkill to make a new plugin just for this.

I can't run tests locally due to `Node Sass does not yet support your current environment: Windows 64-bit with Unsupported runtime (72)`, any idea how to fix?  I'm assuming the CI will catch anything.