### PR TITLE
Ignore messages emitted by the IntelliJ Logger

### DIFF
--- a/plugins/base/src/main/kotlin/DokkaBase.kt
+++ b/plugins/base/src/main/kotlin/DokkaBase.kt
@@ -34,6 +34,7 @@ import org.jetbrains.dokka.base.transformers.pages.tags.SinceKotlinTagContentPro
 import org.jetbrains.dokka.base.translators.descriptors.DefaultExternalDocumentablesProvider
 import org.jetbrains.dokka.base.translators.descriptors.ExternalClasslikesTranslator
 import org.jetbrains.dokka.base.translators.descriptors.ExternalDocumentablesProvider
+import org.jetbrains.dokka.base.utils.NoopIntellijLoggerFactory
 import org.jetbrains.dokka.plugability.DokkaPlugin
 import org.jetbrains.dokka.transformers.documentation.PreMergeDocumentableTransformer
 import org.jetbrains.dokka.transformers.pages.PageTransformer
@@ -271,5 +272,13 @@ class DokkaBase : DokkaPlugin() {
 
     val defaultExternalClasslikesTranslator by extending {
         externalClasslikesTranslator providing ::DefaultDescriptorToDocumentableTranslator
+    }
+
+    private companion object {
+        init {
+            // Suppress messages emitted by the IntelliJ logger since
+            // there's not much the end user can do about it
+            com.intellij.openapi.diagnostic.Logger.setFactory(NoopIntellijLoggerFactory())
+        }
     }
 }

--- a/plugins/base/src/main/kotlin/utils/NoopIntellijLogger.kt
+++ b/plugins/base/src/main/kotlin/utils/NoopIntellijLogger.kt
@@ -1,0 +1,43 @@
+package org.jetbrains.dokka.base.utils
+
+import com.intellij.openapi.diagnostic.Attachment
+import com.intellij.openapi.diagnostic.DefaultLogger
+import com.intellij.openapi.diagnostic.Logger
+
+internal class NoopIntellijLoggerFactory : Logger.Factory {
+    override fun getLoggerInstance(p0: String): Logger = NoopIntellijLogger
+}
+
+/**
+ * Ignores all messages passed to it
+ */
+internal object NoopIntellijLogger : DefaultLogger(null) {
+    override fun isDebugEnabled(): Boolean = false
+    override fun isTraceEnabled(): Boolean = false
+
+    override fun debug(message: String?) {}
+    override fun debug(t: Throwable?) {}
+    override fun debug(message: String?, t: Throwable?) {}
+    override fun debug(message: String, vararg details: Any?) {}
+    override fun debugValues(header: String, values: MutableCollection<*>) {}
+
+    override fun trace(message: String?) {}
+    override fun trace(t: Throwable?) {}
+
+    override fun info(message: String?) {}
+    override fun info(message: String?, t: Throwable?) {}
+    override fun info(t: Throwable) {}
+
+    override fun warn(message: String?, t: Throwable?) {}
+    override fun warn(message: String?) {}
+    override fun warn(t: Throwable) {}
+
+    override fun error(message: String?, t: Throwable?, vararg details: String?) {}
+    override fun error(message: String?) {}
+    override fun error(message: Any?) {}
+    override fun error(message: String?, vararg attachments: Attachment?) {}
+    override fun error(message: String?, t: Throwable?, vararg attachments: Attachment?) {}
+    override fun error(message: String?, vararg details: String?) {}
+    override fun error(message: String?, t: Throwable?) {}
+    override fun error(t: Throwable) {}
+}


### PR DESCRIPTION
If there ever is a developer/debug mode, it should NOT ignore the messages if in this mode so that we can use it during testing and development. I've written it down

Fixes #2559