### PR TITLE
Fix suddenly appearing all-modules-page/index.md file

### DIFF
--- a/core/test-api/src/main/kotlin/testApi/testRunner/TestRunner.kt
+++ b/core/test-api/src/main/kotlin/testApi/testRunner/TestRunner.kt
@@ -28,6 +28,10 @@ abstract class AbstractTest<M : TestMethods, T : TestBuilder<M>, D : DokkaTestGe
         File("src/test/resources/$name").takeIf { it.exists() }?.toPath()
             ?: throw InvalidPathException(name, "Cannot be found")
 
+    /**
+     * @param useOutputLocationFromConfig if set to true, output location specified in [DokkaConfigurationImpl.outputDir]
+     *                                    will be used. If set to false, a temporary folder will be used instead.
+     */
     protected fun testFromData(
         configuration: DokkaConfigurationImpl,
         cleanupOutput: Boolean = true,

--- a/plugins/all-modules-page/src/test/kotlin/templates/MultiModuleDocumentationTest.kt
+++ b/plugins/all-modules-page/src/test/kotlin/templates/MultiModuleDocumentationTest.kt
@@ -39,7 +39,7 @@ class MultiModuleDocumentationTest : MultiModuleAbstractTest() {
             includes = listOf(folder.root.resolve("README.md"))
         }
 
-        testFromData(configuration, preserveOutputLocation = true) {
+        testFromData(configuration) {
             allModulesPageCreationStage = { rootPage ->
                 (rootPage as? MultimoduleRootPageNode)?.content?.dfs { it.dci.kind == ContentKind.Cover }?.children?.firstOrNull()
                     ?.assertNode {

--- a/plugins/all-modules-page/src/test/kotlin/templates/ResolveLinkCommandResolutionTest.kt
+++ b/plugins/all-modules-page/src/test/kotlin/templates/ResolveLinkCommandResolutionTest.kt
@@ -59,7 +59,7 @@ class ResolveLinkCommandResolutionTest : MultiModuleAbstractTest() {
         val contentFile = setup(link)
         val configuration = configuration()
 
-        testFromData(configuration, preserveOutputLocation = true) {
+        testFromData(configuration, useOutputLocationFromConfig = true) {
             finishProcessingSubmodules = {
                 assertHtmlEqualsIgnoringWhitespace(expected, contentFile.readText())
             }
@@ -88,7 +88,7 @@ class ResolveLinkCommandResolutionTest : MultiModuleAbstractTest() {
         val contentFile = setup(link)
         val configuration = configuration()
 
-        testFromData(configuration, preserveOutputLocation = true) {
+        testFromData(configuration, useOutputLocationFromConfig = true) {
             finishProcessingSubmodules = {
                 assertHtmlEqualsIgnoringWhitespace(expected, contentFile.readText())
             }

--- a/plugins/all-modules-page/src/test/kotlin/templates/ResolveLinkGfmCommandResolutionTest.kt
+++ b/plugins/all-modules-page/src/test/kotlin/templates/ResolveLinkGfmCommandResolutionTest.kt
@@ -54,7 +54,7 @@ class ResolveLinkGfmCommandResolutionTest : MultiModuleAbstractTest() {
         val content = setup(link)
         val configuration = configuration()
 
-        testFromData(configuration, pluginOverrides = listOf(GfmTemplateProcessingPlugin(), GfmPlugin()), preserveOutputLocation = true) {
+        testFromData(configuration, pluginOverrides = listOf(GfmTemplateProcessingPlugin(), GfmPlugin()), useOutputLocationFromConfig = true) {
             finishProcessingSubmodules = {
                 assertEquals(expected, content.readText().trim())
             }

--- a/plugins/templating/src/test/kotlin/templates/AddToNavigationCommandResolutionTest.kt
+++ b/plugins/templating/src/test/kotlin/templates/AddToNavigationCommandResolutionTest.kt
@@ -126,7 +126,7 @@ class AddToNavigationCommandResolutionTest : TemplatingAbstractTest() {
         val module2Navigation = module2.resolve("navigation.html")
         module2Navigation.writeText(inputForModule("module2"))
 
-        testFromData(configuration, preserveOutputLocation = true) {
+        testFromData(configuration, useOutputLocationFromConfig = true) {
             finishProcessingSubmodules = { ctx ->
                 test(ctx)
             }

--- a/plugins/templating/src/test/kotlin/templates/AddToSearchCommandResolutionTest.kt
+++ b/plugins/templating/src/test/kotlin/templates/AddToSearchCommandResolutionTest.kt
@@ -55,7 +55,7 @@ class AddToSearchCommandResolutionTest : TemplatingAbstractTest() {
             this.outputDir = outputDir
         }
 
-        testFromData(configuration, preserveOutputLocation = true) {
+        testFromData(configuration, useOutputLocationFromConfig = true) {
             finishProcessingSubmodules = { _ ->
                 val expected = elements.map { it.copy(location = "module1/${it.location}") } +
                         elements.map { it.copy(location = "module2/${it.location}") }

--- a/plugins/templating/src/test/kotlin/templates/SubstitutionCommandResolutionTest.kt
+++ b/plugins/templating/src/test/kotlin/templates/SubstitutionCommandResolutionTest.kt
@@ -102,7 +102,7 @@ class SubstitutionCommandResolutionTest : TemplatingAbstractTest() {
             this.outputDir = folder.root
         }
 
-        testFromData(configuration, preserveOutputLocation = true){
+        testFromData(configuration, useOutputLocationFromConfig = true){
             finishProcessingSubmodules = {
                 assertHtmlEqualsIgnoringWhitespace(expected, testedFile.readText())
             }


### PR DESCRIPTION
This annoying file used to appear whenever you ran tests

https://github.com/Kotlin/dokka/pull/2474/files/cf02a243237306930a7f6d149c43126699b33be6#diff-5b3183ca422abbdc8f2db7e6fd54b5b7d18a40d54c543db3e47b714698a9dc26