### PR TITLE
Retain source language information in Documentable tree

### DIFF
--- a/core/src/main/kotlin/model/Documentable.kt
+++ b/core/src/main/kotlin/model/Documentable.kt
@@ -7,9 +7,10 @@ import org.jetbrains.dokka.model.properties.PropertyContainer
 import org.jetbrains.dokka.model.properties.WithExtraProperties
 
 interface AnnotationTarget
+interface HasSourceLanguage
 
 abstract class Documentable : WithChildren<Documentable>,
-    AnnotationTarget {
+    AnnotationTarget, HasSourceLanguage {
     abstract val name: String?
     abstract val dri: DRI
     abstract val documentation: SourceSetDependent<DocumentationNode>
@@ -384,7 +385,7 @@ data class DTypeAlias(
     override fun withNewExtras(newExtras: PropertyContainer<DTypeAlias>) = copy(extra = newExtras)
 }
 
-sealed class Projection
+sealed class Projection : HasSourceLanguage
 sealed class Bound : Projection()
 data class TypeParameter(
     val dri: DRI,

--- a/core/src/main/kotlin/model/documentableProperties.kt
+++ b/core/src/main/kotlin/model/documentableProperties.kt
@@ -46,3 +46,17 @@ data class CheckedExceptions(val exceptions: SourceSetDependent<List<DRI>>) : Ex
     }
     override val key: ExtraProperty.Key<Documentable, *> = CheckedExceptions
 }
+
+enum class Language {
+    JAVA, KOTLIN, UNKNOWN
+}
+
+data class SourceLanguage(val sourceLanguage: Language) : ExtraProperty<HasSourceLanguage> {
+    companion object : ExtraProperty.Key<HasSourceLanguage, SourceLanguage> {
+        override fun mergeStrategyFor(left: SourceLanguage, right: SourceLanguage) = MergeStrategy.Replace(
+            if (left.sourceLanguage == right.sourceLanguage) SourceLanguage(left.sourceLanguage)
+            else SourceLanguage(Language.UNKNOWN)
+        )
+    }
+    override val key: ExtraProperty.Key<HasSourceLanguage, *> = SourceLanguage
+}

--- a/plugins/all-modules-page/out/index.md
+++ b/plugins/all-modules-page/out/index.md
@@ -1,0 +1,10 @@
+/
+
+# Sample project
+
+Sample documentation with [external link](https://www.google.pl)
+
+## All modules:
+
+| Name |
+|---|

--- a/plugins/base/src/main/kotlin/translators/descriptors/DefaultDescriptorToDocumentableTranslator.kt
+++ b/plugins/base/src/main/kotlin/translators/descriptors/DefaultDescriptorToDocumentableTranslator.kt
@@ -14,7 +14,6 @@ import org.jetbrains.dokka.analysis.from
 import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.base.parsers.MarkdownParser
 import org.jetbrains.dokka.base.translators.psi.parsers.JavadocParser
-import org.jetbrains.dokka.base.translators.psi.DefaultPsiToDocumentableTranslator
 import org.jetbrains.dokka.base.translators.typeConstructorsBeingExceptions
 import org.jetbrains.dokka.base.translators.unquotedValue
 import org.jetbrains.dokka.links.*
@@ -215,7 +214,8 @@ private class DokkaDescriptorVisitor(
                     descriptor.additionalExtras().toSourceSetDependent().toAdditionalModifiers(),
                     descriptor.getAnnotations().toSourceSetDependent().toAnnotations(),
                     ImplementedInterfaces(info.ancestry.allImplementedInterfaces().toSourceSetDependent()),
-                    info.ancestry.exceptionInSupertypesOrNull()
+                    info.ancestry.exceptionInSupertypesOrNull(),
+                    SourceLanguage(Language.KOTLIN)
                 )
             )
         }
@@ -253,7 +253,8 @@ private class DokkaDescriptorVisitor(
                     descriptor.additionalExtras().toSourceSetDependent().toAdditionalModifiers(),
                     descriptor.getAnnotations().toSourceSetDependent().toAnnotations(),
                     ImplementedInterfaces(info.ancestry.allImplementedInterfaces().toSourceSetDependent()),
-                    info.ancestry.exceptionInSupertypesOrNull()
+                    info.ancestry.exceptionInSupertypesOrNull(),
+                    SourceLanguage(Language.KOTLIN)
                 )
             )
         }
@@ -297,7 +298,8 @@ private class DokkaDescriptorVisitor(
                 extra = PropertyContainer.withAll(
                     descriptor.additionalExtras().toSourceSetDependent().toAdditionalModifiers(),
                     descriptor.getAnnotations().toSourceSetDependent().toAnnotations(),
-                    ImplementedInterfaces(info.ancestry.allImplementedInterfaces().toSourceSetDependent())
+                    ImplementedInterfaces(info.ancestry.allImplementedInterfaces().toSourceSetDependent()),
+                    SourceLanguage(Language.KOTLIN)
                 )
             )
         }
@@ -327,7 +329,8 @@ private class DokkaDescriptorVisitor(
                 extra = PropertyContainer.withAll(
                     descriptor.additionalExtras().toSourceSetDependent().toAdditionalModifiers(),
                     descriptor.getAnnotations().toSourceSetDependent().toAnnotations(),
-                    ConstructorValues(descriptor.getAppliedConstructorParameters().toSourceSetDependent())
+                    ConstructorValues(descriptor.getAppliedConstructorParameters().toSourceSetDependent()),
+                    SourceLanguage(Language.KOTLIN)
                 )
             )
         }
@@ -361,7 +364,8 @@ private class DokkaDescriptorVisitor(
                 isExpectActual = (isExpect || isActual),
                 extra = PropertyContainer.withAll(
                     descriptor.additionalExtras().toSourceSetDependent().toAdditionalModifiers(),
-                    descriptor.getAnnotations().toSourceSetDependent().toAnnotations()
+                    descriptor.getAnnotations().toSourceSetDependent().toAnnotations(),
+                    SourceLanguage(Language.KOTLIN)
                 ),
                 companion = descriptor.companionObjectDescriptor?.let { objectDescriptor(it, driWithPlatform) },
                 visibility = descriptor.visibility.toDokkaVisibility().toSourceSetDependent(),
@@ -420,7 +424,8 @@ private class DokkaDescriptorVisitor(
                     descriptor.additionalExtras().toSourceSetDependent().toAdditionalModifiers(),
                     descriptor.getAnnotations().toSourceSetDependent().toAnnotations(),
                     ImplementedInterfaces(info.ancestry.allImplementedInterfaces().toSourceSetDependent()),
-                    info.ancestry.exceptionInSupertypesOrNull()
+                    info.ancestry.exceptionInSupertypesOrNull(),
+                    SourceLanguage(Language.KOTLIN)
                 )
             )
         }
@@ -469,6 +474,7 @@ private class DokkaDescriptorVisitor(
                             .toAnnotations(),
                         descriptor.getDefaultValue()?.let { DefaultValue(it) },
                         InheritedMember(inheritedFrom.toSourceSetDependent()),
+                        SourceLanguage(Language.KOTLIN)
                     )
                 )
             )
@@ -520,6 +526,7 @@ private class DokkaDescriptorVisitor(
                     (descriptor.getAnnotations() + descriptor.fileLevelAnnotations()).toSourceSetDependent()
                         .toAnnotations(),
                     ObviousMember.takeIf { descriptor.isObvious },
+                    SourceLanguage(Language.KOTLIN)
                 )
             )
         }
@@ -568,7 +575,8 @@ private class DokkaDescriptorVisitor(
                 isExpectActual = (isExpect || isActual),
                 extra = PropertyContainer.withAll<DFunction>(
                     descriptor.additionalExtras().toSourceSetDependent().toAdditionalModifiers(),
-                    descriptor.getAnnotations().toSourceSetDependent().toAnnotations()
+                    descriptor.getAnnotations().toSourceSetDependent().toAnnotations(),
+                    SourceLanguage(Language.KOTLIN)
                 ).let {
                     if (descriptor.isPrimary) {
                         it + PrimaryConstructorExtra
@@ -588,7 +596,10 @@ private class DokkaDescriptorVisitor(
         expectPresentInSet = null,
         documentation = descriptor.resolveDescriptorData(),
         sourceSets = setOf(sourceSet),
-        extra = PropertyContainer.withAll(descriptor.getAnnotations().toSourceSetDependent().toAnnotations())
+        extra = PropertyContainer.withAll(
+            descriptor.getAnnotations().toSourceSetDependent().toAnnotations(),
+            SourceLanguage(Language.KOTLIN)
+        )
     )
 
     private suspend fun visitPropertyAccessorDescriptor(
@@ -611,7 +622,8 @@ private class DokkaDescriptorVisitor(
                 sourceSets = setOf(sourceSet),
                 extra = PropertyContainer.withAll(
                     descriptor.additionalExtras().toSourceSetDependent().toAdditionalModifiers(),
-                    getAnnotationsWithBackingField().toSourceSetDependent().toAnnotations()
+                    getAnnotationsWithBackingField().toSourceSetDependent().toAnnotations(),
+                    SourceLanguage(Language.KOTLIN)
                 )
             )
 
@@ -669,7 +681,8 @@ private class DokkaDescriptorVisitor(
                 isExpectActual = (isExpect || isActual),
                 extra = PropertyContainer.withAll(
                     descriptor.additionalExtras().toSourceSetDependent().toAdditionalModifiers(),
-                    descriptor.getAnnotations().toSourceSetDependent().toAnnotations()
+                    descriptor.getAnnotations().toSourceSetDependent().toAnnotations(),
+                    SourceLanguage(Language.KOTLIN)
                 )
             )
         }
@@ -696,6 +709,7 @@ private class DokkaDescriptorVisitor(
                     extra = PropertyContainer.withAll(
                         descriptor.getAnnotations().toSourceSetDependent().toAnnotations(),
                         info.exceptionInSupertypesOrNull(),
+                        SourceLanguage(Language.KOTLIN)
                     )
                 )
             }
@@ -712,7 +726,8 @@ private class DokkaDescriptorVisitor(
             extra = PropertyContainer.withAll(listOfNotNull(
                 descriptor.additionalExtras().toSourceSetDependent().toAdditionalModifiers(),
                 descriptor.getAnnotations().toSourceSetDependent().toAnnotations(),
-                descriptor.getDefaultValue()?.let { DefaultValue(it) }
+                descriptor.getDefaultValue()?.let { DefaultValue(it) },
+                SourceLanguage(Language.KOTLIN)
             ))
         )
 
@@ -774,7 +789,10 @@ private class DokkaDescriptorVisitor(
         GenericTypeConstructor(
             DRI.from(kt.constructor.declarationDescriptor as DeclarationDescriptor),
             kt.arguments.map { it.toProjection() },
-            extra = PropertyContainer.withAll(kt.getAnnotations().toSourceSetDependent().toAnnotations())
+            extra = PropertyContainer.withAll(
+                kt.getAnnotations().toSourceSetDependent().toAnnotations(),
+                SourceLanguage(Language.KOTLIN)
+            )
         )
 
     private suspend fun buildAncestryInformation(
@@ -818,7 +836,8 @@ private class DokkaDescriptorVisitor(
             setOf(sourceSet),
             extra = PropertyContainer.withAll(
                 additionalExtras().toSourceSetDependent().toAdditionalModifiers(),
-                getAnnotations().toSourceSetDependent().toAnnotations()
+                getAnnotations().toSourceSetDependent().toAnnotations(),
+                SourceLanguage(Language.KOTLIN)
             )
         )
 
@@ -827,24 +846,27 @@ private class DokkaDescriptorVisitor(
             .safeAs<StringValue>()?.value?.let { unquotedValue(it) }
 
     private suspend fun KotlinType.toBound(): Bound {
-        suspend fun <T : AnnotationTarget> annotations(): PropertyContainer<T> =
+        suspend fun <T> extras(): PropertyContainer<T> where T:AnnotationTarget, T:HasSourceLanguage =
             getAnnotations().takeIf { it.isNotEmpty() }?.let { annotations ->
-                PropertyContainer.withAll(annotations.toSourceSetDependent().toAnnotations())
-            } ?: PropertyContainer.empty()
+                PropertyContainer.withAll(
+                    annotations.toSourceSetDependent().toAnnotations(),
+                    SourceLanguage(Language.KOTLIN)
+                )
+            } ?: PropertyContainer.withAll(SourceLanguage(Language.KOTLIN))
 
         return when (this) {
             is DynamicType -> Dynamic
             is AbbreviatedType -> TypeAliased(
                 abbreviation.toBound(),
                 expandedType.toBound(),
-                annotations()
+                extras()
             )
             else -> when (val ctor = constructor.declarationDescriptor) {
                 is TypeParameterDescriptor -> TypeParameter(
                     dri = DRI.from(ctor),
                     name = ctor.name.asString(),
                     presentableName = annotations.getPresentableName(),
-                    extra = annotations()
+                    extra = extras()
                 )
                 is FunctionClassDescriptor -> FunctionalTypeConstructor(
                     DRI.from(ctor),
@@ -852,13 +874,13 @@ private class DokkaDescriptorVisitor(
                     isExtensionFunction = isExtensionFunctionType || isBuiltinExtensionFunctionalType,
                     isSuspendable = isSuspendFunctionTypeOrSubtype,
                     presentableName = annotations.getPresentableName(),
-                    extra = annotations()
+                    extra = extras()
                 )
                 else -> GenericTypeConstructor(
                     DRI.from(ctor!!), // TODO: remove '!!'
                     arguments.map { it.toProjection() },
                     annotations.getPresentableName(),
-                    extra = annotations()
+                    extra = extras()
                 )
             }.let {
                 if (isMarkedNullable) Nullable(it) else it

--- a/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
@@ -704,8 +704,8 @@ open class DefaultPageCreator(
     ) {
         (documentable as? WithSources)?.documentableLanguage(sourceSet)?.let {
             when (it) {
-                DocumentableLanguage.KOTLIN -> firstParagraphComment(tag.root)
-                DocumentableLanguage.JAVA -> firstSentenceComment(tag.root)
+                Language.KOTLIN -> firstParagraphComment(tag.root)
+                Language.JAVA -> firstSentenceComment(tag.root)
             }
         } ?: firstParagraphComment(tag.root)
     }

--- a/plugins/base/src/main/kotlin/translators/documentables/documentableLanguage.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/documentableLanguage.kt
@@ -2,14 +2,11 @@ package org.jetbrains.dokka.base.translators.documentables
 
 import org.jetbrains.dokka.DokkaConfiguration
 import org.jetbrains.dokka.analysis.PsiDocumentableSource
+import org.jetbrains.dokka.model.Language
 import org.jetbrains.dokka.model.WithSources
 
-internal enum class DocumentableLanguage {
-    JAVA, KOTLIN
-}
-
-internal fun WithSources.documentableLanguage(sourceSet: DokkaConfiguration.DokkaSourceSet): DocumentableLanguage =
+internal fun WithSources.documentableLanguage(sourceSet: DokkaConfiguration.DokkaSourceSet): Language =
     when (sources[sourceSet]) {
-        is PsiDocumentableSource -> DocumentableLanguage.JAVA
-        else -> DocumentableLanguage.KOTLIN
+        is PsiDocumentableSource -> Language.JAVA
+        else -> Language.KOTLIN
     }

--- a/plugins/base/src/test/kotlin/linking/EnumValuesLinkingTest.kt
+++ b/plugins/base/src/test/kotlin/linking/EnumValuesLinkingTest.kt
@@ -3,7 +3,7 @@ package linking
 import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
 import org.jetbrains.dokka.links.DRIExtraContainer
 import org.jetbrains.dokka.links.EnumEntryDRIExtra
-import org.jetbrains.dokka.model.dfs
+import org.jetbrains.dokka.model.*
 import org.jetbrains.dokka.model.doc.DocumentationLink
 import org.jetbrains.dokka.pages.ContentDRILink
 import org.jetbrains.dokka.pages.ContentPage
@@ -37,7 +37,8 @@ class EnumValuesLinkingTest : BaseAbstractTest() {
                 val classlikes = it.packages.single().children
                 assertEquals(4, classlikes.size)
 
-                val javaLinker = classlikes.single { it.name == "JavaLinker" }
+                val javaLinker = classlikes.single { it.name == "JavaLinker" } as DClass
+                assertEquals(javaLinker.extra[SourceLanguage]!!.sourceLanguage, Language.JAVA)
                 javaLinker.documentation.values.single().children.run {
                     when (val kotlinLink = this[0].children[1].children[1]) {
                         is DocumentationLink -> kotlinLink.dri.run {
@@ -58,7 +59,8 @@ class EnumValuesLinkingTest : BaseAbstractTest() {
                     }
                 }
 
-                val kotlinLinker = classlikes.single { it.name == "KotlinLinker" }
+                val kotlinLinker = classlikes.single { it.name == "KotlinLinker" } as DClass
+                assertEquals(kotlinLinker.extra[SourceLanguage]!!.sourceLanguage, Language.KOTLIN)
                 kotlinLinker.documentation.values.single().children.run {
                     when (val kotlinLink = this[0].children[0].children[5]) {
                         is DocumentationLink -> kotlinLink.dri.run {
@@ -78,6 +80,11 @@ class EnumValuesLinkingTest : BaseAbstractTest() {
                         else -> throw AssertionError("Link node is not DocumentationLink type")
                     }
                 }
+
+                val kotlinEnum = classlikes.single { it.name == "KotlinEnum" } as DEnum
+                assertEquals(kotlinEnum.extra[SourceLanguage]!!.sourceLanguage, Language.KOTLIN)
+                val javaEnum = classlikes.single { it.name == "JavaEnum" } as DEnum
+                assertEquals(javaEnum.extra[SourceLanguage]!!.sourceLanguage, Language.JAVA)
 
                 assertEquals(
                     javaLinker.documentation.values.single().children[0].children[1].children[1].safeAs<DocumentationLink>()?.dri,

--- a/plugins/base/src/test/kotlin/translators/DefaultDescriptorToDocumentableTranslatorTest.kt
+++ b/plugins/base/src/test/kotlin/translators/DefaultDescriptorToDocumentableTranslatorTest.kt
@@ -695,6 +695,7 @@ class DefaultDescriptorToDocumentableTranslatorTest : BaseAbstractTest() {
                     Annotations.Annotation(DRI("sample", "Hello"), emptyMap()),
                     type.extra[Annotations]?.directAnnotations?.values?.single()?.single()
                 )
+                assertEquals(type.extra[SourceLanguage]!!.sourceLanguage, Language.KOTLIN)
             }
         }
     }
@@ -723,6 +724,7 @@ class DefaultDescriptorToDocumentableTranslatorTest : BaseAbstractTest() {
                     type.extra[Annotations]?.directAnnotations?.values?.single()?.single()
                 )
                 assertEquals("kotlin/Int///PointingToDeclaration/", type.dri.toString())
+                assertEquals(type.extra[SourceLanguage]!!.sourceLanguage, Language.KOTLIN)
             }
         }
     }


### PR DESCRIPTION
This will allow dackka to figure out if a DParameter is from Kotlin or from Java
Which is necessary to determine if a bare parameter is non-null K or platform J

Test: added assertions to translator tests and the multilanguage linker test
