### PR TITLE
Add support for header tags in Javadoc

### DIFF
--- a/plugins/base/src/main/kotlin/translators/psi/parsers/JavadocParser.kt
+++ b/plugins/base/src/main/kotlin/translators/psi/parsers/JavadocParser.kt
@@ -421,6 +421,9 @@ class JavadocParser(
                         parsed
                     }
                 }
+                "h1" -> ifChildrenPresent { H1(children) }
+                "h2" -> ifChildrenPresent { H2(children) }
+                "h3" -> ifChildrenPresent { H3(children) }
                 else -> listOf(Text(body = element.ownText()))
             }
         }

--- a/plugins/base/src/test/kotlin/parsers/JavadocParserTest.kt
+++ b/plugins/base/src/test/kotlin/parsers/JavadocParserTest.kt
@@ -374,24 +374,22 @@ class JavadocParserTest : BaseAbstractTest() {
 
                 kotlin.test.assertEquals(
                     listOf(
-                        P(children = listOf(
-                            Text("An example of using the header tags "),
-                            H1(
-                                listOf(
-                                    Text("A header")
-                                )
-                            ),
-                            H2(
-                                listOf(
-                                    Text("A second level header")
-                                )
-                            ),
-                            H3(
-                                listOf(
-                                    Text("A third level header")
-                                )
+                        P(children = listOf(Text("An example of using the header tags "))),
+                        H1(
+                            listOf(
+                                Text("A header")
                             )
-                        ))
+                        ),
+                        H2(
+                            listOf(
+                                Text("A second level header")
+                            )
+                        ),
+                        H3(
+                            listOf(
+                                Text("A third level header")
+                            )
+                        )
                     ),
                     root.children
                 )

--- a/plugins/base/src/test/kotlin/parsers/JavadocParserTest.kt
+++ b/plugins/base/src/test/kotlin/parsers/JavadocParserTest.kt
@@ -349,4 +349,41 @@ class JavadocParserTest : BaseAbstractTest() {
             }
         }
     }
+    
+    @Test
+    fun `header tags are handled properly`() {
+        val source = """
+            |/src/main/kotlin/test/Test.java
+            |package example
+            |
+            | /**
+            | * An example of using the header tags
+            | * <h1>A header</h1>
+            | * <h2>A second level header</h2>
+            | * <h3>A third level header</h3>
+            | */
+            | public class Test  {}
+            """.trimIndent()
+        testInline(
+            source,
+            configuration,
+        ) {
+            documentablesCreationStage = { modules ->
+                val docs = modules.first().packages.first().classlikes.single().documentation.first().value
+                val root = docs.children.first().root
+
+                kotlin.test.assertEquals(
+                    listOf(
+                        P(children = listOf(
+                            Text(body = "An example of using the header tags"),
+                            H1(body = "A header"),
+                            H1(body = "A second level header"),
+                            H3(body = "A third level header")
+                        )),
+                    ),
+                    root.children
+                )
+            }
+        }
+    }
 }

--- a/plugins/base/src/test/kotlin/parsers/JavadocParserTest.kt
+++ b/plugins/base/src/test/kotlin/parsers/JavadocParserTest.kt
@@ -375,13 +375,13 @@ class JavadocParserTest : BaseAbstractTest() {
                 kotlin.test.assertEquals(
                     listOf(
                         P(children = listOf(
-                            Text("An example of using the header tags),
+                            Text("An example of using the header tags"),
                             H1(
                                 listOf(
                                     Text("A header")
                                 )
                             ),
-                            H1(
+                            H2(
                                 listOf(
                                     Text("A second level header")
                                 )
@@ -391,7 +391,7 @@ class JavadocParserTest : BaseAbstractTest() {
                                     Text("A third level header")
                                 )
                             )
-                        )),
+                        ))
                     ),
                     root.children
                 )

--- a/plugins/base/src/test/kotlin/parsers/JavadocParserTest.kt
+++ b/plugins/base/src/test/kotlin/parsers/JavadocParserTest.kt
@@ -375,10 +375,22 @@ class JavadocParserTest : BaseAbstractTest() {
                 kotlin.test.assertEquals(
                     listOf(
                         P(children = listOf(
-                            Text(body = "An example of using the header tags"),
-                            H1(body = "A header"),
-                            H1(body = "A second level header"),
-                            H3(body = "A third level header")
+                            Text("An example of using the header tags),
+                            H1(
+                                listOf(
+                                    Text("A header")
+                                )
+                            ),
+                            H1(
+                                listOf(
+                                    Text("A second level header")
+                                )
+                            ),
+                            H3(
+                                listOf(
+                                    Text("A third level header")
+                                )
+                            )
                         )),
                     ),
                     root.children

--- a/plugins/base/src/test/kotlin/parsers/JavadocParserTest.kt
+++ b/plugins/base/src/test/kotlin/parsers/JavadocParserTest.kt
@@ -375,7 +375,7 @@ class JavadocParserTest : BaseAbstractTest() {
                 kotlin.test.assertEquals(
                     listOf(
                         P(children = listOf(
-                            Text("An example of using the header tags"),
+                            Text("An example of using the header tags "),
                             H1(
                                 listOf(
                                     Text("A header")


### PR DESCRIPTION
Partially fixes https://github.com/Kotlin/dokka/issues/2262#issuecomment-1030359358