### PR TITLE
Fix whitespaces inside `@link` tag

### DIFF
--- a/plugins/base/src/main/kotlin/translators/psi/parsers/JavadocParser.kt
+++ b/plugins/base/src/main/kotlin/translators/psi/parsers/JavadocParser.kt
@@ -332,8 +332,8 @@ class JavadocParser(
         ) =
             when (tag.name) {
                 "link", "linkplain" -> tag.referenceElement()
-                    ?.toDocumentationLinkString(tag.dataElements.filterIsInstance<PsiDocToken>().joinToString("") {
-                        it.stringifyElementAsText(keepFormatting = true).orEmpty()
+                    ?.toDocumentationLinkString(tag.dataElements.filterIsInstance<PsiDocToken>().joinToString(" ") {
+                        it.stringifyElementAsText(keepFormatting = false).orEmpty()
                     })
                 "code" -> "<code data-inline>${dataElementsAsText(tag)}</code>"
                 "literal" -> "<literal>${dataElementsAsText(tag)}</literal>"

--- a/plugins/base/src/test/kotlin/content/params/ContentForParamsTest.kt
+++ b/plugins/base/src/test/kotlin/content/params/ContentForParamsTest.kt
@@ -262,9 +262,10 @@ class ContentForParamsTest : BaseAbstractTest() {
             | * @deprecated Instead of using a target fragment to pass results, the fragment requesting a
             | *              result should use
             | * {@link java.util.HashMap#containsKey(java.lang.Object) FragmentManager#setFragmentResult(String, Bundle)} to deliver results to
-            | * {@link java.util.HashMap#containsKey(java.lang.Object) FragmentResultListener} instances registered by other fragments via
+            | * {@link java.util.HashMap#containsKey(java.lang.Object)
+            | * FragmentResultListener} instances registered by other fragments via
             | * {@link java.util.HashMap#containsKey(java.lang.Object) FragmentManager#setFragmentResultListener(String, LifecycleOwner,
-            | *  FragmentResultListener)}.
+            | * FragmentResultListener)}.
             | */
             | public class DocGenProcessor {
             |    public String setTargetFragment(){


### PR DESCRIPTION
JDK Javadoc replaces breaklines inside `@link` tag on whitespaces.