### PR TITLE
Add numeric types of annotation parameter value

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1329,6 +1329,18 @@ public final class org/jetbrains/dokka/model/DocumentableUtilsKt {
 	public static final fun filtered (Lorg/jetbrains/dokka/DokkaConfiguration$DokkaSourceSet;Ljava/util/Set;)Lorg/jetbrains/dokka/DokkaConfiguration$DokkaSourceSet;
 }
 
+public final class org/jetbrains/dokka/model/DoubleValue : org/jetbrains/dokka/model/LiteralValue {
+	public fun <init> (D)V
+	public final fun component1 ()D
+	public final fun copy (D)Lorg/jetbrains/dokka/model/DoubleValue;
+	public static synthetic fun copy$default (Lorg/jetbrains/dokka/model/DoubleValue;DILjava/lang/Object;)Lorg/jetbrains/dokka/model/DoubleValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()D
+	public fun hashCode ()I
+	public fun text ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class org/jetbrains/dokka/model/Dynamic : org/jetbrains/dokka/model/Bound {
 	public static final field INSTANCE Lorg/jetbrains/dokka/model/Dynamic;
 }
@@ -1478,6 +1490,18 @@ public final class org/jetbrains/dokka/model/ExtraModifiers$KotlinOnlyModifiers$
 	public static final field INSTANCE Lorg/jetbrains/dokka/model/ExtraModifiers$KotlinOnlyModifiers$VarArg;
 }
 
+public final class org/jetbrains/dokka/model/FloatValue : org/jetbrains/dokka/model/LiteralValue {
+	public fun <init> (F)V
+	public final fun component1 ()F
+	public final fun copy (F)Lorg/jetbrains/dokka/model/FloatValue;
+	public static synthetic fun copy$default (Lorg/jetbrains/dokka/model/FloatValue;FILjava/lang/Object;)Lorg/jetbrains/dokka/model/FloatValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()F
+	public fun hashCode ()I
+	public fun text ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class org/jetbrains/dokka/model/FunctionalTypeConstructor : org/jetbrains/dokka/model/TypeConstructor, org/jetbrains/dokka/model/properties/WithExtraProperties {
 	public fun <init> (Lorg/jetbrains/dokka/links/DRI;Ljava/util/List;ZZLjava/lang/String;Lorg/jetbrains/dokka/model/properties/PropertyContainer;)V
 	public synthetic fun <init> (Lorg/jetbrains/dokka/links/DRI;Ljava/util/List;ZZLjava/lang/String;Lorg/jetbrains/dokka/model/properties/PropertyContainer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -1557,6 +1581,18 @@ public final class org/jetbrains/dokka/model/InheritedMember : org/jetbrains/dok
 public final class org/jetbrains/dokka/model/InheritedMember$Companion : org/jetbrains/dokka/model/properties/ExtraProperty$Key {
 	public synthetic fun mergeStrategyFor (Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
 	public fun mergeStrategyFor (Lorg/jetbrains/dokka/model/InheritedMember;Lorg/jetbrains/dokka/model/InheritedMember;)Lorg/jetbrains/dokka/model/properties/MergeStrategy$Replace;
+}
+
+public final class org/jetbrains/dokka/model/IntValue : org/jetbrains/dokka/model/LiteralValue {
+	public fun <init> (I)V
+	public final fun component1 ()I
+	public final fun copy (I)Lorg/jetbrains/dokka/model/IntValue;
+	public static synthetic fun copy$default (Lorg/jetbrains/dokka/model/IntValue;IILjava/lang/Object;)Lorg/jetbrains/dokka/model/IntValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public fun text ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class org/jetbrains/dokka/model/Invariance : org/jetbrains/dokka/model/Variance {
@@ -1691,6 +1727,23 @@ public final class org/jetbrains/dokka/model/KotlinVisibility$Public : org/jetbr
 	public static final field INSTANCE Lorg/jetbrains/dokka/model/KotlinVisibility$Public;
 }
 
+public abstract class org/jetbrains/dokka/model/LiteralValue : org/jetbrains/dokka/model/AnnotationParameterValue {
+	public fun <init> ()V
+	public abstract fun text ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/dokka/model/LongValue : org/jetbrains/dokka/model/LiteralValue {
+	public fun <init> (J)V
+	public final fun component1 ()J
+	public final fun copy (J)Lorg/jetbrains/dokka/model/LongValue;
+	public static synthetic fun copy$default (Lorg/jetbrains/dokka/model/LongValue;JILjava/lang/Object;)Lorg/jetbrains/dokka/model/LongValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()J
+	public fun hashCode ()I
+	public fun text ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract class org/jetbrains/dokka/model/Modifier {
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getName ()Ljava/lang/String;
@@ -1739,7 +1792,7 @@ public final class org/jetbrains/dokka/model/Star : org/jetbrains/dokka/model/Pr
 	public static final field INSTANCE Lorg/jetbrains/dokka/model/Star;
 }
 
-public final class org/jetbrains/dokka/model/StringValue : org/jetbrains/dokka/model/AnnotationParameterValue {
+public final class org/jetbrains/dokka/model/StringValue : org/jetbrains/dokka/model/LiteralValue {
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun copy (Ljava/lang/String;)Lorg/jetbrains/dokka/model/StringValue;
@@ -1747,6 +1800,7 @@ public final class org/jetbrains/dokka/model/StringValue : org/jetbrains/dokka/m
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
+	public fun text ()Ljava/lang/String;
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/core/src/main/kotlin/model/additionalExtras.kt
+++ b/core/src/main/kotlin/model/additionalExtras.kt
@@ -72,7 +72,24 @@ data class AnnotationValue(val annotation: Annotations.Annotation) : AnnotationP
 data class ArrayValue(val value: List<AnnotationParameterValue>) : AnnotationParameterValue()
 data class EnumValue(val enumName: String, val enumDri: DRI) : AnnotationParameterValue()
 data class ClassValue(val className: String, val classDRI: DRI) : AnnotationParameterValue()
-data class StringValue(val value: String) : AnnotationParameterValue() {
+abstract class LiteralValue : AnnotationParameterValue() {
+    abstract fun text() : String
+}
+data class IntValue(val value: Int) : LiteralValue() {
+    override fun text(): String = value.toString()
+}
+
+data class LongValue(val value: Long) : LiteralValue() {
+    override fun text(): String = value.toString()
+}
+data class FloatValue(val value: Float) : LiteralValue() {
+    override fun text(): String = value.toString()
+}
+data class DoubleValue(val value: Double) : LiteralValue() {
+    override fun text(): String = value.toString()
+}
+data class StringValue(val value: String) : LiteralValue() {
+    override fun text(): String = value
     override fun toString(): String = value
 }
 

--- a/plugins/base/src/main/kotlin/signatures/JvmSignatureUtils.kt
+++ b/plugins/base/src/main/kotlin/signatures/JvmSignatureUtils.kt
@@ -104,7 +104,7 @@ interface JvmSignatureUtils {
         }
         is EnumValue -> link(a.enumName, a.enumDri)
         is ClassValue -> link(a.className + classExtension, a.classDRI)
-        is StringValue -> group(styles = setOf(TextStyle.Breakable)) { text(a.value) }
+        is LiteralValue -> group(styles = setOf(TextStyle.Breakable)) { text(a.text()) }
     }
 
     fun PageContentBuilder.DocumentableContentBuilder.annotationsBlockWithIgnored(

--- a/plugins/base/src/main/kotlin/translators/descriptors/DefaultDescriptorToDocumentableTranslator.kt
+++ b/plugins/base/src/main/kotlin/translators/descriptors/DefaultDescriptorToDocumentableTranslator.kt
@@ -69,6 +69,12 @@ import org.jetbrains.kotlin.resolve.constants.AnnotationValue as ConstantsAnnota
 import org.jetbrains.kotlin.resolve.constants.ArrayValue as ConstantsArrayValue
 import org.jetbrains.kotlin.resolve.constants.EnumValue as ConstantsEnumValue
 import org.jetbrains.kotlin.resolve.constants.KClassValue as ConstantsKtClassValue
+import org.jetbrains.kotlin.resolve.constants.DoubleValue as ConstantsDoubleValue
+import org.jetbrains.kotlin.resolve.constants.FloatValue as ConstantsFloatValue
+import org.jetbrains.kotlin.resolve.constants.IntValue as ConstantsIntValue
+import org.jetbrains.kotlin.resolve.constants.LongValue as ConstantsLongValue
+import org.jetbrains.kotlin.resolve.constants.UIntValue as ConstantsUIntValue
+import org.jetbrains.kotlin.resolve.constants.ULongValue as ConstantsULongValue
 
 class DefaultDescriptorToDocumentableTranslator(
     context: DokkaContext
@@ -963,6 +969,12 @@ private class DokkaDescriptorVisitor(
                 )
             }
         }
+        is ConstantsFloatValue -> FloatValue(value)
+        is ConstantsDoubleValue -> DoubleValue(value)
+        is ConstantsUIntValue -> IntValue(value)
+        is ConstantsULongValue -> LongValue(value)
+        is ConstantsIntValue -> IntValue(value)
+        is ConstantsLongValue -> LongValue(value)
         else -> StringValue(unquotedValue(toString()))
     }
 

--- a/plugins/base/src/main/kotlin/translators/psi/DefaultPsiToDocumentableTranslator.kt
+++ b/plugins/base/src/main/kotlin/translators/psi/DefaultPsiToDocumentableTranslator.kt
@@ -602,6 +602,15 @@ class DefaultPsiToDocumentableTranslator(
                 val psiClass = ((type as PsiImmediateClassType).parameters.single() as PsiClassReferenceType).resolve()
                 psiClass?.let { ClassValue(text ?: "", DRI.from(psiClass)) }
             }
+            is PsiLiteralExpression -> toValue()
+            else -> StringValue(text ?: "")
+        }
+
+        private fun PsiLiteralExpression.toValue(): AnnotationParameterValue? = when (type) {
+            PsiType.INT -> (value as? Int)?.let { IntValue(it) }
+            PsiType.LONG -> (value as? Long)?.let { LongValue(it) }
+            PsiType.FLOAT -> (value as? Float)?.let { FloatValue(it) }
+            PsiType.DOUBLE -> (value as? Double)?.let { DoubleValue(it) }
             else -> StringValue(text ?: "")
         }
 

--- a/plugins/base/src/test/kotlin/model/FunctionsTest.kt
+++ b/plugins/base/src/test/kotlin/model/FunctionsTest.kt
@@ -324,7 +324,7 @@ class FunctionTest : AbstractModelTest("/src/main/kotlin/function/Test.kt", "fun
                     with(this.first()) {
                         dri.classNames equals "Fancy"
                         params.entries counts 1
-                        (params["size"] as StringValue).value equals "1"
+                        (params["size"] as IntValue).value equals 1
                     }
                 }
             }


### PR DESCRIPTION
I have added new types for ```int```, ```long```, ```float```, ```double``` annotation parameter value. 
I do not know do i need to add  ```boolean``` type or ```null``` value.

The PR is linked to #1950.  