### PR TITLE
Implement url to multiple sources

### DIFF
--- a/core/src/main/kotlin/Formats/KotlinWebsiteHtmlFormatService.kt
+++ b/core/src/main/kotlin/Formats/KotlinWebsiteHtmlFormatService.kt
@@ -189,9 +189,7 @@ open class KotlinWebsiteHtmlOutputBuilder(
         val nonJRE6 = platforms.filterNot { it.key.isJREVersion() && it.key.endsWith("6") }
         nonJRE6.forEach { (platform, nodes) ->
             nodes.firstOrNull { node ->
-                node.details(NodeKind.SourceUrl).firstOrNull()?.takeUnless { usedSourceUrls.contains(it.name) }?.also {
-                    usedSourceUrls.add(it.name)
-                } != null
+                node.details(NodeKind.SourceUrl).firstOrNull()?.takeIf { usedSourceUrls.add(it.name) } != null
             }?.let { nodeWithUnusedSourceUrl ->
                 platformToSourceUrl[platform] = nodeWithUnusedSourceUrl
             }

--- a/core/src/main/kotlin/Formats/KotlinWebsiteHtmlFormatService.kt
+++ b/core/src/main/kotlin/Formats/KotlinWebsiteHtmlFormatService.kt
@@ -114,13 +114,17 @@ open class KotlinWebsiteHtmlOutputBuilder(
 
     override fun appendSoftLineBreak() {
         if (needHardLineBreaks)
-            to.append("<br/>")
+            appendHardLineBreak()
     }
 
     override fun appendIndentedSoftLineBreak() {
         if (needHardLineBreaks) {
             to.append("<br/>&nbsp;&nbsp;&nbsp;&nbsp;")
         }
+    }
+
+    override fun appendHardLineBreak() {
+        to.append("<br/>")
     }
 
     private fun identifierClassName(kind: IdentifierKind) = when (kind) {

--- a/core/src/main/kotlin/Formats/StructuredFormatService.kt
+++ b/core/src/main/kotlin/Formats/StructuredFormatService.kt
@@ -178,6 +178,9 @@ abstract class StructuredOutputBuilder(val to: StringBuilder,
     open fun appendIndentedSoftLineBreak() {
     }
 
+    open fun appendHardLineBreak() {
+    }
+
     fun appendContent(content: List<ContentNode>) {
         for (contentNode in content) {
             appendContent(contentNode)
@@ -450,7 +453,7 @@ abstract class StructuredOutputBuilder(val to: StringBuilder,
                 }
                 appendAsSignature(rendered) {
                     appendCode { appendContent(rendered) }
-                    item.appendSourceLink()
+                    item.appendSourceLink(appendLineBreak = true)
                 }
                 item.appendOverrides()
                 item.appendDeprecation()
@@ -477,7 +480,12 @@ abstract class StructuredOutputBuilder(val to: StringBuilder,
 
                     appendAsSignature(sign) {
                         appendCode { appendContent(sign) }
-                        appendSourceLinks(platforms) { this.appendSourceLink(it) }
+
+                        var appendLineBreak = true
+                        appendSourceLinks(platforms) {
+                            this.appendSourceLink(appendLineBreak, it)
+                            appendLineBreak = false
+                        }
                     }
                     first.appendOverrides()
                     first.appendDeprecation()
@@ -486,10 +494,16 @@ abstract class StructuredOutputBuilder(val to: StringBuilder,
             }
         }
 
-        private fun DocumentationNode.appendSourceLink(platform: String? = null) {
+        private fun DocumentationNode.appendSourceLink(appendLineBreak: Boolean, platform: String? = null) {
             val sourceUrl = details(NodeKind.SourceUrl).firstOrNull()
             if (sourceUrl != null) {
-                to.append(" ")
+
+                if (appendLineBreak) {
+                    appendHardLineBreak()
+                } else {
+                    to.append(" ")
+                }
+
                 val text = if (platform == null) "(source)" else "($platform source)"
                 appendLink(sourceUrl.name) { to.append(text) }
             }

--- a/core/src/main/kotlin/Formats/StructuredFormatService.kt
+++ b/core/src/main/kotlin/Formats/StructuredFormatService.kt
@@ -292,6 +292,12 @@ abstract class StructuredOutputBuilder(val to: StringBuilder,
         }
     }
 
+    protected open fun appendSourceLinks(platforms: PlatformsData, appendSourceLink: DocumentationNode.(platform: String?) -> Unit) {
+        platforms.forEach { (platform, nodes) ->
+            nodes.first().appendSourceLink(platform)
+        }
+    }
+
     protected open fun appendBreadcrumbs(path: Iterable<FormatLink>) {
         for ((index, item) in path.withIndex()) {
             if (index > 0) {
@@ -471,6 +477,7 @@ abstract class StructuredOutputBuilder(val to: StringBuilder,
 
                     appendAsSignature(sign) {
                         appendCode { appendContent(sign) }
+                        appendSourceLinks(platforms) { this.appendSourceLink(it) }
                     }
                     first.appendOverrides()
                     first.appendDeprecation()
@@ -479,11 +486,12 @@ abstract class StructuredOutputBuilder(val to: StringBuilder,
             }
         }
 
-        private fun DocumentationNode.appendSourceLink() {
+        private fun DocumentationNode.appendSourceLink(platform: String? = null) {
             val sourceUrl = details(NodeKind.SourceUrl).firstOrNull()
             if (sourceUrl != null) {
                 to.append(" ")
-                appendLink(sourceUrl.name) { to.append("(source)") }
+                val text = if (platform == null) "(source)" else "($platform source)"
+                appendLink(sourceUrl.name) { to.append(text) }
             }
         }
 


### PR DESCRIPTION
* For signatures declared in a single location only `(source)` hyperlink is added.
* For builtins (common, jvm, js take from `kotlin/core/builtins` while k/n has separate implementation) `(Common source) (Native source)` hyperlinks are added.
* For multiplatform declarations with `expect/actual` `(Common source) (JVM source) (JS source) (Native source)` hyperlinks are added.
* For signatures declared in multiple platform, e.g. JVM and Native, `(JVM source) (Native source)` hyperlinks are added.

The hyperlinks follow the signature, thus often make the signature line very long. Maybe adding the hyperlinks in a separate line or even in a separate section might be better. Another approach is to add hyperlinks to signature platform tags.