### PR TITLE
Missing receiver docs

### DIFF
--- a/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
@@ -23,7 +23,7 @@ import org.jetbrains.dokka.base.transformers.documentables.ClashingDriIdentifier
 private typealias GroupedTags = Map<KClass<out TagWrapper>, List<Pair<DokkaSourceSet?, TagWrapper>>>
 
 private val specialTags: Set<KClass<out TagWrapper>> =
-    setOf(Property::class, Description::class, Constructor::class, Receiver::class, Param::class, See::class)
+    setOf(Property::class, Description::class, Constructor::class, Param::class, See::class)
 
 open class DefaultPageCreator(
     configuration: DokkaBaseConfiguration?,
@@ -382,18 +382,10 @@ open class DefaultPageCreator(
                     styles = setOf(ContentStyle.WithExtraAttributes)
                 ) {
                     sourceSetDependentHint(sourceSets = platforms.toSet(), kind = ContentKind.SourceSetDependentHint) {
-                        val receiver = tags.withTypeUnnamed<Receiver>()
                         val params = tags.withTypeNamed<Param>()
                         table(kind = ContentKind.Parameters) {
                             platforms.forEach { platform ->
                                 val possibleFallbacks = d.getPossibleFallbackSourcesets(platform)
-                                (receiver[platform] ?: receiver.fallback(possibleFallbacks))?.let {
-                                    row(sourceSets = setOf(platform), kind = ContentKind.Parameters) {
-                                        text("<receiver>", styles = mainStyles + ContentStyle.RowTitle)
-                                        comment(it.root)
-                                    }
-                                }
-
                                 params.mapNotNull { (_, param) ->
                                     (param[platform] ?: param.fallback(possibleFallbacks))?.let {
                                         row(sourceSets = setOf(platform), kind = ContentKind.Parameters) {

--- a/plugins/base/src/test/kotlin/content/params/ContentForParamsTest.kt
+++ b/plugins/base/src/test/kotlin/content/params/ContentForParamsTest.kt
@@ -1256,14 +1256,14 @@ class ContentForParamsTest : BaseAbstractTest() {
                             }
                             after {
                                 group { pWrapped("comment to function") }
+                                group {
+                                    header(4){ +"Receiver" }
+                                    pWrapped("comment to receiver")
+                                }
                                 header(2) { +"Parameters" }
                                 group {
                                     platformHinted {
                                         table {
-                                            group {
-                                                +"<receiver>"
-                                                group { group { +"comment to receiver" } }
-                                            }
                                             group {
                                                 +"abc"
                                                 group { group { +"comment to param" } }

--- a/plugins/base/src/test/kotlin/content/receiver/ContentForReceiverTest.kt
+++ b/plugins/base/src/test/kotlin/content/receiver/ContentForReceiverTest.kt
@@ -1,0 +1,57 @@
+package content.receiver
+
+import junit.framework.Assert.assertEquals
+import junit.framework.Assert.assertNotNull
+import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
+import org.jetbrains.dokka.model.dfs
+import org.jetbrains.dokka.model.doc.Receiver
+import org.jetbrains.dokka.model.doc.Text
+import org.jetbrains.dokka.pages.ContentHeader
+import org.jetbrains.dokka.pages.ContentText
+import org.jetbrains.dokka.pages.MemberPageNode
+import org.junit.jupiter.api.Test
+import utils.docs
+
+class ContentForReceiverTest: BaseAbstractTest() {
+    private val testConfiguration = dokkaConfiguration {
+        sourceSets {
+            sourceSet {
+                sourceRoots = listOf("src/")
+                analysisPlatform = "jvm"
+            }
+        }
+    }
+
+    @Test
+    fun `should have docs for receiver`(){
+        testInline(
+            """
+            |/src/main/kotlin/test/source.kt
+            |package test
+            |/**
+            | * docs
+            | * @receiver docs for string
+            | */
+            |fun String.asd2(): String = this
+            """.trimIndent(),
+            testConfiguration
+        ){
+            documentablesTransformationStage = { module ->
+                with(module.packages.flatMap { it.functions }.first()){
+                    val receiver = docs().firstOrNull { it is Receiver }
+                    assertNotNull(receiver)
+                    val content = receiver?.dfs { it is Text } as Text
+                    assertEquals("docs for string", content.body)
+                }
+            }
+            pagesTransformationStage = { rootPageNode ->
+                val functionPage = rootPageNode.dfs { it is MemberPageNode } as MemberPageNode
+                val header = functionPage.content.dfs { it is ContentHeader && it.children.firstOrNull() is ContentText }
+                val text = functionPage.content.dfs { it is ContentText && it.text == "docs for string" }
+
+                assertNotNull(header)
+                assertNotNull(text)
+            }
+        }
+    }
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15652452/125817597-2df93995-3075-4468-a71a-f276deae8778.png)

In fact they were not "missing" but just were displayed with parameters. Caveat was that when function had no parameters then the receiver also was not displayed. I've changed it to be present as normal tag since i don't think that presenting it as in the compiled code is the way to go