### PR TITLE
Another take at removing the kotlin-stdlib dependency from the Gradle Plugin

### DIFF
--- a/runners/gradle-plugin/build.gradle.kts
+++ b/runners/gradle-plugin/build.gradle.kts
@@ -32,13 +32,27 @@ dependencies {
 
 // Gradle will put its own version of the stdlib in the classpath, do not pull our own we will end up with
 // warnings like 'Runtime JAR files in the classpath should have the same version'
-configurations.api {
-    exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
-    exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk7")
-    exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
-    exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-common")
+configurations.api.configure {
+    excludeGradleCommonDependencies()
 }
 
+/**
+ * These dependencies will be provided by Gradle, and we should prevent version conflict
+ * Code taken from the Kotlin Gradle plugin:
+ * https://github.com/JetBrains/kotlin/blob/70e15b281cb43379068facb82b8e4bcb897a3c4f/buildSrc/src/main/kotlin/GradleCommon.kt#L72
+ */
+fun Configuration.excludeGradleCommonDependencies() {
+    dependencies
+        .withType<ModuleDependency>()
+        .configureEach {
+            exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
+            exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk7")
+            exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
+            exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-common")
+            exclude(group = "org.jetbrains.kotlin", module = "kotlin-reflect")
+            exclude(group = "org.jetbrains.kotlin", module = "kotlin-script-runtime")
+        }
+}
 
 val sourceJar by tasks.registering(Jar::class) {
     archiveClassifier.set("sources")


### PR DESCRIPTION
Follow up from https://github.com/Kotlin/dokka/pull/2543
See also [this kotlinlang slack discussion](https://kotlinlang.slack.com/archives/C19FD9681/p1656593570021959)

Looks like the "com.gradle.plugin-publish" creates its own pom that doesn't find "configuration-level" excludes but requires "dependency-level" exclude. This PR mimics the behaviour from the Kotlin Gradle Plugin. It's hard to test end to end, especially since "com.gradle.plugin-publish" is closed source but I could verify that the file at `dokka/runners/gradle-plugin/build/publish-generated-resources/pom.xml` now contains excludes 🤞 