### PR TITLE
Fix `publishPlugin` task dependency on `dokkaPublish`

### DIFF
--- a/buildSrc/src/main/kotlin/org/jetbrains/publication.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/publication.kt
@@ -84,10 +84,6 @@ fun Project.createDokkaPublishTaskIfNecessary() {
         if (publicationChannels.any { it.isMavenRepository() }) {
             dependsOn(tasks.named("publishToSonatype"))
         }
-
-        if (publicationChannels.any { it.isGradlePluginPortal() }) {
-            dependsOn(tasks.named("publishPlugins"))
-        }
     }
 }
 

--- a/runners/gradle-plugin/build.gradle.kts
+++ b/runners/gradle-plugin/build.gradle.kts
@@ -92,6 +92,12 @@ publishing {
     }
 }
 
+tasks.maybeCreate("dokkaPublish").run {
+    if (publicationChannels.any { it.isGradlePluginPortal() }) {
+        dependsOn(tasks.named("publishPlugins"))
+    }
+}
+
 tasks.withType<PublishToMavenRepository>().configureEach {
     onlyIf { publication != publishing.publications["dokkaGradlePluginForIntegrationTests"] }
 }


### PR DESCRIPTION
It tries to find `publishPlugin` task for every subproject otherwise and fails

Should work now, at least it fails like I expect it to :) Will test next release :sweat_smile: 