### PR TITLE
Remove various caches from `JvmDependenciesIndexImpl`

### DIFF
--- a/plugins/base/src/main/kotlin/translators/psi/DefaultPsiToDocumentableTranslator.kt
+++ b/plugins/base/src/main/kotlin/translators/psi/DefaultPsiToDocumentableTranslator.kt
@@ -59,6 +59,7 @@ import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstance
 import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
 
 class DefaultPsiToDocumentableTranslator(
     context: DokkaContext
@@ -116,7 +117,7 @@ class DefaultPsiToDocumentableTranslator(
 
         private val javadocParser: JavaDocumentationParser = JavadocParser(logger, facade)
 
-        private val cachedBounds = hashMapOf<String, Bound>()
+        private val cachedBounds = ConcurrentHashMap<String, Bound>()
 
         private fun PsiModifierListOwner.getVisibility() = modifierList?.let {
             val ml = it.children.toList()
@@ -483,7 +484,7 @@ class DefaultPsiToDocumentableTranslator(
             //We would like to cache most of the bounds since it is not common to annotate them,
             //but if this is the case, we treat them as 'one of'
             return if (annotationsFromType().isEmpty()) {
-                cachedBounds.getOrPut(type.canonicalText) {
+                cachedBounds.computeIfAbsent(type.canonicalText) {
                     bound()
                 }
             } else {

--- a/plugins/base/src/main/kotlin/translators/psi/DefaultPsiToDocumentableTranslator.kt
+++ b/plugins/base/src/main/kotlin/translators/psi/DefaultPsiToDocumentableTranslator.kt
@@ -59,7 +59,6 @@ import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstance
 import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 import java.io.File
-import java.util.concurrent.ConcurrentHashMap
 
 class DefaultPsiToDocumentableTranslator(
     context: DokkaContext
@@ -117,7 +116,7 @@ class DefaultPsiToDocumentableTranslator(
 
         private val javadocParser: JavaDocumentationParser = JavadocParser(logger, facade)
 
-        private val cachedBounds = ConcurrentHashMap<String, Bound>()
+        private val cachedBounds = hashMapOf<String, Bound>()
 
         private fun PsiModifierListOwner.getVisibility() = modifierList?.let {
             val ml = it.children.toList()
@@ -484,7 +483,7 @@ class DefaultPsiToDocumentableTranslator(
             //We would like to cache most of the bounds since it is not common to annotate them,
             //but if this is the case, we treat them as 'one of'
             return if (annotationsFromType().isEmpty()) {
-                cachedBounds.computeIfAbsent(type.canonicalText) {
+                cachedBounds.getOrPut(type.canonicalText) {
                     bound()
                 }
             } else {

--- a/plugins/base/src/main/kotlin/translators/psi/parsers/JavadocParser.kt
+++ b/plugins/base/src/main/kotlin/translators/psi/parsers/JavadocParser.kt
@@ -29,6 +29,7 @@ import org.jsoup.nodes.Element
 import org.jsoup.nodes.Node
 import org.jsoup.nodes.TextNode
 import java.util.*
+import java.util.concurrent.ConcurrentHashMap
 
 fun interface JavaDocumentationParser {
     fun parseDocumentation(element: PsiNamedElement): DocumentationNode
@@ -46,7 +47,7 @@ class JavadocParser(
      * It has to be mutable to allow for adding entries when @inheritDoc resolves to kotlin code,
      * from which we get a DocTags not descriptors.
      */
-    private var inheritDocSections: MutableMap<UUID, DocumentationNode> = mutableMapOf()
+    private var inheritDocSections = ConcurrentHashMap<UUID, DocumentationNode>()
 
     override fun parseDocumentation(element: PsiNamedElement): DocumentationNode {
         return when(val comment = findClosestDocComment(element, logger)){


### PR DESCRIPTION
Removed various caches and did some `dokkaHtmlMultiModule` benchmarking on [kotlinx-coroutines](https://github.com/Kotlin/kotlinx.coroutines).

I benchmarked 4 times: baseline (current master) + once for each removed cache (`#1`, `#2` and `#3`, will outline them by comments) to see the impact of each removed cache. 

[The results (html link)](https://ignatberesnev.github.io/static/dokka/removed-cache-benchmark/combined-results.html) show that there's no significant build time degradation, but the benchmarks are not as ideal as they could be:
1. Now that I understand how these caches work, perhaps `kotlinx-coroutines` wasn't the best project to benchmark on -- it doesn't have that many dependencies and roots, so the cache is relatively small in size. I wonder if the results will be any different on a large scale enterprise project
2. As far as I understand, the caches were introduced to reduce load on IO, so supposedly we'll see the biggest difference on slow aged HDDs, whereas the benchmarks were performed on a pristine new gen SSD with a lot of free memory, so the files were probably cached as well.

Alternatively, it's possible to add some basic thread safety to the current solution by synchronizing on individual `Cache` objects when working with them, but because there's a section where two caches need to be locked consecutively, I can come up with a hypothetical concurrent scenario in which a deadlock happens (whether it could actually happen is a good question, need more time to investigate). 

P.S., turns out, `JvmDependenciesIndexImpl` was [copy-pasted from the kotlin repo](https://github.com/JetBrains/kotlin/blob/master/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/index/JvmDependenciesIndexImpl.kt) (it also has caches), which makes it a little scary to remove (hopefully it was introduced to kotlin based on some testing). I was unable to find the PR or any attached issue to introducing the caches, so not sure what the motivation was behind it, and its primary contributor does not work at JB anymore, so I can't ask directly.