### PR TITLE
Improve annotations rendering

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -681,6 +681,18 @@ public final class org/jetbrains/dokka/model/ArrayValue : org/jetbrains/dokka/mo
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class org/jetbrains/dokka/model/BooleanValue : org/jetbrains/dokka/model/LiteralValue {
+	public fun <init> (Z)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lorg/jetbrains/dokka/model/BooleanValue;
+	public static synthetic fun copy$default (Lorg/jetbrains/dokka/model/BooleanValue;ZILjava/lang/Object;)Lorg/jetbrains/dokka/model/BooleanValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Z
+	public fun hashCode ()I
+	public fun text ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract class org/jetbrains/dokka/model/Bound : org/jetbrains/dokka/model/Projection, org/jetbrains/dokka/model/AnnotationTarget {
 }
 
@@ -1747,6 +1759,11 @@ public final class org/jetbrains/dokka/model/LongValue : org/jetbrains/dokka/mod
 public abstract class org/jetbrains/dokka/model/Modifier {
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getName ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/dokka/model/NullValue : org/jetbrains/dokka/model/LiteralValue {
+	public static final field INSTANCE Lorg/jetbrains/dokka/model/NullValue;
+	public fun text ()Ljava/lang/String;
 }
 
 public final class org/jetbrains/dokka/model/Nullable : org/jetbrains/dokka/model/Bound {

--- a/core/src/main/kotlin/model/additionalExtras.kt
+++ b/core/src/main/kotlin/model/additionalExtras.kt
@@ -88,6 +88,12 @@ data class FloatValue(val value: Float) : LiteralValue() {
 data class DoubleValue(val value: Double) : LiteralValue() {
     override fun text(): String = value.toString()
 }
+object NullValue : LiteralValue() {
+    override fun text(): String = "null"
+}
+data class BooleanValue(val value: Boolean) : LiteralValue() {
+    override fun text(): String = value.toString()
+}
 data class StringValue(val value: String) : LiteralValue() {
     override fun text(): String = value
     override fun toString(): String = value

--- a/plugins/base/src/main/kotlin/translators/descriptors/DefaultDescriptorToDocumentableTranslator.kt
+++ b/plugins/base/src/main/kotlin/translators/descriptors/DefaultDescriptorToDocumentableTranslator.kt
@@ -75,6 +75,8 @@ import org.jetbrains.kotlin.resolve.constants.IntValue as ConstantsIntValue
 import org.jetbrains.kotlin.resolve.constants.LongValue as ConstantsLongValue
 import org.jetbrains.kotlin.resolve.constants.UIntValue as ConstantsUIntValue
 import org.jetbrains.kotlin.resolve.constants.ULongValue as ConstantsULongValue
+import org.jetbrains.kotlin.resolve.constants.BooleanValue as ConstantsBooleanValue
+import org.jetbrains.kotlin.resolve.constants.NullValue as ConstantsNullValue
 
 class DefaultDescriptorToDocumentableTranslator(
     context: DokkaContext
@@ -975,6 +977,8 @@ private class DokkaDescriptorVisitor(
         is ConstantsULongValue -> LongValue(value)
         is ConstantsIntValue -> IntValue(value)
         is ConstantsLongValue -> LongValue(value)
+        is ConstantsBooleanValue -> BooleanValue(value)
+        is ConstantsNullValue -> NullValue
         else -> StringValue(unquotedValue(toString()))
     }
 

--- a/plugins/base/src/main/kotlin/translators/psi/DefaultPsiToDocumentableTranslator.kt
+++ b/plugins/base/src/main/kotlin/translators/psi/DefaultPsiToDocumentableTranslator.kt
@@ -611,6 +611,8 @@ class DefaultPsiToDocumentableTranslator(
             PsiType.LONG -> (value as? Long)?.let { LongValue(it) }
             PsiType.FLOAT -> (value as? Float)?.let { FloatValue(it) }
             PsiType.DOUBLE -> (value as? Double)?.let { DoubleValue(it) }
+            PsiType.BOOLEAN -> (value as? Boolean)?.let { BooleanValue(it) }
+            PsiType.NULL -> NullValue
             else -> StringValue(text ?: "")
         }
 

--- a/plugins/base/src/test/kotlin/content/annotations/ContentForAnnotationsTest.kt
+++ b/plugins/base/src/test/kotlin/content/annotations/ContentForAnnotationsTest.kt
@@ -188,6 +188,7 @@ class ContentForAnnotationsTest : BaseAbstractTest() {
             |    val ref: Reference = Reference(value = 1),
             |    val reportedBy: Array<Reference>,
             |    val showStopper: Boolean = false
+            |    val previousReport: BugReport?
             |) {
             |    enum class Status {
             |        UNCONFIRMED, CONFIRMED, FIXED, NOTABUG
@@ -205,7 +206,8 @@ class ContentForAnnotationsTest : BaseAbstractTest() {
             |    ref = Reference(value = 2u),
             |    reportedBy = [Reference(value = 2UL), Reference(value = 4L), 
             |                  ReferenceReal(value = 4.9), ReferenceReal(value = 2f)],
-            |    showStopper = true
+            |    showStopper = true,
+            |    previousReport = null
             |)
             |val ltint: Int = 5
         """.trimIndent(), testConfiguration
@@ -233,6 +235,8 @@ class ContentForAnnotationsTest : BaseAbstractTest() {
                     expectedAnnotationValue("ReferenceReal", FloatValue(2f))
                 ))
                 assertEquals(reportedByParam, annotationParams["reportedBy"])
+                assertEquals(BooleanValue(true), annotationParams["showStopper"])
+                assertEquals(NullValue, annotationParams["previousReport"])
             }
 
             pagesTransformationStage = { module ->
@@ -246,7 +250,8 @@ class ContentForAnnotationsTest : BaseAbstractTest() {
                                 "status",
                                 "ref",
                                 "reportedBy",
-                                "showStopper"
+                                "showStopper",
+                                "previousReport"
                             )
                         ), "", "", emptySet(), "val", "ltint", "Int", "5"
                     )

--- a/plugins/base/src/test/kotlin/signatures/SignatureTest.kt
+++ b/plugins/base/src/test/kotlin/signatures/SignatureTest.kt
@@ -270,7 +270,7 @@ class SignatureTest : BaseAbstractTest() {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example/simple-fun.html").firstSignature().match(
                     Div(
-                        Div("@", A("Marking"), "()")
+                        Div("@", A("Marking"))
                     ),
                     "fun ", A("simpleFun"),
                     "(): ", A("String"), Span()
@@ -309,8 +309,8 @@ class SignatureTest : BaseAbstractTest() {
                     .firstSignature()
                     .match(
                         Div(
-                            Div("@", A("Marking"), "(", Span("msg = ", Span("Nenya")), Wbr, ")"),
-                            Div("@", A("Marking2"), "(", Span("int = ", Span("1")), Wbr, ")")
+                           Div("@", A("Marking"), "(", Span("msg = ", Span("\"Nenya\"")), Wbr, ")"),
+                           Div("@", A("Marking2"), "(", Span("int = ", Span("1")), Wbr, ")")
                         ),
                         "fun ", A("simpleFun"),
                         "(): ", A("String"), Span()
@@ -346,9 +346,9 @@ class SignatureTest : BaseAbstractTest() {
                         Div(
                             "@", A("Marking"), "(", Span(
                                 "msg = [",
-                                Span(Span("Nenya"), ", "), Wbr,
-                                Span(Span("Vilya"), ", "), Wbr,
-                                Span(Span("Narya")), Wbr, "]"
+                                Span(Span("\"Nenya\""), ", "), Wbr,
+                                Span(Span("\"Vilya\""), ", "), Wbr,
+                                Span(Span("\"Narya\"")), Wbr, "]"
                             ), Wbr, ")"
                         )
                     ),
@@ -457,7 +457,7 @@ class SignatureTest : BaseAbstractTest() {
                 writerPlugin.writer.renderedContent("root/example/index.html").signature().first().match(
                     Div(
                         Div(
-                            "@", A("SomeAnnotation"), "()"
+                            "@", A("SomeAnnotation")
                         )
                     ),
                     "typealias ", A("PlainTypealias"), " = ", A("Int"), Span()

--- a/plugins/base/src/test/kotlin/utils/contentUtils.kt
+++ b/plugins/base/src/test/kotlin/utils/contentUtils.kt
@@ -242,14 +242,16 @@ fun ContentMatcherBuilder<*>.unwrapAnnotation(elem: Map.Entry<String, Set<String
     group {
         +"@"
         link { +elem.key }
-        +"("
-        elem.value.forEach {
-            group {
-                +("$it = ")
-                skipAllNotMatching()
+        if(elem.value.isNotEmpty()) {
+            +"("
+            elem.value.forEach {
+                group {
+                    +("$it = ")
+                    skipAllNotMatching()
+                }
             }
+            +")"
         }
-        +")"
     }
 }
 

--- a/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/pages/htmlPreprocessors.kt
+++ b/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/pages/htmlPreprocessors.kt
@@ -5,7 +5,7 @@ import org.jetbrains.dokka.base.transformers.documentables.deprecatedAnnotation
 import org.jetbrains.dokka.base.transformers.documentables.isDeprecated
 import org.jetbrains.dokka.base.transformers.documentables.isException
 import org.jetbrains.dokka.model.Documentable
-import org.jetbrains.dokka.model.StringValue
+import org.jetbrains.dokka.model.BooleanValue
 import org.jetbrains.dokka.model.WithSupertypes
 import org.jetbrains.dokka.pages.*
 import org.jetbrains.dokka.transformers.pages.PageTransformer
@@ -113,7 +113,7 @@ object DeprecatedPageCreator : PageTransformer {
                     (this as? WithBrief)?.brief.orEmpty()
                 )
                 getOrPut(deprecatedPageSection) { mutableSetOf() }.add(deprecatedNode)
-                if (deprecatedAnnotation?.params?.get("forRemoval") == StringValue("true")) {
+                if (deprecatedAnnotation?.params?.get("forRemoval") == BooleanValue(true)) {
                     getOrPut(DeprecatedPageSection.DeprecatedForRemoval) { mutableSetOf() }.add(deprecatedNode)
                 }
             }

--- a/plugins/javadoc/src/test/kotlin/org/jetbrains/dokka/javadoc/JavadocClasslikeTemplateMapTest.kt
+++ b/plugins/javadoc/src/test/kotlin/org/jetbrains/dokka/javadoc/JavadocClasslikeTemplateMapTest.kt
@@ -149,13 +149,13 @@ internal class JavadocClasslikeTemplateMapTest : AbstractJavadocTemplateMapTest(
             val map = allPagesOfType<JavadocClasslikePageNode>().first { it.name == "TestClass" }.templateMap
             assertEquals("TestClass", map["name"])
             val signature = assertIsInstance<Map<String, Any?>>(map["signature"])
-            assertEquals("@<a href=Author.html>Author</a>(name = Benjamin Franklin)", signature["annotations"])
+            assertEquals("@<a href=Author.html>Author</a>(name = \"Benjamin Franklin\")", signature["annotations"])
 
             val methods = assertIsInstance<Map<Any, Any?>>(map["methods"])
             val ownMethods = assertIsInstance<List<*>>(methods["own"])
             val method = assertIsInstance<Map<String, Any?>>(ownMethods.single())
             val methodSignature = assertIsInstance<Map<String, Any?>>(method["signature"])
-            assertEquals("@<a href=Author.html>Author</a>(name = Franklin D. Roosevelt)", methodSignature["annotations"])
+            assertEquals("@<a href=Author.html>Author</a>(name = \"Franklin D. Roosevelt\")", methodSignature["annotations"])
         }
     }
 


### PR DESCRIPTION
According to  #2015:

1. omit parentheses if there are no parameters 
2. add quotes for string literals into annotations