### PR TITLE
Make see tag display as other tables

### DIFF
--- a/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
@@ -422,7 +422,7 @@ open class DefaultPageCreator(
                                         row(
                                             sourceSets = setOf(platform),
                                             kind = ContentKind.Comment,
-                                            styles = this@sourceSetDependentHint.mainStyles + ContentStyle.RowTitle,
+                                            styles = this@sourceSetDependentHint.mainStyles,
                                         ) {
                                             if (it.address != null) link(
                                                 it.name,

--- a/plugins/base/src/main/kotlin/translators/psi/parsers/JavadocParser.kt
+++ b/plugins/base/src/main/kotlin/translators/psi/parsers/JavadocParser.kt
@@ -139,7 +139,7 @@ class JavadocParser(
                 ) // Workaround: PSI returns first word after @author tag as a `DOC_TAG_VALUE_ELEMENT`, then the rest as a `DOC_COMMENT_DATA`, so for `Name Surname` we get them parted
                 JavadocTag.SEE -> {
                     val name =
-                        tag.resolveToElement()?.getKotlinFqName()?.asString() ?: tag.referenceElement()?.text.orEmpty()
+                        tag.resolveToElement()?.getKotlinFqName()?.asString() ?: tag.referenceElement()?.text.orEmpty().removePrefix("#")
                     getSeeTagElementContent(tag, resolutionContext.copy(name = name)).let {
                         See(
                             wrapTagIfNecessary(it.first),
@@ -179,9 +179,10 @@ class JavadocParser(
         tag: PsiDocTag,
         context: CommentResolutionContext
     ): Pair<List<DocTag>, DRI?> {
-        val linkElement = tag.referenceElement()?.toDocumentationLink(context = context)
+        val referenceElement = tag.referenceElement()
+        val linkElement = referenceElement?.toDocumentationLink(context = context)
         val content = convertJavadocElements(
-            tag.dataElements.dropWhile { it is PsiWhiteSpace || (it as? LazyParseablePsiElement)?.tokenType == JavaDocElementType.DOC_REFERENCE_HOLDER },
+            tag.dataElements.dropWhile { it is PsiWhiteSpace || (it as? LazyParseablePsiElement)?.tokenType == JavaDocElementType.DOC_REFERENCE_HOLDER || it == referenceElement },
             context = context
         )
         return Pair(content, linkElement?.dri)

--- a/plugins/base/src/test/kotlin/content/seealso/ContentForSeeAlsoTest.kt
+++ b/plugins/base/src/test/kotlin/content/seealso/ContentForSeeAlsoTest.kt
@@ -4,6 +4,11 @@ import matchers.content.*
 import org.jetbrains.dokka.pages.ContentDRILink
 import org.jetbrains.dokka.pages.ContentPage
 import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
+import org.jetbrains.dokka.links.Callable
+import org.jetbrains.dokka.links.DRI
+import org.jetbrains.dokka.links.JavaClassReference
+import org.jetbrains.dokka.model.doc.See
+import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
 import org.junit.jupiter.api.Test
 import utils.*
 import kotlin.test.assertEquals
@@ -466,6 +471,81 @@ class ContentForSeeAlsoTest : BaseAbstractTest() {
                         }
                     }
                 }
+            }
+        }
+    }
+
+    @Test
+    fun `undocumented see also from java`(){
+        testInline(
+            """
+            |/src/main/java/example/Source.java
+            |package example;
+            |
+            |public interface Source {
+            |   String getProperty(String k, String v);
+            |
+            |   /**
+            |    * @see #getProperty(String, String)
+            |    */
+            |   String getProperty(String k);
+            |}
+        """.trimIndent(), testConfiguration
+        ) {
+            documentablesTransformationStage = { module ->
+                val functionWithSeeTag = module.packages.flatMap { it.classlikes }.flatMap { it.functions }.find { it.name == "getProperty" && it.parameters.count() == 1 }
+                val seeTag = functionWithSeeTag?.docs()?.firstIsInstanceOrNull<See>()
+                val expectedLinkDestinationDRI = DRI(
+                    packageName = "example",
+                    classNames = "Source",
+                    callable = Callable(
+                        name = "getProperty",
+                        params = listOf(JavaClassReference("java.lang.String"), JavaClassReference("java.lang.String"))
+                    )
+                )
+
+                kotlin.test.assertNotNull(seeTag)
+                assertEquals("getProperty(String, String)", seeTag.name)
+                assertEquals(expectedLinkDestinationDRI, seeTag.address)
+                assertEquals(emptyList(), seeTag.children)
+            }
+        }
+    }
+
+    @Test
+    fun `documented see also from java`(){
+        testInline(
+            """
+            |/src/main/java/example/Source.java
+            |package example;
+            |
+            |public interface Source {
+            |   String getProperty(String k, String v);
+            |
+            |   /**
+            |    * @see #getProperty(String, String) this is a reference to a method that is present on the same class.
+            |    */
+            |   String getProperty(String k);
+            |}
+        """.trimIndent(), testConfiguration
+        ) {
+            documentablesTransformationStage = { module ->
+                val functionWithSeeTag = module.packages.flatMap { it.classlikes }.flatMap { it.functions }.find { it.name == "getProperty" && it.parameters.size == 1 }
+                val seeTag = functionWithSeeTag?.docs()?.firstIsInstanceOrNull<See>()
+                val expectedLinkDestinationDRI = DRI(
+                    packageName = "example",
+                    classNames = "Source",
+                    callable = Callable(
+                        name = "getProperty",
+                        params = listOf(JavaClassReference("java.lang.String"), JavaClassReference("java.lang.String"))
+                    )
+                )
+
+                kotlin.test.assertNotNull(seeTag)
+                assertEquals("getProperty(String, String)", seeTag.name)
+                assertEquals(expectedLinkDestinationDRI, seeTag.address)
+                assertEquals("this is a reference to a method that is present on the same class.", seeTag.children.first().text().trim())
+                assertEquals(1, seeTag.children.size)
             }
         }
     }


### PR DESCRIPTION
Compare [previous state](https://user-images.githubusercontent.com/15652452/133392491-00d38ea2-7e10-4d79-8fa8-70ca7b4ad876.png) with:
![image](https://user-images.githubusercontent.com/15652452/133791123-24777ccd-acf0-4729-b936-789ba0c8d24e.png)

- i've removed the `#` as this is just for sake of referencing a method and should not be displayed
- changed the way it is displayed to match other contents