### PR TITLE
Bump Jackson version to 2.13

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ kotlin_plugin_version=213-1.7.0-RC2-release-258-IJ6777.52
 jsoup_version=1.14.3
 idea_version=213.6777.52
 language_version=1.4
-jackson_version=2.12.4
+jackson_version=2.13.3
 freemarker_version=2.3.31
 # Code style
 kotlin.code.style=official


### PR DESCRIPTION
Jackson version is out of date and has `CVE-2020-36518` vuln