### PR TITLE
Add horizontal margin to breadcrumbs delimiter (KT-50296)

### DIFF
--- a/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
@@ -605,7 +605,9 @@ open class HtmlRenderer(
             if (path.size > 1) {
                 buildNavigationElement(path.first(), page)
                 path.drop(1).forEach { node ->
-                    text("/")
+                    span(classes = "delimiter") {
+                        text("/")
+                    }
                     buildNavigationElement(node, page)
                 }
             }

--- a/plugins/base/src/main/resources/dokka/styles/style.css
+++ b/plugins/base/src/main/resources/dokka/styles/style.css
@@ -146,6 +146,10 @@ html ::-webkit-scrollbar-thumb {
     overflow-wrap: break-word;
 }
 
+.breadcrumbs .delimiter {
+    margin: auto 2px;
+}
+
 .tabs-section > .section-tab:first-child,
 .platform-hinted > .platform-bookmarks-row > .platform-bookmark:first-child {
     margin-left: 0;


### PR DESCRIPTION
Fixes [KT-50296](https://youtrack.jetbrains.com/issue/KT-50296)

# Before
![delimiter-margin-before](https://user-images.githubusercontent.com/22685910/147094321-061cee0e-cb8a-402e-8f75-eba6c41fcca2.png)

# After
![delimiter-margin-after](https://user-images.githubusercontent.com/22685910/147094326-538bb020-d212-4205-b4db-d967de9ee25b.png)
