### PR TITLE
Update references and documentation to Dokka 1.7.10

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,13 +29,13 @@ Here's how to import and configure Dokka in IntelliJ IDEA:
   
 If you want to use/test your locally built Dokka in a project, do the following:
 1. Change `dokka_version` in `gradle.properties` to something that you will use later on as the dependency version.
-   For instance, you can set it to something like `1.7.0-my-fix-SNAPSHOT`.
+   For instance, you can set it to something like `1.7.10-my-fix-SNAPSHOT`.
 2. Publish it to maven local (`./gradlew publishToMavenLocal`)
 3. In the project you want to generate documentation for, add maven local as a plugin/dependency
    repository (`mavenLocal()`)
 4. Update your dokka dependency to the version you've just published:
 ```kotlin
 plugins {
-    id("org.jetbrains.dokka") version "1.7.0-my-fix-SNAPSHOT"
+    id("org.jetbrains.dokka") version "1.7.10-my-fix-SNAPSHOT"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and can generate documentation in multiple formats including standard Javadoc, H
 
 ## Using Dokka
 
-**Full documentation is available at [https://kotlin.github.io/dokka/1.7.0/](https://kotlin.github.io/dokka/1.7.0/)**
+**Full documentation is available at [https://kotlin.github.io/dokka/1.7.10/](https://kotlin.github.io/dokka/1.7.10/)**
 
 ### Using the Gradle plugin
 _Note: If you are upgrading from 0.10.x to a current release of Dokka, please have a look at our 
@@ -22,7 +22,7 @@ The preferred way is to use `plugins` block.
 build.gradle.kts:
 ```kotlin
 plugins {
-    id("org.jetbrains.dokka") version "1.7.0"
+    id("org.jetbrains.dokka") version "1.7.10"
 }
 
 repositories {
@@ -37,7 +37,7 @@ Dokka plugin creates Gradle configuration for each output format in the form of 
 
 ```kotlin
 dependencies {
-    dokkaHtmlPlugin("org.jetbrains.dokka:kotlin-as-java-plugin:1.7.0")
+    dokkaHtmlPlugin("org.jetbrains.dokka:kotlin-as-java-plugin:1.7.10")
 }
 ``` 
 
@@ -46,7 +46,7 @@ You can also create a custom Dokka task and add plugins directly inside:
 ```kotlin
 val customDokkaTask by creating(DokkaTask::class) {
     dependencies {
-        plugins("org.jetbrains.dokka:kotlin-as-java-plugin:1.7.0")
+        plugins("org.jetbrains.dokka:kotlin-as-java-plugin:1.7.10")
     }
 }
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     kotlin("jvm") apply false
     id("java")
-    id("org.jetbrains.dokka") version "1.6.20"
+    id("org.jetbrains.dokka") version "1.7.10"
     id("io.github.gradle-nexus.publish-plugin")
 }
 

--- a/docs/src/doc/docs/community/plugins-list.md
+++ b/docs/src/doc/docs/community/plugins-list.md
@@ -155,6 +155,6 @@ For instance, `fun foo(bar: Bar): Baz` will be rendered as `public final Baz foo
 
 `Kotlin as Java` plugin is published to maven central as a 
 [separate artifact](https://mvnrepository.com/artifact/org.jetbrains.dokka/kotlin-as-java-plugin): 
-`org.jetbrains.dokka:kotlin-as-java-plugin:1.7.0`. 
+`org.jetbrains.dokka:kotlin-as-java-plugin:1.7.10`. 
 
 [Plugin source code on GitHub](https://github.com/Kotlin/dokka/tree/master/plugins/kotlin-as-java)

--- a/docs/src/doc/docs/developer_guide/workflow.md
+++ b/docs/src/doc/docs/developer_guide/workflow.md
@@ -42,7 +42,7 @@ Having built Dokka locally, you can publish it to `mavenLocal()`. This will allo
 project as well as debug code remotely.
 
 1. Change `dokka_version` in `gradle.properties` to something that you will use later on as the dependency version.
-   For instance, you can set it to something like `1.7.0-my-fix-SNAPSHOT`. This version will be propagated to plugins
+   For instance, you can set it to something like `1.7.10-my-fix-SNAPSHOT`. This version will be propagated to plugins
    that reside inside Dokka's project (such as `mathjax`, `kotlin-as-java`, etc).
 2. Publish it to maven local (`./gradlew publishToMavenLocal`). Corresponding artifacts should appear in `~/.m2`
 3. In the project you want to generate documentation for or debug on, add maven local as a plugin/dependency
@@ -55,7 +55,7 @@ repositories {
 4. Update your dokka dependency to the version you've just published:
 ```kotlin
 plugins {
-    id("org.jetbrains.dokka") version "1.7.0-my-fix-SNAPSHOT"
+    id("org.jetbrains.dokka") version "1.7.10-my-fix-SNAPSHOT"
 }
 ```
 

--- a/docs/src/doc/docs/user_guide/applying/cli.md
+++ b/docs/src/doc/docs/user_guide/applying/cli.md
@@ -93,8 +93,8 @@ The content of JSON file ```dokkaConfiguration.json```:
         "sourceSetName": "main"
       },
       "classpath": [
-        "libs/kotlin-stdlib-1.7.0.jar",
-        "libs/kotlin-stdlib-common-1.7.0.jar"
+        "libs/kotlin-stdlib-1.7.10.jar",
+        "libs/kotlin-stdlib-common-1.7.10.jar"
       ],
       "sourceRoots": [
         "/home/Vadim.Mishenev/dokka/examples/cli/src/main/kotlin"
@@ -135,11 +135,11 @@ The content of JSON file ```dokkaConfiguration.json```:
     }
   ],
   "pluginsClasspath": [
-    "plugins/dokka-base-1.7.0.jar",
+    "plugins/dokka-base-1.7.10.jar",
     "libs/kotlinx-html-jvm-0.7.3.jar",
-    "libs/dokka-analysis-1.7.0.jar",
-    "libs/kotlin-analysis-intellij-1.7.0.jar",
-    "libs/kotlin-analysis-compiler-1.7.0.jar"
+    "libs/dokka-analysis-1.7.10.jar",
+    "libs/kotlin-analysis-intellij-1.7.10.jar",
+    "libs/kotlin-analysis-compiler-1.7.10.jar"
   ],
   "pluginsConfiguration": [
     {

--- a/docs/src/doc/docs/user_guide/applying/gradle.md
+++ b/docs/src/doc/docs/user_guide/applying/gradle.md
@@ -14,7 +14,7 @@ The preferred way is to use `plugins` block.
 build.gradle.kts:
 ```kotlin
 plugins {
-    id("org.jetbrains.dokka") version "1.7.0"
+    id("org.jetbrains.dokka") version "1.7.10"
 }
 
 repositories {
@@ -269,7 +269,7 @@ Dokka plugin creates Gradle configuration for each output format in the form of 
 
 ```kotlin
 dependencies {
-    dokkaHtmlPlugin("org.jetbrains.dokka:kotlin-as-java-plugin:1.7.0")
+    dokkaHtmlPlugin("org.jetbrains.dokka:kotlin-as-java-plugin:1.7.10")
 }
 ``` 
 
@@ -278,7 +278,7 @@ You can also create a custom Dokka task and add plugins directly inside:
 ```kotlin
 val customDokkaTask by creating(DokkaTask::class) {
     dependencies {
-        plugins("org.jetbrains.dokka:kotlin-as-java-plugin:1.7.0")
+        plugins("org.jetbrains.dokka:kotlin-as-java-plugin:1.7.10")
     }
 }
 ```
@@ -311,7 +311,7 @@ For example, you can add `DokkaBase` to gain access to aforementioned configurat
 buildscript {
     dependencies {
         // classpath("<plugin coordinates>:<plugin version>")
-        classpath("org.jetbrains.dokka:dokka-base:1.7.0")
+        classpath("org.jetbrains.dokka:dokka-base:1.7.10")
     }
 }
 ```

--- a/examples/gradle/dokka-customFormat-example/build.gradle.kts
+++ b/examples/gradle/dokka-customFormat-example/build.gradle.kts
@@ -2,12 +2,12 @@ import org.jetbrains.dokka.gradle.DokkaTask
 
 plugins {
     kotlin("jvm") version "1.7.10"
-    id("org.jetbrains.dokka") version ("1.7.0")
+    id("org.jetbrains.dokka") version ("1.7.10")
 }
 
 buildscript {
     dependencies {
-        classpath("org.jetbrains.dokka:dokka-base:1.7.0")
+        classpath("org.jetbrains.dokka:dokka-base:1.7.10")
     }
 }
 

--- a/examples/gradle/dokka-gradle-example/build.gradle.kts
+++ b/examples/gradle/dokka-gradle-example/build.gradle.kts
@@ -3,7 +3,7 @@ import java.net.URL
 
 plugins {
     kotlin("jvm") version "1.7.10"
-    id("org.jetbrains.dokka") version ("1.7.0")
+    id("org.jetbrains.dokka") version ("1.7.10")
 }
 
 repositories {

--- a/examples/gradle/dokka-kotlinAsJava-example/build.gradle.kts
+++ b/examples/gradle/dokka-kotlinAsJava-example/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     kotlin("jvm") version "1.7.10"
-    id("org.jetbrains.dokka") version ("1.7.0")
+    id("org.jetbrains.dokka") version ("1.7.10")
 }
 
 repositories {
@@ -12,11 +12,11 @@ dependencies {
     testImplementation(kotlin("test-junit"))
 
     // Will apply the plugin to all dokka tasks
-    dokkaPlugin("org.jetbrains.dokka:kotlin-as-java-plugin:1.7.0")
+    dokkaPlugin("org.jetbrains.dokka:kotlin-as-java-plugin:1.7.10")
 
     // Will apply the plugin only to the `:dokkaHtml` task
-    //dokkaHtmlPlugin("org.jetbrains.dokka:kotlin-as-java-plugin:1.7.0")
+    //dokkaHtmlPlugin("org.jetbrains.dokka:kotlin-as-java-plugin:1.7.10")
 
     // Will apply the plugin only to the `:dokkaGfm` task
-    //dokkaGfmPlugin("org.jetbrains.dokka:kotlin-as-java-plugin:1.7.0")
+    //dokkaGfmPlugin("org.jetbrains.dokka:kotlin-as-java-plugin:1.7.10")
 }

--- a/examples/gradle/dokka-library-publishing-example/build.gradle.kts
+++ b/examples/gradle/dokka-library-publishing-example/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     kotlin("jvm") version "1.7.10"
-    id("org.jetbrains.dokka") version ("1.7.0")
+    id("org.jetbrains.dokka") version ("1.7.10")
     `java-library`
     `maven-publish`
 }

--- a/examples/gradle/dokka-multimodule-example/settings.gradle.kts
+++ b/examples/gradle/dokka-multimodule-example/settings.gradle.kts
@@ -1,7 +1,7 @@
 pluginManagement {
     plugins {
         kotlin("jvm") version "1.7.10"
-        id("org.jetbrains.dokka") version ("1.7.0")
+        id("org.jetbrains.dokka") version ("1.7.10")
     }
 }
 

--- a/examples/gradle/dokka-multiplatform-example/build.gradle.kts
+++ b/examples/gradle/dokka-multiplatform-example/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.dokka.Platform
 
 plugins {
     kotlin("multiplatform") version "1.7.10"
-    id("org.jetbrains.dokka") version "1.7.0"
+    id("org.jetbrains.dokka") version "1.7.10"
 }
 
 repositories {

--- a/examples/gradle/dokka-versioning-multimodule-example/build.gradle.kts
+++ b/examples/gradle/dokka-versioning-multimodule-example/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     kotlin("jvm") version "1.7.10"
-    id("org.jetbrains.dokka") version ("1.7.0") apply false
+    id("org.jetbrains.dokka") version ("1.7.10") apply false
 }
 
 // The versioning plugin should be applied in all submodules
@@ -14,6 +14,6 @@ subprojects {
     }
     val dokkaPlugin by configurations
     dependencies {
-        dokkaPlugin("org.jetbrains.dokka:versioning-plugin:1.7.0")
+        dokkaPlugin("org.jetbrains.dokka:versioning-plugin:1.7.10")
     }
 }

--- a/examples/gradle/dokka-versioning-multimodule-example/parentProject/build.gradle.kts
+++ b/examples/gradle/dokka-versioning-multimodule-example/parentProject/build.gradle.kts
@@ -9,8 +9,8 @@ val olderVersionsFolder = "olderVersions"
 // The previously documentations should be generated with the versioning plugin
 val generatePreviouslyDocTask by tasks.register<DokkaMultiModuleTask>("dokkaPreviouslyDocumentation") {
     dependencies {
-        dokkaPlugin("org.jetbrains.dokka:all-modules-page-plugin:1.7.0")
-        dokkaPlugin("org.jetbrains.dokka:versioning-plugin:1.7.0")
+        dokkaPlugin("org.jetbrains.dokka:all-modules-page-plugin:1.7.10")
+        dokkaPlugin("org.jetbrains.dokka:versioning-plugin:1.7.10")
     }
     val configuredVersion = "0.9"
     outputDirectory.set(file(projectDir.toPath().resolve(olderVersionsFolder).resolve(configuredVersion)))

--- a/examples/maven/pom.xml
+++ b/examples/maven/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0-SNAPSHOT</version>
     <properties>
         <kotlin.version>1.7.10</kotlin.version>
-        <dokka.version>1.7.0</dokka.version>
+        <dokka.version>1.7.10</dokka.version>
     </properties>
 
     <dependencies>

--- a/examples/plugin/hide-internal-api/build.gradle.kts
+++ b/examples/plugin/hide-internal-api/build.gradle.kts
@@ -2,8 +2,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.net.URI
 
 plugins {
-    kotlin("jvm") version "1.7.0"
-    id("org.jetbrains.dokka") version "1.7.0"
+    kotlin("jvm") version "1.7.10"
+    id("org.jetbrains.dokka") version "1.7.10"
     `maven-publish`
     signing
 }

--- a/examples/plugin/hide-internal-api/gradle.properties
+++ b/examples/plugin/hide-internal-api/gradle.properties
@@ -1,1 +1,1 @@
-dokkaVersion=1.7.0
+dokkaVersion=1.7.10

--- a/integration-tests/gradle/projects/it-basic/build.gradle.kts
+++ b/integration-tests/gradle/projects/it-basic/build.gradle.kts
@@ -16,7 +16,7 @@ buildscript {
     }
 }
 
-version = "1.7.0-SNAPSHOT"
+version = "1.7.10-SNAPSHOT"
 
 apply(from = "../template.root.gradle.kts")
 

--- a/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/BasicGradleIntegrationTest.kt
+++ b/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/BasicGradleIntegrationTest.kt
@@ -156,7 +156,7 @@ class BasicGradleIntegrationTest(override val versions: BuildVersions) : Abstrac
         val indexFile = File(this, "index.html")
         assertTrue(indexFile.isFile, "Missing index.html")
         assertTrue(
-            """<title>Basic Project 1.7.0-SNAPSHOT API </title>""" in indexFile.readText(),
+            """<title>Basic Project 1.7.10-SNAPSHOT API </title>""" in indexFile.readText(),
             "Header with version number not present in index.html"
         )
 

--- a/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/TestedVersions.kt
+++ b/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/TestedVersions.kt
@@ -32,6 +32,6 @@ internal object TestedVersions {
         "1.6.0" to "-Preact_version=17.0.2-pre.280-kotlin-1.6.0",
         "1.5.31" to "-Preact_version=17.0.2-pre.265-kotlin-1.5.31",
         "1.6.21" to "-Preact_version=18.0.0-pre.332-kotlin-1.6.21",
-        "1.7.10" to "-Preact_version=18.2.0-pre.351" // TODO update to confirmed 1.7.10
+        "1.7.10" to "-Preact_version=18.2.0-pre.354"
     )
 }


### PR DESCRIPTION
This is for **master**, and this cannot be cherry picked into the release `1.7.10` branch, so there will be a separate PR for that