### PR TITLE
Update mkdocs gradle plugin to fix documentation generation

### DIFF
--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -1,3 +1,3 @@
 plugins {
-    id("ru.vyarus.mkdocs") version "2.2.0"
+    id("ru.vyarus.mkdocs") version "2.3.0"
 }


### PR DESCRIPTION
Currently documentation generation fails, this update fixes https://github.com/xvik/gradle-mkdocs-plugin/issues/29