### PR TITLE
Fix Gradle plugin application

### DIFF
--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/gradleConfigurations.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/gradleConfigurations.kt
@@ -2,6 +2,7 @@ package org.jetbrains.dokka.gradle
 
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.Dependency
 import org.gradle.api.attributes.Usage
 
 internal fun Project.maybeCreateDokkaDefaultPluginConfiguration(): Configuration {
@@ -18,14 +19,13 @@ internal fun Project.maybeCreateDokkaDefaultRuntimeConfiguration(): Configuratio
     }
 }
 
-internal fun Project.maybeCreateDokkaPluginConfiguration(dokkaTaskName: String): Configuration {
+internal fun Project.maybeCreateDokkaPluginConfiguration(dokkaTaskName: String, additionalDependencies: Collection<Dependency> = emptySet()): Configuration {
     return project.configurations.maybeCreate("${dokkaTaskName}Plugin") {
         extendsFrom(maybeCreateDokkaDefaultPluginConfiguration())
         attributes.attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage::class.java, "java-runtime"))
         isCanBeConsumed = false
-        defaultDependencies { dependencies ->
-            dependencies.add(project.dokkaArtifacts.dokkaBase)
-        }
+        dependencies.add(project.dokkaArtifacts.dokkaBase)
+        dependencies.addAll(additionalDependencies)
     }
 }
 

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/main.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/main.kt
@@ -61,14 +61,13 @@ open class DokkaPlugin : Plugin<Project> {
         if (project.subprojects.isNotEmpty()) {
             if (multiModuleTaskSupported) {
                 val multiModuleName = "${name}MultiModule"
-                project.maybeCreateDokkaPluginConfiguration(multiModuleName)
+                project.maybeCreateDokkaPluginConfiguration(multiModuleName, setOf(allModulesPageAndTemplateProcessing))
                 project.maybeCreateDokkaRuntimeConfiguration(multiModuleName)
 
                 project.tasks.register<DokkaMultiModuleTask>(multiModuleName) {
                     addSubprojectChildTasks("${name}Partial")
                     configuration()
                     description = "Runs all subprojects '$name' tasks and generates module navigation page"
-                    plugins.dependencies.add(allModulesPageAndTemplateProcessing)
                 }
 
                 project.tasks.register<DefaultTask>("${name}Multimodule") {


### PR DESCRIPTION
Default dependency to dokka-base in dokkaPluginConfiguration was changed to a regular dependency. Applying client-side plugins overrode the default dokka-base dependency thus changing the version to a (possibly) lower one. This could lead to unpredictable Dokka crashes due to the inconsistency between the Gradle runner and dokka-base versions. Dependencies can still be manually removed from the configuration in specific projects, if needed (not likely)