### PR TITLE
Fix filtering suppresed extensions

### DIFF
--- a/core/src/main/kotlin/plugability/DokkaContext.kt
+++ b/core/src/main/kotlin/plugability/DokkaContext.kt
@@ -124,7 +124,11 @@ private class DokkaContextConfigurationImpl(
     }
 
     private fun findNotOverridden(bucket: Set<Extension<*, *, *>>): Extension<*, *, *> {
-        val filtered = bucket.filter { it !in suppressedExtensions }
+        // Let's filter out all suppressedExtensions that are not only overrides.
+        // suppressedExtensions can be polluted by suppressions that completely disables the extension, and would break dokka behaviour
+        // if not filtered out
+        val suppressedExtensionsByOverrides = suppressedExtensions.filterNot { it.value.any { it !is Suppression.ByExtension } }
+        val filtered = bucket.filterNot { it in suppressedExtensionsByOverrides }
         return filtered.singleOrNull()
             ?: throw IllegalStateException("Conflicting overrides: $filtered")
     }


### PR DESCRIPTION
A potential fix for a problem that suppressing extensions was breaking the dokka run. I hope I will manage to cover it with some tests.