### PR TITLE
Reuse `ObjectMapper`

### DIFF
--- a/core/src/main/kotlin/links/DRI.kt
+++ b/core/src/main/kotlin/links/DRI.kt
@@ -33,17 +33,20 @@ abstract class DRIExtraProperty<T> {
         ?: (this.javaClass.let { it.`package`.name + "." + it.simpleName.ifEmpty { "anonymous" } })
 }
 
-private val DRI_EXTRA_OBJECT_MAPPER = ObjectMapper()
 
 class DRIExtraContainer(val data: String? = null) {
-    val map: MutableMap<String, Any> = if (data != null) DRI_EXTRA_OBJECT_MAPPER.readValue(data) else mutableMapOf()
+    val map: MutableMap<String, Any> = if (data != null) OBJECT_MAPPER.readValue(data) else mutableMapOf()
     inline operator fun <reified T> get(prop: DRIExtraProperty<T>): T? =
         map[prop.key]?.let { prop as? T }
 
     inline operator fun <reified T> set(prop: DRIExtraProperty<T>, value: T) =
         value.also { map[prop.key] = it as Any }
 
-    fun encode(): String = DRI_EXTRA_OBJECT_MAPPER.writeValueAsString(map)
+    fun encode(): String = OBJECT_MAPPER.writeValueAsString(map)
+
+    private companion object {
+        private val OBJECT_MAPPER = ObjectMapper()
+    }
 }
 
 val DriOfUnit = DRI("kotlin", "Unit")

--- a/core/src/main/kotlin/links/DRI.kt
+++ b/core/src/main/kotlin/links/DRI.kt
@@ -33,15 +33,17 @@ abstract class DRIExtraProperty<T> {
         ?: (this.javaClass.let { it.`package`.name + "." + it.simpleName.ifEmpty { "anonymous" } })
 }
 
+private val DRI_EXTRA_OBJECT_MAPPER = ObjectMapper()
+
 class DRIExtraContainer(val data: String? = null) {
-    val map: MutableMap<String, Any> = if (data != null) ObjectMapper().readValue(data) else mutableMapOf()
+    val map: MutableMap<String, Any> = if (data != null) DRI_EXTRA_OBJECT_MAPPER.readValue(data) else mutableMapOf()
     inline operator fun <reified T> get(prop: DRIExtraProperty<T>): T? =
         map[prop.key]?.let { prop as? T }
 
     inline operator fun <reified T> set(prop: DRIExtraProperty<T>, value: T) =
         value.also { map[prop.key] = it as Any }
 
-    fun encode(): String = ObjectMapper().writeValueAsString(map)
+    fun encode(): String = DRI_EXTRA_OBJECT_MAPPER.writeValueAsString(map)
 }
 
 val DriOfUnit = DRI("kotlin", "Unit")


### PR DESCRIPTION
Accidentally came across this. I don't think it's very performance critical, but it's recommended and usually is reused (common practice)

As per [documentation](https://github.com/FasterXML/jackson-docs/wiki/Presentation:-Jackson-Performance#basics-things-you-should-do-anyway),

> There are some basic ground rules to follow to ensure that Jackson processes things efficiently (close to optimal level). These are things that you should "do anyway", even if you do not have actual performance problems ...
> 1. Reuse heavy-weight objects: ObjectMapper (data-binding) ...
> ...