### PR TITLE
Downgrade Jackson due to broken 1.4 support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ kotlin_plugin_version=213-1.7.0-RC2-release-258-IJ6777.52
 jsoup_version=1.14.3
 idea_version=213.6777.52
 language_version=1.4
-jackson_version=2.13.3
+jackson_version=2.12.7
 freemarker_version=2.3.31
 # Code style
 kotlin.code.style=official


### PR DESCRIPTION
Jackson was bumped to 2.13 in #2525, but support for Kotlin 1.4 is broken in that version (https://github.com/FasterXML/jackson-module-kotlin/issues/556)

Downgraded to [2.12.7](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.12.7), which should still contain the CVE fix.

Integration tests were not run for the previous PR, will fix it to not hit it again