### PR TITLE
Add ability to specify older versions as a list of files

### DIFF
--- a/docs/src/doc/docs/user_guide/versioning/versioning.md
+++ b/docs/src/doc/docs/user_guide/versioning/versioning.md
@@ -9,6 +9,9 @@ Versioning can be configured using:
 
 * version - a string value representing a version that should be displayed in the dropdown.
 * olderVersionsDir - an optional file that represents the parent directory containing folders with previous Dokka outputs.
+* olderVersions - an optional list of directories, each containing a previous Dokka output.  Used after the contents of 
+  `olderVersionsDir` 
+  (if it's specified).
 * versionsOrdering - an optional list of strings representing the ordering of versions that should be visible. 
   By default, Dokka will try to use semantic versioning to create such ordering.
   
@@ -21,7 +24,7 @@ Configuration object is named `org.jetbrains.dokka.versioning.VersioningConfigur
 
 ### Directory structure required
 
-Versioning plugins requires documentation authors to keep previous outputs in a set structure:
+If you pass previous versions using `olderVersionsDir`, a particular directory structure is required:
 
 ```
 .
@@ -34,6 +37,12 @@ Versioning plugins requires documentation authors to keep previous outputs in a 
 ```
 
 As can be seen on the diagram, `olderVersionsDir` should be a parent directory of previous output directories.
+
+This can be avoided by manually specifying each past output directory with `olderVersions`, or they can be used 
+together.
+
+`olderVersions` directories need to contain a past Dokka output.  For the above example, you would pass 
+`older_versions_dir/1.4.10, older_versions_dir/1.4.20`.
 
 ### Example
 

--- a/plugins/versioning/api/versioning.api
+++ b/plugins/versioning/api/versioning.api
@@ -56,18 +56,21 @@ public final class org/jetbrains/dokka/versioning/SemVerVersionOrdering : org/je
 public final class org/jetbrains/dokka/versioning/VersioningConfiguration : org/jetbrains/dokka/plugability/ConfigurableBlock {
 	public static final field Companion Lorg/jetbrains/dokka/versioning/VersioningConfiguration$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/io/File;Ljava/util/List;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/io/File;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/io/File;Ljava/util/List;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/io/File;Ljava/util/List;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/io/File;
 	public final fun component2 ()Ljava/util/List;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/io/File;Ljava/util/List;Ljava/lang/String;)Lorg/jetbrains/dokka/versioning/VersioningConfiguration;
-	public static synthetic fun copy$default (Lorg/jetbrains/dokka/versioning/VersioningConfiguration;Ljava/io/File;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/dokka/versioning/VersioningConfiguration;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/io/File;Ljava/util/List;Ljava/util/List;Ljava/lang/String;)Lorg/jetbrains/dokka/versioning/VersioningConfiguration;
+	public static synthetic fun copy$default (Lorg/jetbrains/dokka/versioning/VersioningConfiguration;Ljava/io/File;Ljava/util/List;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/dokka/versioning/VersioningConfiguration;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOlderVersions ()Ljava/util/List;
 	public final fun getOlderVersionsDir ()Ljava/io/File;
 	public final fun getVersion ()Ljava/lang/String;
 	public final fun getVersionsOrdering ()Ljava/util/List;
 	public fun hashCode ()I
+	public final fun setOlderVersions (Ljava/util/List;)V
 	public final fun setOlderVersionsDir (Ljava/io/File;)V
 	public final fun setVersion (Ljava/lang/String;)V
 	public final fun setVersionsOrdering (Ljava/util/List;)V
@@ -75,6 +78,7 @@ public final class org/jetbrains/dokka/versioning/VersioningConfiguration : org/
 }
 
 public final class org/jetbrains/dokka/versioning/VersioningConfiguration$Companion {
+	public final fun getDefaultOlderVersions ()Ljava/util/List;
 	public final fun getDefaultOlderVersionsDir ()Ljava/io/File;
 	public final fun getDefaultVersion ()Ljava/lang/Void;
 	public final fun getDefaultVersionsOrdering ()Ljava/util/List;

--- a/plugins/versioning/src/main/kotlin/versioning/VersioningConfiguration.kt
+++ b/plugins/versioning/src/main/kotlin/versioning/VersioningConfiguration.kt
@@ -5,6 +5,7 @@ import org.jetbrains.dokka.plugability.DokkaContext
 import java.io.File
 
 data class VersioningConfiguration(
+    var olderVersionsDir: File? = defaultOlderVersionsDir,
     var olderVersions: List<File>? = defaultOlderVersions,
     var versionsOrdering: List<String>? = defaultVersionsOrdering,
     var version: String? = defaultVersion,
@@ -12,11 +13,15 @@ data class VersioningConfiguration(
     internal fun versionFromConfigurationOrModule(dokkaContext: DokkaContext): String =
         version ?: dokkaContext.configuration.moduleVersion ?: "1.0"
 
-    fun olderVersionDir(dir: File) {
-        olderVersions = dir.listFiles()?.toList() ?: error("Path $dir is not a directory")
+    internal fun allOlderVersions(): List<File> {
+        if (olderVersionsDir != null)
+            assert(olderVersionsDir!!.isDirectory) { "Supplied previous version $olderVersionsDir is not a directory!" }
+
+        return olderVersionsDir?.listFiles()?.toList().orEmpty() + olderVersions.orEmpty()
     }
 
     companion object {
+        val defaultOlderVersionsDir: File? = null
         val defaultOlderVersions: List<File>? = null
         val defaultVersionsOrdering: List<String>? = null
         val defaultVersion = null

--- a/plugins/versioning/src/main/kotlin/versioning/VersioningConfiguration.kt
+++ b/plugins/versioning/src/main/kotlin/versioning/VersioningConfiguration.kt
@@ -5,15 +5,19 @@ import org.jetbrains.dokka.plugability.DokkaContext
 import java.io.File
 
 data class VersioningConfiguration(
-    var olderVersionsDir: File? = defaultOlderVersionsDir,
+    var olderVersions: List<File>? = defaultOlderVersions,
     var versionsOrdering: List<String>? = defaultVersionsOrdering,
     var version: String? = defaultVersion,
 ) : ConfigurableBlock {
     internal fun versionFromConfigurationOrModule(dokkaContext: DokkaContext): String =
         version ?: dokkaContext.configuration.moduleVersion ?: "1.0"
 
+    fun olderVersionDir(dir: File) {
+        olderVersions = dir.listFiles()?.toList() ?: error("Path $dir is not a directory")
+    }
+
     companion object {
-        val defaultOlderVersionsDir: File? = null
+        val defaultOlderVersions: List<File>? = null
         val defaultVersionsOrdering: List<String>? = null
         val defaultVersion = null
     }

--- a/plugins/versioning/src/main/kotlin/versioning/VersioningHandler.kt
+++ b/plugins/versioning/src/main/kotlin/versioning/VersioningHandler.kt
@@ -43,7 +43,7 @@ class DefaultVersioningHandler(val context: DokkaContext) : VersioningHandler {
         configuration?.let { versionsConfiguration ->
             versions =
                 mapOf(versionsConfiguration.versionFromConfigurationOrModule(context) to context.configuration.outputDir)
-            versionsConfiguration.olderVersions?.let {
+            versionsConfiguration.allOlderVersions().let {
                 handlePreviousVersions(it, context.configuration.outputDir)
             }
             mapper.writeValue(


### PR DESCRIPTION
Fixes #1889.  I'm not aware of a good Java globbing implementation (the JDK one doesn't use base directories) unless you already have a dependency for one.  If you do I can add a setter method.

The older version directory's subfolders and the older versions list are added together, so either or both can be specified.  I don't love the `olderVersions` name but I couldn't think of a better one.  `additionalOlderVersions` maybe?