### PR TITLE
Don't force @literal in javadoc to be surrounded by code tag

### DIFF
--- a/plugins/base/src/main/kotlin/translators/psi/parsers/JavadocParser.kt
+++ b/plugins/base/src/main/kotlin/translators/psi/parsers/JavadocParser.kt
@@ -333,8 +333,8 @@ class JavadocParser(
             when (tag.name) {
                 "link", "linkplain" -> tag.referenceElement()
                     ?.toDocumentationLinkString(tag.dataElements.filterIsInstance<PsiDocToken>())
-                "code", "literal" -> "<code data-inline>${tag.dataElements.joinToString("") { it.stringifyElementAsText(keepFormatting = true)
-                    .toString() }.htmlEscape()}</code>"
+                "code" -> "<code data-inline>${dataElementsAsText(tag)}</code>"
+                "literal" -> dataElementsAsText(tag)
                 "index" -> "<index>${tag.children.filterIsInstance<PsiDocTagValue>().joinToString { it.text }}</index>"
                 "inheritDoc" -> inheritDocResolver.resolveFromContext(context)
                     ?.fold(ParsingResult(javadocTag)) { result, e ->
@@ -342,6 +342,11 @@ class JavadocParser(
                     }?.parsedLine.orEmpty()
                 else -> tag.text
             }
+
+        private fun dataElementsAsText(tag: PsiInlineDocTag) =
+            tag.dataElements.joinToString("") {
+                it.stringifyElementAsText(keepFormatting = true).toString()
+            }.htmlEscape()
 
         private fun createLink(element: Element, children: List<DocTag>): DocTag {
             return when {

--- a/plugins/base/src/main/kotlin/translators/psi/parsers/JavadocParser.kt
+++ b/plugins/base/src/main/kotlin/translators/psi/parsers/JavadocParser.kt
@@ -334,7 +334,7 @@ class JavadocParser(
                 "link", "linkplain" -> tag.referenceElement()
                     ?.toDocumentationLinkString(tag.dataElements.filterIsInstance<PsiDocToken>())
                 "code" -> "<code data-inline>${dataElementsAsText(tag)}</code>"
-                "literal" -> dataElementsAsText(tag)
+                "literal" -> "<literal>${dataElementsAsText(tag)}</literal>"
                 "index" -> "<index>${tag.children.filterIsInstance<PsiDocTagValue>().joinToString { it.text }}</index>"
                 "inheritDoc" -> inheritDocResolver.resolveFromContext(context)
                     ?.fold(ParsingResult(javadocTag)) { result, e ->

--- a/plugins/base/src/test/kotlin/parsers/JavadocParserTest.kt
+++ b/plugins/base/src/test/kotlin/parsers/JavadocParserTest.kt
@@ -6,6 +6,8 @@ import org.jetbrains.dokka.model.DEnum
 import org.jetbrains.dokka.model.DModule
 import org.jetbrains.dokka.model.doc.CodeBlock
 import org.jetbrains.dokka.model.doc.CodeInline
+import org.jetbrains.dokka.model.doc.P
+import org.jetbrains.dokka.model.doc.Pre
 import org.jetbrains.dokka.model.doc.Text
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -103,6 +105,70 @@ class JavadocParserTest : BaseAbstractTest() {
                 kotlin.test.assertEquals(
                     CodeBlock(children = listOf(Text(body = "\nSet<String> s2;\nSystem.out\n        .println(\"s2 = \" + s2);\n"))),
                     root.children[1]
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `literal tag`() {
+        val source = """
+            |/src/main/kotlin/test/Test.java
+            |package example
+            |
+            | /**
+            | * An example of using the literal tag
+            | * {@literal @}Entity
+            | * public class User {}
+            | */
+            | public class Test {}
+            """.trimIndent()
+        testInline(
+            source,
+            configuration,
+        ) {
+            documentablesCreationStage = { modules ->
+                val docs = modules.first().packages.first().classlikes.single().documentation.first().value
+                val root = docs.children.first().root
+
+                kotlin.test.assertEquals(
+                    Text(body = "An example of using the literal tag @Entity public class User {}"),
+                    root.children[0].children.first()
+                )
+            }
+        }
+    }
+
+
+    @Test
+    fun `literal tag nested under pre tag`() {
+        val source = """
+            |/src/main/kotlin/test/Test.java
+            |package example
+            |
+            | /**
+            | * An example of using the literal tag
+            | * <pre>
+            | * {@literal @}Entity
+            | * public class User {}
+            | * </pre>
+            | */
+            | public class Test  {}
+            """.trimIndent()
+        testInline(
+            source,
+            configuration,
+        ) {
+            documentablesCreationStage = { modules ->
+                val docs = modules.first().packages.first().classlikes.single().documentation.first().value
+                val root = docs.children.first().root
+
+                kotlin.test.assertEquals(
+                    listOf(
+                        P(children = listOf(Text(body = "An example of using the literal tag "))),
+                        Pre(children = listOf(Text(body = "@Entity\npublic class User {}\n")))
+                    ),
+                    root.children
                 )
             }
         }

--- a/plugins/base/src/test/kotlin/parsers/JavadocParserTest.kt
+++ b/plugins/base/src/test/kotlin/parsers/JavadocParserTest.kt
@@ -132,13 +132,16 @@ class JavadocParserTest : BaseAbstractTest() {
                 val root = docs.children.first().root
 
                 kotlin.test.assertEquals(
-                    Text(body = "An example of using the literal tag @Entity public class User {}"),
-                    root.children[0].children.first()
+                    listOf(
+                        Text(body = "An example of using the literal tag "),
+                        Text(body = "@"),
+                        Text(body = "Entity public class User {}"),
+                    ),
+                    root.children.first().children
                 )
             }
         }
     }
-
 
     @Test
     fun `literal tag nested under pre tag`() {
@@ -166,7 +169,45 @@ class JavadocParserTest : BaseAbstractTest() {
                 kotlin.test.assertEquals(
                     listOf(
                         P(children = listOf(Text(body = "An example of using the literal tag "))),
-                        Pre(children = listOf(Text(body = "@Entity\npublic class User {}\n")))
+                        Pre(children =
+                            listOf(
+                                Text(body = "@"),
+                                Text(body = "Entity\npublic class User {}\n")
+                            )
+                        )
+                    ),
+                    root.children
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `literal tag containing angle brackets`() {
+        val source = """
+            |/src/main/kotlin/test/Test.java
+            |package example
+            |
+            | /**
+            | * An example of using the literal tag
+            | * {@literal a<B>c}
+            | */
+            | public class Test  {}
+            """.trimIndent()
+        testInline(
+            source,
+            configuration,
+        ) {
+            documentablesCreationStage = { modules ->
+                val docs = modules.first().packages.first().classlikes.single().documentation.first().value
+                val root = docs.children.first().root
+
+                kotlin.test.assertEquals(
+                    listOf(
+                        P(children = listOf(
+                            Text(body = "An example of using the literal tag "),
+                            Text(body = "a<B>c")
+                        )),
                     ),
                     root.children
                 )


### PR DESCRIPTION
### Don't force @literal in javadoc to be surrounded by code tag

Fixes #2088

After experimenting while looking into #2088, I found what appears to be a solution (at least for my use case), so I figured I'd make a PR just in case this is a reasonable general solution as well. The change is small, we simple do not wrap the value of `{@literal @}` in a code tag, as I believe the semantics of it do not require that (it can itself be wrapped in `pre` or `code`) and among other things, it makes formatting examples of annotations in doc strings difficult.

I've run my simple example from the last test in the PR with a few different versions of Dokka for comparison.

#### Dokka 1.5.0

![dokka-1 5 0](https://user-images.githubusercontent.com/12353283/130492242-6ba26b9f-beb3-4ca1-a2c1-0e69e4df8099.png)

#### Dokka 1.5.21-dev-113

![dokka-HEAD](https://user-images.githubusercontent.com/12353283/130492340-c7c51508-e440-46d3-ab17-72bf68af3cc8.png)

#### Dokka patch (this PR)

![dokka-PATCH](https://user-images.githubusercontent.com/12353283/130492365-9c3c123b-9df0-470e-ac3b-4fcd32a8c1b4.png)


