### PR TITLE
Dont escape text inside gfm code blocks

### DIFF
--- a/plugins/base/src/main/kotlin/translators/documentables/PageContentBuilder.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/PageContentBuilder.kt
@@ -382,7 +382,7 @@ open class PageContentBuilder(
         }
 
         fun codeInline(
-            language: String,
+            language: String = "",
             kind: Kind = ContentKind.Main,
             sourceSets: Set<DokkaSourceSet> = mainSourcesetData,
             styles: Set<Style> = mainStyles,

--- a/plugins/gfm/src/main/kotlin/org/jetbrains/dokka/gfm/renderer/CommonmarkRenderer.kt
+++ b/plugins/gfm/src/main/kotlin/org/jetbrains/dokka/gfm/renderer/CommonmarkRenderer.kt
@@ -315,7 +315,17 @@ open class CommonmarkRenderer(
         append("```")
         append(code.language.ifEmpty { "kotlin" })
         buildNewLine()
-        code.children.forEach { it.build(this, pageContext) }
+        code.children.forEach {
+            if (it is ContentText) {
+                // since this is a code block where text will be rendered as is,
+                // no need to escape text, apply styles, etc. Just need the plain value
+                append(it.text)
+            } else if (it is ContentBreakLine) {
+                // since this is a code block where text will be rendered as is,
+                // there's no need to add tailing slash for line breaks
+                buildNewLine()
+            }
+        }
         buildNewLine()
         append("```")
         buildNewLine()
@@ -323,7 +333,7 @@ open class CommonmarkRenderer(
 
     override fun StringBuilder.buildCodeInline(code: ContentCodeInline, pageContext: ContentPage) {
         append("`")
-        code.children.forEach { it.build(this, pageContext) }
+        code.children.filterIsInstance<ContentText>().forEach { append(it.text) }
         append("`")
     }
 

--- a/plugins/gfm/src/test/kotlin/renderers/gfm/CodeWrappingTest.kt
+++ b/plugins/gfm/src/test/kotlin/renderers/gfm/CodeWrappingTest.kt
@@ -25,14 +25,32 @@ class CodeWrappingTest : GfmRenderingOnlyTestBase() {
     }
 
     @Test
+    fun `should preserve original text without escaping`() {
+        val page = testPage {
+            codeBlock {
+                text("<----> **text** & ~~this~~  and \"that\"")
+            }
+        }
+        val expect = """|//[testPage](test-page.md)
+                        |
+                        |```kotlin
+                        |<----> **text** & ~~this~~  and "that"
+                        |```""".trimMargin()
+
+        CommonmarkRenderer(context).render(page)
+        assertEquals(expect, renderedContent)
+    }
+
+
+    @Test
     fun wrappedInlineCode() {
         val page = testPage {
             text("This function adds the values of ")
-            codeInline("") { 
+            codeInline {
                 text("left") 
             }
             text(" and ")
-            codeInline("") {
+            codeInline {
                 text("right")
             }
             text(".\nBoth numbers must be finite, or an exception occurs.\n")
@@ -41,6 +59,23 @@ class CodeWrappingTest : GfmRenderingOnlyTestBase() {
                         |
                         |This function adds the values of `left` and `right`.
                         |Both numbers must be finite, or an exception occurs.""".trimMargin()
+
+        CommonmarkRenderer(context).render(page)
+        assertEquals(expect, renderedContent)
+    }
+
+    @Test
+    fun `should not add trailing backslash to newline elements for code inline code`() {
+        val page = testPage {
+            text("This adds some symbols (")
+            codeInline {
+                text("<----> **text** & ~~this~~  and \"that\"")
+            }
+            text(") to the test")
+        }
+        val expect = """|//[testPage](test-page.md)
+                        |
+                        |This adds some symbols (`<----> **text** & ~~this~~  and "that"`) to the test""".trimMargin()
 
         CommonmarkRenderer(context).render(page)
         assertEquals(expect, renderedContent)


### PR DESCRIPTION
Previously it generated trailing slashes for newlines inside code blocks + performed `htmlEscape()` on code text, which resulted in something like this:

___


Completion of an *active* coroutine's body or a call to CompletableJob.complete transitions the job to the *completing* state. It waits in the *completing* state for all its children to complete before transitioning to the *completed* state. Note that *completing* state is purely internal to the job. For an outside observer a *completing* job is still active, while internally it is waiting for its children.

```kotlin
                                          wait children\
    +-----+ start  +--------+ complete   +-------------+  finish  +-----------+\
    | New | -----&gt; | Active | ---------&gt; | Completing  | -------&gt; | Completed |\
    +-----+        +--------+            +-------------+          +-----------+\
                     |  cancel / fail       |\
                     |     +----------------+\
                     |     |\
                     V     V\
                 +------------+                           finish  +-----------+\
                 | Cancelling | --------------------------------&gt; | Cancelled |\
                 +------------+                                   +-----------+
```

A `Job` instance in the [coroutineContext](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.coroutines/coroutine-context.html) represents the coroutine itself.
