### PR TITLE
Make `dokka-analysis` dependency compileOnly in base plugin

### DIFF
--- a/integration-tests/cli/build.gradle.kts
+++ b/integration-tests/cli/build.gradle.kts
@@ -23,6 +23,7 @@ val basePluginShadow: Configuration by configurations.creating {
 
 dependencies {
     basePluginShadow(project(":plugins:base"))
+    basePluginShadow(project(":kotlin-analysis")) // compileOnly in base plugin
 }
 val basePluginShadowJar by tasks.register("basePluginShadowJar", ShadowJar::class) {
     configurations = listOf(basePluginShadow)

--- a/integration-tests/gradle/projects/it-basic/build.gradle.kts
+++ b/integration-tests/gradle/projects/it-basic/build.gradle.kts
@@ -12,9 +12,7 @@ plugins {
 
 buildscript {
     dependencies {
-        classpath("org.jetbrains.dokka:dokka-base:${System.getenv("DOKKA_VERSION")}") {
-            exclude(group = "org.jetbrains.dokka", module = "dokka-analysis") // Gradle has embeddable Kotlin compiler
-        }
+        classpath("org.jetbrains.dokka:dokka-base:${System.getenv("DOKKA_VERSION")}")
     }
 }
 

--- a/plugins/all-modules-page/build.gradle.kts
+++ b/plugins/all-modules-page/build.gradle.kts
@@ -5,6 +5,7 @@ registerDokkaArtifactPublication("dokkaAllModulesPage") {
 }
 
 dependencies {
+    compileOnly(project(":kotlin-analysis"))
     implementation(project(":plugins:base"))
     implementation(project(":plugins:templating"))
     testImplementation(project(":plugins:base"))

--- a/plugins/base/build.gradle.kts
+++ b/plugins/base/build.gradle.kts
@@ -5,7 +5,7 @@ dependencies {
     val coroutines_version: String by project
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version")
 
-    api(project(":kotlin-analysis"))
+    compileOnly(project(":kotlin-analysis"))
     val jsoup_version: String by project
     implementation("org.jsoup:jsoup:$jsoup_version")
 
@@ -20,6 +20,8 @@ dependencies {
 
     val kotlinx_html_version: String by project
     implementation("org.jetbrains.kotlinx:kotlinx-html-jvm:$kotlinx_html_version")
+
+    testCompileOnly(project(":kotlin-analysis"))
 }
 
 val projectDistDir = project(":plugins:base:frontend").file("dist")

--- a/plugins/base/build.gradle.kts
+++ b/plugins/base/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     val kotlinx_html_version: String by project
     implementation("org.jetbrains.kotlinx:kotlinx-html-jvm:$kotlinx_html_version")
 
-    testCompileOnly(project(":kotlin-analysis"))
+    testImplementation(project(":kotlin-analysis"))
 }
 
 val projectDistDir = project(":plugins:base:frontend").file("dist")

--- a/plugins/base/src/test/kotlin/signatures/FunctionalTypeConstructorsSignatureTest.kt
+++ b/plugins/base/src/test/kotlin/signatures/FunctionalTypeConstructorsSignatureTest.kt
@@ -9,6 +9,7 @@ import utils.A
 import utils.Span
 import utils.TestOutputWriterPlugin
 import utils.match
+import java.lang.IllegalStateException
 
 class FunctionalTypeConstructorsSignatureTest : BaseAbstractTest() {
     private val configuration = dokkaConfiguration {
@@ -16,6 +17,19 @@ class FunctionalTypeConstructorsSignatureTest : BaseAbstractTest() {
             sourceSet {
                 sourceRoots = listOf("src/")
                 classpath = listOf(commonStdlibPath!!)
+                externalDocumentationLinks = listOf(
+                    stdlibExternalDocumentationLink,
+                    DokkaConfiguration.ExternalDocumentationLink.Companion.jdk(8)
+                )
+            }
+        }
+    }
+
+    private val jvmConfiguration = dokkaConfiguration {
+        sourceSets {
+            sourceSet {
+                sourceRoots = listOf("src/")
+                classpath = listOf(jvmStdlibPath ?: throw IllegalStateException("JVM stdlib is not found"))
                 externalDocumentationLinks = listOf(
                     stdlibExternalDocumentationLink,
                     DokkaConfiguration.ExternalDocumentationLink.Companion.jdk(8)
@@ -282,7 +296,7 @@ class FunctionalTypeConstructorsSignatureTest : BaseAbstractTest() {
 
         testInline(
             source,
-            configuration,
+            jvmConfiguration,
             pluginOverrides = listOf(writerPlugin)
         ) {
             renderingStage = { _, _ ->

--- a/plugins/base/src/test/kotlin/signatures/SignatureTest.kt
+++ b/plugins/base/src/test/kotlin/signatures/SignatureTest.kt
@@ -15,7 +15,7 @@ class SignatureTest : BaseAbstractTest() {
         sourceSets {
             sourceSet {
                 sourceRoots = listOf("src/")
-                classpath = listOf(commonStdlibPath!!)
+                classpath = listOf(commonStdlibPath ?: throw IllegalStateException("Common stdlib is not found"), jvmStdlibPath ?: throw IllegalStateException("JVM stdlib is not found"))
                 externalDocumentationLinks = listOf(stdlibExternalDocumentationLink)
             }
         }

--- a/plugins/javadoc/build.gradle.kts
+++ b/plugins/javadoc/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.jetbrains.registerDokkaArtifactPublication
 
 dependencies {
+    compileOnly(project(":kotlin-analysis"))
     implementation("com.soywiz.korlibs.korte:korte-jvm:2.7.0")
     implementation(project(":plugins:base"))
     implementation(project(":plugins:kotlin-as-java"))

--- a/plugins/kotlin-as-java/build.gradle.kts
+++ b/plugins/kotlin-as-java/build.gradle.kts
@@ -1,12 +1,14 @@
 import org.jetbrains.registerDokkaArtifactPublication
 
 dependencies {
+    compileOnly(project(":kotlin-analysis"))
     implementation(project(":plugins:base"))
     testImplementation(project(":plugins:base"))
     testImplementation(project(":plugins:base:base-test-utils"))
     testImplementation(project(":core:content-matcher-test-utils"))
     val jsoup_version: String by project
     testImplementation("org.jsoup:jsoup:$jsoup_version")
+    testCompileOnly(project(":kotlin-analysis"))
 }
 
 registerDokkaArtifactPublication("kotlinAsJavaPlugin") {

--- a/plugins/kotlin-as-java/build.gradle.kts
+++ b/plugins/kotlin-as-java/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
     testImplementation(project(":core:content-matcher-test-utils"))
     val jsoup_version: String by project
     testImplementation("org.jsoup:jsoup:$jsoup_version")
-    testCompileOnly(project(":kotlin-analysis"))
+    testImplementation(project(":kotlin-analysis"))
 }
 
 registerDokkaArtifactPublication("kotlinAsJavaPlugin") {

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaArtifacts.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaArtifacts.kt
@@ -10,6 +10,7 @@ internal class DokkaArtifacts(private val project: Project) {
     private fun fromModuleName(name: String): Dependency =
         project.dependencies.create("org.jetbrains.dokka:$name:${DokkaVersion.version}")
 
+    val dokkaAnalysis get() = fromModuleName("dokka-analysis")
     val allModulesPage get() = fromModuleName("all-modules-page-plugin")
     val dokkaCore get() = fromModuleName("dokka-core")
     val dokkaBase get() = fromModuleName("dokka-base")

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/gradleConfigurations.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/gradleConfigurations.kt
@@ -24,6 +24,7 @@ internal fun Project.maybeCreateDokkaPluginConfiguration(dokkaTaskName: String, 
         extendsFrom(maybeCreateDokkaDefaultPluginConfiguration())
         attributes.attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage::class.java, "java-runtime"))
         isCanBeConsumed = false
+        dependencies.add(project.dokkaArtifacts.dokkaAnalysis) // compileOnly in base plugin
         dependencies.add(project.dokkaArtifacts.dokkaBase)
         dependencies.addAll(additionalDependencies)
     }

--- a/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
+++ b/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
@@ -257,7 +257,8 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
             offlineMode = offlineMode,
             cacheRoot = cacheRoot?.let(::File),
             sourceSets = listOf(sourceSet),
-            pluginsClasspath = getArtifactByMaven("org.jetbrains.dokka", "dokka-base", dokkaVersion) +
+            pluginsClasspath = getArtifactByMaven("org.jetbrains.dokka", "dokka-analysis", dokkaVersion) + // compileOnly in base plugin
+                    getArtifactByMaven("org.jetbrains.dokka", "dokka-base", dokkaVersion) +
                     dokkaPlugins.map { getArtifactByMaven(it.groupId, it.artifactId, it.version ?: dokkaVersion) }
                         .flatten(),
             pluginsConfiguration = pluginsConfiguration.toMutableList(),


### PR DESCRIPTION
Otherwise we had incompatibility with Kotlin compiler from Gradle in buildscript dependencies. 