### PR TITLE
Support definitely non-nullable types

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1378,6 +1378,17 @@ public final class org/jetbrains/dokka/model/DefaultValue$Companion : org/jetbra
 	public fun mergeStrategyFor (Lorg/jetbrains/dokka/model/DefaultValue;Lorg/jetbrains/dokka/model/DefaultValue;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
 }
 
+public final class org/jetbrains/dokka/model/DefinitelyNonNullable : org/jetbrains/dokka/model/Bound {
+	public fun <init> (Lorg/jetbrains/dokka/model/Bound;)V
+	public final fun component1 ()Lorg/jetbrains/dokka/model/Bound;
+	public final fun copy (Lorg/jetbrains/dokka/model/Bound;)Lorg/jetbrains/dokka/model/DefinitelyNonNullable;
+	public static synthetic fun copy$default (Lorg/jetbrains/dokka/model/DefinitelyNonNullable;Lorg/jetbrains/dokka/model/Bound;ILjava/lang/Object;)Lorg/jetbrains/dokka/model/DefinitelyNonNullable;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInner ()Lorg/jetbrains/dokka/model/Bound;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class org/jetbrains/dokka/model/DisplaySourceSet : org/jetbrains/dokka/utilities/SelfRepresentingSingletonSet {
 	public fun <init> (Lorg/jetbrains/dokka/DokkaConfiguration$DokkaSourceSet;)V
 	public fun <init> (Lorg/jetbrains/dokka/model/CompositeSourceSetID;Ljava/lang/String;Lorg/jetbrains/dokka/Platform;)V

--- a/core/src/main/kotlin/model/Documentable.kt
+++ b/core/src/main/kotlin/model/Documentable.kt
@@ -459,6 +459,11 @@ data class UnresolvedBound(
 // The following Projections are not AnnotationTargets; they cannot be annotated.
 data class Nullable(val inner: Bound) : Bound()
 
+/**
+ * It introduces [definitely non-nullable types](https://github.com/Kotlin/KEEP/blob/c72601cf35c1e95a541bb4b230edb474a6d1d1a8/proposals/definitely-non-nullable-types.md)
+ */
+data class DefinitelyNonNullable(val inner: Bound) : Bound()
+
 sealed class Variance<out T : Bound> : Projection() {
     abstract val inner: T
 }

--- a/plugins/base/src/main/kotlin/signatures/KotlinSignatureProvider.kt
+++ b/plugins/base/src/main/kotlin/signatures/KotlinSignatureProvider.kt
@@ -430,6 +430,11 @@ class KotlinSignatureProvider(ctcc: CommentsToContentConverter, logger: DokkaLog
                 signatureForProjection(p.inner, showFullyQualifiedName)
                 operator("?")
             }
+            is DefinitelyNonNullable -> group(styles = emptySet()) {
+                signatureForProjection(p.inner, showFullyQualifiedName)
+                operator(" & ")
+                link("Any", DriOfAny)
+            }
 
             is TypeAliased -> signatureForProjection(p.typeAlias)
             is JavaObject -> {

--- a/plugins/base/src/main/kotlin/signatures/KotlinSignatureUtils.kt
+++ b/plugins/base/src/main/kotlin/signatures/KotlinSignatureUtils.kt
@@ -39,6 +39,7 @@ object KotlinSignatureUtils : JvmSignatureUtils {
                 is TypeParameter -> dri
                 is TypeConstructor -> dri
                 is Nullable -> inner.driOrNull
+                is DefinitelyNonNullable -> inner.driOrNull
                 is PrimitiveJavaType -> dri
                 is Void -> DriOfUnit
                 is JavaObject -> DriOfAny
@@ -52,6 +53,7 @@ object KotlinSignatureUtils : JvmSignatureUtils {
         is TypeParameter -> listOf(dri)
         is TypeConstructor -> listOf(dri) + projections.flatMap { it.drisOfAllNestedBounds }
         is Nullable -> inner.drisOfAllNestedBounds
+        is DefinitelyNonNullable -> inner.drisOfAllNestedBounds
         is PrimitiveJavaType -> listOf(dri)
         is Void -> listOf(DriOfUnit)
         is JavaObject -> listOf(DriOfAny)

--- a/plugins/base/src/main/kotlin/transformers/documentables/ExtensionExtractorTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/ExtensionExtractorTransformer.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.toList
-import org.jetbrains.dokka.base.signatures.KotlinSignatureUtils.driOrNull
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.links.DriOfAny
 import org.jetbrains.dokka.model.*
@@ -91,6 +90,7 @@ private fun Callable.asPairsWithReceiverDRIs(): Sequence<Pair<DRI, Callable>> =
 // care about it since there is nowhere to put documentation of given extension.
 private fun Callable.findReceiverDRIs(bound: Bound): Sequence<DRI> = when (bound) {
     is Nullable -> findReceiverDRIs(bound.inner)
+    is DefinitelyNonNullable -> findReceiverDRIs(bound.inner)
     is TypeParameter ->
         if (this is DFunction && bound.dri == this.dri)
             generics.find { it.name == bound.name }?.bounds?.asSequence()?.flatMap(::findReceiverDRIs).orEmpty()

--- a/plugins/base/src/main/kotlin/translators/descriptors/DefaultDescriptorToDocumentableTranslator.kt
+++ b/plugins/base/src/main/kotlin/translators/descriptors/DefaultDescriptorToDocumentableTranslator.kt
@@ -910,6 +910,9 @@ private class DokkaDescriptorVisitor(
                 expandedType.toBound(),
                 annotations()
             )
+            is DefinitelyNotNullType -> DefinitelyNonNullable(
+                original.toBound()
+            )
             else -> when (val ctor = constructor.declarationDescriptor) {
                 is TypeParameterDescriptor -> TypeParameter(
                     dri = DRI.from(ctor),

--- a/plugins/base/src/test/kotlin/signatures/SignatureTest.kt
+++ b/plugins/base/src/test/kotlin/signatures/SignatureTest.kt
@@ -186,6 +186,31 @@ class SignatureTest : BaseAbstractTest() {
     }
 
     @Test
+    fun `fun with definitely non-nullable types`() {
+        val source = source("fun <T> elvisLike(x: T, y: T & Any): T & Any = x ?: y")
+        val writerPlugin = TestOutputWriterPlugin()
+
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin)
+        ) {
+            renderingStage = { _, _ ->
+                writerPlugin.writer.renderedContent("root/example/elvis-like.html").firstSignature().match(
+                    "fun <", A("T"), "> ", A("elvisLike"),
+                    "(",
+                    Span(
+                        Span("x: ", A("T"), ", "),
+                        Span("y: ", A("T"), " & ", A("Any"))
+                    ),
+                    "): ", A("T"), " & ", A("Any"), Span(),
+                    ignoreSpanWithTokenStyle = true
+                )
+            }
+        }
+    }
+
+    @Test
     fun `fun with keywords, params and generic bound`() {
         val source = source("inline suspend fun <T : String> simpleFun(a: Int, b: String): T = \"Celebrimbor\" as T")
         val writerPlugin = TestOutputWriterPlugin()

--- a/plugins/base/src/test/kotlin/utils/TestUtils.kt
+++ b/plugins/base/src/test/kotlin/utils/TestUtils.kt
@@ -66,6 +66,7 @@ val DClass.supers
 val Bound.name: String?
     get() = when (this) {
         is Nullable -> inner.name
+        is DefinitelyNonNullable -> inner.name
         is TypeParameter -> name
         is PrimitiveJavaType -> name
         is TypeConstructor -> dri.classNames

--- a/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/signatures/JavadocSignatureProvider.kt
+++ b/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/signatures/JavadocSignatureProvider.kt
@@ -205,6 +205,7 @@ class JavadocSignatureProvider(ctcc: CommentsToContentConverter, logger: DokkaLo
         }
         is Star -> text("?")
         is Nullable -> signatureForProjection(p.inner)
+        is DefinitelyNonNullable -> signatureForProjection(p.inner)
         is JavaObject, is Dynamic -> link("Object", DRI("java.lang", "Object"))
         is Void -> text("void")
         is PrimitiveJavaType -> text(p.name)

--- a/plugins/kotlin-as-java/src/main/kotlin/converters/KotlinToJavaConverter.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/converters/KotlinToJavaConverter.kt
@@ -305,6 +305,7 @@ private fun Bound.asJava(): Bound = when (this) {
         inner = inner.asJava()
     )
     is Nullable -> copy(inner.asJava())
+    is DefinitelyNonNullable -> copy(inner.asJava())
     is PrimitiveJavaType -> this
     is Void -> this
     is JavaObject -> this

--- a/plugins/kotlin-as-java/src/main/kotlin/signatures/JavaSignatureProvider.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/signatures/JavaSignatureProvider.kt
@@ -196,6 +196,7 @@ class JavaSignatureProvider internal constructor(ctcc: CommentsToContentConverte
         is Star -> operator("?")
 
         is Nullable -> signatureForProjection(p.inner)
+        is DefinitelyNonNullable -> signatureForProjection(p.inner)
 
         is JavaObject, is Dynamic -> link("Object", DRI("java.lang", "Object"))
         is Void -> text("void")

--- a/plugins/kotlin-as-java/src/test/kotlin/KotlinAsJavaSignatureTest.kt
+++ b/plugins/kotlin-as-java/src/test/kotlin/KotlinAsJavaSignatureTest.kt
@@ -1,0 +1,59 @@
+package kotlinAsJavaPlugin
+
+import org.jetbrains.dokka.DokkaConfiguration
+import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
+import org.jetbrains.dokka.jdk
+import org.junit.jupiter.api.Test
+import signatures.firstSignature
+import signatures.renderedContent
+import utils.*
+
+class KotlinAsJavaSignatureTest : BaseAbstractTest() {
+
+    private val configuration = dokkaConfiguration {
+        sourceSets {
+            sourceSet {
+                sourceRoots = listOf("src/")
+                externalDocumentationLinks = listOf(
+                    DokkaConfiguration.ExternalDocumentationLink.jdk(8),
+                    stdlibExternalDocumentationLink
+                )
+            }
+        }
+    }
+
+    @Suppress("SameParameterValue")
+    private fun source(signature: String) =
+        """
+            |/src/main/kotlin/kotlinAsJavaPlugin/Test.kt
+            |package kotlinAsJavaPlugin
+            |
+            | $signature
+            """.trimIndent()
+
+    @Test
+    fun `fun with definitely non-nullable types as java`() {
+        val source = source("fun <T> elvisLike(x: T, y: T & Any): T & Any = x ?: y")
+        val writerPlugin = TestOutputWriterPlugin()
+
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin)
+        ) {
+            renderingStage = { _, _ ->
+                val signature = writerPlugin.writer.renderedContent("root/kotlinAsJavaPlugin/-test-kt/elvis-like.html").firstSignature()
+                signature.match(
+                    "public final static ", Span("T"), A("elvisLike"),
+                    "<T extends ", A("Any"), ">(",
+                    Span(
+                        Span(Span(), " x, "),
+                        Span(Span(), " y")
+                    ),
+                    ")", Span(),
+                    ignoreSpanWithTokenStyle = true
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
[definitely non-nullable types](https://github.com/Kotlin/KEEP/blob/c72601cf35c1e95a541bb4b230edb474a6d1d1a8/proposals/definitely-non-nullable-types.md) are enabled since Kotlin 1.7