### PR TITLE
Make the `kotlin-as-java` plugin include information about access modifiers for functions

### DIFF
--- a/plugins/kotlin-as-java/src/main/kotlin/signatures/JavaSignatureProvider.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/signatures/JavaSignatureProvider.kt
@@ -131,6 +131,7 @@ class JavaSignatureProvider internal constructor(ctcc: CommentsToContentConverte
                 sourceSets = setOf(sourceSet)
             ) {
                 annotationsBlock(f)
+                f.visibility[sourceSet]?.takeIf { it !in ignoredVisibilities }?.name?.let { keyword("$it ") }
                 f.modifier[sourceSet]?.takeIf { it !in ignoredModifiers }?.name?.plus(" ")?.let { keyword(it) }
                 f.modifiers()[sourceSet]?.toSignatureString()?.let { keyword(it) }
                 val returnType = f.type

--- a/plugins/kotlin-as-java/src/test/kotlin/KotlinAsJavaPluginTest.kt
+++ b/plugins/kotlin-as-java/src/test/kotlin/KotlinAsJavaPluginTest.kt
@@ -176,7 +176,7 @@ class KotlinAsJavaPluginTest : BaseAbstractTest() {
                         divergentInstance {
                             divergent {
                                 group {
-                                    +"final "
+                                    +"public final "
                                     group {
                                         link {
                                             +"String"
@@ -331,7 +331,7 @@ class KotlinAsJavaPluginTest : BaseAbstractTest() {
         ) {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/kotlinAsJavaPlugin/-a-b-c/some-fun.html").firstSignature().match(
-                    "final ", A("Integer"), A("someFun"), "(", Parameters(
+                    "public final ", A("Integer"), A("someFun"), "(", Parameters(
                         Parameter(A("Integer"), "xd")
                     ), ")", Span(), ignoreSpanWithTokenStyle = true
                 )
@@ -370,7 +370,7 @@ class KotlinAsJavaPluginTest : BaseAbstractTest() {
         ) {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/kotlinAsJavaPlugin/-a-b-c/some-fun.html").firstSignature().match(
-                    "final ", A("Integer"), A("someFun"), "(", Parameters(
+                    "public final ", A("Integer"), A("someFun"), "(", Parameters(
                         Parameter(A("Map"), "<", A("String"), ", ", A("Integer"), "> xd"),
                     ), ")", Span(), ignoreSpanWithTokenStyle = true
                 )
@@ -436,7 +436,7 @@ class KotlinAsJavaPluginTest : BaseAbstractTest() {
         ) {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/kotlinAsJavaPlugin/-test-kt/sample.html").firstSignature().match(
-                    "final static ", A("String"), A("sample"), "(", Parameters(
+                    "public final static ", A("String"), A("sample"), "(", Parameters(
                         Parameter(A("Integer"), "a"),
                     ), ")", Span(), ignoreSpanWithTokenStyle = true
                 )


### PR DESCRIPTION
### Preface
This PR fixes the problem described [here](https://github.com/Kotlin/dokka/issues/2492). Please take a look at the issue before moving on.

### What was the problem?
The `DFunction` successfully collected information about the access modifier, but this information was not considered when generating/rendering output.

### Additional changes
Additionally, a few of the `kotlin-as-java` plugin tests required modification. These tests failed as they expected no access modifiers for public functions in the output.
