### PR TITLE
Fix compatibility with Gradle's configuration cache

### DIFF
--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/AbstractDokkaTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/AbstractDokkaTask.kt
@@ -6,7 +6,7 @@ import groovy.lang.Closure
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.Task
-import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
@@ -76,10 +76,10 @@ abstract class AbstractDokkaTask : DefaultTask() {
     }
 
     @Classpath
-    val plugins: Configuration = project.maybeCreateDokkaPluginConfiguration(name)
+    val plugins: ConfigurableFileCollection = project.objects.fileCollection()
 
     @Classpath
-    val runtime: Configuration = project.maybeCreateDokkaRuntimeConfiguration(name)
+    val runtime: ConfigurableFileCollection = project.objects.fileCollection()
 
     final override fun doFirst(action: Action<in Task>): Task = super.doFirst(action)
 

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaCollectorTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaCollectorTask.kt
@@ -18,7 +18,7 @@ abstract class DokkaCollectorTask : AbstractDokkaParentTask() {
             cacheRoot = cacheRoot.getSafe(),
             failOnWarning = failOnWarning.getSafe(),
             offlineMode = offlineMode.getSafe(),
-            pluginsClasspath = plugins.resolve().toList(),
+            pluginsClasspath = plugins.toList(),
             pluginsConfiguration = buildPluginsConfiguration(),
             suppressObviousFunctions = suppressObviousFunctions.getSafe(),
             suppressInheritedMembers = suppressInheritedMembers.getSafe(),

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaMultiModuleTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaMultiModuleTask.kt
@@ -58,7 +58,7 @@ abstract class DokkaMultiModuleTask : AbstractDokkaParentTask() {
         pluginsConfiguration = buildPluginsConfiguration(),
         failOnWarning = failOnWarning.getSafe(),
         offlineMode = offlineMode.getSafe(),
-        pluginsClasspath = plugins.resolve().toList(),
+        pluginsClasspath = plugins.toList(),
         modules = childDokkaTasks.map { dokkaTask ->
             DokkaModuleDescriptionImpl(
                 name = dokkaTask.moduleName.getSafe(),

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaTask.kt
@@ -16,7 +16,7 @@ abstract class DokkaTask : AbstractDokkaLeafTask() {
             failOnWarning = failOnWarning.getSafe(),
             sourceSets = unsuppressedSourceSets.build(),
             pluginsConfiguration = buildPluginsConfiguration(),
-            pluginsClasspath = plugins.resolve().toList(),
+            pluginsClasspath = plugins.toList(),
             suppressObviousFunctions = suppressObviousFunctions.getSafe(),
             suppressInheritedMembers = suppressInheritedMembers.getSafe(),
         )

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaTaskPartial.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaTaskPartial.kt
@@ -17,7 +17,7 @@ abstract class DokkaTaskPartial : AbstractDokkaLeafTask() {
             failOnWarning = failOnWarning.getSafe(),
             sourceSets = unsuppressedSourceSets.build(),
             pluginsConfiguration = buildPluginsConfiguration(),
-            pluginsClasspath = plugins.resolve().toList(),
+            pluginsClasspath = plugins.toList(),
             delayTemplateSubstitution = true,
             suppressObviousFunctions = suppressObviousFunctions.getSafe(),
             suppressInheritedMembers = suppressInheritedMembers.getSafe(),

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/dokkaBootstrapFactory.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/dokkaBootstrapFactory.kt
@@ -2,13 +2,12 @@
 
 package org.jetbrains.dokka.gradle
 
-import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.FileCollection
 import org.jetbrains.dokka.DokkaBootstrap
 import java.net.URLClassLoader
 import kotlin.reflect.KClass
 
-fun DokkaBootstrap(configuration: Configuration, bootstrapClass: KClass<out DokkaBootstrap>): DokkaBootstrap {
-    val runtimeJars = configuration.resolve()
+fun DokkaBootstrap(runtimeJars: FileCollection, bootstrapClass: KClass<out DokkaBootstrap>): DokkaBootstrap {
     val runtimeClassLoader = URLClassLoader(
         runtimeJars.map { it.toURI().toURL() }.toTypedArray(),
         ClassLoader.getSystemClassLoader().parent

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/main.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/main.kt
@@ -4,6 +4,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency
+import org.gradle.api.file.FileCollection
 import org.gradle.kotlin.dsl.register
 import org.gradle.util.GradleVersion
 
@@ -14,6 +15,8 @@ open class DokkaPlugin : Plugin<Project> {
         }
 
         project.setupDokkaTasks("dokkaHtml") {
+            runtime.from(project.configurations.getByName("dokkaHtmlRuntime"))
+            plugins.from(project.configurations.getByName("dokkaHtmlPlugin"))
             description = "Generates documentation in 'html' format"
         }
 
@@ -21,17 +24,29 @@ open class DokkaPlugin : Plugin<Project> {
             name = "dokkaJavadoc",
             multiModuleTaskSupported = false
         ) {
-            plugins.dependencies.add(project.dokkaArtifacts.javadocPlugin)
+            project.configurations.getByName("dokkaJavadocPlugin") {
+                it.dependencies.add(project.dokkaArtifacts.javadocPlugin)
+            }
+            runtime.from(project.configurations.getByName("dokkaJavadocRuntime"))
+            plugins.from(project.configurations.getByName("dokkaJavadocPlugin"))
             description = "Generates documentation in 'javadoc' format"
         }
 
         project.setupDokkaTasks("dokkaGfm", allModulesPageAndTemplateProcessing = project.dokkaArtifacts.gfmTemplateProcessing) {
-            plugins.dependencies.add(project.dokkaArtifacts.gfmPlugin)
+            project.configurations.getByName("dokkaGfmPlugin") {
+                it.dependencies.add(project.dokkaArtifacts.gfmPlugin)
+            }
+            runtime.from(project.configurations.getByName("dokkaGfmRuntime"))
+            plugins.from(project.configurations.getByName("dokkaGfmPlugin"))
             description = "Generates documentation in GitHub flavored markdown format"
         }
 
         project.setupDokkaTasks("dokkaJekyll", allModulesPageAndTemplateProcessing = project.dokkaArtifacts.jekyllTemplateProcessing) {
-            plugins.dependencies.add(project.dokkaArtifacts.jekyllPlugin)
+            project.configurations.getByName("dokkaJekyllPlugin") {
+                it.dependencies.add(project.dokkaArtifacts.jekyllPlugin)
+            }
+            runtime.from(project.configurations.getByName("dokkaJekyllRuntime"))
+            plugins.from(project.configurations.getByName("dokkaJekyllPlugin"))
             description = "Generates documentation in Jekyll flavored markdown format"
         }
     }

--- a/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaCollectorTaskTest.kt
+++ b/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaCollectorTaskTest.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.dokka.gradle
 
 import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.repositories
 import org.gradle.kotlin.dsl.withType
 import org.gradle.testfixtures.ProjectBuilder
 import org.jetbrains.dokka.DokkaConfigurationImpl
@@ -21,8 +22,9 @@ class DokkaCollectorTaskTest {
 
         rootProject.allprojects { project ->
             project.plugins.apply("org.jetbrains.dokka")
-            project.tasks.withType<AbstractDokkaTask>().configureEach { task ->
-                task.plugins.withDependencies { dependencies -> dependencies.clear() }
+            project.repositories {
+                mavenLocal()
+                mavenCentral()
             }
             project.tasks.withType<DokkaTask>().configureEach { task ->
                 task.dokkaSourceSets.configureEach { sourceSet ->
@@ -56,7 +58,7 @@ class DokkaCollectorTaskTest {
                         .map { it.sourceSets }
                         .reduce { acc, list -> acc + list },
                     pluginsClasspath = task.childDokkaTasks
-                        .map { it.plugins.resolve().toList() }
+                        .map { it.plugins.toList() }
                         .reduce { acc, mutableSet -> acc + mutableSet }
                 ),
                 dokkaConfiguration

--- a/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaConfigurationJsonTest.kt
+++ b/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaConfigurationJsonTest.kt
@@ -2,6 +2,7 @@
 
 package org.jetbrains.dokka.gradle
 
+import org.gradle.kotlin.dsl.repositories
 import org.gradle.kotlin.dsl.withType
 import org.gradle.testfixtures.ProjectBuilder
 import org.jetbrains.dokka.*
@@ -17,8 +18,9 @@ class DokkaConfigurationJsonTest {
         val project = ProjectBuilder.builder().build()
         project.plugins.apply("org.jetbrains.dokka")
         val dokkaTask = project.tasks.withType<DokkaTask>().first()
-        dokkaTask.plugins.withDependencies { dependencies ->
-            dependencies.clear()
+        project.repositories {
+            mavenLocal()
+            mavenCentral()
         }
         dokkaTask.apply {
             this.failOnWarning by true

--- a/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaConfigurationSerializableTest.kt
+++ b/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaConfigurationSerializableTest.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.dokka.gradle
 
+import org.gradle.kotlin.dsl.repositories
 import org.gradle.kotlin.dsl.withType
 import org.gradle.testfixtures.ProjectBuilder
 import org.jetbrains.dokka.DokkaConfiguration
@@ -25,8 +26,9 @@ class DokkaConfigurationSerializableTest {
         val project = ProjectBuilder.builder().build()
         project.plugins.apply("org.jetbrains.dokka")
         val dokkaTask = project.tasks.withType<DokkaTask>().first()
-        dokkaTask.plugins.withDependencies { dependencies ->
-            dependencies.clear()
+        project.repositories {
+            mavenLocal()
+            mavenCentral()
         }
         dokkaTask.apply {
             this.failOnWarning by true

--- a/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaMultiModuleTaskTest.kt
+++ b/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaMultiModuleTaskTest.kt
@@ -25,14 +25,6 @@ class DokkaMultiModuleTaskTest {
         addChildTask(childDokkaTask)
     }
 
-    init {
-        rootProject.allprojects { project ->
-            project.tasks.withType<AbstractDokkaTask>().configureEach { task ->
-                task.plugins.withDependencies { dependencies -> dependencies.clear() }
-            }
-        }
-    }
-
     @Test
     fun `child project is withing root project`() {
         assertEquals(

--- a/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaPluginApplyTest.kt
+++ b/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaPluginApplyTest.kt
@@ -1,11 +1,11 @@
 package org.jetbrains.dokka.gradle
 
 import org.gradle.api.plugins.JavaBasePlugin
+import org.gradle.kotlin.dsl.repositories
 import org.gradle.kotlin.dsl.withType
 import org.gradle.testfixtures.ProjectBuilder
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class DokkaPluginApplyTest {
@@ -40,12 +40,16 @@ class DokkaPluginApplyTest {
     fun `dokka plugin configurations extend dokkaPlugin`() {
         val project = ProjectBuilder.builder().build()
         project.plugins.apply("org.jetbrains.dokka")
+        project.repositories {
+            mavenLocal()
+            mavenCentral()
+        }
 
         val dokkaPluginsConfiguration = project.maybeCreateDokkaDefaultPluginConfiguration()
 
         project.tasks.withType<DokkaTask>().forEach { dokkaTask ->
-            assertSame(
-                dokkaTask.plugins.extendsFrom.single(), dokkaPluginsConfiguration,
+            assertTrue(
+                dokkaTask.plugins.files.containsAll(dokkaPluginsConfiguration.files),
                 "Expected dokka plugins configuration to extend default ${dokkaPluginsConfiguration.name} configuration"
             )
         }


### PR DESCRIPTION
Fixes #1217 
Fixes #2231

I've tested locally with success.

The changes are fairly simple, but because the configurations are now resolved when executing certain tests, those tests fail if the dependencies aren't available (this includes project dependencies as well as external dependencies).

The way to properly achieve this would be to publish the required artifacts to either `mavenLocal()` or a custom local file repository and adding that repository so they're made available to the tests.

Publishing for review first though in case there's another approach to follow.