### PR TITLE
Fix default value for actual declarations

### DIFF
--- a/core/src/main/kotlin/model/defaultValues.kt
+++ b/core/src/main/kotlin/model/defaultValues.kt
@@ -5,7 +5,11 @@ import org.jetbrains.dokka.model.properties.MergeStrategy
 
 class DefaultValue(val value: Expression): ExtraProperty<Documentable> {
     companion object : ExtraProperty.Key<Documentable, DefaultValue> {
-        override fun mergeStrategyFor(left: DefaultValue, right: DefaultValue): MergeStrategy<Documentable> = MergeStrategy.Remove // TODO pass a logger somehow and log this
+        override fun mergeStrategyFor(left: DefaultValue, right: DefaultValue): MergeStrategy<Documentable> =
+            if (left.value == right.value)
+                MergeStrategy.Replace(DefaultValue(left.value))
+            else
+                MergeStrategy.Remove // TODO pass a logger somehow and log this
     }
 
     override val key: ExtraProperty.Key<Documentable, *>


### PR DESCRIPTION
In StdLib there are many cases when arguments of actual functions have default values.
See https://github.com/JetBrains/kotlin/search?q=ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS

This PR is a shorter solution than #2449 because I suppose there is no sense to have an actual default value that differs from an expect one.