### PR TITLE
Add a level of indentation to childless items in navigation tree (KT-50294)

### DIFF
--- a/plugins/base/src/main/resources/dokka/styles/style.css
+++ b/plugins/base/src/main/resources/dokka/styles/style.css
@@ -301,6 +301,7 @@ code.paragraph {
 }
 
 .overview > .navButton {
+    position: absolute;
     align-items: center;
     display: flex;
     justify-content: flex-end;
@@ -433,6 +434,7 @@ code.paragraph {
     align-items: center;
     color: var(--default-font-color);
     overflow: hidden;
+    padding-left: 23px;
 }
 
 


### PR DESCRIPTION
Before, the indentation for a package element with children came from the button itself (it physically occupied 24px). Now there's real and consistent indentation for all tree elements, regardless of any buttons

# Before
![nav-indent-before](https://user-images.githubusercontent.com/22685910/147357470-9c7bf1d0-e8ae-40e6-80e6-2a363d208744.png)

# After
![nav-indent-after](https://user-images.githubusercontent.com/22685910/147357465-5bffe938-a661-4612-ad05-c5586c69f7de.png)
