### PR TITLE
Bring back merging of divergent entries

### DIFF
--- a/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
@@ -631,6 +631,7 @@ open class DefaultPageCreator(
                                 kind = kind,
                                 styles = setOf(ContentStyle.RowTitle),
                                 sourceSets = elements.sourceSets.toSet(),
+                                extra = extra
                             )
                             divergentGroup(
                                 ContentDivergentGroup.GroupID(name),
@@ -649,7 +650,7 @@ open class DefaultPageCreator(
                                                 +buildSignature(it)
                                             }
                                         }
-                                        after {
+                                        after(extra = PropertyContainer.empty()) {
                                             contentForBrief(it)
                                             contentForSinceKotlin(it)
                                         }


### PR DESCRIPTION
the issue was that `SymbolAnchorHint` extra was leaking into the children therefore an anchor was generated in html with broke merging of entries in divergent. 

the difference is visible on stdlib, you can compare it with current master: http://dokka-snapshots.s3.eu-central-1.amazonaws.com/master/stdlib/88ff6bd/kotlin-stdlib/kotlin/index.html

Please note that some descriptions won't be collapsed into tabs before they contain sourceset specific link, an example of that is `Any`