### PR TITLE
Add enum synthetic functions to documentable model

### DIFF
--- a/plugins/base/src/test/kotlin/enums/EnumsTest.kt
+++ b/plugins/base/src/test/kotlin/enums/EnumsTest.kt
@@ -276,6 +276,45 @@ class EnumsTest : BaseAbstractTest() {
         }
     }
 
+
+    @Test
+    fun `should contain synthetic values and valueOf functions`() {
+        val configuration = dokkaConfiguration {
+            sourceSets {
+                sourceSet {
+                    sourceRoots = listOf("src/")
+                }
+            }
+        }
+
+        testInline(
+            """
+            |/src/main/kotlin/basic/Test.kt
+            |package testpackage
+            |
+            |enum class TestEnum {
+            |   E1,
+            |   E2;
+            |}
+        """.trimMargin(),
+            configuration
+        ) {
+            // stage is important because they will get filtered out later on
+            documentablesCreationStage = { modules ->
+                val pckg = modules.flatMap { it.packages }.single { it.packageName == "testpackage" }
+                val enum = pckg.children.single { it is DEnum } as DEnum
+
+                val valueOf = enum.functions.single { it.name == "valueOf" }
+                assertEquals("testpackage/TestEnum/valueOf/#kotlin.String/PointingToDeclaration/", valueOf.dri.toString())
+                assertNotNull(valueOf.extra[ObviousMember])
+
+                val values = enum.functions.single { it.name == "values" }
+                assertEquals("testpackage/TestEnum/values/#/PointingToDeclaration/", values.dri.toString())
+                assertNotNull(values.extra[ObviousMember])
+            }
+        }
+    }
+
     @Test
     fun enumWithMethods() {
         val configuration = dokkaConfiguration {

--- a/plugins/base/src/test/kotlin/enums/KotlinEnumTest.kt
+++ b/plugins/base/src/test/kotlin/enums/KotlinEnumTest.kt
@@ -13,7 +13,7 @@ import signatures.renderedContent
 import utils.TestOutputWriter
 import utils.TestOutputWriterPlugin
 
-class EnumsTest : BaseAbstractTest() {
+class KotlinEnumTest : BaseAbstractTest() {
 
     @Test
     fun `should preserve enum source ordering for documentables`() {

--- a/plugins/javadoc/src/test/kotlin/org/jetbrains/dokka/javadoc/JavadocIndexTest.kt
+++ b/plugins/javadoc/src/test/kotlin/org/jetbrains/dokka/javadoc/JavadocIndexTest.kt
@@ -60,7 +60,8 @@ internal class JavadocIndexTest : AbstractJavadocTemplateMapTest() {
     @Test
     fun `generates correct number of index pages`() {
         testIndexPages(commonTestQuery) { indexPages ->
-            assertEquals(12, indexPages.size)
+            // index pages with letters of the alphabet, so A, B, C, D, E, etc
+            assertEquals(13, indexPages.size)
         }
     }
 
@@ -71,7 +72,7 @@ internal class JavadocIndexTest : AbstractJavadocTemplateMapTest() {
             AnnotationTarget.ANNOTATION_CLASS::class.java.methods.any { it.name == "describeConstable" }
 
         testIndexPages(commonTestQuery) { indexPages ->
-            assertEquals(if (hasAdditionalFunction()) 31 else 30, indexPages.sumBy { it.elements.size })
+            assertEquals(if (hasAdditionalFunction()) 33 else 32, indexPages.sumBy { it.elements.size })
         }
     }
 


### PR DESCRIPTION
Previously `values` and `valueOf` enum functions were not present in the documentable model

Even though we skip obvious members for our formats, other plugins might want to use it