### PR TITLE
Kotlin-as-Java fixes for external invocation

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1837,6 +1837,11 @@ public final class org/jetbrains/dokka/model/JavaVisibility$Public : org/jetbrai
 	public static final field INSTANCE Lorg/jetbrains/dokka/model/JavaVisibility$Public;
 }
 
+public final class org/jetbrains/dokka/model/JvmFieldKt {
+	public static final fun isJvmField (Lorg/jetbrains/dokka/links/DRI;)Z
+	public static final fun isJvmField (Lorg/jetbrains/dokka/model/Annotations$Annotation;)Z
+}
+
 public final class org/jetbrains/dokka/model/JvmNameKt {
 	public static final fun isJvmName (Lorg/jetbrains/dokka/links/DRI;)Z
 	public static final fun isJvmName (Lorg/jetbrains/dokka/model/Annotations$Annotation;)Z

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -3436,6 +3436,7 @@ public final class org/jetbrains/dokka/model/properties/PropertyContainer$Compan
 }
 
 public final class org/jetbrains/dokka/model/properties/PropertyContainerKt {
+	public static final fun addMaybe (Lorg/jetbrains/dokka/model/properties/PropertyContainer;Lorg/jetbrains/dokka/model/properties/ExtraProperty;)Lorg/jetbrains/dokka/model/properties/PropertyContainer;
 	public static final fun mergeExtras (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
 	public static final fun plus (Lorg/jetbrains/dokka/model/properties/PropertyContainer;Lorg/jetbrains/dokka/model/properties/ExtraProperty;)Lorg/jetbrains/dokka/model/properties/PropertyContainer;
 }

--- a/core/src/main/kotlin/model/JvmField.kt
+++ b/core/src/main/kotlin/model/JvmField.kt
@@ -1,0 +1,7 @@
+package org.jetbrains.dokka.model
+
+import org.jetbrains.dokka.links.DRI
+
+fun DRI.isJvmField(): Boolean = packageName == "kotlin.jvm" && classNames == "JvmField"
+
+fun Annotations.Annotation.isJvmField(): Boolean = dri.isJvmName()

--- a/core/src/main/kotlin/model/properties/PropertyContainer.kt
+++ b/core/src/main/kotlin/model/properties/PropertyContainer.kt
@@ -29,6 +29,8 @@ data class PropertyContainer<C : Any> internal constructor(
 operator fun <D: Any> PropertyContainer<D>.plus(prop: ExtraProperty<D>?): PropertyContainer<D> =
     if (prop == null) this else PropertyContainer(map + (prop.key to prop))
 
+// alias because sometimes compiler insists on using non-nullable version of `plus`
+fun <D: Any> PropertyContainer<D>.addMaybe(prop: ExtraProperty<D>?): PropertyContainer<D> = plus(prop)
 
 interface WithExtraProperties<C : Any> {
     val extra: PropertyContainer<C>

--- a/plugins/base/api/base.api
+++ b/plugins/base/api/base.api
@@ -46,6 +46,7 @@ public final class org/jetbrains/dokka/base/DokkaBase : org/jetbrains/dokka/plug
 	public final fun getPageMergerStrategy ()Lorg/jetbrains/dokka/plugability/ExtensionPoint;
 	public final fun getPathToRootConsumer ()Lorg/jetbrains/dokka/plugability/Extension;
 	public final fun getPreMergeDocumentableTransformer ()Lorg/jetbrains/dokka/plugability/ExtensionPoint;
+	public final fun getPropertiesMergerTransformer ()Lorg/jetbrains/dokka/plugability/Extension;
 	public final fun getPsiToDocumentableTranslator ()Lorg/jetbrains/dokka/plugability/Extension;
 	public final fun getReplaceVersionConsumer ()Lorg/jetbrains/dokka/plugability/Extension;
 	public final fun getResolveLinkConsumer ()Lorg/jetbrains/dokka/plugability/Extension;
@@ -1159,6 +1160,11 @@ public final class org/jetbrains/dokka/base/transformers/documentables/KotlinArr
 public final class org/jetbrains/dokka/base/transformers/documentables/ObviousFunctionsDocumentableFilterTransformer : org/jetbrains/dokka/base/transformers/documentables/SuppressedByConditionDocumentableFilterTransformer {
 	public fun <init> (Lorg/jetbrains/dokka/plugability/DokkaContext;)V
 	public fun shouldBeSuppressed (Lorg/jetbrains/dokka/model/Documentable;)Z
+}
+
+public final class org/jetbrains/dokka/base/transformers/documentables/PropertiesMergerTransformer : org/jetbrains/dokka/transformers/documentation/PreMergeDocumentableTransformer {
+	public fun <init> ()V
+	public fun invoke (Ljava/util/List;)Ljava/util/List;
 }
 
 public final class org/jetbrains/dokka/base/transformers/documentables/SuppressTagDocumentableFilter : org/jetbrains/dokka/base/transformers/documentables/SuppressedByConditionDocumentableFilterTransformer {

--- a/plugins/base/src/main/kotlin/DokkaBase.kt
+++ b/plugins/base/src/main/kotlin/DokkaBase.kt
@@ -122,6 +122,12 @@ class DokkaBase : DokkaPlugin() {
         preMergeDocumentableTransformer providing ::ModuleAndPackageDocumentationTransformer
     }
 
+    val propertiesMergerTransformer by extending {
+        preMergeDocumentableTransformer with PropertiesMergerTransformer() order {
+            before(documentableVisibilityFilter)
+        }
+    }
+
     val actualTypealiasAdder by extending {
         CoreExtensions.documentableTransformer with ActualTypealiasAdder()
     }

--- a/plugins/base/src/main/kotlin/transformers/documentables/PropertiesMergerTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/PropertiesMergerTransformer.kt
@@ -1,0 +1,86 @@
+package org.jetbrains.dokka.base.transformers.documentables
+
+import org.jetbrains.dokka.model.*
+import org.jetbrains.dokka.transformers.documentation.PreMergeDocumentableTransformer
+import org.jetbrains.kotlin.load.java.JvmAbi
+import org.jetbrains.kotlin.load.java.propertyNameByGetMethodName
+import org.jetbrains.kotlin.load.java.propertyNamesBySetMethodName
+import org.jetbrains.kotlin.name.Name
+
+class PropertiesMergerTransformer : PreMergeDocumentableTransformer {
+
+    override fun invoke(modules: List<DModule>) =
+        modules.map { it.copy(packages = it.packages.map {
+            it.mergeBeansAndField().copy(
+                classlikes = it.classlikes.map { it.mergeBeansAndField() }
+            )
+        }) }
+
+    private fun <T : Documentable> T.mergeBeansAndField(): T = when (this) {
+        is DClass -> {
+            val (functions, properties) = mergePotentialBeansAndField(this.functions, this.properties)
+            this.copy(functions = functions, properties = properties)
+        }
+        is DEnum -> {
+            val (functions, properties) = mergePotentialBeansAndField(this.functions, this.properties)
+            this.copy(functions = functions, properties = properties)
+        }
+        is DInterface -> {
+            val (functions, properties) = mergePotentialBeansAndField(this.functions, this.properties)
+            this.copy(functions = functions, properties = properties)
+        }
+        is DObject -> {
+            val (functions, properties) = mergePotentialBeansAndField(this.functions, this.properties)
+            this.copy(functions = functions, properties = properties)
+        }
+        is DAnnotation -> {
+            val (functions, properties) = mergePotentialBeansAndField(this.functions, this.properties)
+            this.copy(functions = functions, properties = properties)
+        }
+        is DPackage -> {
+            val (functions, properties) = mergePotentialBeansAndField(this.functions, this.properties)
+            this.copy(functions = functions, properties = properties)
+        }
+        else -> this
+    } as T
+
+    private fun DFunction.getPropertyNameForFunction() =
+        when {
+            JvmAbi.isGetterName(name) -> propertyNameByGetMethodName(Name.identifier(name))?.asString()
+            JvmAbi.isSetterName(name) -> propertyNamesBySetMethodName(Name.identifier(name)).firstOrNull()
+                ?.asString()
+            else -> null
+        }
+
+    private fun mergePotentialBeansAndField(
+        functions: List<DFunction>,
+        fields: List<DProperty>
+    ): Pair<List<DFunction>, List<DProperty>> {
+        val fieldNames = fields.associateBy { it.name }
+        val accessors = mutableMapOf<DProperty, MutableList<DFunction>>()
+        val regularMethods = mutableListOf<DFunction>()
+        functions.forEach { method ->
+            val field = method.getPropertyNameForFunction()?.let { name -> fieldNames[name] }
+            if (field != null) {
+                accessors.getOrPut(field, ::mutableListOf).add(method)
+            } else {
+                regularMethods.add(method)
+            }
+        }
+        return regularMethods.toList() to accessors.map { (dProperty, dFunctions) ->
+            if (dProperty.visibility.values.all { it is KotlinVisibility.Private }) {
+                dFunctions.flatMap { it.visibility.values }.toSet().singleOrNull()?.takeIf {
+                    it in listOf(KotlinVisibility.Public, KotlinVisibility.Protected)
+                }?.let { visibility ->
+                    dProperty.copy(
+                        getter = dFunctions.firstOrNull { it.type == dProperty.type },
+                        setter = dFunctions.firstOrNull { it.parameters.isNotEmpty() },
+                        visibility = dProperty.visibility.mapValues { visibility }
+                    )
+                } ?: dProperty
+            } else {
+                dProperty
+            }
+        } + fields.toSet().minus(accessors.keys.toSet())
+    }
+}

--- a/plugins/base/src/main/kotlin/translators/descriptors/DefaultDescriptorToDocumentableTranslator.kt
+++ b/plugins/base/src/main/kotlin/translators/descriptors/DefaultDescriptorToDocumentableTranslator.kt
@@ -919,9 +919,9 @@ private class DokkaDescriptorVisitor(
         )
     } ?: getJavaDocs())?.takeIf { it.children.isNotEmpty() }
 
-    private fun DeclarationDescriptor.getJavaDocs() = (this as? CallableDescriptor)
-        ?.overriddenDescriptors
-        ?.mapNotNull { it.findPsi() as? PsiNamedElement }
+    private fun DeclarationDescriptor.getJavaDocs() = (
+            ((this as? CallableDescriptor)?.overriddenDescriptors ?: emptyList()) + listOf(this)
+        )?.mapNotNull { it.findPsi() as? PsiNamedElement }
         ?.firstOrNull()
         ?.let { javadocParser.parseDocumentation(it) }
 

--- a/plugins/base/src/main/kotlin/translators/descriptors/DefaultDescriptorToDocumentableTranslator.kt
+++ b/plugins/base/src/main/kotlin/translators/descriptors/DefaultDescriptorToDocumentableTranslator.kt
@@ -430,10 +430,8 @@ private class DokkaDescriptorVisitor(
         originalDescriptor: PropertyDescriptor,
         parent: DRIWithPlatformInfo
     ): DProperty {
-        val (dri, inheritedFrom) = originalDescriptor.createDRI().let {
-            if (it.second != null) (it.second to it.first) as Pair<DRI, DRI?>
-            else it
-        }
+        val (dri, _) = originalDescriptor.createDRI()
+        val inheritedFrom = dri.copy(callable = null).takeIf { parent.dri.classNames != dri.classNames }
         val descriptor = originalDescriptor.getConcreteDescriptor()
         val isExpect = descriptor.isExpect
         val isActual = descriptor.isActual
@@ -471,7 +469,7 @@ private class DokkaDescriptorVisitor(
                         (descriptor.getAnnotationsWithBackingField() + descriptor.fileLevelAnnotations()).toSourceSetDependent()
                             .toAnnotations(),
                         descriptor.getDefaultValue()?.let { DefaultValue(it) },
-                        InheritedMember(inheritedFrom.toSourceSetDependent()),
+                        inheritedFrom?.let { InheritedMember(it.toSourceSetDependent()) },
                     )
                 )
             )
@@ -488,10 +486,8 @@ private class DokkaDescriptorVisitor(
         originalDescriptor: FunctionDescriptor,
         parent: DRIWithPlatformInfo
     ): DFunction {
-        val (dri, inheritedFrom) = originalDescriptor.createDRI().let {
-            if (it.second != null) (it.second to it.first) as Pair<DRI, DRI?>
-            else it
-        }
+        val (dri, _) = originalDescriptor.createDRI()
+        val inheritedFrom = dri.copy(callable = null).takeIf { parent.dri.classNames != dri.classNames }
         val descriptor = originalDescriptor.getConcreteDescriptor()
         val isExpect = descriptor.isExpect
         val isActual = descriptor.isActual
@@ -521,7 +517,7 @@ private class DokkaDescriptorVisitor(
                 sourceSets = setOf(sourceSet),
                 isExpectActual = (isExpect || isActual),
                 extra = PropertyContainer.withAll(
-                    InheritedMember(inheritedFrom.toSourceSetDependent()),
+                    inheritedFrom?.let { InheritedMember(it.toSourceSetDependent()) },
                     descriptor.additionalExtras().toSourceSetDependent().toAdditionalModifiers(),
                     (descriptor.getAnnotations() + descriptor.fileLevelAnnotations()).toSourceSetDependent()
                         .toAnnotations(),
@@ -601,10 +597,9 @@ private class DokkaDescriptorVisitor(
         descriptor: PropertyAccessorDescriptor,
         propertyDescriptor: PropertyDescriptor,
         parent: DRI,
-        parentInheritedFrom: DRI? = null
+        inheritedFrom: DRI? = null
     ): DFunction {
         val dri = parent.copy(callable = Callable.from(descriptor))
-        val inheritedFrom = parentInheritedFrom?.copy(callable = Callable.from(descriptor))
         val isGetter = descriptor is PropertyGetterDescriptor
         val isExpect = descriptor.isExpect
         val isActual = descriptor.isActual
@@ -689,7 +684,7 @@ private class DokkaDescriptorVisitor(
                 extra = PropertyContainer.withAll(
                     descriptor.additionalExtras().toSourceSetDependent().toAdditionalModifiers(),
                     descriptor.getAnnotations().toSourceSetDependent().toAnnotations(),
-                    InheritedMember(inheritedFrom.toSourceSetDependent())
+                    inheritedFrom?.let { InheritedMember(it.toSourceSetDependent()) }
                 )
             )
         }

--- a/plugins/base/src/main/kotlin/translators/psi/DefaultPsiToDocumentableTranslator.kt
+++ b/plugins/base/src/main/kotlin/translators/psi/DefaultPsiToDocumentableTranslator.kt
@@ -470,6 +470,15 @@ class DefaultPsiToDocumentableTranslator(
                 Annotations.Annotation(DRI("kotlin.jvm", "JvmStatic"), emptyMap())
         }
 
+        /**
+         * Workaround for getting JvmField Kotlin annotation in PSIs
+         */
+        private fun Collection<PsiAnnotation>.getJvmFieldAnnotation() = filter {
+            it.qualifiedName == "kotlin.jvm.JvmField"
+        }.map {
+            Annotations.Annotation(DRI("kotlin.jvm", "JvmField"), emptyMap())
+        }.distinct()
+
         private fun <T : AnnotationTarget> PsiTypeParameter.annotations(): PropertyContainer<T> = this.annotations.toList().toListOfAnnotations().annotations()
         private fun <T : AnnotationTarget> PsiType.annotations(): PropertyContainer<T> = this.annotations.toList().toListOfAnnotations().annotations()
 
@@ -491,7 +500,7 @@ class DefaultPsiToDocumentableTranslator(
                     type.resolve()?.let { resolved ->
                         when {
                             resolved.qualifiedName == "java.lang.Object" -> JavaObject(type.annotations())
-                            resolved is PsiTypeParameter -> getProjection(resolved)
+                            resolved is PsiTypeParameter -> getProjection(resolved).copy(extra = type.annotations())
                             Regex("kotlin\\.jvm\\.functions\\.Function.*").matches(resolved.qualifiedName ?: "") ||
                                     Regex("java\\.util\\.function\\.Function.*").matches(
                                         resolved.qualifiedName ?: ""
@@ -628,9 +637,10 @@ class DefaultPsiToDocumentableTranslator(
                     PropertyContainer.withAll(
                         InheritedMember(inheritedFrom.toSourceSetDependent()),
                         it.toSourceSetDependent().toAdditionalModifiers(),
-                        (psi.annotations.toList()
-                            .toListOfAnnotations() + it.toListOfAnnotations()).toSourceSetDependent()
-                            .toAnnotations()
+                        (psi.annotations.toList().toListOfAnnotations() +
+                                it.toListOfAnnotations() +
+                                psi.annotations.toList().getJvmFieldAnnotation()
+                        ).toSourceSetDependent().toAnnotations()
                     )
                 }
             )

--- a/plugins/base/src/main/kotlin/translators/psi/DefaultPsiToDocumentableTranslator.kt
+++ b/plugins/base/src/main/kotlin/translators/psi/DefaultPsiToDocumentableTranslator.kt
@@ -438,7 +438,7 @@ class DefaultPsiToDocumentableTranslator(
                 false,
                 psi.additionalExtras().let {
                     PropertyContainer.withAll(
-                        InheritedMember(inheritedFrom.toSourceSetDependent()),
+                        inheritedFrom?.let { InheritedMember(it.toSourceSetDependent()) },
                         it.toSourceSetDependent().toAdditionalModifiers(),
                         (psi.annotations.toList()
                             .toListOfAnnotations() + it.toListOfAnnotations()).toSourceSetDependent()
@@ -635,7 +635,7 @@ class DefaultPsiToDocumentableTranslator(
                 false,
                 psi.additionalExtras().let {
                     PropertyContainer.withAll(
-                        InheritedMember(inheritedFrom.toSourceSetDependent()),
+                        inheritedFrom?.let { InheritedMember(it.toSourceSetDependent()) },
                         it.toSourceSetDependent().toAdditionalModifiers(),
                         (psi.annotations.toList().toListOfAnnotations() +
                                 it.toListOfAnnotations() +

--- a/plugins/base/src/main/kotlin/translators/psi/DefaultPsiToDocumentableTranslator.kt
+++ b/plugins/base/src/main/kotlin/translators/psi/DefaultPsiToDocumentableTranslator.kt
@@ -122,6 +122,9 @@ class DefaultPsiToDocumentableTranslator(
         private val PsiMethod.hash: Int
             get() = "$returnType $name$parameterList".hashCode()
 
+        private val PsiField.hash: Int
+            get() = "$type $name".hashCode()
+
         private val PsiClassType.shouldBeIgnored: Boolean
             get() = isClass("java.lang.Enum") || isClass("java.lang.Object")
 
@@ -171,10 +174,16 @@ class DefaultPsiToDocumentableTranslator(
                 val dri = parent.withClass(name.toString())
                 val superMethodsKeys = hashSetOf<Int>()
                 val superMethods = mutableListOf<Pair<PsiMethod, DRI>>()
+                val superFieldsKeys = hashSetOf<Int>()
+                val superFields = mutableListOf<Pair<PsiField, DRI>>()
                 methods.asIterable().parallelForEach { superMethodsKeys.add(it.hash) }
 
                 /**
-                 * Caution! This method mutates superMethodsKeys and superMethods
+                 * Caution! This method mutates
+                 * - superMethodsKeys
+                 * - superMethods
+                 * - superFieldsKeys
+                 * - superKeys
                  */
                 fun Array<PsiClassType>.getSuperTypesPsiClasses(): List<Pair<PsiClass, JavaClassKindTypes>> {
                     forEach { type ->
@@ -187,6 +196,13 @@ class DefaultPsiToDocumentableTranslator(
                                 ) {
                                     superMethodsKeys.add(hash)
                                     superMethods.add(Pair(method, definedAt))
+                                }
+                            }
+                            it.fields.forEach { field ->
+                                val hash = field.hash
+                                if (!superFieldsKeys.contains(hash)) {
+                                    superFieldsKeys.add(hash)
+                                    superFields.add(Pair(field, definedAt))
                                 }
                             }
                         }
@@ -217,7 +233,22 @@ class DefaultPsiToDocumentableTranslator(
                 }
 
                 val ancestry: AncestryNode = traversePsiClassForAncestorsAndInheritedMembers(this)
-                val (regularFunctions, accessors) = splitFunctionsAndAccessors()
+                val (regularFunctions, accessors) = splitFunctionsAndAccessors(psi.fields, psi.methods)
+                val (regularSuperFunctions, superAccessors) = splitFunctionsAndAccessors(superFields.map { it.first }.toTypedArray(), superMethods.map { it.first }.toTypedArray())
+
+                val regularSuperFunctionsKeys = regularSuperFunctions.map { it.hash }.toSet()
+
+                val regularSuperFunctionsWithDRI = superMethods.filter { it.first.hash in regularSuperFunctionsKeys }
+
+                val superAccessorsWithDRI = superAccessors
+                    .mapValues { (field, methods) ->
+                    if (field.annotations.mapNotNull { it.toAnnotation() }.any { it.isJvmField() }) {
+                        emptyList()
+                    } else {
+                        methods.mapNotNull { method -> superMethods.find { it.first.hash == method.hash } }
+                    }
+                }
+
                 val overridden = regularFunctions.flatMap { it.findSuperMethods().toList() }
                 val documentation = javadocParser.parseDocumentation(this).toSourceSetDependent()
                 val allFunctions = async {
@@ -226,7 +257,15 @@ class DefaultPsiToDocumentableTranslator(
                             it,
                             parentDRI = dri
                         ) else null
-                    } + superMethods.filter { it.first !in overridden }.parallelMap { parseFunction(it.first, inheritedFrom = it.second) }
+                    } + regularSuperFunctionsWithDRI.filter { it.first !in overridden }.parallelMap { parseFunction(it.first, inheritedFrom = it.second) }
+                }
+                val allFields = async {
+                    fields.toList().parallelMapNotNull { parseField(it, accessors[it].orEmpty()) } +
+                    superFields.parallelMapNotNull { parseFieldWithInheritingAccessors(
+                        it.first,
+                        superAccessorsWithDRI[it.first].orEmpty(),
+                        inheritedFrom = it.second)
+                    }
                 }
                 val source = PsiDocumentableSource(this).toSourceSetDependent()
                 val classlikes = async { innerClasses.asIterable().parallelMap { parseClasslike(it, dri) } }
@@ -251,7 +290,7 @@ class DefaultPsiToDocumentableTranslator(
                             null,
                             source,
                             allFunctions.await(),
-                            fields.mapNotNull { parseField(it, accessors[it].orEmpty()) },
+                            allFields.await(),
                             classlikes.await(),
                             visibility,
                             null,
@@ -310,7 +349,7 @@ class DefaultPsiToDocumentableTranslator(
                         null,
                         source,
                         allFunctions.await(),
-                        fields.mapNotNull { parseField(it, accessors[it].orEmpty()) },
+                        allFields.await(),
                         classlikes.await(),
                         visibility,
                         null,
@@ -329,7 +368,7 @@ class DefaultPsiToDocumentableTranslator(
                         name.orEmpty(),
                         constructors.map { parseFunction(it, true) },
                         allFunctions.await(),
-                        fields.mapNotNull { parseField(it, accessors[it].orEmpty()) },
+                        allFields.await(),
                         classlikes.await(),
                         source,
                         visibility,
@@ -539,7 +578,7 @@ class DefaultPsiToDocumentableTranslator(
                     else -> null
                 }
 
-        private fun PsiClass.splitFunctionsAndAccessors(): Pair<MutableList<PsiMethod>, MutableMap<PsiField, MutableList<PsiMethod>>> {
+        private fun splitFunctionsAndAccessors(fields: Array<PsiField>, methods: Array<PsiMethod>): Pair<MutableList<PsiMethod>, MutableMap<PsiField, MutableList<PsiMethod>>> {
             val fieldNames = fields.associateBy { it.name }
             val accessors = mutableMapOf<PsiField, MutableList<PsiMethod>>()
             val regularMethods = mutableListOf<PsiMethod>()
@@ -554,7 +593,21 @@ class DefaultPsiToDocumentableTranslator(
             return regularMethods to accessors
         }
 
-        private fun parseField(psi: PsiField, accessors: List<PsiMethod>): DProperty {
+        private fun parseFieldWithInheritingAccessors(psi: PsiField, accessors: List<Pair<PsiMethod, DRI>>, inheritedFrom: DRI): DProperty = parseField(
+            psi,
+            accessors.firstOrNull { it.first.hasParameters() }?.let { parseFunction(it.first, inheritedFrom = it.second) },
+            accessors.firstOrNull { it.first.returnType == psi.type }?.let { parseFunction(it.first, inheritedFrom = it.second) },
+            inheritedFrom
+        )
+
+        private fun parseField(psi: PsiField, accessors: List<PsiMethod>, inheritedFrom: DRI? = null): DProperty = parseField(
+            psi,
+            accessors.firstOrNull { it.hasParameters() }?.let { parseFunction(it) },
+            accessors.firstOrNull { it.returnType == psi.type }?.let { parseFunction(it) },
+            inheritedFrom
+        )
+
+        private fun parseField(psi: PsiField, getter: DFunction?, setter: DFunction?, inheritedFrom: DRI? = null): DProperty {
             val dri = DRI.from(psi)
             return DProperty(
                 dri,
@@ -565,14 +618,15 @@ class DefaultPsiToDocumentableTranslator(
                 psi.getVisibility().toSourceSetDependent(),
                 getBound(psi.type),
                 null,
-                accessors.firstOrNull { it.hasParameters() }?.let { parseFunction(it) },
-                accessors.firstOrNull { it.returnType == psi.type }?.let { parseFunction(it) },
+                getter,
+                setter,
                 psi.getModifier().toSourceSetDependent(),
                 setOf(sourceSetData),
                 emptyList(),
                 false,
                 psi.additionalExtras().let {
                     PropertyContainer.withAll(
+                        InheritedMember(inheritedFrom.toSourceSetDependent()),
                         it.toSourceSetDependent().toAdditionalModifiers(),
                         (psi.annotations.toList()
                             .toListOfAnnotations() + it.toListOfAnnotations()).toSourceSetDependent()

--- a/plugins/base/src/test/kotlin/model/PropertyTest.kt
+++ b/plugins/base/src/test/kotlin/model/PropertyTest.kt
@@ -155,7 +155,7 @@ class PropertyTest : AbstractModelTest("/src/main/kotlin/property/Test.kt", "pro
         ) {
             with((this / "property").cast<DPackage>()) {
                 with((this / "Bar" / "property").cast<DProperty>()) {
-                    dri.classNames equals "Bar"
+                    dri.classNames equals "Foo"
                     name equals "property"
                     children counts 0
                     with(getter.assertNotNull("Getter")) {
@@ -163,6 +163,7 @@ class PropertyTest : AbstractModelTest("/src/main/kotlin/property/Test.kt", "pro
                     }
                     extra[InheritedMember]?.inheritedFrom?.values?.single()?.run {
                         classNames equals "Foo"
+                        callable equals null
                     }
                 }
             }

--- a/plugins/base/src/test/kotlin/model/PropertyTest.kt
+++ b/plugins/base/src/test/kotlin/model/PropertyTest.kt
@@ -1,10 +1,13 @@
 package model
 
+import org.jetbrains.dokka.links.Callable
+import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.model.*
 import org.junit.jupiter.api.Test
 import utils.AbstractModelTest
 import utils.assertNotNull
 import utils.name
+import kotlin.test.assertEquals
 
 class PropertyTest : AbstractModelTest("/src/main/kotlin/property/Test.kt", "property") {
 
@@ -152,11 +155,14 @@ class PropertyTest : AbstractModelTest("/src/main/kotlin/property/Test.kt", "pro
         ) {
             with((this / "property").cast<DPackage>()) {
                 with((this / "Bar" / "property").cast<DProperty>()) {
-                    dri.classNames equals "Foo"
+                    dri.classNames equals "Bar"
                     name equals "property"
                     children counts 0
                     with(getter.assertNotNull("Getter")) {
                         type.name equals "Int"
+                    }
+                    extra[InheritedMember]?.inheritedFrom?.values?.single()?.run {
+                        classNames equals "Foo"
                     }
                 }
             }

--- a/plugins/base/src/test/kotlin/superFields/DescriptorSuperPropertiesTest.kt
+++ b/plugins/base/src/test/kotlin/superFields/DescriptorSuperPropertiesTest.kt
@@ -44,14 +44,14 @@ class DescriptorSuperPropertiesTest : BaseAbstractTest() {
                     Assertions.assertNull(this.setter)
                     this.extra[InheritedMember]?.inheritedFrom?.values?.single()?.run {
                         assertEquals(
-                            DRI(packageName = "test", classNames = "A", callable = Callable("a", params = emptyList())),
+                            DRI(packageName = "test", classNames = "A"),
                             this
                         )
                     }
                     this.getter.run {
                         this!!.extra[InheritedMember]?.inheritedFrom?.values?.single()?.run {
                             assertEquals(
-                                DRI(packageName = "test", classNames = "A", callable = Callable("getA", params = emptyList())),
+                                DRI(packageName = "test", classNames = "A"),
                                 this
                             )
                         }
@@ -94,14 +94,14 @@ class DescriptorSuperPropertiesTest : BaseAbstractTest() {
                     Assertions.assertNotNull(this.setter)
                     this.extra[InheritedMember]?.inheritedFrom?.values?.single()?.run {
                         assertEquals(
-                            DRI(packageName = "test", classNames = "A", callable = Callable("a", params = emptyList())),
+                            DRI(packageName = "test", classNames = "A"),
                             this
                         )
                     }
                     this.getter.run {
                         this!!.extra[InheritedMember]?.inheritedFrom?.values?.single()?.run {
                             assertEquals(
-                                DRI(packageName = "test", classNames = "A", callable = Callable("getA", params = emptyList())),
+                                DRI(packageName = "test", classNames = "A"),
                                 this
                             )
                         }
@@ -109,11 +109,7 @@ class DescriptorSuperPropertiesTest : BaseAbstractTest() {
                     this.setter.run {
                         this!!.extra[InheritedMember]?.inheritedFrom?.values?.single()?.run {
                             assertEquals(
-                                DRI(packageName = "test", classNames = "A",
-                                    callable = Callable("setA",
-                                        params = listOf(TypeConstructor("kotlin.Int", emptyList()))
-                                    )
-                                ),
+                                DRI(packageName = "test", classNames = "A"),
                                 this
                             )
                         }
@@ -157,7 +153,7 @@ class DescriptorSuperPropertiesTest : BaseAbstractTest() {
                     Assertions.assertNull(this.setter)
                     this.extra[InheritedMember]?.inheritedFrom?.values?.single()?.run {
                         assertEquals(
-                            DRI(packageName = "test", classNames = "A", callable = Callable("a", params = emptyList())),
+                            DRI(packageName = "test", classNames = "A"),
                             this
                         )
                     }

--- a/plugins/base/src/test/kotlin/superFields/DescriptorSuperPropertiesTest.kt
+++ b/plugins/base/src/test/kotlin/superFields/DescriptorSuperPropertiesTest.kt
@@ -1,0 +1,168 @@
+package superFields
+
+import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
+import org.jetbrains.dokka.links.Callable
+import org.jetbrains.dokka.links.DRI
+import org.jetbrains.dokka.links.TypeConstructor
+import org.jetbrains.dokka.links.TypeReference
+import org.jetbrains.dokka.model.InheritedMember
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class DescriptorSuperPropertiesTest : BaseAbstractTest() {
+
+    @Test
+    fun `kotlin inheriting java should append getter`() {
+        testInline(
+            """
+            |/src/test/A.java
+            |package test;
+            |public class A {
+            |   private int a = 1;
+            |   public int getA() { return a; }
+            |}
+            |
+            |/src/test/B.kt
+            |package test
+            |class B : A {}
+        """.trimIndent(),
+            dokkaConfiguration {
+                sourceSets {
+                    sourceSet {
+                        sourceRoots = listOf("src/")
+                        analysisPlatform = "jvm"
+                        name = "jvm"
+                    }
+                }
+            }
+        ) {
+            this.documentablesTransformationStage = {
+                it.packages.single().classlikes.single { it.name == "B" }.properties.single { it.name == "a" }.run {
+                    Assertions.assertNotNull(this)
+                    Assertions.assertNotNull(this.getter)
+                    Assertions.assertNull(this.setter)
+                    this.extra[InheritedMember]?.inheritedFrom?.values?.single()?.run {
+                        assertEquals(
+                            DRI(packageName = "test", classNames = "A", callable = Callable("a", params = emptyList())),
+                            this
+                        )
+                    }
+                    this.getter.run {
+                        this!!.extra[InheritedMember]?.inheritedFrom?.values?.single()?.run {
+                            assertEquals(
+                                DRI(packageName = "test", classNames = "A", callable = Callable("getA", params = emptyList())),
+                                this
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `kotlin inheriting java should append getter and setter`() {
+        testInline(
+            """
+            |/src/test/A.java
+            |package test;
+            |public class A {
+            |   private int a = 1;
+            |   public int getA() { return a; }
+            |   public void setA(int a) { this.a = a; }
+            |}
+            |
+            |/src/test/B.kt
+            |package test
+            |class B : A {}
+        """.trimIndent(),
+            dokkaConfiguration {
+                sourceSets {
+                    sourceSet {
+                        sourceRoots = listOf("src/")
+                        analysisPlatform = "jvm"
+                        name = "jvm"
+                    }
+                }
+            }
+        ) {
+            documentablesMergingStage = {
+                it.packages.single().classlikes.single { it.name == "B" }.properties.single { it.name == "a" }.run {
+                    Assertions.assertNotNull(this)
+                    Assertions.assertNotNull(this.getter)
+                    Assertions.assertNotNull(this.setter)
+                    this.extra[InheritedMember]?.inheritedFrom?.values?.single()?.run {
+                        assertEquals(
+                            DRI(packageName = "test", classNames = "A", callable = Callable("a", params = emptyList())),
+                            this
+                        )
+                    }
+                    this.getter.run {
+                        this!!.extra[InheritedMember]?.inheritedFrom?.values?.single()?.run {
+                            assertEquals(
+                                DRI(packageName = "test", classNames = "A", callable = Callable("getA", params = emptyList())),
+                                this
+                            )
+                        }
+                    }
+                    this.setter.run {
+                        this!!.extra[InheritedMember]?.inheritedFrom?.values?.single()?.run {
+                            assertEquals(
+                                DRI(packageName = "test", classNames = "A",
+                                    callable = Callable("setA",
+                                        params = listOf(TypeConstructor("kotlin.Int", emptyList()))
+                                    )
+                                ),
+                                this
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `kotlin inheriting java should not append anything since field is public`() {
+        testInline(
+            """
+            |/src/test/A.java
+            |package test;
+            |public class A {
+            |   public int a = 1;
+            |   public int getA() { return a; }
+            |   public void setA(int a) { this.a = a; }
+            |}
+            |
+            |/src/test/B.kt
+            |package test
+            |class B : A {}
+        """.trimIndent(),
+            dokkaConfiguration {
+                sourceSets {
+                    sourceSet {
+                        sourceRoots = listOf("src/")
+                        analysisPlatform = "jvm"
+                        name = "jvm"
+                        classpath += jvmStdlibPath!!
+                    }
+                }
+            }
+        ) {
+            documentablesMergingStage = {
+                it.packages.single().classlikes.single { it.name == "B" }.properties.single { it.name == "a" }.run {
+                    Assertions.assertNotNull(this)
+                    Assertions.assertNull(this.getter)
+                    Assertions.assertNull(this.setter)
+                    this.extra[InheritedMember]?.inheritedFrom?.values?.single()?.run {
+                        assertEquals(
+                            DRI(packageName = "test", classNames = "A", callable = Callable("a", params = emptyList())),
+                            this
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/plugins/base/src/test/kotlin/superFields/PsiSuperFieldsTest.kt
+++ b/plugins/base/src/test/kotlin/superFields/PsiSuperFieldsTest.kt
@@ -2,6 +2,7 @@ package superFields
 
 import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
 import org.jetbrains.dokka.links.DRI
+import org.jetbrains.dokka.model.Annotations
 import org.jetbrains.dokka.model.InheritedMember
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -124,6 +125,10 @@ class PsiSuperFieldsTest : BaseAbstractTest() {
                     assertNotNull(this)
                     assertNull(this.getter)
                     assertNull(this.setter)
+                    assertNotNull(this.extra[Annotations]?.directAnnotations?.values?.single()?.find {
+                        it.dri.packageName == "kotlin.jvm" &&
+                                it.dri.classNames == "JvmField"
+                    })
                     this.extra[InheritedMember]?.inheritedFrom?.values?.single()?.run {
                         assertEquals(
                             DRI(packageName = "test", classNames = "A"),

--- a/plugins/base/src/test/kotlin/superFields/PsiSuperFieldsTest.kt
+++ b/plugins/base/src/test/kotlin/superFields/PsiSuperFieldsTest.kt
@@ -1,0 +1,137 @@
+package superFields
+
+import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
+import org.jetbrains.dokka.links.DRI
+import org.jetbrains.dokka.model.InheritedMember
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+
+class PsiSuperFieldsTest : BaseAbstractTest() {
+
+    @Disabled // TODO: Remove with Kotlin 1.6.20
+    @Test
+    fun `java inheriting java`() {
+        testInline(
+            """
+            |/src/test/A.java
+            |package test;
+            |public class A {
+            |    public int a = 1;
+            |}
+            |
+            |/src/test/B.java
+            |package test;
+            |public class B extends A {}
+        """.trimIndent(),
+            dokkaConfiguration {
+                sourceSets {
+                    sourceSet {
+                        sourceRoots = listOf("src/")
+                        analysisPlatform = "jvm"
+                        name = "jvm"
+                    }
+                }
+            }
+        ) {
+            documentablesMergingStage = {
+                it.packages.single().classlikes.single { it.name == "B" }.properties.single { it.name == "a" }.run {
+                    assertNotNull(this)
+                    this.extra[InheritedMember]?.inheritedFrom?.values?.single()?.run {
+                        assertEquals(
+                            DRI(packageName = "test", classNames = "A"),
+                            this
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    @Disabled // TODO: Remove with Kotlin 1.6.20
+    @Test
+    fun `java inheriting kotlin`() {
+        testInline(
+            """
+            |/src/test/A.kt
+            |package test
+            |open class A {
+            |    var a: Int = 1
+            |}
+            |
+            |/src/test/B.java
+            |package test;
+            |public class B extends A {}
+        """.trimIndent(),
+            dokkaConfiguration {
+                sourceSets {
+                    sourceSet {
+                        sourceRoots = listOf("src/")
+                        analysisPlatform = "jvm"
+                        name = "jvm"
+                    }
+                }
+            }
+        ) {
+            documentablesMergingStage = {
+                it.packages.single().classlikes.single { it.name == "B" }.properties.single { it.name == "a" }.run {
+                    assertNotNull(this)
+                    assertNotNull(this.getter)
+                    assertNotNull(this.setter)
+                    this.extra[InheritedMember]?.inheritedFrom?.values?.single()?.run {
+                        assertEquals(
+                            DRI(packageName = "test", classNames = "A"),
+                            this
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    @Disabled // TODO: Remove with Kotlin 1.6.20
+    @Test
+    fun `java inheriting kotlin with @JvmField should not inherit beans`() {
+        testInline(
+            """
+            |/src/test/A.kt
+            |package test
+            |open class A {
+            |    @kotlin.jvm.JvmField
+            |    var a: Int = 1
+            |}
+            |
+            |/src/test/B.java
+            |package test;
+            |public class B extends A {}
+        """.trimIndent(),
+            dokkaConfiguration {
+                sourceSets {
+                    sourceSet {
+                        sourceRoots = listOf("src/")
+                        analysisPlatform = "jvm"
+                        name = "jvm"
+                        classpath += jvmStdlibPath!!
+                    }
+                }
+            }
+        ) {
+            documentablesMergingStage = {
+                it.packages.single().classlikes.single { it.name == "B" }.properties.single { it.name == "a" }.run {
+                    assertNotNull(this)
+                    assertNull(this.getter)
+                    assertNull(this.setter)
+                    this.extra[InheritedMember]?.inheritedFrom?.values?.single()?.run {
+                        assertEquals(
+                            DRI(packageName = "test", classNames = "A"),
+                            this
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/plugins/javadoc/src/test/kotlin/org/jetbrains/dokka/javadoc/JavadocIndexTest.kt
+++ b/plugins/javadoc/src/test/kotlin/org/jetbrains/dokka/javadoc/JavadocIndexTest.kt
@@ -21,7 +21,7 @@ internal class JavadocIndexTest : AbstractJavadocTemplateMapTest() {
             AnnotationTarget.ANNOTATION_CLASS::class.java.methods.any { it.name == "describeConstable" }
 
         testIndexPages { indexPages ->
-            assertEquals(if (hasAdditionalFunction()) 41 else 40, indexPages.sumBy { it.elements.size })
+            assertEquals(if (hasAdditionalFunction()) 32 else 31, indexPages.sumBy { it.elements.size })
         }
     }
 

--- a/plugins/kotlin-as-java/api/kotlin-as-java.api
+++ b/plugins/kotlin-as-java/api/kotlin-as-java.api
@@ -7,12 +7,12 @@ public final class org/jetbrains/dokka/kotlinAsJava/KotlinAsJavaPlugin : org/jet
 }
 
 public final class org/jetbrains/dokka/kotlinAsJava/TransformToJavaKt {
-	public static final fun transformToJava (Lorg/jetbrains/dokka/model/DClasslike;Lorg/jetbrains/dokka/plugability/DokkaContext;)Lorg/jetbrains/dokka/model/DClasslike;
-	public static final fun transformToJava (Lorg/jetbrains/dokka/model/DFunction;Lorg/jetbrains/dokka/plugability/DokkaContext;Ljava/lang/String;Z)Ljava/util/List;
-	public static final fun transformToJava (Lorg/jetbrains/dokka/model/DPackage;Lorg/jetbrains/dokka/plugability/DokkaContext;)Lorg/jetbrains/dokka/model/DPackage;
-	public static final fun transformToJava (Lorg/jetbrains/dokka/model/DProperty;Lorg/jetbrains/dokka/plugability/DokkaContext;ZLjava/lang/String;)Lorg/jetbrains/dokka/model/DProperty;
-	public static synthetic fun transformToJava$default (Lorg/jetbrains/dokka/model/DFunction;Lorg/jetbrains/dokka/plugability/DokkaContext;Ljava/lang/String;ZILjava/lang/Object;)Ljava/util/List;
-	public static synthetic fun transformToJava$default (Lorg/jetbrains/dokka/model/DProperty;Lorg/jetbrains/dokka/plugability/DokkaContext;ZLjava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/dokka/model/DProperty;
+	public static final fun transformToJava (Lorg/jetbrains/dokka/model/DClasslike;Lorg/jetbrains/dokka/utilities/DokkaLogger;)Lorg/jetbrains/dokka/model/DClasslike;
+	public static final fun transformToJava (Lorg/jetbrains/dokka/model/DFunction;Lorg/jetbrains/dokka/utilities/DokkaLogger;Ljava/lang/String;Z)Ljava/util/List;
+	public static final fun transformToJava (Lorg/jetbrains/dokka/model/DPackage;Lorg/jetbrains/dokka/utilities/DokkaLogger;)Lorg/jetbrains/dokka/model/DPackage;
+	public static final fun transformToJava (Lorg/jetbrains/dokka/model/DProperty;Lorg/jetbrains/dokka/utilities/DokkaLogger;ZLjava/lang/String;)Lorg/jetbrains/dokka/model/DProperty;
+	public static synthetic fun transformToJava$default (Lorg/jetbrains/dokka/model/DFunction;Lorg/jetbrains/dokka/utilities/DokkaLogger;Ljava/lang/String;ZILjava/lang/Object;)Ljava/util/List;
+	public static synthetic fun transformToJava$default (Lorg/jetbrains/dokka/model/DProperty;Lorg/jetbrains/dokka/utilities/DokkaLogger;ZLjava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/dokka/model/DProperty;
 }
 
 public final class org/jetbrains/dokka/kotlinAsJava/converters/KotlinToJavaConverterKt {

--- a/plugins/kotlin-as-java/api/kotlin-as-java.api
+++ b/plugins/kotlin-as-java/api/kotlin-as-java.api
@@ -6,6 +6,19 @@ public final class org/jetbrains/dokka/kotlinAsJava/KotlinAsJavaPlugin : org/jet
 	public final fun getKotlinAsJavaDocumentableTransformer ()Lorg/jetbrains/dokka/plugability/Extension;
 }
 
+public final class org/jetbrains/dokka/kotlinAsJava/OriginalProperty : org/jetbrains/dokka/model/properties/ExtraProperty {
+	public static final field Companion Lorg/jetbrains/dokka/kotlinAsJava/OriginalProperty$Companion;
+	public fun <init> (Lorg/jetbrains/dokka/model/DProperty;)V
+	public fun getKey ()Lorg/jetbrains/dokka/kotlinAsJava/OriginalProperty$Companion;
+	public synthetic fun getKey ()Lorg/jetbrains/dokka/model/properties/ExtraProperty$Key;
+	public final fun getOriginal ()Lorg/jetbrains/dokka/model/DProperty;
+}
+
+public final class org/jetbrains/dokka/kotlinAsJava/OriginalProperty$Companion : org/jetbrains/dokka/model/properties/ExtraProperty$Key {
+	public synthetic fun mergeStrategyFor (Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
+	public fun mergeStrategyFor (Lorg/jetbrains/dokka/kotlinAsJava/OriginalProperty;Lorg/jetbrains/dokka/kotlinAsJava/OriginalProperty;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
+}
+
 public final class org/jetbrains/dokka/kotlinAsJava/TransformToJavaKt {
 	public static final fun transformToJava (Lorg/jetbrains/dokka/model/DClasslike;Lorg/jetbrains/dokka/utilities/DokkaLogger;)Lorg/jetbrains/dokka/model/DClasslike;
 	public static final fun transformToJava (Lorg/jetbrains/dokka/model/DFunction;Lorg/jetbrains/dokka/utilities/DokkaLogger;Ljava/lang/String;Z)Ljava/util/List;

--- a/plugins/kotlin-as-java/src/main/kotlin/OriginalProperty.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/OriginalProperty.kt
@@ -1,0 +1,11 @@
+package org.jetbrains.dokka.kotlinAsJava
+
+import org.jetbrains.dokka.model.DFunction
+import org.jetbrains.dokka.model.DProperty
+import org.jetbrains.dokka.model.properties.ExtraProperty
+import org.jetbrains.dokka.model.properties.MergeStrategy
+
+class OriginalProperty(val original: DProperty) : ExtraProperty<DFunction> {
+    override val key = OriginalProperty
+    companion object: ExtraProperty.Key<DFunction, OriginalProperty>
+}

--- a/plugins/kotlin-as-java/src/main/kotlin/converters/KotlinToJavaConverter.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/converters/KotlinToJavaConverter.kt
@@ -275,7 +275,7 @@ internal fun DClass.functionsInJava(): List<DFunction> =
         .flatMap { property -> listOfNotNull(property.getter, property.setter) }
         .plus(functions)
         .filterNot { it.hasJvmSynthetic() }
-        .flatMap { it.asJava(dri.classNames ?: name) }
+        .flatMap { it.asJava(it.dri.classNames ?: it.name) }
 
 private fun DTypeParameter.asJava(): DTypeParameter = copy(
     variantTypeParameter = variantTypeParameter.withDri(dri.possiblyAsJava()),

--- a/plugins/kotlin-as-java/src/main/kotlin/converters/KotlinToJavaConverter.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/converters/KotlinToJavaConverter.kt
@@ -317,7 +317,7 @@ internal fun DEnum.asJava(): DEnum = copy(
     functions = functions
         .plus(
             properties
-                .filterNot { it.hasJvmSynthetic() }
+                .filter { it.jvmField() == null && !it.hasJvmSynthetic() }
                 .flatMap { listOf(it.getter, it.setter) }
         )
         .filterNotNull()
@@ -335,7 +335,7 @@ internal fun DObject.asJava(): DObject = copy(
     functions = functions
         .plus(
             properties
-                .filterNot { it.hasJvmSynthetic() }
+                .filter { it.jvmField() == null && !it.hasJvmSynthetic() }
                 .flatMap { listOf(it.getter, it.setter) }
         )
         .filterNotNull()
@@ -373,7 +373,7 @@ internal fun DInterface.asJava(): DInterface = copy(
     functions = functions
         .plus(
             properties
-                .filterNot { it.hasJvmSynthetic() }
+                .filter { it.jvmField() == null && !it.hasJvmSynthetic() }
                 .flatMap { listOf(it.getter, it.setter) }
         )
         .filterNotNull()

--- a/plugins/kotlin-as-java/src/main/kotlin/converters/KotlinToJavaConverter.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/converters/KotlinToJavaConverter.kt
@@ -87,7 +87,7 @@ internal fun DProperty.asJava(isTopLevel: Boolean = false, relocateToClass: Stri
         visibility = visibility.mapValues {
             if (isTopLevel && isConst) {
                 JavaVisibility.Public
-            } else if (jvmField() != null) {
+            } else if (jvmField() != null || (getter == null && setter == null)) {
                 it.value.asJava()
             } else {
                 it.value.propertyVisibilityAsJava()

--- a/plugins/kotlin-as-java/src/main/kotlin/transformToJava.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/transformToJava.kt
@@ -7,23 +7,24 @@ import org.jetbrains.dokka.model.DFunction
 import org.jetbrains.dokka.model.DPackage
 import org.jetbrains.dokka.model.DProperty
 import org.jetbrains.dokka.plugability.DokkaContext
+import org.jetbrains.dokka.utilities.DokkaLogger
 
 private val JVM_NAME_DOCUMENTABLE_TRANSFORMER by lazy {
     JvmNameDocumentableTransformer()
 }
 
-fun DPackage.transformToJava(context: DokkaContext): DPackage {
-    return JVM_NAME_DOCUMENTABLE_TRANSFORMER.transform(this.asJava(), context)
+fun DPackage.transformToJava(logger: DokkaLogger): DPackage {
+    return JVM_NAME_DOCUMENTABLE_TRANSFORMER.transform(this.asJava(), logger)
 }
 
-fun DClasslike.transformToJava(context: DokkaContext): DClasslike {
-    return JVM_NAME_DOCUMENTABLE_TRANSFORMER.transform(this.asJava(), context)
+fun DClasslike.transformToJava(logger: DokkaLogger): DClasslike {
+    return JVM_NAME_DOCUMENTABLE_TRANSFORMER.transform(this.asJava(), logger)
 }
 
-fun DFunction.transformToJava(context: DokkaContext, containingClassName: String, isTopLevel: Boolean = false): List<DFunction> {
-    return this.asJava(containingClassName, isTopLevel).map { JVM_NAME_DOCUMENTABLE_TRANSFORMER.transform(it, context) }
+fun DFunction.transformToJava(logger: DokkaLogger, containingClassName: String, isTopLevel: Boolean = false): List<DFunction> {
+    return this.asJava(containingClassName, isTopLevel).map { JVM_NAME_DOCUMENTABLE_TRANSFORMER.transform(it, logger) }
 }
 
-fun DProperty.transformToJava(context: DokkaContext, isTopLevel: Boolean = false, relocateToClass: String? = null): DProperty {
-    return JVM_NAME_DOCUMENTABLE_TRANSFORMER.transform(this.asJava(isTopLevel, relocateToClass), context)
+fun DProperty.transformToJava(logger: DokkaLogger, isTopLevel: Boolean = false, relocateToClass: String? = null): DProperty {
+    return JVM_NAME_DOCUMENTABLE_TRANSFORMER.transform(this.asJava(isTopLevel, relocateToClass), logger)
 }

--- a/plugins/kotlin-as-java/src/main/kotlin/transformers/JvmNameDocumentableTransformer.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/transformers/JvmNameDocumentableTransformer.kt
@@ -4,21 +4,22 @@ import org.jetbrains.dokka.model.*
 import org.jetbrains.dokka.model.properties.PropertyContainer
 import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.transformers.documentation.DocumentableTransformer
+import org.jetbrains.dokka.utilities.DokkaLogger
 
 class JvmNameDocumentableTransformer : DocumentableTransformer {
     private val jvmNameProvider = JvmNameProvider()
 
     override fun invoke(original: DModule, context: DokkaContext): DModule {
-        return original.copy(packages = original.packages.map { transform(it, context) })
+        return original.copy(packages = original.packages.map { transform(it, context.logger) })
     }
 
-    internal fun <T : Documentable> transform(documentable: T, context: DokkaContext): T =
+    internal fun <T : Documentable> transform(documentable: T, logger: DokkaLogger): T =
         with(documentable) {
             when (this) {
                 is DPackage -> copy(
-                    functions = functions.map { transform(it, context) },
-                    properties = properties.map { transform(it, context) },
-                    classlikes = classlikes.map { transform(it, context) },
+                    functions = functions.map { transform(it, logger) },
+                    properties = properties.map { transform(it, logger) },
+                    classlikes = classlikes.map { transform(it, logger) },
                 )
                 is DFunction -> {
                     val name = jvmNameProvider.nameFor(this)
@@ -29,14 +30,14 @@ class JvmNameDocumentableTransformer : DocumentableTransformer {
                     )
                 }
                 is DProperty -> transformGetterAndSetter(this)
-                is DClasslike -> transformClassLike(this, context)
+                is DClasslike -> transformClassLike(this, logger)
                 is DEnumEntry -> copy(
-                    functions = functions.map { transform(it, context) },
-                    properties = properties.map { transform(it, context) },
-                    classlikes = classlikes.map { transform(it, context) },
+                    functions = functions.map { transform(it, logger) },
+                    properties = properties.map { transform(it, logger) },
+                    classlikes = classlikes.map { transform(it, logger) },
                 )
                 else -> {
-                    context.logger.warn("Failed to translate a JvmName for ${this.javaClass.canonicalName}")
+                    logger.warn("Failed to translate a JvmName for ${this.javaClass.canonicalName}")
                     this
                 }
             }
@@ -53,33 +54,33 @@ class JvmNameDocumentableTransformer : DocumentableTransformer {
         return extraWithoutAnnotations.addAll(listOfNotNull(annotationsWithoutJvmName))
     }
 
-    private fun transformClassLike(documentable: DClasslike, context: DokkaContext): DClasslike =
+    private fun transformClassLike(documentable: DClasslike, logger: DokkaLogger): DClasslike =
         with(documentable) {
             when (this) {
                 is DClass -> copy(
-                    functions = functions.map { transform(it, context) },
-                    properties = properties.map { transform(it, context) },
-                    classlikes = classlikes.map { transform(it, context) },
+                    functions = functions.map { transform(it, logger) },
+                    properties = properties.map { transform(it, logger) },
+                    classlikes = classlikes.map { transform(it, logger) },
                 )
                 is DAnnotation -> copy(
-                    functions = functions.map { transform(it, context) },
-                    properties = properties.map { transform(it, context) },
-                    classlikes = classlikes.map { transform(it, context) },
+                    functions = functions.map { transform(it, logger) },
+                    properties = properties.map { transform(it, logger) },
+                    classlikes = classlikes.map { transform(it, logger) },
                 )
                 is DObject -> copy(
-                    functions = functions.map { transform(it, context) },
-                    properties = properties.map { transform(it, context) },
-                    classlikes = classlikes.map { transform(it, context) },
+                    functions = functions.map { transform(it, logger) },
+                    properties = properties.map { transform(it, logger) },
+                    classlikes = classlikes.map { transform(it, logger) },
                 )
                 is DEnum -> copy(
-                    functions = functions.map { transform(it, context) },
-                    properties = properties.map { transform(it, context) },
-                    classlikes = classlikes.map { transform(it, context) },
+                    functions = functions.map { transform(it, logger) },
+                    properties = properties.map { transform(it, logger) },
+                    classlikes = classlikes.map { transform(it, logger) },
                 )
                 is DInterface -> copy(
-                    functions = functions.map { transform(it, context) },
-                    properties = properties.map { transform(it, context) },
-                    classlikes = classlikes.map { transform(it, context) },
+                    functions = functions.map { transform(it, logger) },
+                    properties = properties.map { transform(it, logger) },
+                    classlikes = classlikes.map { transform(it, logger) },
                 )
             }
         }

--- a/plugins/kotlin-as-java/src/test/kotlin/JvmFieldTest.kt
+++ b/plugins/kotlin-as-java/src/test/kotlin/JvmFieldTest.kt
@@ -5,6 +5,7 @@ import org.jetbrains.dokka.model.JavaVisibility
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 class JvmFieldTest : BaseAbstractTest() {
     val configuration = dokkaConfiguration {
@@ -75,6 +76,33 @@ class JvmFieldTest : BaseAbstractTest() {
                     JavaVisibility.Public,
                     classLike.functions.first { it.name.startsWith("get") }.visibility.values.first()
                 )
+            }
+        }
+    }
+
+    @Test
+    fun `object jvmfield property should have no getters`(){
+        testInline(
+            """
+            |/src/main/kotlin/kotlinAsJavaPlugin/sample.kt
+            |package kotlinAsJavaPlugin
+            |object MyObject {
+            |    @JvmField
+            |    val property: String = TODO()
+            |}
+        """.trimMargin(),
+            configuration,
+        ) {
+            documentablesTransformationStage = { module ->
+                val classLike = module.packages.flatMap { it.classlikes }.first()
+                val property = classLike.properties.singleOrNull { it.name == "property" }
+                assertNotNull(property)
+                assertEquals(
+                    emptyList(),
+                    classLike.functions.map { it.name }
+                )
+                assertNull(property.getter)
+                assertNull(property.setter)
             }
         }
     }


### PR DESCRIPTION
This PR brings few improvements to Kotlin-as-Java, especially in cases when it is not used as a transformer:

- java accessors retains information about the original property
- companion objects are transformed to java classes (this change is irrelevant to the normal execution of dokka, as the `companion` property of `DClass` was ignored when the KaJ plugin was enabled)
- generation of java accessors was unified for classes and objects
- lateinit properties are retaining their fields

**This is a follow-up PR to the #2353**