### PR TITLE
Fix reversed ordering of enum entries

### DIFF
--- a/plugins/base/src/main/kotlin/renderers/html/htmlPreprocessors.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/htmlPreprocessors.kt
@@ -26,15 +26,21 @@ abstract class NavigationDataProvider {
             children = page.navigableChildren()
         )
 
-    private fun ContentPage.navigableChildren(): List<NavigationNode> =
-        when {
-            this !is ClasslikePageNode ->
-                children.filterIsInstance<ContentPage>().map { visit(it) }
-            documentables.any { it is DEnum } ->
-                children.filter { it is WithDocumentables && it.documentables.any { it is DEnumEntry } }
-                    .map { visit(it as ContentPage) }
-            else -> emptyList()
-        }.sortedBy { it.name.toLowerCase() }
+    private fun ContentPage.navigableChildren(): List<NavigationNode> {
+        return if (this !is ClasslikePageNode) {
+            children
+                .filterIsInstance<ContentPage>()
+                .map { visit(it) }
+                .sortedBy { it.name.toLowerCase() }
+        } else if (documentables.any { it is DEnum }) {
+            // no sorting for enum entries, should be the same as in source code
+            children
+                .filter { child -> child is WithDocumentables && child.documentables.any { it is DEnumEntry } }
+                .map { visit(it as ContentPage) }
+        } else {
+            emptyList()
+        }
+    }
 
     /**
      * Parenthesis is applied in 1 case:

--- a/plugins/base/src/main/kotlin/transformers/documentables/DocumentableVisibilityFilterTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/DocumentableVisibilityFilterTransformer.kt
@@ -216,7 +216,7 @@ class DocumentableVisibilityFilterTransformer(val context: DokkaContext) : PreMe
         }
 
         private fun filterEnumEntries(entries: List<DEnumEntry>, filteredPlatforms: Set<DokkaSourceSet>): Pair<Boolean, List<DEnumEntry>> =
-            entries.foldRight(Pair(false, emptyList())) { entry, acc ->
+            entries.fold(Pair(false, emptyList())) { acc, entry ->
                 val intersection = filteredPlatforms.intersect(entry.sourceSets)
                 if (intersection.isEmpty()) Pair(true, acc.second)
                 else {

--- a/plugins/base/src/test/kotlin/enums/EnumsTest.kt
+++ b/plugins/base/src/test/kotlin/enums/EnumsTest.kt
@@ -7,11 +7,13 @@ import org.jetbrains.dokka.model.*
 import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstance
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import signatures.renderedContent
+import utils.TestOutputWriterPlugin
 
 class EnumsTest : BaseAbstractTest() {
 
     @Test
-    fun basicEnum() {
+    fun `should preserve enum source ordering for documentables`() {
         val configuration = dokkaConfiguration {
             sourceSets {
                 sourceSet {
@@ -20,29 +22,170 @@ class EnumsTest : BaseAbstractTest() {
             }
         }
 
+        val writerPlugin = TestOutputWriterPlugin()
+
         testInline(
             """
             |/src/main/kotlin/basic/Test.kt
-            |package enums
+            |package testpackage
             |
-            |enum class Test {
+            |enum class TestEnum {
             |   E1,
-            |   E2
+            |   E2,
+            |   E3,
+            |   E4,
+            |   E5,
+            |   E6,
+            |   E7,
+            |   E8,
+            |   E9,
+            |   E10
             |}
         """.trimMargin(),
-            configuration
+            configuration,
+            pluginOverrides = listOf(writerPlugin)
         ) {
-            pagesGenerationStage = {
-                val map = it.getClasslikeToMemberMap()
-                val test = map.filterKeys { it.name == "Test" }.values.firstOrNull()
-                assertTrue(test != null) { "Test not found" }
-                assertTrue(test!!.any { it.name == "E1" } && test.any { it.name == "E2" }) { "Enum entries missing in parent" }
+            documentablesTransformationStage = { module ->
+                val testPackage = module.packages[0]
+                assertEquals("testpackage", testPackage.name)
+
+                val testEnum = testPackage.classlikes[0] as DEnum
+                assertEquals("TestEnum", testEnum.name)
+
+                val enumEntries = testEnum.entries
+                assertEquals(10, enumEntries.count())
+
+                assertEquals("E1", enumEntries[0].name)
+                assertEquals("E2", enumEntries[1].name)
+                assertEquals("E3", enumEntries[2].name)
+                assertEquals("E4", enumEntries[3].name)
+                assertEquals("E5", enumEntries[4].name)
+                assertEquals("E6", enumEntries[5].name)
+                assertEquals("E7", enumEntries[6].name)
+                assertEquals("E8", enumEntries[7].name)
+                assertEquals("E9", enumEntries[8].name)
+                assertEquals("E10", enumEntries[9].name)
             }
         }
     }
 
     @Test
-    fun enumWithCompanion() {
+    fun `should preserve enum source ordering for generated pages`() {
+        val configuration = dokkaConfiguration {
+            sourceSets {
+                sourceSet {
+                    sourceRoots = listOf("src/")
+                }
+            }
+        }
+
+        val writerPlugin = TestOutputWriterPlugin()
+
+        testInline(
+            """
+            |/src/main/kotlin/basic/Test.kt
+            |package testpackage
+            |
+            |enum class TestEnum {
+            |   E1,
+            |   E2,
+            |   E3,
+            |   E4,
+            |   E5,
+            |   E6,
+            |   E7,
+            |   E8,
+            |   E9,
+            |   E10
+            |}
+        """.trimMargin(),
+            configuration,
+            pluginOverrides = listOf(writerPlugin)
+        ) {
+            pagesGenerationStage = { rootPage ->
+                val packagePage = rootPage.children[0]
+                assertEquals("testpackage", packagePage.name)
+
+                val testEnumNode = packagePage.children[0]
+                assertEquals("TestEnum", testEnumNode.name)
+
+                val enumEntries = testEnumNode.children
+                assertEquals(10, enumEntries.size)
+
+                assertEquals("E1", enumEntries[0].name)
+                assertEquals("E2", enumEntries[1].name)
+                assertEquals("E3", enumEntries[2].name)
+                assertEquals("E4", enumEntries[3].name)
+                assertEquals("E5", enumEntries[4].name)
+                assertEquals("E6", enumEntries[5].name)
+                assertEquals("E7", enumEntries[6].name)
+                assertEquals("E8", enumEntries[7].name)
+                assertEquals("E9", enumEntries[8].name)
+                assertEquals("E10", enumEntries[9].name)
+            }
+        }
+    }
+
+    @Test
+    fun `should preserve enum source ordering for rendered entries`() {
+        val configuration = dokkaConfiguration {
+            sourceSets {
+                sourceSet {
+                    sourceRoots = listOf("src/")
+                }
+            }
+        }
+
+        val writerPlugin = TestOutputWriterPlugin()
+
+        testInline(
+            """
+            |/src/main/kotlin/basic/Test.kt
+            |package testpackage
+            |
+            |enum class TestEnum {
+            |   E1,
+            |   E2,
+            |   E3,
+            |   E4,
+            |   E5,
+            |   E6,
+            |   E7,
+            |   E8,
+            |   E9,
+            |   E10
+            |}
+        """.trimMargin(),
+            configuration,
+            pluginOverrides = listOf(writerPlugin)
+        ) {
+            renderingStage = { rootPage, context ->
+                val enumEntriesOnPage = writerPlugin.writer.renderedContent("root/testpackage/-test-enum/index.html")
+                    .select("div.table[data-togglable=Entries]")
+                    .select("div.table-row")
+                    .select("div.keyValue")
+                    .select("div.title")
+                    .select("a")
+
+                val enumEntries = enumEntriesOnPage.map { it.text() }
+                assertEquals(10, enumEntries.size)
+
+                assertEquals("E1", enumEntries[0])
+                assertEquals("E2", enumEntries[1])
+                assertEquals("E3", enumEntries[2])
+                assertEquals("E4", enumEntries[3])
+                assertEquals("E5", enumEntries[4])
+                assertEquals("E6", enumEntries[5])
+                assertEquals("E7", enumEntries[6])
+                assertEquals("E8", enumEntries[7])
+                assertEquals("E9", enumEntries[8])
+                assertEquals("E10", enumEntries[9])
+            }
+        }
+    }
+
+    @Test
+    fun `should handle companion object within enum`() {
         val configuration = dokkaConfiguration {
             sourceSets {
                 sourceSet {
@@ -54,9 +197,9 @@ class EnumsTest : BaseAbstractTest() {
         testInline(
             """
             |/src/main/kotlin/basic/Test.kt
-            |package enums
+            |package testpackage
             |
-            |enum class Test {
+            |enum class TestEnum {
             |   E1,
             |   E2;
             |   companion object {}
@@ -71,17 +214,9 @@ class EnumsTest : BaseAbstractTest() {
                         assertTrue(c.isNotEmpty(), "Classlikes list cannot be empty")
 
                         val enum = c.first() as DEnum
-                        assertEquals(enum.name, "Test")
-                        assertEquals(enum.entries.count(), 2)
                         assertNotNull(enum.companion)
                     }
                 }
-            }
-            pagesGenerationStage = { module ->
-                val map = module.getClasslikeToMemberMap()
-                val test = map.filterKeys { it.name == "Test" }.values.firstOrNull()
-                assertNotNull(test, "Test not found")
-                assertTrue(test!!.any { it.name == "E1" } && test.any { it.name == "E2" }) { "Enum entries missing in parent" }
             }
         }
     }
@@ -98,11 +233,11 @@ class EnumsTest : BaseAbstractTest() {
 
         testInline(
             """
-            |/src/main/kotlin/basic/Test.kt
-            |package enums
+            |/src/main/kotlin/basic/TestEnum.kt
+            |package testpackage
             |
             |
-            |enum class Test(name: String, index: Int, excluded: Boolean) {
+            |enum class TestEnum(name: String, index: Int, excluded: Boolean) {
             |   E1("e1", 1, true),
             |   E2("e2", 2, false);
             |}
@@ -125,7 +260,7 @@ class EnumsTest : BaseAbstractTest() {
             pagesGenerationStage = { module ->
                 val entryPage = module.dfs { it.name == "E1" } as ClasslikePageNode
                 val signaturePart = (entryPage.content.dfs {
-                    it is ContentGroup && it.dci.toString() == "[enums/Test.E1///PointingToDeclaration/{\"org.jetbrains.dokka.links.EnumEntryDRIExtra\":{\"key\":\"org.jetbrains.dokka.links.EnumEntryDRIExtra\"}}][Symbol]"
+                    it is ContentGroup && it.dci.toString() == "[testpackage/TestEnum.E1///PointingToDeclaration/{\"org.jetbrains.dokka.links.EnumEntryDRIExtra\":{\"key\":\"org.jetbrains.dokka.links.EnumEntryDRIExtra\"}}][Symbol]"
                 } as ContentGroup)
                 assertEquals("(\"e1\", 1, true)", signaturePart.constructorSignature())
             }
@@ -144,15 +279,15 @@ class EnumsTest : BaseAbstractTest() {
 
         testInline(
             """
-            |/src/main/kotlin/basic/Test.kt
-            |package enums
+            |/src/main/kotlin/basic/TestEnum.kt
+            |package testpackage
             |
             |
             |interface Sample {
             |    fun toBeImplemented(): String
             |}
             |
-            |enum class Test: Sample {
+            |enum class TestEnum: Sample {
             |    E1 {
             |        override fun toBeImplemented(): String = "e1"
             |    }
@@ -176,7 +311,7 @@ class EnumsTest : BaseAbstractTest() {
     }
 
     @Test
-    fun enumWithAnnotationsOnEntries(){
+    fun enumWithAnnotationsOnEntries() {
         val configuration = dokkaConfiguration {
             sourceSets {
                 sourceSet {
@@ -187,10 +322,10 @@ class EnumsTest : BaseAbstractTest() {
 
         testInline(
             """
-            |/src/main/kotlin/basic/Test.kt
-            |package enums
+            |/src/main/kotlin/basic/TestEnum.kt
+            |package testpackage
             |
-            |enum class Test {
+            |enum class TestEnum {
             |    /**
             |       Sample docs for E1
             |    **/
@@ -201,8 +336,8 @@ class EnumsTest : BaseAbstractTest() {
             configuration
         ) {
             pagesTransformationStage = { m ->
-                val entryNode = m.children.first { it.name == "enums" }.children.first { it.name == "Test" }.children.firstIsInstance<ClasslikePageNode>()
-                val signature = (entryNode.content as ContentGroup).dfs { it is ContentGroup && it.dci.toString() == "[enums/Test.E1///PointingToDeclaration/{\"org.jetbrains.dokka.links.EnumEntryDRIExtra\":{\"key\":\"org.jetbrains.dokka.links.EnumEntryDRIExtra\"}}][Cover]" } as ContentGroup
+                val entryNode = m.children.first { it.name == "testpackage" }.children.first { it.name == "TestEnum" }.children.firstIsInstance<ClasslikePageNode>()
+                val signature = (entryNode.content as ContentGroup).dfs { it is ContentGroup && it.dci.toString() == "[testpackage/TestEnum.E1///PointingToDeclaration/{\"org.jetbrains.dokka.links.EnumEntryDRIExtra\":{\"key\":\"org.jetbrains.dokka.links.EnumEntryDRIExtra\"}}][Cover]" } as ContentGroup
 
                 signature.assertNode {
                     header(1) { +"E1" }
@@ -225,10 +360,6 @@ class EnumsTest : BaseAbstractTest() {
             }
         }
     }
-
-
-    fun RootPageNode.getClasslikeToMemberMap() =
-        this.parentMap.filterValues { it is ClasslikePageNode }.entries.groupBy({ it.value }) { it.key }
 
     private fun ContentGroup.constructorSignature(): String =
         (children.single() as ContentGroup).children.drop(1).joinToString(separator = "") { (it as ContentText).text }

--- a/plugins/base/src/test/kotlin/enums/EnumsTest.kt
+++ b/plugins/base/src/test/kotlin/enums/EnumsTest.kt
@@ -33,16 +33,16 @@ class EnumsTest : BaseAbstractTest() {
             |package testpackage
             |
             |enum class TestEnum {
-            |   E1,
-            |   E2,
-            |   E3,
-            |   E4,
-            |   E5,
-            |   E6,
-            |   E7,
-            |   E8,
-            |   E9,
-            |   E10
+            |   ZERO,
+            |   ONE,
+            |   TWO,
+            |   THREE,
+            |   FOUR,
+            |   FIVE,
+            |   SIX,
+            |   SEVEN,
+            |   EIGHT,
+            |   NINE
             |}
         """.trimMargin(),
             configuration,
@@ -58,16 +58,16 @@ class EnumsTest : BaseAbstractTest() {
                 val enumEntries = testEnum.entries
                 assertEquals(10, enumEntries.count())
 
-                assertEquals("E1", enumEntries[0].name)
-                assertEquals("E2", enumEntries[1].name)
-                assertEquals("E3", enumEntries[2].name)
-                assertEquals("E4", enumEntries[3].name)
-                assertEquals("E5", enumEntries[4].name)
-                assertEquals("E6", enumEntries[5].name)
-                assertEquals("E7", enumEntries[6].name)
-                assertEquals("E8", enumEntries[7].name)
-                assertEquals("E9", enumEntries[8].name)
-                assertEquals("E10", enumEntries[9].name)
+                assertEquals("ZERO", enumEntries[0].name)
+                assertEquals("ONE", enumEntries[1].name)
+                assertEquals("TWO", enumEntries[2].name)
+                assertEquals("THREE", enumEntries[3].name)
+                assertEquals("FOUR", enumEntries[4].name)
+                assertEquals("FIVE", enumEntries[5].name)
+                assertEquals("SIX", enumEntries[6].name)
+                assertEquals("SEVEN", enumEntries[7].name)
+                assertEquals("EIGHT", enumEntries[8].name)
+                assertEquals("NINE", enumEntries[9].name)
             }
         }
     }
@@ -90,16 +90,16 @@ class EnumsTest : BaseAbstractTest() {
             |package testpackage
             |
             |enum class TestEnum {
-            |   E1,
-            |   E2,
-            |   E3,
-            |   E4,
-            |   E5,
-            |   E6,
-            |   E7,
-            |   E8,
-            |   E9,
-            |   E10
+            |   ZERO,
+            |   ONE,
+            |   TWO,
+            |   THREE,
+            |   FOUR,
+            |   FIVE,
+            |   SIX,
+            |   SEVEN,
+            |   EIGHT,
+            |   NINE
             |}
         """.trimMargin(),
             configuration,
@@ -115,16 +115,16 @@ class EnumsTest : BaseAbstractTest() {
                 val enumEntries = testEnumNode.children
                 assertEquals(10, enumEntries.size)
 
-                assertEquals("E1", enumEntries[0].name)
-                assertEquals("E2", enumEntries[1].name)
-                assertEquals("E3", enumEntries[2].name)
-                assertEquals("E4", enumEntries[3].name)
-                assertEquals("E5", enumEntries[4].name)
-                assertEquals("E6", enumEntries[5].name)
-                assertEquals("E7", enumEntries[6].name)
-                assertEquals("E8", enumEntries[7].name)
-                assertEquals("E9", enumEntries[8].name)
-                assertEquals("E10", enumEntries[9].name)
+                assertEquals("ZERO", enumEntries[0].name)
+                assertEquals("ONE", enumEntries[1].name)
+                assertEquals("TWO", enumEntries[2].name)
+                assertEquals("THREE", enumEntries[3].name)
+                assertEquals("FOUR", enumEntries[4].name)
+                assertEquals("FIVE", enumEntries[5].name)
+                assertEquals("SIX", enumEntries[6].name)
+                assertEquals("SEVEN", enumEntries[7].name)
+                assertEquals("EIGHT", enumEntries[8].name)
+                assertEquals("NINE", enumEntries[9].name)
             }
         }
     }
@@ -147,16 +147,16 @@ class EnumsTest : BaseAbstractTest() {
             |package testpackage
             |
             |enum class TestEnum {
-            |   E1,
-            |   E2,
-            |   E3,
-            |   E4,
-            |   E5,
-            |   E6,
-            |   E7,
-            |   E8,
-            |   E9,
-            |   E10
+            |   ZERO,
+            |   ONE,
+            |   TWO,
+            |   THREE,
+            |   FOUR,
+            |   FIVE,
+            |   SIX,
+            |   SEVEN,
+            |   EIGHT,
+            |   NINE
             |}
         """.trimMargin(),
             configuration,
@@ -173,16 +173,16 @@ class EnumsTest : BaseAbstractTest() {
                 val enumEntries = enumEntriesOnPage.map { it.text() }
                 assertEquals(10, enumEntries.size)
 
-                assertEquals("E1", enumEntries[0])
-                assertEquals("E2", enumEntries[1])
-                assertEquals("E3", enumEntries[2])
-                assertEquals("E4", enumEntries[3])
-                assertEquals("E5", enumEntries[4])
-                assertEquals("E6", enumEntries[5])
-                assertEquals("E7", enumEntries[6])
-                assertEquals("E8", enumEntries[7])
-                assertEquals("E9", enumEntries[8])
-                assertEquals("E10", enumEntries[9])
+                assertEquals("ZERO", enumEntries[0])
+                assertEquals("ONE", enumEntries[1])
+                assertEquals("TWO", enumEntries[2])
+                assertEquals("THREE", enumEntries[3])
+                assertEquals("FOUR", enumEntries[4])
+                assertEquals("FIVE", enumEntries[5])
+                assertEquals("SIX", enumEntries[6])
+                assertEquals("SEVEN", enumEntries[7])
+                assertEquals("EIGHT", enumEntries[8])
+                assertEquals("NINE", enumEntries[9])
             }
         }
     }
@@ -205,16 +205,16 @@ class EnumsTest : BaseAbstractTest() {
             |package testpackage
             |
             |enum class TestEnum {
-            |   E1,
-            |   E2,
-            |   E3,
-            |   E4,
-            |   E5,
-            |   E6,
-            |   E7,
-            |   E8,
-            |   E9,
-            |   E10
+            |   ZERO,
+            |   ONE,
+            |   TWO,
+            |   THREE,
+            |   FOUR,
+            |   FIVE,
+            |   SIX,
+            |   SEVEN,
+            |   EIGHT,
+            |   NINE
             |}
         """.trimMargin(),
             configuration,
@@ -223,16 +223,16 @@ class EnumsTest : BaseAbstractTest() {
             renderingStage = { _, _ ->
                 val sideMenu = writerPlugin.writer.navigationHtml().select("div.sideMenuPart")
 
-                assertEquals("E1", sideMenu.select("#root-nav-submenu-0-0-0").text())
-                assertEquals("E2", sideMenu.select("#root-nav-submenu-0-0-1").text())
-                assertEquals("E3", sideMenu.select("#root-nav-submenu-0-0-2").text())
-                assertEquals("E4", sideMenu.select("#root-nav-submenu-0-0-3").text())
-                assertEquals("E5", sideMenu.select("#root-nav-submenu-0-0-4").text())
-                assertEquals("E6", sideMenu.select("#root-nav-submenu-0-0-5").text())
-                assertEquals("E7", sideMenu.select("#root-nav-submenu-0-0-6").text())
-                assertEquals("E8", sideMenu.select("#root-nav-submenu-0-0-7").text())
-                assertEquals("E9", sideMenu.select("#root-nav-submenu-0-0-8").text())
-                assertEquals("E10", sideMenu.select("#root-nav-submenu-0-0-9").text())
+                assertEquals("ZERO", sideMenu.select("#root-nav-submenu-0-0-0").text())
+                assertEquals("ONE", sideMenu.select("#root-nav-submenu-0-0-1").text())
+                assertEquals("TWO", sideMenu.select("#root-nav-submenu-0-0-2").text())
+                assertEquals("THREE", sideMenu.select("#root-nav-submenu-0-0-3").text())
+                assertEquals("FOUR", sideMenu.select("#root-nav-submenu-0-0-4").text())
+                assertEquals("FIVE", sideMenu.select("#root-nav-submenu-0-0-5").text())
+                assertEquals("SIX", sideMenu.select("#root-nav-submenu-0-0-6").text())
+                assertEquals("SEVEN", sideMenu.select("#root-nav-submenu-0-0-7").text())
+                assertEquals("EIGHT", sideMenu.select("#root-nav-submenu-0-0-8").text())
+                assertEquals("NINE", sideMenu.select("#root-nav-submenu-0-0-9").text())
             }
         }
     }


### PR DESCRIPTION
Fixes #2466

Before
* ordered by name in navigation,
* reversed order on the enum page

Now - same order as in source, both for navigation and the enum page

For class
```kotlin
/**
 * Selects whether to correct for atmospheric refraction, and if so, how.
 */
enum class Refraction(s: String = "EMPTY") {
    EMPTY,
    /**
     * No atmospheric refraction correction (airless).
     */
    None("Hello"),

    /**
     * Recommended correction for standard atmospheric refraction.
     */
    Normal("World"),

    /**
     * Used only for compatibility testing with JPL Horizons online tool.
     */
    JplHor("GitHub"),
}
```

![2022-04-26_02-49-20](https://user-images.githubusercontent.com/22685910/165192341-bc948115-d15e-46b2-a6b4-16e6b3f326cd.png)
