### PR TITLE
GFM renderer: sanitize line ends

### DIFF
--- a/plugins/gfm/src/main/kotlin/org/jetbrains/dokka/gfm/renderer/CommonmarkRenderer.kt
+++ b/plugins/gfm/src/main/kotlin/org/jetbrains/dokka/gfm/renderer/CommonmarkRenderer.kt
@@ -344,7 +344,10 @@ open class CommonmarkRenderer(
         }
     }
 
-    private fun String.withEntersAsHtml(): String = replace("[\n]+".toRegex(), "<br>")
+    private fun String.withEntersAsHtml(): String = this
+        .replace("\\\n", "\n\n")
+        .replace("\n[\n]+".toRegex(), "<br>")
+        .replace("\n", " ")
 
     private fun List<Pair<ContentDivergentInstance, DisplaySourceSet>>.getInstanceAndSourceSets() =
         this.let { Pair(it.first().first, it.map { it.second }.toSet()) }

--- a/plugins/gfm/src/test/kotlin/renderers/gfm/DivergentTest.kt
+++ b/plugins/gfm/src/test/kotlin/renderers/gfm/DivergentTest.kt
@@ -41,7 +41,7 @@ class DivergentTest : GfmRenderingOnlyTestBase() {
                 }
             }
         }
-        val expect = "//[testPage](test-page.md)\n\n[js]  \nContent  \na  \n\n\n"
+        val expect = "//[testPage](test-page.md)\n\n[js]\\\nContent\\\na"
         CommonmarkRenderer(context).render(page)
         assert(renderedContent == expect)
     }
@@ -57,7 +57,7 @@ class DivergentTest : GfmRenderingOnlyTestBase() {
                 }
             }
         }
-        val expect = "//[testPage](test-page.md)\n\n[js]  \nContent  \na  \n\n\n"
+        val expect = "//[testPage](test-page.md)\n\n[js]\\\nContent\\\na"
         CommonmarkRenderer(context).render(page)
         assert(renderedContent == expect)
     }
@@ -83,7 +83,7 @@ class DivergentTest : GfmRenderingOnlyTestBase() {
                 }
             }
         }
-        val expect = "//[testPage](test-page.md)\n\n[js, jvm, native]  \nContent  \n[js]  \na  \n[jvm]  \nb  \n[native]  \nc  \n\n\n"
+        val expect = "//[testPage](test-page.md)\n\n[js, jvm, native]\\\nContent\\\n[js]\\\na\\\n[jvm]\\\nb\\\n[native]\\\nc"
         CommonmarkRenderer(context).render(page)
         assert(renderedContent == expect)
     }
@@ -109,7 +109,7 @@ class DivergentTest : GfmRenderingOnlyTestBase() {
                 }
             }
         }
-        val expect = "//[testPage](test-page.md)\n\n[js]  \nContent  \na  \nb  \nc  \n\n\n"
+        val expect = "//[testPage](test-page.md)\n\n[js]\\\nContent\\\na\\\nb\\\nc"
         CommonmarkRenderer(context).render(page)
         assert(renderedContent == expect)
     }
@@ -145,7 +145,7 @@ class DivergentTest : GfmRenderingOnlyTestBase() {
                 }
             }
         }
-        val expect = "//[testPage](test-page.md)\n\n[native, js, jvm]  \nContent  \n[native]  \na  \n[js]  \nb  \n[jvm]  \nc  \n[js]  \nd  \n[native]  \ne  \n\n\n"
+        val expect = "//[testPage](test-page.md)\n\n[native, js, jvm]\\\nContent\\\n[native]\\\na\\\n[js]\\\nb\\\n[jvm]\\\nc\\\n[js]\\\nd\\\n[native]\\\ne"
         CommonmarkRenderer(context).render(page)
         assert(renderedContent == expect)
     }
@@ -193,7 +193,7 @@ class DivergentTest : GfmRenderingOnlyTestBase() {
                 }
             }
         }
-        val expect = "//[testPage](test-page.md)\n\n[native]  \nContent  \na  \nMore info  \na+  \n\n\n[js]  \nContent  \nb  \nd  \nMore info  \nbd+  \n\n\n[jvm]  \nContent  \nc  \n\n\n[native]  \nContent  \ne  \nMore info  \ne+  \n\n\n"
+        val expect = "//[testPage](test-page.md)\n\n[native]\\\nContent\\\na\\\nMore info\\\na+\n\n[js]\\\nContent\\\nb\\\nd\\\nMore info\\\nbd+\n\n[jvm]\\\nContent\\\nc\n\n[native]\\\nContent\\\ne\\\nMore info\\\ne+"
         CommonmarkRenderer(context).render(page)
         assert(renderedContent == expect)
     }
@@ -220,7 +220,7 @@ class DivergentTest : GfmRenderingOnlyTestBase() {
                 }
             }
         }
-        val expect = "//[testPage](test-page.md)\n\n[native]  \nBrief description  \nab-  \nContent  \na  \nb  \n\n\n"
+        val expect = "//[testPage](test-page.md)\n\n[native]\\\nBrief description\\\nab-\\\nContent\\\na\\\nb"
         CommonmarkRenderer(context).render(page)
         assert(renderedContent == expect)
     }
@@ -247,7 +247,7 @@ class DivergentTest : GfmRenderingOnlyTestBase() {
                 }
             }
         }
-        val expect = "//[testPage](test-page.md)\n\n[native]  \nContent  \na  \nb  \nMore info  \nab+  \n\n\n"
+        val expect = "//[testPage](test-page.md)\n\n[native]\\\nContent\\\na\\\nb\\\nMore info\\\nab+"
         CommonmarkRenderer(context).render(page)
         assert(renderedContent == expect)
     }
@@ -280,7 +280,7 @@ class DivergentTest : GfmRenderingOnlyTestBase() {
                 }
             }
         }
-        val expect = "//[testPage](test-page.md)\n\n[native]  \nBrief description  \nab-  \nContent  \na  \nb  \nMore info  \nab+  \n\n\n"
+        val expect = "//[testPage](test-page.md)\n\n[native]\\\nBrief description\\\nab-\\\nContent\\\na\\\nb\\\nMore info\\\nab+"
         CommonmarkRenderer(context).render(page)
         assert(renderedContent == expect)
     }
@@ -313,7 +313,7 @@ class DivergentTest : GfmRenderingOnlyTestBase() {
                 }
             }
         }
-        val expect = "//[testPage](test-page.md)\n\n[native]  \nBrief description  \na-  \nContent  \na  \nMore info  \nab+  \n\n\n[native]  \nBrief description  \nb-  \nContent  \nb  \nMore info  \nab+  \n\n\n"
+        val expect = "//[testPage](test-page.md)\n\n[native]\\\nBrief description\\\na-\\\nContent\\\na\\\nMore info\\\nab+\n\n[native]\\\nBrief description\\\nb-\\\nContent\\\nb\\\nMore info\\\nab+"
         CommonmarkRenderer(context).render(page)
         assert(renderedContent == expect)
     }
@@ -364,7 +364,7 @@ class DivergentTest : GfmRenderingOnlyTestBase() {
                 }
             }
         }
-        val expect = "//[testPage](test-page.md)\n\n[native]  \nContent  \na  \nMore info  \na+  \n\n\n[js, jvm]  \nContent  \n[js]  \nb  \n[jvm]  \nc  \n[js]  \nd  \nMore info  \nbd+  \n\n\n[native]  \nContent  \ne  \nMore info  \ne+  \n\n\n"
+        val expect = "//[testPage](test-page.md)\n\n[native]\\\nContent\\\na\\\nMore info\\\na+\n\n[js, jvm]\\\nContent\\\n[js]\\\nb\\\n[jvm]\\\nc\\\n[js]\\\nd\\\nMore info\\\nbd+\n\n[native]\\\nContent\\\ne\\\nMore info\\\ne+"
         CommonmarkRenderer(context).render(page)
         assert(renderedContent == expect)
     }

--- a/plugins/gfm/src/test/kotlin/renderers/gfm/GroupWrappingTest.kt
+++ b/plugins/gfm/src/test/kotlin/renderers/gfm/GroupWrappingTest.kt
@@ -34,7 +34,7 @@ class GroupWrappingTest : GfmRenderingOnlyTestBase() {
 
         CommonmarkRenderer(context).render(page)
 
-        assert(renderedContent == "//[testPage](test-page.md)\n\n\n\nab\n\nc")
+        assert(renderedContent == "//[testPage](test-page.md)\n\nab\n\nc")
     }
 
     @Test
@@ -48,8 +48,7 @@ class GroupWrappingTest : GfmRenderingOnlyTestBase() {
         }
 
         CommonmarkRenderer(context).render(page)
-
-        assert(renderedContent == "//[testPage](test-page.md)\n\nab  \nc")
+        assert(renderedContent == "//[testPage](test-page.md)\n\nab\n\nc")
     }
 
     @Test
@@ -70,7 +69,7 @@ class GroupWrappingTest : GfmRenderingOnlyTestBase() {
         CommonmarkRenderer(context).render(page)
 
 //        renderedContent.match(Div("a", Div(Div("bc")), "d"))
-        assert(renderedContent == "//[testPage](test-page.md)\n\nabc  \n  \nd  \n")
+        assert(renderedContent == "//[testPage](test-page.md)\n\nabc\n\nd")
     }
 
 }

--- a/plugins/gfm/src/test/kotlin/renderers/gfm/SimpleElementsTest.kt
+++ b/plugins/gfm/src/test/kotlin/renderers/gfm/SimpleElementsTest.kt
@@ -15,7 +15,7 @@ class SimpleElementsTest : GfmRenderingOnlyTestBase() {
         val page = testPage {
             header(1, "The Hobbit or There and Back Again")
         }
-        val expect = "//[testPage](test-page.md)\n\n\n\n# The Hobbit or There and Back Again  \n"
+        val expect = "//[testPage](test-page.md)\n\n# The Hobbit or There and Back Again"
         CommonmarkRenderer(context).render(page)
         assertEquals(expect, renderedContent)
     }
@@ -123,12 +123,10 @@ class SimpleElementsTest : GfmRenderingOnlyTestBase() {
 
         val expect = """\//[testPage](test-page.md)
             \
-            \  
             \|  Col1 |  Col2 |  Col3 | 
             \|---|---|---|
             \| <a name="////PointingToDeclaration/"></a>Text1| <a name="////PointingToDeclaration/"></a>Text2| <a name="////PointingToDeclaration/"></a>Text3|
-            \| <a name="////PointingToDeclaration/"></a>Text4| <a name="////PointingToDeclaration/"></a>Text5| <a name="////PointingToDeclaration/"></a>Text6|
-            \""".trimMargin("\\")
+            \| <a name="////PointingToDeclaration/"></a>Text4| <a name="////PointingToDeclaration/"></a>Text5| <a name="////PointingToDeclaration/"></a>Text6|""".trimMargin("\\")
 
         CommonmarkRenderer(context).render(page)
         assertEquals(expect, renderedContent)
@@ -153,12 +151,10 @@ class SimpleElementsTest : GfmRenderingOnlyTestBase() {
 
         val expect = """\//[testPage](test-page.md)
             \
-            \  
             \| | | |
             \|---|---|---|
             \| <a name="////PointingToDeclaration/"></a>Text1| <a name="////PointingToDeclaration/"></a>Text2| <a name="////PointingToDeclaration/"></a>Text3|
-            \| <a name="////PointingToDeclaration/"></a>Text4| <a name="////PointingToDeclaration/"></a>Text5| <a name="////PointingToDeclaration/"></a>Text6|
-            \""".trimMargin("\\")
+            \| <a name="////PointingToDeclaration/"></a>Text4| <a name="////PointingToDeclaration/"></a>Text5| <a name="////PointingToDeclaration/"></a>Text6|""".trimMargin("\\")
 
         CommonmarkRenderer(context).render(page)
         assertEquals(expect, renderedContent)

--- a/plugins/gfm/src/test/kotlin/renderers/gfm/SourceSetDependentHintTest.kt
+++ b/plugins/gfm/src/test/kotlin/renderers/gfm/SourceSetDependentHintTest.kt
@@ -41,7 +41,7 @@ class SourceSetDependentHintTest : GfmRenderingOnlyTestBase() {
         }
 
         CommonmarkRenderer(context).render(page)
-        assert(renderedContent == "//[testPage](test-page.md)\n\n [pl1, pl2, pl3] abc  \n   \n")
+        assert(renderedContent == "//[testPage](test-page.md)\n\n [pl1, pl2, pl3] abc")
     }
 
     @Test
@@ -55,7 +55,7 @@ class SourceSetDependentHintTest : GfmRenderingOnlyTestBase() {
         }
 
         CommonmarkRenderer(context).render(page)
-        assert(renderedContent == "//[testPage](test-page.md)\n\n [pl1] a  \n   \n [pl2] b  \n   \n [pl3] c  \n   \n")
+        assert(renderedContent == "//[testPage](test-page.md)\n\n [pl1] a\n\n [pl2] b\n\n [pl3] c")
     }
 
     @Test
@@ -69,7 +69,7 @@ class SourceSetDependentHintTest : GfmRenderingOnlyTestBase() {
         }
 
         CommonmarkRenderer(context).render(page)
-        assert(renderedContent == "//[testPage](test-page.md)\n\n [pl1] ab  \n   \n [pl2] bc  \n   \n")
+        assert(renderedContent == "//[testPage](test-page.md)\n\n [pl1] ab\n\n [pl2] bc")
     }
 
     @Test
@@ -83,7 +83,7 @@ class SourceSetDependentHintTest : GfmRenderingOnlyTestBase() {
         }
 
         CommonmarkRenderer(context).render(page)
-        assert(renderedContent == "//[testPage](test-page.md)\n\n [pl1, pl2] ab  \n   \n")
+        assert(renderedContent == "//[testPage](test-page.md)\n\n [pl1, pl2] ab")
     }
 
     @Test
@@ -99,7 +99,7 @@ class SourceSetDependentHintTest : GfmRenderingOnlyTestBase() {
         }
 
         CommonmarkRenderer(context).render(page)
-        assert(renderedContent == "//[testPage](test-page.md)\n\n [pl1] ab  \n  \n   \n [pl2] a  \nb  \n   \n")
+        assert(renderedContent == "//[testPage](test-page.md)\n\n [pl1] ab\n\n [pl2] a\n\nb")
     }
 
     @Test
@@ -115,7 +115,7 @@ class SourceSetDependentHintTest : GfmRenderingOnlyTestBase() {
         }
 
         CommonmarkRenderer(context).render(page)
-        assert(renderedContent == "//[testPage](test-page.md)\n\n [pl1, pl2] ab   \n")
+        assert(renderedContent == "//[testPage](test-page.md)\n\n [pl1, pl2] ab")
     }
 
     @Test
@@ -129,6 +129,6 @@ class SourceSetDependentHintTest : GfmRenderingOnlyTestBase() {
         }
 
         CommonmarkRenderer(context).render(page)
-        assert(renderedContent == "//[testPage](test-page.md)\n\n [pl1, pl2] a  \n   \n [pl3] b  \n   \n")
+        assert(renderedContent == "//[testPage](test-page.md)\n\n [pl1, pl2] a\n\n [pl3] b")
     }
 }


### PR DESCRIPTION
Cleanup work for line and paragraph ends in rendered GFM, from current bloody mess to (almost) ideomatic markdown.
If accepted - more cleanups will follow.

Ready for review and merge.