### PR TITLE
Minor: rename `buildNewLine`

### DIFF
--- a/plugins/base/api/base.api
+++ b/plugins/base/api/base.api
@@ -225,11 +225,11 @@ public abstract class org/jetbrains/dokka/base/renderers/DefaultRenderer : org/j
 	public abstract fun buildHeader (Ljava/lang/Object;ILorg/jetbrains/dokka/pages/ContentHeader;Lkotlin/jvm/functions/Function1;)V
 	public fun buildHeader (Ljava/lang/Object;Lorg/jetbrains/dokka/pages/ContentHeader;Lorg/jetbrains/dokka/pages/ContentPage;Ljava/util/Set;)V
 	public static synthetic fun buildHeader$default (Lorg/jetbrains/dokka/base/renderers/DefaultRenderer;Ljava/lang/Object;Lorg/jetbrains/dokka/pages/ContentHeader;Lorg/jetbrains/dokka/pages/ContentPage;Ljava/util/Set;ILjava/lang/Object;)V
+	public abstract fun buildLineBreak (Ljava/lang/Object;)V
 	public abstract fun buildLink (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun buildList (Ljava/lang/Object;Lorg/jetbrains/dokka/pages/ContentList;Lorg/jetbrains/dokka/pages/ContentPage;Ljava/util/Set;)V
 	public static synthetic fun buildList$default (Lorg/jetbrains/dokka/base/renderers/DefaultRenderer;Ljava/lang/Object;Lorg/jetbrains/dokka/pages/ContentList;Lorg/jetbrains/dokka/pages/ContentPage;Ljava/util/Set;ILjava/lang/Object;)V
 	public abstract fun buildNavigation (Ljava/lang/Object;Lorg/jetbrains/dokka/pages/PageNode;)V
-	public abstract fun buildNewLine (Ljava/lang/Object;)V
 	public abstract fun buildPage (Lorg/jetbrains/dokka/pages/ContentPage;Lkotlin/jvm/functions/Function2;)Ljava/lang/String;
 	public fun buildPageContent (Ljava/lang/Object;Lorg/jetbrains/dokka/pages/ContentPage;)V
 	public fun buildPlatformDependent (Ljava/lang/Object;Lorg/jetbrains/dokka/pages/PlatformHintedContent;Lorg/jetbrains/dokka/pages/ContentPage;Ljava/util/Set;)V
@@ -341,6 +341,8 @@ public class org/jetbrains/dokka/base/renderers/html/HtmlRenderer : org/jetbrain
 	public synthetic fun buildHeader (Ljava/lang/Object;ILorg/jetbrains/dokka/pages/ContentHeader;Lkotlin/jvm/functions/Function1;)V
 	public fun buildHeader (Lkotlinx/html/FlowContent;ILorg/jetbrains/dokka/pages/ContentHeader;Lkotlin/jvm/functions/Function1;)V
 	public fun buildHtml (Lorg/jetbrains/dokka/pages/PageNode;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Ljava/lang/String;
+	public synthetic fun buildLineBreak (Ljava/lang/Object;)V
+	public fun buildLineBreak (Lkotlinx/html/FlowContent;)V
 	public synthetic fun buildLink (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public fun buildLink (Lkotlinx/html/FlowContent;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public final fun buildLink (Lkotlinx/html/FlowContent;Lorg/jetbrains/dokka/links/DRI;Ljava/util/List;Lorg/jetbrains/dokka/pages/PageNode;Lkotlin/jvm/functions/Function1;)V
@@ -353,8 +355,6 @@ public class org/jetbrains/dokka/base/renderers/html/HtmlRenderer : org/jetbrain
 	public static synthetic fun buildListItems$default (Lorg/jetbrains/dokka/base/renderers/html/HtmlRenderer;Lkotlinx/html/UL;Ljava/util/List;Lorg/jetbrains/dokka/pages/ContentPage;Ljava/util/Set;ILjava/lang/Object;)V
 	public synthetic fun buildNavigation (Ljava/lang/Object;Lorg/jetbrains/dokka/pages/PageNode;)V
 	public fun buildNavigation (Lkotlinx/html/FlowContent;Lorg/jetbrains/dokka/pages/PageNode;)V
-	public synthetic fun buildNewLine (Ljava/lang/Object;)V
-	public fun buildNewLine (Lkotlinx/html/FlowContent;)V
 	public fun buildPage (Lorg/jetbrains/dokka/pages/ContentPage;Lkotlin/jvm/functions/Function2;)Ljava/lang/String;
 	public synthetic fun buildPlatformDependent (Ljava/lang/Object;Lorg/jetbrains/dokka/pages/PlatformHintedContent;Lorg/jetbrains/dokka/pages/ContentPage;Ljava/util/Set;)V
 	public fun buildPlatformDependent (Lkotlinx/html/FlowContent;Lorg/jetbrains/dokka/pages/PlatformHintedContent;Lorg/jetbrains/dokka/pages/ContentPage;Ljava/util/Set;)V

--- a/plugins/base/src/main/kotlin/renderers/DefaultRenderer.kt
+++ b/plugins/base/src/main/kotlin/renderers/DefaultRenderer.kt
@@ -34,7 +34,7 @@ abstract class DefaultRenderer<T>(
         sourceSetRestriction: Set<DisplaySourceSet>? = null
     )
 
-    abstract fun T.buildNewLine()
+    abstract fun T.buildLineBreak()
     abstract fun T.buildResource(node: ContentEmbeddedResource, pageContext: ContentPage)
     abstract fun T.buildTable(
         node: ContentTable,
@@ -115,7 +115,7 @@ abstract class DefaultRenderer<T>(
                 is ContentList -> buildList(node, pageContext, sourceSetRestriction)
                 is ContentTable -> buildTable(node, pageContext, sourceSetRestriction)
                 is ContentGroup -> buildGroup(node, pageContext, sourceSetRestriction)
-                is ContentBreakLine -> buildNewLine()
+                is ContentBreakLine -> buildLineBreak()
                 is PlatformHintedContent -> buildPlatformDependent(node, pageContext, sourceSetRestriction)
                 is ContentDivergentGroup -> buildDivergent(node, pageContext)
                 is ContentDivergentInstance -> buildDivergentInstance(node, pageContext)

--- a/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
@@ -656,7 +656,7 @@ open class HtmlRenderer(
 
     override fun buildError(node: ContentNode) = context.logger.error("Unknown ContentNode type: $node")
 
-    override fun FlowContent.buildNewLine() = br()
+    override fun FlowContent.buildLineBreak() = br()
 
     override fun FlowContent.buildLink(address: String, content: FlowContent.() -> Unit) =
         a(href = address, block = content)

--- a/plugins/gfm/api/gfm.api
+++ b/plugins/gfm/api/gfm.api
@@ -48,14 +48,14 @@ public class org/jetbrains/dokka/gfm/renderer/CommonmarkRenderer : org/jetbrains
 	public fun buildError (Lorg/jetbrains/dokka/pages/ContentNode;)V
 	public synthetic fun buildHeader (Ljava/lang/Object;ILorg/jetbrains/dokka/pages/ContentHeader;Lkotlin/jvm/functions/Function1;)V
 	public fun buildHeader (Ljava/lang/StringBuilder;ILorg/jetbrains/dokka/pages/ContentHeader;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun buildLineBreak (Ljava/lang/Object;)V
+	public fun buildLineBreak (Ljava/lang/StringBuilder;)V
 	public synthetic fun buildLink (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public fun buildLink (Ljava/lang/StringBuilder;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun buildList (Ljava/lang/Object;Lorg/jetbrains/dokka/pages/ContentList;Lorg/jetbrains/dokka/pages/ContentPage;Ljava/util/Set;)V
 	public fun buildList (Ljava/lang/StringBuilder;Lorg/jetbrains/dokka/pages/ContentList;Lorg/jetbrains/dokka/pages/ContentPage;Ljava/util/Set;)V
 	public synthetic fun buildNavigation (Ljava/lang/Object;Lorg/jetbrains/dokka/pages/PageNode;)V
 	public fun buildNavigation (Ljava/lang/StringBuilder;Lorg/jetbrains/dokka/pages/PageNode;)V
-	public synthetic fun buildNewLine (Ljava/lang/Object;)V
-	public fun buildNewLine (Ljava/lang/StringBuilder;)V
 	public fun buildPage (Lorg/jetbrains/dokka/pages/ContentPage;Lkotlin/jvm/functions/Function2;)Ljava/lang/String;
 	public synthetic fun buildPlatformDependent (Ljava/lang/Object;Lorg/jetbrains/dokka/pages/PlatformHintedContent;Lorg/jetbrains/dokka/pages/ContentPage;Ljava/util/Set;)V
 	public fun buildPlatformDependent (Ljava/lang/StringBuilder;Lorg/jetbrains/dokka/pages/PlatformHintedContent;Lorg/jetbrains/dokka/pages/ContentPage;Ljava/util/Set;)V

--- a/plugins/gfm/src/main/kotlin/org/jetbrains/dokka/gfm/renderer/CommonmarkRenderer.kt
+++ b/plugins/gfm/src/main/kotlin/org/jetbrains/dokka/gfm/renderer/CommonmarkRenderer.kt
@@ -100,16 +100,16 @@ open class CommonmarkRenderer(
 
     override fun StringBuilder.buildLineBreak() {
         append("\\")
-        appendNewLine()
+        buildNewLine()
     }
 
-    private fun StringBuilder.appendNewLine() {
+    private fun StringBuilder.buildNewLine() {
         append("\n")
     }
 
     private fun StringBuilder.buildParagraph() {
-        appendNewLine()
-        appendNewLine()
+        buildNewLine()
+        buildNewLine()
     }
 
     override fun StringBuilder.buildPlatformDependent(
@@ -154,18 +154,18 @@ open class CommonmarkRenderer(
         pageContext: ContentPage,
         sourceSetRestriction: Set<DisplaySourceSet>?
     ) {
-        appendNewLine()
+        buildNewLine()
         if (node.dci.kind == ContentKind.Sample || node.dci.kind == ContentKind.Parameters) {
             node.sourceSets.forEach { sourcesetData ->
                 append(sourcesetData.name)
-                appendNewLine()
+                buildNewLine()
                 buildTable(
                     node.copy(
                         children = node.children.filter { it.sourceSets.contains(sourcesetData) },
                         dci = node.dci.copy(kind = ContentKind.Main)
                     ), pageContext, sourceSetRestriction
                 )
-                appendNewLine()
+                buildNewLine()
             }
         } else {
             val size = node.header.firstOrNull()?.children?.size ?: node.children.firstOrNull()?.children?.size ?: 0
@@ -183,11 +183,11 @@ open class CommonmarkRenderer(
                 append("| ".repeat(size))
             }
             append("|")
-            appendNewLine()
+            buildNewLine()
 
             append("|---".repeat(size))
             append("|")
-            appendNewLine()
+            buildNewLine()
 
             node.children.forEach { row ->
                 row.children.forEach { cell ->
@@ -202,7 +202,7 @@ open class CommonmarkRenderer(
                     append(" ")
                 }
                 append("|")
-                appendNewLine()
+                buildNewLine()
             }
         }
     }

--- a/plugins/gfm/src/main/kotlin/org/jetbrains/dokka/gfm/renderer/CommonmarkRenderer.kt
+++ b/plugins/gfm/src/main/kotlin/org/jetbrains/dokka/gfm/renderer/CommonmarkRenderer.kt
@@ -98,7 +98,7 @@ open class CommonmarkRenderer(
         } else buildText(node.children, pageContext, sourceSetRestriction)
     }
 
-    override fun StringBuilder.buildNewLine() {
+    override fun StringBuilder.buildLineBreak() {
         append("\\")
         appendNewLine()
     }
@@ -135,7 +135,7 @@ open class CommonmarkRenderer(
             distinct.filter { it.key.isNotBlank() }.forEach { (text, platforms) ->
                 buildParagraph()
                 buildSourceSetTags(platforms.toSet())
-                buildNewLine()
+                buildLineBreak()
                 append(text.trim())
                 buildParagraph()
             }
@@ -254,7 +254,7 @@ open class CommonmarkRenderer(
 
             buildParagraph()
             buildSourceSetTags(sourceSets)
-            buildNewLine()
+            buildLineBreak()
 
             instance.before?.let {
                 buildContentNode(
@@ -270,7 +270,7 @@ open class CommonmarkRenderer(
                     val (innerInstance, innerSourceSets) = innerEntry.getInstanceAndSourceSets()
                     if (sourceSets.size > 1) {
                         buildSourceSetTags(innerSourceSets)
-                        buildNewLine()
+                        buildLineBreak()
                     }
                     innerInstance.divergent.build(
                         this@buildDivergent,


### PR DESCRIPTION
Minor patch closing GFM cleanup series
Just renames two functions, for consistency and reduce confusion probability.