### PR TITLE
Render quotes as blockquotes instead of code blocks.

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -4277,6 +4277,7 @@ public final class org/jetbrains/dokka/pages/TextStyle : java/lang/Enum, org/jet
 	public static final field Italic Lorg/jetbrains/dokka/pages/TextStyle;
 	public static final field Monospace Lorg/jetbrains/dokka/pages/TextStyle;
 	public static final field Paragraph Lorg/jetbrains/dokka/pages/TextStyle;
+	public static final field Quotation Lorg/jetbrains/dokka/pages/TextStyle;
 	public static final field Span Lorg/jetbrains/dokka/pages/TextStyle;
 	public static final field Strikethrough Lorg/jetbrains/dokka/pages/TextStyle;
 	public static final field Strong Lorg/jetbrains/dokka/pages/TextStyle;

--- a/core/src/main/kotlin/pages/ContentNodes.kt
+++ b/core/src/main/kotlin/pages/ContentNodes.kt
@@ -384,7 +384,7 @@ enum class TokenStyle : Style {
 
 enum class TextStyle : Style {
     Bold, Italic, Strong, Strikethrough, Paragraph,
-    Block, Span, Monospace, Indented, Cover, UnderCoverText, BreakableAfter, Breakable, InlineComment
+    Block, Span, Monospace, Indented, Cover, UnderCoverText, BreakableAfter, Breakable, InlineComment, Quotation
 }
 
 enum class ContentStyle : Style {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Project Settings
-dokka_version=1.7.0-quotations-SNAPSHOT
+dokka_version=1.7.0-SNAPSHOT
 dokka_integration_test_parallelism=2
 # Versions
 kotlin_version=1.6.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Project Settings
-dokka_version=1.7.0-SNAPSHOT
+dokka_version=1.7.0-quotations-SNAPSHOT
 dokka_integration_test_parallelism=2
 # Versions
 kotlin_version=1.6.21

--- a/plugins/base/base-test-utils/api/base-test-utils.api
+++ b/plugins/base/base-test-utils/api/base-test-utils.api
@@ -113,6 +113,10 @@ public final class utils/B : utils/Tag {
 	public fun <init> ([Ljava/lang/Object;)V
 }
 
+public final class utils/BlockQuote : utils/Tag {
+	public fun <init> ([Ljava/lang/Object;)V
+}
+
 public final class utils/Br : utils/Tag {
 	public static final field INSTANCE Lutils/Br;
 }

--- a/plugins/base/base-test-utils/src/main/kotlin/renderers/JsoupUtils.kt
+++ b/plugins/base/base-test-utils/src/main/kotlin/renderers/JsoupUtils.kt
@@ -29,6 +29,8 @@ class A(vararg matchers: Any) : Tag("a", *matchers)
 class B(vararg matchers: Any) : Tag("b", *matchers)
 class I(vararg matchers: Any) : Tag("i", *matchers)
 class STRIKE(vararg matchers: Any) : Tag("strike", *matchers)
+
+class BLOCKQUOTE(vararg matchers: Any) : Tag("blockquote", *matchers)
 class Dl(vararg matchers: Any) : Tag("dl", *matchers)
 class Dt(vararg matchers: Any) : Tag("dt", *matchers)
 class Dd(vararg matchers: Any) : Tag("dd", *matchers)

--- a/plugins/base/base-test-utils/src/main/kotlin/renderers/JsoupUtils.kt
+++ b/plugins/base/base-test-utils/src/main/kotlin/renderers/JsoupUtils.kt
@@ -30,7 +30,7 @@ class B(vararg matchers: Any) : Tag("b", *matchers)
 class I(vararg matchers: Any) : Tag("i", *matchers)
 class STRIKE(vararg matchers: Any) : Tag("strike", *matchers)
 
-class BLOCKQUOTE(vararg matchers: Any) : Tag("blockquote", *matchers)
+class BlockQuote(vararg matchers: Any) : Tag("blockquote", *matchers)
 class Dl(vararg matchers: Any) : Tag("dl", *matchers)
 class Dt(vararg matchers: Any) : Tag("dt", *matchers)
 class Dd(vararg matchers: Any) : Tag("dd", *matchers)

--- a/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
@@ -128,6 +128,7 @@ open class HtmlRenderer(
             }
             node.hasStyle(TextStyle.Paragraph) -> p(additionalClasses) { childrenCallback() }
             node.hasStyle(TextStyle.Block) -> div(additionalClasses) { childrenCallback() }
+            node.hasStyle(TextStyle.Quotation) -> blockQuote(additionalClasses) { childrenCallback() }
             node.isAnchorable -> buildAnchor(
                 node.anchor!!,
                 node.anchorLabel!!,

--- a/plugins/base/src/main/kotlin/transformers/pages/comments/DocTagToContentConverter.kt
+++ b/plugins/base/src/main/kotlin/transformers/pages/comments/DocTagToContentConverter.kt
@@ -123,7 +123,15 @@ open class DocTagToContentConverter : CommentsToContentConverter {
                     styles
                 )
             )
-            is BlockQuote, is Pre, is CodeBlock -> listOf(
+            is BlockQuote -> listOf(
+                ContentGroup(
+                    buildChildren(docTag),
+                    dci,
+                    sourceSets.toDisplaySourceSets(),
+                    styles + TextStyle.Quotation,
+                )
+            )
+            is Pre, is CodeBlock -> listOf(
                 ContentCodeBlock(
                     buildChildren(docTag),
                     docTag.params.getOrDefault("lang", ""),

--- a/plugins/base/src/main/resources/dokka/styles/style.css
+++ b/plugins/base/src/main/resources/dokka/styles/style.css
@@ -612,10 +612,11 @@ a small {
 }
 
 blockquote {
-    border-left: 1px solid #e5e5e5;
+    border-left: 1ch solid var(--default-gray);
     margin: 0;
-    padding: 0 0 0 20px;
+    padding-left: 1ch;
     font-style: italic;
+    color: var(--average-color);
 }
 
 pre {

--- a/plugins/base/src/test/kotlin/renderers/html/TextStylesTest.kt
+++ b/plugins/base/src/test/kotlin/renderers/html/TextStylesTest.kt
@@ -69,6 +69,14 @@ class TextStylesTest : HtmlRenderingOnlyTestBase() {
         files.contents.getValue("test-page.html").contains("&nbsp;<strike><b>styled text</b></strike>")
     }
 
+    @Test
+    fun `should include blockquote`() {
+        val page = testPage {
+            text("blockquote text", styles = setOf(TextStyle.Quotation))
+        }
+        HtmlRenderer(context).render(page)
+        renderedContent.match(BLOCKQUOTE("blockquote text"))
+    }
 
     override val renderedContent: Element
         get() = files.contents.getValue("test-page.html").let { Jsoup.parse(it) }.select("#content").single()

--- a/plugins/base/src/test/kotlin/renderers/html/TextStylesTest.kt
+++ b/plugins/base/src/test/kotlin/renderers/html/TextStylesTest.kt
@@ -72,10 +72,12 @@ class TextStylesTest : HtmlRenderingOnlyTestBase() {
     @Test
     fun `should include blockquote`() {
         val page = testPage {
-            text("blockquote text", styles = setOf(TextStyle.Quotation))
+            group(styles = setOf(TextStyle.Quotation)) {
+                text("blockquote text")
+            }
         }
         HtmlRenderer(context).render(page)
-        renderedContent.match(BLOCKQUOTE("blockquote text"))
+        renderedContent.match(BlockQuote("blockquote text"))
     }
 
     override val renderedContent: Element

--- a/plugins/base/src/test/kotlin/transformers/CommentsToContentConverterTest.kt
+++ b/plugins/base/src/test/kotlin/transformers/CommentsToContentConverterTest.kt
@@ -14,8 +14,8 @@ class CommentsToContentConverterTest {
     private val converter = DocTagToContentConverter()
 
     private fun executeTest(
-        docTag:DocTag,
-        match: ContentMatcherBuilder<ContentComposite>.() -> Unit
+        docTag: DocTag,
+        match: ContentMatcherBuilder<ContentComposite>.() -> Unit,
     ) {
         val dci = DCI(
             setOf(
@@ -225,12 +225,16 @@ class CommentsToContentConverterTest {
         )
         executeTest(docTag) {
             group {
-                node<ContentCodeBlock> {
-                    +"Blockquotes are very handy in email to emulate reply text. This line is part of the same quote."
+                group {
+                    group {
+                        +"Blockquotes are very handy in email to emulate reply text. This line is part of the same quote."
+                    }
                 }
                 group { +"Quote break." }
-                node<ContentCodeBlock> {
-                    +"Quote"
+                group {
+                    group {
+                        +"Quote"
+                    }
                 }
             }
         }
@@ -261,16 +265,16 @@ class CommentsToContentConverterTest {
         )
         executeTest(docTag) {
             group {
-                node<ContentCodeBlock> {
-                    +"text 1 text 2"
-                    node<ContentCodeBlock> {
-                        +"text 3 text 4"
+                group {
+                    group { +"text 1 text 2" }
+                    group {
+                        group { +"text 3 text 4" }
                     }
-                    +"text 5"
+                    group { +"text 5" }
                 }
                 group { +"Quote break." }
-                node<ContentCodeBlock> {
-                    +"Quote"
+                group {
+                    group { +"Quote" }
                 }
             }
         }
@@ -326,48 +330,49 @@ class CommentsToContentConverterTest {
             )
         )
         executeTest(docTag) {
-            group { link {
-                +"I'm an inline-style link"
-                check {
-                    assertEquals(
-                        assertedCast<ContentResolvedLink> { "Link should be resolved" }.address,
-                        "https://www.google.com"
-                    )
+            group {
+                link {
+                    +"I'm an inline-style link"
+                    check {
+                        assertEquals(
+                            assertedCast<ContentResolvedLink> { "Link should be resolved" }.address,
+                            "https://www.google.com"
+                        )
+                    }
                 }
-            } }
+            }
         }
     }
-
 
 
     @Test
     fun `ordered list`() {
         val docTag =
             Ol(
-            listOf(
-                Li(
-                    listOf(
-                        P(listOf(Text("test1"))),
-                        P(listOf(Text("test2"))),
-                    )
-                ),
-                Li(
-                    listOf(
-                        P(listOf(Text("test3"))),
-                        P(listOf(Text("test4"))),
+                listOf(
+                    Li(
+                        listOf(
+                            P(listOf(Text("test1"))),
+                            P(listOf(Text("test2"))),
+                        )
+                    ),
+                    Li(
+                        listOf(
+                            P(listOf(Text("test3"))),
+                            P(listOf(Text("test4"))),
+                        )
                     )
                 )
             )
-        )
         executeTest(docTag) {
             node<ContentList> {
                 group {
-                        +"test1"
-                        +"test2"
+                    +"test1"
+                    +"test2"
                 }
                 group {
-                        +"test3"
-                        +"test4"
+                    +"test3"
+                    +"test4"
                 }
             }
         }


### PR DESCRIPTION
This is not 100% done yet, I still want to make some changes to the styling and add some tests (as @IgnatBeresnev requested).
Blockquotes are being rendered though.
(this is my first PR to dokka, so please tell me if i'm doing something wrong without realizing it)

```
/**
* > Matches 0 or 1 of the preceding token, effectively making it optional.
*/ 
```
![image](https://user-images.githubusercontent.com/65342367/167625542-73b8feef-d826-4267-814f-bbffc2c9ec31.png)

Closes #2491