### PR TITLE
Fix for incorrect rendering of deprecated code

### DIFF
--- a/plugins/gfm/src/main/kotlin/org/jetbrains/dokka/gfm/renderer/CommonmarkRenderer.kt
+++ b/plugins/gfm/src/main/kotlin/org/jetbrains/dokka/gfm/renderer/CommonmarkRenderer.kt
@@ -213,10 +213,11 @@ open class CommonmarkRenderer(
             append(textNode.text)
         } else if (textNode.text.isNotBlank()) {
             val decorators = decorators(textNode.style)
+            val containsStrikethrough = textNode.style.contains(TextStyle.Strikethrough)
             append(textNode.text.takeWhile { it == ' ' })
-            append(decorators)
+            if (containsStrikethrough) append("<s>") else append(decorators)
             append(textNode.text.trim().htmlEscape())
-            append(decorators.reversed())
+            if (containsStrikethrough) append("</s>") else append(decorators.reversed())
             append(textNode.text.takeLastWhile { it == ' ' })
         }
     }

--- a/plugins/gfm/src/test/kotlin/renderers/gfm/ParseRenderTest.kt
+++ b/plugins/gfm/src/test/kotlin/renderers/gfm/ParseRenderTest.kt
@@ -1,0 +1,54 @@
+package renderers.gfm
+
+import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
+import org.jetbrains.dokka.gfm.GfmPlugin
+import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Test
+import utils.TestOutputWriterPlugin
+
+class ParseRenderTest : BaseAbstractTest() {
+
+    @Test
+    fun `deprecated fun markdown`() {
+        val configuration = dokkaConfiguration {
+            sourceSets {
+                sourceSet {
+                    sourceRoots = listOf("src/main/kotlin/test/Test.kt")
+                }
+            }
+        }
+        val source =
+            """
+            |/src/main/kotlin/test/Test.kt
+            |package example
+            | /**
+            | * Just a deprecated function
+            | */
+            | @Deprecated("This is deprecated")
+            | fun simpleFun(test: Int): String = "This is the one ring"
+            """.trimIndent()
+        val expected =
+            """
+            //[root](../../index.md)/[example](index.md)
+            
+            # Package example
+
+            ## Functions
+
+            | Name | Summary |
+            |---|---|
+            | [simpleFun](simple-fun.md) | [JVM]<br><s>fun</s> [<s>simpleFun</s>](simple-fun.md)<s>(</s><s>test</s><s>:</s> Int<s>)</s><s>:</s> String<br>Just a deprecated function |
+            """.trimIndent()
+        val writerPlugin = TestOutputWriterPlugin()
+
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin, GfmPlugin())
+        ) {
+            renderingStage = { _, _ ->
+                assertEquals(expected, writerPlugin.writer.contents["root/example/index.md"])
+            }
+        }
+    }
+}

--- a/plugins/gfm/src/test/kotlin/renderers/gfm/SimpleElementsTest.kt
+++ b/plugins/gfm/src/test/kotlin/renderers/gfm/SimpleElementsTest.kt
@@ -78,7 +78,7 @@ class SimpleElementsTest : GfmRenderingOnlyTestBase() {
             )
         }
         val expect =
-            "//[testPage](test-page.md)\n\n~~A day may come when the courage of men fails… but it is not THIS day~~"
+            "//[testPage](test-page.md)\n\n<s>A day may come when the courage of men fails… but it is not THIS day</s>"
         CommonmarkRenderer(context).render(page)
         assertEquals(expect, renderedContent)
     }


### PR DESCRIPTION
Closes #2177.  This PR fixes an issue where consecutive `ContentText` nodes have strikethrough styling.  This isn't the best fix, but it's the cleanest as it only changes CommonmarkRenderer.  Instead of surrounding `ContentText` with `~~`, it surrounds it with `<s>` and `</s>`.  I think ideally the `ContentGroup` should be surrounding with strikethrough instead of each text, but that requires more changes.