### PR TITLE
Fix MathJax rendering bug (#2175)

### DIFF
--- a/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
@@ -340,6 +340,18 @@ open class DefaultPageCreator(
                     }
                 }
             }
+            val customTags = d.customTags
+            if (customTags.isNotEmpty()) {
+                group(styles = setOf(TextStyle.Block)) {
+                    customTags.forEach {
+                        group(styles = setOf(TextStyle.Block)) {
+                            it.value.values.forEach {
+                                comment(it.root)
+                            }
+                        }
+                    }
+                }
+            }
 
             val unnamedTags = tags.filterNot { (k, _) -> k.isSubclassOf(NamedTagWrapper::class) || k in specialTags }
                 .values.flatten().groupBy { it.first }.mapValues { it.value.map { it.second } }
@@ -705,6 +717,9 @@ open class DefaultPageCreator(
 
     private val Documentable.descriptions: SourceSetDependent<Description>
         get() = groupedTags.withTypeUnnamed<Description>()
+
+    private val Documentable.customTags: Map<String, SourceSetDependent<CustomTagWrapper>>
+        get() = groupedTags.withTypeNamed()
 
     private val Documentable.hasSeparatePage: Boolean
         get() = this !is DTypeAlias


### PR DESCRIPTION
Fix a bug where using the `@usesMathJax` custom tag would cause the
documentation to fail to render. I fixed this by making all custom tags
render to the screen, which were being ignored.

Along with this, I updated the existing test case to check for the
presence of content in the output.

Fixes #2175