### PR TITLE
Don't expose enum constructor arguments to documentations

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -858,24 +858,6 @@ public final class org/jetbrains/dokka/model/CompositeSourceSetIDKt {
 	public static final fun plus (Lorg/jetbrains/dokka/DokkaSourceSetID;Lorg/jetbrains/dokka/DokkaSourceSetID;)Lorg/jetbrains/dokka/model/CompositeSourceSetID;
 }
 
-public final class org/jetbrains/dokka/model/ConstructorValues : org/jetbrains/dokka/model/properties/ExtraProperty {
-	public static final field Companion Lorg/jetbrains/dokka/model/ConstructorValues$Companion;
-	public fun <init> (Ljava/util/Map;)V
-	public final fun component1 ()Ljava/util/Map;
-	public final fun copy (Ljava/util/Map;)Lorg/jetbrains/dokka/model/ConstructorValues;
-	public static synthetic fun copy$default (Lorg/jetbrains/dokka/model/ConstructorValues;Ljava/util/Map;ILjava/lang/Object;)Lorg/jetbrains/dokka/model/ConstructorValues;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getKey ()Lorg/jetbrains/dokka/model/properties/ExtraProperty$Key;
-	public final fun getValues ()Ljava/util/Map;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class org/jetbrains/dokka/model/ConstructorValues$Companion : org/jetbrains/dokka/model/properties/ExtraProperty$Key {
-	public synthetic fun mergeStrategyFor (Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
-	public fun mergeStrategyFor (Lorg/jetbrains/dokka/model/ConstructorValues;Lorg/jetbrains/dokka/model/ConstructorValues;)Lorg/jetbrains/dokka/model/properties/MergeStrategy$Replace;
-}
-
 public final class org/jetbrains/dokka/model/Contravariance : org/jetbrains/dokka/model/Variance {
 	public fun <init> (Lorg/jetbrains/dokka/model/Bound;)V
 	public final fun component1 ()Lorg/jetbrains/dokka/model/Bound;

--- a/core/src/main/kotlin/model/additionalExtras.kt
+++ b/core/src/main/kotlin/model/additionalExtras.kt
@@ -115,12 +115,3 @@ data class ActualTypealias(val underlyingType: SourceSetDependent<Bound>) : Extr
 
     override val key: ExtraProperty.Key<DClasslike, ActualTypealias> = ActualTypealias
 }
-
-data class ConstructorValues(val values: SourceSetDependent<List<Expression>>) : ExtraProperty<DEnumEntry> {
-    companion object : ExtraProperty.Key<DEnumEntry, ConstructorValues> {
-        override fun mergeStrategyFor(left: ConstructorValues, right: ConstructorValues) =
-            MergeStrategy.Replace(ConstructorValues(left.values + right.values))
-    }
-
-    override val key: ExtraProperty.Key<DEnumEntry, ConstructorValues> = ConstructorValues
-}

--- a/plugins/base/src/main/kotlin/signatures/KotlinSignatureProvider.kt
+++ b/plugins/base/src/main/kotlin/signatures/KotlinSignatureProvider.kt
@@ -78,17 +78,6 @@ class KotlinSignatureProvider(ctcc: CommentsToContentConverter, logger: DokkaLog
                 group(styles = setOf(TextStyle.Block)) {
                     annotationsBlock(e)
                     link(e.name, e.dri, styles = emptySet())
-                    e.extra[ConstructorValues]?.let { constructorValues ->
-                        constructorValues.values[it]?.let { values ->
-                            list(
-                                elements = values,
-                                prefix = "(",
-                                suffix = ")",
-                                separator = ", ",
-                                separatorStyles = mainStyles + TokenStyle.Punctuation,
-                            ) { highlightValue(it) }
-                        }
-                    }
                 }
             }
         }

--- a/plugins/base/src/main/kotlin/translators/descriptors/DefaultDescriptorToDocumentableTranslator.kt
+++ b/plugins/base/src/main/kotlin/translators/descriptors/DefaultDescriptorToDocumentableTranslator.kt
@@ -321,8 +321,7 @@ private class DokkaDescriptorVisitor(
                 expectPresentInSet = sourceSet.takeIf { isExpect },
                 extra = PropertyContainer.withAll(
                     descriptor.additionalExtras().toSourceSetDependent().toAdditionalModifiers(),
-                    descriptor.getAnnotations().toSourceSetDependent().toAnnotations(),
-                    ConstructorValues(descriptor.getAppliedConstructorParameters().toSourceSetDependent())
+                    descriptor.getAnnotations().toSourceSetDependent().toAnnotations()
                 )
             )
         }

--- a/plugins/base/src/test/kotlin/signatures/SignatureTest.kt
+++ b/plugins/base/src/test/kotlin/signatures/SignatureTest.kt
@@ -876,7 +876,7 @@ class SignatureTest : BaseAbstractTest() {
     }
 
     @Test
-    fun `should have no empty parentheses for enum entries`() {
+    fun `should not expose enum constructor entry arguments`() {
         val writerPlugin = TestOutputWriterPlugin()
 
         testInline(

--- a/plugins/base/src/test/kotlin/signatures/SignatureTest.kt
+++ b/plugins/base/src/test/kotlin/signatures/SignatureTest.kt
@@ -876,7 +876,7 @@ class SignatureTest : BaseAbstractTest() {
     }
 
     @Test
-    fun `should have no empty parentheses for no-arg enum entry`() {
+    fun `should have no empty parentheses for enum entries`() {
         val writerPlugin = TestOutputWriterPlugin()
 
         testInline(
@@ -905,7 +905,7 @@ class SignatureTest : BaseAbstractTest() {
                 )
 
                 enumEntrySignatures[1].match(
-                    A("WITH_ARG"), "(\"arg\")",
+                    A("WITH_ARG"),
                     ignoreSpanWithTokenStyle = true
                 )
             }


### PR DESCRIPTION
Enum constructor arguments is mostly internal detail of enums that
isn't supposed to be exposed to clients of some library so let's
don't put it in the generated documentations result.

As https://github.com/Kotlin/dokka/issues/2468#issuecomment-1125162625

Fixes #2468 

Hopefully is in a correct direction, it passes the test suit I can say and even though a test is removed there is another test that practices the new behavior.