### PR TITLE
Fix failing integration tests if jcenter times out

### DIFF
--- a/integration-tests/gradle/projects/template.root.gradle.kts
+++ b/integration-tests/gradle/projects/template.root.gradle.kts
@@ -1,7 +1,7 @@
 allprojects {
     repositories {
-        maven("https://cache-redirector.jetbrains.com/jcenter.bintray.com")
         mavenLocal()
+        maven("https://cache-redirector.jetbrains.com/jcenter.bintray.com")
         mavenCentral()
         google()
         maven("https://cache-redirector.jetbrains.com/dl.bintray.com/kotlin/kotlin-eap")


### PR DESCRIPTION
Integration tests fail after getting time out from jcenter for dokka-base-1.7.0 which is not supposed to be in jcenter