### PR TITLE
Rework AnnotationTarget to be stricter.

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -784,7 +784,7 @@ public final class org/jetbrains/dokka/model/BooleanValue : org/jetbrains/dokka/
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract class org/jetbrains/dokka/model/Bound : org/jetbrains/dokka/model/Projection, org/jetbrains/dokka/model/AnnotationTarget {
+public abstract class org/jetbrains/dokka/model/Bound : org/jetbrains/dokka/model/Projection {
 }
 
 public abstract interface class org/jetbrains/dokka/model/Callable : org/jetbrains/dokka/model/WithAbstraction, org/jetbrains/dokka/model/WithIsExpectActual, org/jetbrains/dokka/model/WithSources, org/jetbrains/dokka/model/WithType, org/jetbrains/dokka/model/WithVisibility {
@@ -1802,7 +1802,7 @@ public final class org/jetbrains/dokka/model/JavaModifier$Final : org/jetbrains/
 	public static final field INSTANCE Lorg/jetbrains/dokka/model/JavaModifier$Final;
 }
 
-public final class org/jetbrains/dokka/model/JavaObject : org/jetbrains/dokka/model/Bound, org/jetbrains/dokka/model/properties/WithExtraProperties {
+public final class org/jetbrains/dokka/model/JavaObject : org/jetbrains/dokka/model/Bound, org/jetbrains/dokka/model/AnnotationTarget, org/jetbrains/dokka/model/properties/WithExtraProperties {
 	public fun <init> ()V
 	public fun <init> (Lorg/jetbrains/dokka/model/properties/PropertyContainer;)V
 	public synthetic fun <init> (Lorg/jetbrains/dokka/model/properties/PropertyContainer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -1949,15 +1949,20 @@ public final class org/jetbrains/dokka/model/PrimaryConstructorExtra : org/jetbr
 	public fun mergeStrategyFor (Lorg/jetbrains/dokka/model/PrimaryConstructorExtra;Lorg/jetbrains/dokka/model/PrimaryConstructorExtra;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
 }
 
-public final class org/jetbrains/dokka/model/PrimitiveJavaType : org/jetbrains/dokka/model/Bound {
-	public fun <init> (Ljava/lang/String;)V
+public final class org/jetbrains/dokka/model/PrimitiveJavaType : org/jetbrains/dokka/model/Bound, org/jetbrains/dokka/model/AnnotationTarget, org/jetbrains/dokka/model/properties/WithExtraProperties {
+	public fun <init> (Ljava/lang/String;Lorg/jetbrains/dokka/model/properties/PropertyContainer;)V
+	public synthetic fun <init> (Ljava/lang/String;Lorg/jetbrains/dokka/model/properties/PropertyContainer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lorg/jetbrains/dokka/model/PrimitiveJavaType;
-	public static synthetic fun copy$default (Lorg/jetbrains/dokka/model/PrimitiveJavaType;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/dokka/model/PrimitiveJavaType;
+	public final fun component2 ()Lorg/jetbrains/dokka/model/properties/PropertyContainer;
+	public final fun copy (Ljava/lang/String;Lorg/jetbrains/dokka/model/properties/PropertyContainer;)Lorg/jetbrains/dokka/model/PrimitiveJavaType;
+	public static synthetic fun copy$default (Lorg/jetbrains/dokka/model/PrimitiveJavaType;Ljava/lang/String;Lorg/jetbrains/dokka/model/properties/PropertyContainer;ILjava/lang/Object;)Lorg/jetbrains/dokka/model/PrimitiveJavaType;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getExtra ()Lorg/jetbrains/dokka/model/properties/PropertyContainer;
 	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+	public synthetic fun withNewExtras (Lorg/jetbrains/dokka/model/properties/PropertyContainer;)Ljava/lang/Object;
+	public fun withNewExtras (Lorg/jetbrains/dokka/model/properties/PropertyContainer;)Lorg/jetbrains/dokka/model/PrimitiveJavaType;
 }
 
 public abstract class org/jetbrains/dokka/model/Projection {
@@ -1990,20 +1995,25 @@ public final class org/jetbrains/dokka/model/StringValue : org/jetbrains/dokka/m
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class org/jetbrains/dokka/model/TypeAliased : org/jetbrains/dokka/model/Bound {
-	public fun <init> (Lorg/jetbrains/dokka/model/Bound;Lorg/jetbrains/dokka/model/Bound;)V
+public final class org/jetbrains/dokka/model/TypeAliased : org/jetbrains/dokka/model/Bound, org/jetbrains/dokka/model/AnnotationTarget, org/jetbrains/dokka/model/properties/WithExtraProperties {
+	public fun <init> (Lorg/jetbrains/dokka/model/Bound;Lorg/jetbrains/dokka/model/Bound;Lorg/jetbrains/dokka/model/properties/PropertyContainer;)V
+	public synthetic fun <init> (Lorg/jetbrains/dokka/model/Bound;Lorg/jetbrains/dokka/model/Bound;Lorg/jetbrains/dokka/model/properties/PropertyContainer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lorg/jetbrains/dokka/model/Bound;
 	public final fun component2 ()Lorg/jetbrains/dokka/model/Bound;
-	public final fun copy (Lorg/jetbrains/dokka/model/Bound;Lorg/jetbrains/dokka/model/Bound;)Lorg/jetbrains/dokka/model/TypeAliased;
-	public static synthetic fun copy$default (Lorg/jetbrains/dokka/model/TypeAliased;Lorg/jetbrains/dokka/model/Bound;Lorg/jetbrains/dokka/model/Bound;ILjava/lang/Object;)Lorg/jetbrains/dokka/model/TypeAliased;
+	public final fun component3 ()Lorg/jetbrains/dokka/model/properties/PropertyContainer;
+	public final fun copy (Lorg/jetbrains/dokka/model/Bound;Lorg/jetbrains/dokka/model/Bound;Lorg/jetbrains/dokka/model/properties/PropertyContainer;)Lorg/jetbrains/dokka/model/TypeAliased;
+	public static synthetic fun copy$default (Lorg/jetbrains/dokka/model/TypeAliased;Lorg/jetbrains/dokka/model/Bound;Lorg/jetbrains/dokka/model/Bound;Lorg/jetbrains/dokka/model/properties/PropertyContainer;ILjava/lang/Object;)Lorg/jetbrains/dokka/model/TypeAliased;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getExtra ()Lorg/jetbrains/dokka/model/properties/PropertyContainer;
 	public final fun getInner ()Lorg/jetbrains/dokka/model/Bound;
 	public final fun getTypeAlias ()Lorg/jetbrains/dokka/model/Bound;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+	public synthetic fun withNewExtras (Lorg/jetbrains/dokka/model/properties/PropertyContainer;)Ljava/lang/Object;
+	public fun withNewExtras (Lorg/jetbrains/dokka/model/properties/PropertyContainer;)Lorg/jetbrains/dokka/model/TypeAliased;
 }
 
-public abstract class org/jetbrains/dokka/model/TypeConstructor : org/jetbrains/dokka/model/Bound {
+public abstract class org/jetbrains/dokka/model/TypeConstructor : org/jetbrains/dokka/model/Bound, org/jetbrains/dokka/model/AnnotationTarget {
 	public abstract fun getDri ()Lorg/jetbrains/dokka/links/DRI;
 	public abstract fun getPresentableName ()Ljava/lang/String;
 	public abstract fun getProjections ()Ljava/util/List;
@@ -2022,7 +2032,7 @@ public final class org/jetbrains/dokka/model/TypeConstructorWithKind {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class org/jetbrains/dokka/model/TypeParameter : org/jetbrains/dokka/model/Bound, org/jetbrains/dokka/model/properties/WithExtraProperties {
+public final class org/jetbrains/dokka/model/TypeParameter : org/jetbrains/dokka/model/Bound, org/jetbrains/dokka/model/AnnotationTarget, org/jetbrains/dokka/model/properties/WithExtraProperties {
 	public fun <init> (Lorg/jetbrains/dokka/links/DRI;Ljava/lang/String;Ljava/lang/String;Lorg/jetbrains/dokka/model/properties/PropertyContainer;)V
 	public synthetic fun <init> (Lorg/jetbrains/dokka/links/DRI;Ljava/lang/String;Ljava/lang/String;Lorg/jetbrains/dokka/model/properties/PropertyContainer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lorg/jetbrains/dokka/links/DRI;
@@ -2042,15 +2052,20 @@ public final class org/jetbrains/dokka/model/TypeParameter : org/jetbrains/dokka
 	public fun withNewExtras (Lorg/jetbrains/dokka/model/properties/PropertyContainer;)Lorg/jetbrains/dokka/model/TypeParameter;
 }
 
-public final class org/jetbrains/dokka/model/UnresolvedBound : org/jetbrains/dokka/model/Bound {
-	public fun <init> (Ljava/lang/String;)V
+public final class org/jetbrains/dokka/model/UnresolvedBound : org/jetbrains/dokka/model/Bound, org/jetbrains/dokka/model/AnnotationTarget, org/jetbrains/dokka/model/properties/WithExtraProperties {
+	public fun <init> (Ljava/lang/String;Lorg/jetbrains/dokka/model/properties/PropertyContainer;)V
+	public synthetic fun <init> (Ljava/lang/String;Lorg/jetbrains/dokka/model/properties/PropertyContainer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lorg/jetbrains/dokka/model/UnresolvedBound;
-	public static synthetic fun copy$default (Lorg/jetbrains/dokka/model/UnresolvedBound;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/dokka/model/UnresolvedBound;
+	public final fun component2 ()Lorg/jetbrains/dokka/model/properties/PropertyContainer;
+	public final fun copy (Ljava/lang/String;Lorg/jetbrains/dokka/model/properties/PropertyContainer;)Lorg/jetbrains/dokka/model/UnresolvedBound;
+	public static synthetic fun copy$default (Lorg/jetbrains/dokka/model/UnresolvedBound;Ljava/lang/String;Lorg/jetbrains/dokka/model/properties/PropertyContainer;ILjava/lang/Object;)Lorg/jetbrains/dokka/model/UnresolvedBound;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getExtra ()Lorg/jetbrains/dokka/model/properties/PropertyContainer;
 	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+	public synthetic fun withNewExtras (Lorg/jetbrains/dokka/model/properties/PropertyContainer;)Ljava/lang/Object;
+	public fun withNewExtras (Lorg/jetbrains/dokka/model/properties/PropertyContainer;)Lorg/jetbrains/dokka/model/UnresolvedBound;
 }
 
 public abstract class org/jetbrains/dokka/model/Variance : org/jetbrains/dokka/model/Projection {

--- a/plugins/base/src/main/kotlin/translators/psi/DefaultPsiToDocumentableTranslator.kt
+++ b/plugins/base/src/main/kotlin/translators/psi/DefaultPsiToDocumentableTranslator.kt
@@ -472,13 +472,14 @@ class DefaultPsiToDocumentableTranslator(
                                 extra = type.annotations()
                             )
                         }
-                    } ?: UnresolvedBound(type.presentableText)
+                    } ?: UnresolvedBound(type.presentableText, type.annotations())
                 is PsiArrayType -> GenericTypeConstructor(
                     DRI("kotlin", "Array"),
                     listOf(getProjection(type.componentType)),
                     extra = type.annotations()
                 )
-                is PsiPrimitiveType -> if (type.name == "void") Void else PrimitiveJavaType(type.name)
+                is PsiPrimitiveType -> if (type.name == "void") Void
+                    else PrimitiveJavaType(type.name, type.annotations())
                 is PsiImmediateClassType -> JavaObject(type.annotations())
                 else -> throw IllegalStateException("${type.presentableText} is not supported by PSI parser")
             }

--- a/plugins/base/src/test/kotlin/translators/DefaultPsiToDocumentableTranslatorTest.kt
+++ b/plugins/base/src/test/kotlin/translators/DefaultPsiToDocumentableTranslatorTest.kt
@@ -4,14 +4,12 @@ import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.model.Annotations
-import org.jetbrains.dokka.model.GenericTypeConstructor
 import org.jetbrains.dokka.model.TypeConstructor
 import org.jetbrains.dokka.model.doc.Text
 import org.jetbrains.dokka.model.firstMemberOfType
 import org.jetbrains.dokka.plugability.DokkaPlugin
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import utils.assertNotNull
 
@@ -257,58 +255,6 @@ class DefaultPsiToDocumentableTranslatorTest : BaseAbstractTest() {
                     "String",
                     (kotlinSubclassFunction.parameters.firstOrNull()?.type as? TypeConstructor)?.dri?.classNames
                 )
-            }
-        }
-    }
-
-    @Disabled // The compiler throws away annotations on unresolved types upstream
-    @Test
-    fun `Can annotate UnresolvedBound`() {
-        testInline(
-            """
-            |/src/main/java/sample/FooLibrary.kt
-            |package sample;
-            |@MustBeDocumented
-            |@Target(AnnotationTarget.TYPE)
-            |annotation class Hello()
-            |fun bar(): @Hello() TypeThatDoesntResolve
-            """.trimMargin(),
-            configuration
-        ) {
-            documentablesMergingStage = { module ->
-                val type = module.packages.single().functions.single().type as GenericTypeConstructor
-                assertEquals(
-                    Annotations.Annotation(DRI("sample", "Hello"), emptyMap()),
-                    type.extra[Annotations]?.directAnnotations?.values?.single()?.single()
-                )
-            }
-        }
-    }
-
-    /**
-     * Kotlin Int becomes java int. Java int cannot be annotated in source, but Kotlin Int can be.
-     * This is paired with KotlinAsJavaPluginTest.`Java primitive annotations work`()
-     */
-    @Test
-    fun `Java primitive annotations work`() {
-        testInline(
-            """
-            |/src/main/java/sample/FooLibrary.kt
-            |package sample;
-            |@MustBeDocumented
-            |@Target(AnnotationTarget.TYPE)
-            |annotation class Hello()
-            |fun bar(): @Hello() Int
-            """.trimMargin(),
-            configuration
-        ) {
-            documentablesMergingStage = { module ->
-                val type = module.packages.single().functions.single().type as GenericTypeConstructor
-                assertEquals(
-                    Annotations.Annotation(DRI("sample", "Hello"), emptyMap()),
-                    type.extra[Annotations]?.directAnnotations?.values?.single()?.single()
-                )
-                assertEquals("kotlin/Int///PointingToDeclaration/", type.dri.toString())
             }
         }
     }

--- a/plugins/base/src/test/kotlin/translators/DefaultPsiToDocumentableTranslatorTest.kt
+++ b/plugins/base/src/test/kotlin/translators/DefaultPsiToDocumentableTranslatorTest.kt
@@ -1,13 +1,14 @@
 package translators
 
-import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.model.Annotations
+import org.jetbrains.dokka.model.GenericTypeConstructor
 import org.jetbrains.dokka.model.TypeConstructor
 import org.jetbrains.dokka.model.doc.Text
 import org.jetbrains.dokka.model.firstMemberOfType
 import org.jetbrains.dokka.plugability.DokkaPlugin
+import org.junit.Ignore
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -255,6 +256,58 @@ class DefaultPsiToDocumentableTranslatorTest : BaseAbstractTest() {
                     "String",
                     (kotlinSubclassFunction.parameters.firstOrNull()?.type as? TypeConstructor)?.dri?.classNames
                 )
+            }
+        }
+    }
+
+    @Ignore // The compiler throws away annotations on unresolved types upstream
+    @Test
+    fun `Can annotate UnresolvedBound`() {
+        testInline(
+            """
+            |/src/main/java/sample/FooLibrary.kt
+            |package sample;
+            |@MustBeDocumented
+            |@Target(AnnotationTarget.TYPE)
+            |annotation class Hello()
+            |fun bar(): @Hello() TypeThatDoesntResolve
+            """.trimMargin(),
+            configuration
+        ) {
+            documentablesMergingStage = { module ->
+                val type = module.packages.single().functions.single().type as GenericTypeConstructor
+                assertEquals(
+                    Annotations.Annotation(DRI("sample", "Hello"), emptyMap()),
+                    type.extra[Annotations]?.directAnnotations?.values?.single()?.single()
+                )
+            }
+        }
+    }
+
+    /**
+     * Kotlin Int becomes java int. Java int cannot be annotated in source, but Kotlin Int can be.
+     * This is paired with KotlinAsJavaPluginTest.`Java primitive annotations work`()
+     */
+    @Test
+    fun `Java primitive annotations work`() {
+        testInline(
+            """
+            |/src/main/java/sample/FooLibrary.kt
+            |package sample;
+            |@MustBeDocumented
+            |@Target(AnnotationTarget.TYPE)
+            |annotation class Hello()
+            |fun bar(): @Hello() Int
+            """.trimMargin(),
+            configuration
+        ) {
+            documentablesMergingStage = { module ->
+                val type = module.packages.single().functions.single().type as GenericTypeConstructor
+                assertEquals(
+                    Annotations.Annotation(DRI("sample", "Hello"), emptyMap()),
+                    type.extra[Annotations]?.directAnnotations?.values?.single()?.single()
+                )
+                assertEquals("kotlin/Int///PointingToDeclaration/", type.dri.toString())
             }
         }
     }

--- a/plugins/base/src/test/kotlin/translators/DefaultPsiToDocumentableTranslatorTest.kt
+++ b/plugins/base/src/test/kotlin/translators/DefaultPsiToDocumentableTranslatorTest.kt
@@ -1,5 +1,6 @@
 package translators
 
+import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.model.Annotations
@@ -8,9 +9,9 @@ import org.jetbrains.dokka.model.TypeConstructor
 import org.jetbrains.dokka.model.doc.Text
 import org.jetbrains.dokka.model.firstMemberOfType
 import org.jetbrains.dokka.plugability.DokkaPlugin
-import org.junit.Ignore
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import utils.assertNotNull
 
@@ -260,7 +261,7 @@ class DefaultPsiToDocumentableTranslatorTest : BaseAbstractTest() {
         }
     }
 
-    @Ignore // The compiler throws away annotations on unresolved types upstream
+    @Disabled // The compiler throws away annotations on unresolved types upstream
     @Test
     fun `Can annotate UnresolvedBound`() {
         testInline(

--- a/plugins/kotlin-as-java/src/test/kotlin/KotlinAsJavaPluginTest.kt
+++ b/plugins/kotlin-as-java/src/test/kotlin/KotlinAsJavaPluginTest.kt
@@ -541,7 +541,7 @@ class KotlinAsJavaPluginTest : BaseAbstractTest() {
 
     /**
      * Kotlin Int becomes java int. Java int cannot be annotated in source, but Kotlin Int can be.
-     * This is paired with DefaultPsiToDocumentableTranslatorTest.`Java primitive annotations work`()
+     * This is paired with DefaultDescriptorToDocumentableTranslatorTest.`Java primitive annotations work`()
      *
      * This test currently does not do anything because Kotlin.Int currently becomes java.lang.Integer not primitive int
      */

--- a/plugins/kotlin-as-java/src/test/kotlin/KotlinAsJavaPluginTest.kt
+++ b/plugins/kotlin-as-java/src/test/kotlin/KotlinAsJavaPluginTest.kt
@@ -4,10 +4,14 @@ import matchers.content.*
 import org.jetbrains.dokka.DokkaConfiguration
 import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
 import org.jetbrains.dokka.jdk
+import org.jetbrains.dokka.links.DRI
+import org.jetbrains.dokka.model.Annotations
+import org.jetbrains.dokka.model.GenericTypeConstructor
 import org.jetbrains.dokka.model.dfs
 import org.jetbrains.dokka.pages.*
 import org.jetbrains.kotlin.utils.addToStdlib.cast
 import org.junit.Assert
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import signatures.Parameter
 import signatures.Parameters
@@ -531,6 +535,54 @@ class KotlinAsJavaPluginTest : BaseAbstractTest() {
                         Parameter(A("String"), "s").withClasses("indented"),
                     ).withClasses("wrapped"), ")", Span(), ignoreSpanWithTokenStyle = true
                 )
+            }
+        }
+    }
+
+    /**
+     * Kotlin Int becomes java int. Java int cannot be annotated in source, but Kotlin Int can be.
+     * This is paired with DefaultPsiToDocumentableTranslatorTest.`Java primitive annotations work`()
+     *
+     * This test currently does not do anything because Kotlin.Int currently becomes java.lang.Integer not primitive int
+     */
+    @Test
+    fun `Java primitive annotations work`() {
+        val writerPlugin = TestOutputWriterPlugin()
+        val configuration = dokkaConfiguration {
+            sourceSets {
+                sourceSet {
+                    sourceRoots = listOf("src/")
+                    externalDocumentationLinks = listOf(
+                        DokkaConfiguration.ExternalDocumentationLink.jdk(8),
+                        stdlibExternalDocumentationLink
+                    )
+                }
+            }
+        }
+        testInline(
+            """
+            |/src/main/kotlin/kotlinAsJavaPlugin/Test.kt
+            |package kotlinAsJavaPlugin
+            |@MustBeDocumented
+            |@Target(AnnotationTarget.TYPE)
+            |annotation class Hello()
+            |fun bar(): @Hello() Int
+        """.trimMargin(),
+            configuration,
+            pluginOverrides = listOf(writerPlugin),
+            cleanupOutput = true
+        ) {
+            documentablesTransformationStage = { module ->
+                val type = module.packages.single()
+                    .classlikes.first { it.name == "TestKt" }
+                    .functions.single()
+                    .type as GenericTypeConstructor
+                Assertions.assertEquals(
+                    Annotations.Annotation(DRI("kotlinAsJavaPlugin", "Hello"), emptyMap()),
+                    type.extra[Annotations]?.directAnnotations?.values?.single()?.single()
+                )
+                // A bug; the GenericTypeConstructor cast should fail and this should be a PrimitiveJavaType
+                Assertions.assertEquals("java.lang/Integer///PointingToDeclaration/", type.dri.toString())
             }
         }
     }


### PR DESCRIPTION
Rework AnnotationTarget to be stricter. Now the things that can be annotated are precisely the things which implement AnnotationTarget.

Also adds tests, though they currently don't do anything because of pre-existing bugs

This replaces github.com/Kotlin/dokka/pull/2210. I believe all the commends from that PR are addressed.

This is based on our desire to have PrimitiveJavaObject 


The two things that I think are bugs that limits the effectiveness of the tests:
1. Even after this change, `UnresolvedType` will not be annotable.

To allow that to happen would require a change in `org.jetbrains.kotlin.types.ErrorType` and `.UnresolvedType` to take and use an `annotations` parameter rather than explicitly override the class property it to empty, and then for that parameter to be backpropagated into `org.jetbrains.kotlin.types.ErrorUtils.createUnresolvedType` and `org.jetbrains.kotlin.resolve.resolveTypeElement.visitUserType`, using the there-local `annotations` property.

The justification for why you might want this is iffy.
a) Documentation generation can potentially be run on incomplete parts of the codebase, for speed, incrementality, (integration) tests, etc. In these circumstances, we expect to see unresolved types. Being more able to handle unresolved types as though they were real types would help us do such things.
b) Annotation processors might find it more convenient, to debug if nothing else?

2. It appears that dokka's `KotlinToJavaConverter` turns `Kotlin.Int` into `java.lang.Integer` not primitive `int` as dackka does. This means that you don't need the ability to have `PrimitiveJavaType` be `withExtraProperties`. However, `com.intellij.psi.PsiPrimitiveType` supports annotations, so it should be valid to support them in dokka.