### PR TITLE
Add information about checked exceptions inherited from java

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -771,7 +771,7 @@ public abstract interface class org/jetbrains/dokka/model/Callable : org/jetbrai
 	public abstract fun getReceiver ()Lorg/jetbrains/dokka/model/DParameter;
 }
 
-public final class org/jetbrains/dokka/model/CheckedExceptions : org/jetbrains/dokka/model/properties/ExtraProperty, org/jetbrains/dokka/model/properties/ExtraProperty$Key {
+public final class org/jetbrains/dokka/model/CheckedExceptions : org/jetbrains/dokka/model/properties/ExtraProperty {
 	public static final field Companion Lorg/jetbrains/dokka/model/CheckedExceptions$Companion;
 	public fun <init> (Ljava/util/Map;)V
 	public final fun component1 ()Ljava/util/Map;
@@ -781,8 +781,6 @@ public final class org/jetbrains/dokka/model/CheckedExceptions : org/jetbrains/d
 	public final fun getExceptions ()Ljava/util/Map;
 	public fun getKey ()Lorg/jetbrains/dokka/model/properties/ExtraProperty$Key;
 	public fun hashCode ()I
-	public synthetic fun mergeStrategyFor (Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
-	public fun mergeStrategyFor (Lorg/jetbrains/dokka/model/ObviousMember;Lorg/jetbrains/dokka/model/ObviousMember;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/core/src/main/kotlin/model/documentableProperties.kt
+++ b/core/src/main/kotlin/model/documentableProperties.kt
@@ -39,7 +39,7 @@ object ObviousMember : ExtraProperty<Documentable>, ExtraProperty.Key<Documentab
     override val key: ExtraProperty.Key<Documentable, *> = this
 }
 
-data class CheckedExceptions(val exceptions: SourceSetDependent<List<DRI>>) : ExtraProperty<Documentable>, ExtraProperty.Key<Documentable, ObviousMember> {
+data class CheckedExceptions(val exceptions: SourceSetDependent<List<DRI>>) : ExtraProperty<Documentable> {
     companion object : ExtraProperty.Key<Documentable, CheckedExceptions> {
         override fun mergeStrategyFor(left: CheckedExceptions, right: CheckedExceptions) =
             MergeStrategy.Replace(CheckedExceptions(left.exceptions + right.exceptions))


### PR DESCRIPTION
Dokka is filling in information about checked exceptions declared in java method signatures. However, it is ignoring kotlin methods that are overriding Java methods. This is incorrect as those methods can be seen from java as throwing checked exceptions.

This PR is the effect of me trying to fix that. It is incomplete as it relies on preserving `PSIMethod`s for methods defined in Java, which is not always the case. It will fail in some cases in finding checked exceptions but I think it is still better than not having any information about them.

@vmishenev: Is it even possible to obtain information about checked exceptions using `JavaMethodDescriptor` and `DokkaResolutionFacade`, without preserved PSI trees?