### PR TITLE
Attempt to fix GitGub Action tests

### DIFF
--- a/.github/workflows/gradle-test.pr.yml
+++ b/.github/workflows/gradle-test.pr.yml
@@ -21,6 +21,8 @@ jobs:
         version: [ 11, 15, 16 ]
       fail-fast: false
     runs-on: windows-latest
+    env:
+      GRADLE_OPTS: -Xms3G -Xmx5G
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1


### PR DESCRIPTION
GH Actions runners have max 7Gb of RAM memory
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources 