### PR TITLE
[Jekyll Plugin] Remove extra dash

### DIFF
--- a/plugins/jekyll/src/main/kotlin/JekyllPlugin.kt
+++ b/plugins/jekyll/src/main/kotlin/JekyllPlugin.kt
@@ -45,7 +45,7 @@ class JekyllRenderer(
     override fun buildPage(page: ContentPage, content: (StringBuilder, ContentPage) -> Unit): String {
         val builder = StringBuilder()
         builder.append("---\n")
-        builder.append("title: ${page.name} -\n")
+        builder.append("title: ${page.name}\n")
         builder.append("---\n")
         content(builder, page)
         return builder.toString()


### PR DESCRIPTION
## Version

Dokka 1.4.32

## Issue

The use of `dokkaJekyll` task adds a final `dash` to every title in the header like:

```
---
title: Const -
---
```

## Solution

Remove the extra dash.