### PR TITLE
Do not expose kotlin stdlib in the Gradle plugin dependencies

### DIFF
--- a/runners/gradle-plugin/build.gradle.kts
+++ b/runners/gradle-plugin/build.gradle.kts
@@ -30,6 +30,15 @@ dependencies {
     )
 }
 
+// Gradle will put its own version of the stdlib in the classpath, do not pull our own we will end up with
+// warnings like 'Runtime JAR files in the classpath should have the same version'
+configurations.api {
+    exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
+    exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk7")
+    exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
+}
+
+
 val sourceJar by tasks.registering(Jar::class) {
     archiveClassifier.set("sources")
     from(sourceSets["main"].allSource)

--- a/runners/gradle-plugin/build.gradle.kts
+++ b/runners/gradle-plugin/build.gradle.kts
@@ -36,6 +36,7 @@ configurations.api {
     exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
     exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk7")
     exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
+    exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-common")
 }
 
 

--- a/runners/gradle-plugin/gradle.properties
+++ b/runners/gradle-plugin/gradle.properties
@@ -1,0 +1,1 @@
+kotlin.stdlib.default.dependency=false


### PR DESCRIPTION
Because Gradle will put its own Kotlin stdlib in the classpath, it's no use adding it as a transitive dependency. It might even cause compilation errors.

See https://kotlinlang.slack.com/archives/C0F4UNJET/p1655743911527999