### PR TITLE
Disable copy button for signatures

### DIFF
--- a/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
@@ -95,7 +95,6 @@ open class HtmlRenderer(
             }
             node.dci.kind in setOf(ContentKind.Symbol) -> div("symbol $additionalClasses") {
                 childrenCallback()
-                if (node.hasStyle(TextStyle.Monospace)) copyButton()
             }
             node.hasStyle(TextStyle.BreakableAfter) -> {
                 span { childrenCallback() }
@@ -472,9 +471,9 @@ open class HtmlRenderer(
                             div {
                                 it.build(this, pageContext, sourceSetRestriction)
                             }
-                            if (it is ContentLink && !anchorDestination.isNullOrBlank()) buildAnchorCopyButton(
-                                anchorDestination
-                            )
+                            if (it is ContentLink && !anchorDestination.isNullOrBlank()) {
+                                buildAnchorCopyButton(anchorDestination)
+                            }
                         }
                     }
             }

--- a/plugins/base/src/main/resources/dokka/styles/style.css
+++ b/plugins/base/src/main/resources/dokka/styles/style.css
@@ -401,7 +401,6 @@ code.paragraph {
     left: -15em;
 }
 
-.symbol:hover .copy-popup-wrapper.active-popup,
 .sample-container:hover .copy-popup-wrapper.active-popup {
     display: flex !important;
 }

--- a/plugins/base/src/main/resources/dokka/styles/style.css
+++ b/plugins/base/src/main/resources/dokka/styles/style.css
@@ -343,15 +343,15 @@ code.paragraph {
     cursor: pointer;
 }
 
-.symbol span.copy-icon, .sample-container span.copy-icon {
+.sample-container span.copy-icon {
     display: none;
 }
 
-.symbol:hover span.copy-icon, .sample-container:hover span.copy-icon {
+.sample-container:hover span.copy-icon {
     display: inline-block;
 }
 
-.symbol span.copy-icon::before, .sample-container span.copy-icon::before {
+.sample-container span.copy-icon::before {
     width: 24px;
     height: 24px;
     display: inline-block;
@@ -364,7 +364,7 @@ code.paragraph {
     background-color: var(--copy-icon-color);
 }
 
-.symbol span.copy-icon:hover::before, .sample-container span.copy-icon:hover::before {
+.sample-container span.copy-icon:hover::before {
     background-color: var(--copy-icon-hover-color);
 }
 

--- a/plugins/base/src/test/kotlin/signatures/FunctionalTypeConstructorsSignatureTest.kt
+++ b/plugins/base/src/test/kotlin/signatures/FunctionalTypeConstructorsSignatureTest.kt
@@ -58,7 +58,7 @@ class FunctionalTypeConstructorsSignatureTest : BaseAbstractTest() {
         ) {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example/index.html").firstSignature().match(
-                    "val ", A("nF"), ": (", A("Int"), ") -> ", A("String"), Span(),
+                    "val ", A("nF"), ": (", A("Int"), ") -> ", A("String"),
                         ignoreSpanWithTokenStyle = true
                 )
             }
@@ -77,7 +77,7 @@ class FunctionalTypeConstructorsSignatureTest : BaseAbstractTest() {
         ) {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example/index.html").firstSignature().match(
-                    "val ", A("nF"), ": (", A("Int"), ") -> ", A("String"), Span(),
+                    "val ", A("nF"), ": (", A("Int"), ") -> ", A("String"),
                         ignoreSpanWithTokenStyle = true
                 )
             }
@@ -96,7 +96,7 @@ class FunctionalTypeConstructorsSignatureTest : BaseAbstractTest() {
         ) {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example/index.html").firstSignature().match(
-                    "val ", A("nF"), ": ", A("Boolean"), ".(", A("Int"), ") -> ", A("String"), Span(),
+                    "val ", A("nF"), ": ", A("Boolean"), ".(", A("Int"), ") -> ", A("String"),
                         ignoreSpanWithTokenStyle = true
                 )
             }
@@ -115,7 +115,7 @@ class FunctionalTypeConstructorsSignatureTest : BaseAbstractTest() {
         ) {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example/index.html").firstSignature().match(
-                    "val ", A("nF"), ": (param: ", A("Int"), ") -> ", A("String"), Span(),
+                    "val ", A("nF"), ": (param: ", A("Int"), ") -> ", A("String"),
                         ignoreSpanWithTokenStyle = true
                 )
             }
@@ -141,7 +141,7 @@ class FunctionalTypeConstructorsSignatureTest : BaseAbstractTest() {
                     "fun <", A("T"), "> ",
                     A("f"), "(): (param1:", A("T"),
                     ", param2: ", Span("@", A("Fancy")), " () -> ", A("Unit"),
-                    ") -> ", A("String"), Span(),
+                    ") -> ", A("String"),
                     ignoreSpanWithTokenStyle = true
                 )
             }
@@ -160,7 +160,7 @@ class FunctionalTypeConstructorsSignatureTest : BaseAbstractTest() {
         ) {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example/index.html").firstSignature().match(
-                    "val ", A("nF"), ": suspend (", A("Int"), ") -> ", A("String"), Span(),
+                    "val ", A("nF"), ": suspend (", A("Int"), ") -> ", A("String"),
                         ignoreSpanWithTokenStyle = true
                 )
             }
@@ -179,7 +179,7 @@ class FunctionalTypeConstructorsSignatureTest : BaseAbstractTest() {
         ) {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example/index.html").firstSignature().match(
-                    "val ", A("nF"), ": suspend (", A("Int"), ") -> ", A("String"), Span(),
+                    "val ", A("nF"), ": suspend (", A("Int"), ") -> ", A("String"),
                         ignoreSpanWithTokenStyle = true
                 )
             }
@@ -198,7 +198,7 @@ class FunctionalTypeConstructorsSignatureTest : BaseAbstractTest() {
         ) {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example/index.html").firstSignature().match(
-                    "val ", A("nF"), ": suspend ", A("Boolean"), ".(", A("Int"), ") -> ", A("String"), Span(),
+                    "val ", A("nF"), ": suspend ", A("Boolean"), ".(", A("Int"), ") -> ", A("String"),
                         ignoreSpanWithTokenStyle = true
                 )
             }
@@ -217,7 +217,7 @@ class FunctionalTypeConstructorsSignatureTest : BaseAbstractTest() {
         ) {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example/index.html").firstSignature().match(
-                    "val ", A("nF"), ": suspend (param: ", A("Int"), ") -> ", A("String"), Span(),
+                    "val ", A("nF"), ": suspend (param: ", A("Int"), ") -> ", A("String"),
                         ignoreSpanWithTokenStyle = true
                 )
             }
@@ -249,8 +249,7 @@ class FunctionalTypeConstructorsSignatureTest : BaseAbstractTest() {
                     A("Boolean"),
                     ") -> ",
                     A("String"),
-                    Span(),
-                        ignoreSpanWithTokenStyle = true
+                    ignoreSpanWithTokenStyle = true
                 )
             }
         }
@@ -275,7 +274,7 @@ class FunctionalTypeConstructorsSignatureTest : BaseAbstractTest() {
         ) {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example/-java-class/index.html").lastSignature().match(
-                    "open var ", A("javaFunction"), ": (", A("Integer"), ") -> ", A("String"), Span(),
+                    "open var ", A("javaFunction"), ": (", A("Integer"), ") -> ", A("String"),
                         ignoreSpanWithTokenStyle = true
                 )
             }
@@ -301,7 +300,7 @@ class FunctionalTypeConstructorsSignatureTest : BaseAbstractTest() {
         ) {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example/-java-class/index.html").lastSignature().match(
-                    "open var ", A("kotlinFunction"), ": (", A("Integer"), ") -> ", A("String"), Span(),
+                    "open var ", A("kotlinFunction"), ": (", A("Integer"), ") -> ", A("String"),
                         ignoreSpanWithTokenStyle = true
                 )
             }

--- a/plugins/base/src/test/kotlin/signatures/InheritedAccessorsSignatureTest.kt
+++ b/plugins/base/src/test/kotlin/signatures/InheritedAccessorsSignatureTest.kt
@@ -54,7 +54,7 @@ class InheritedAccessorsSignatureTest : BaseAbstractTest() {
 
                     val property = signatures[2]
                     property.match(
-                        "var ", A("a"), ":", A("Int"), Span(),
+                        "var ", A("a"), ":", A("Int"),
                         ignoreSpanWithTokenStyle = true
                     )
                 }
@@ -68,7 +68,7 @@ class InheritedAccessorsSignatureTest : BaseAbstractTest() {
 
                     val property = signatures[1]
                     property.match(
-                        "open var ", A("a"), ":", A("Int"), Span(),
+                        "open var ", A("a"), ":", A("Int"),
                         ignoreSpanWithTokenStyle = true
                     )
                 }
@@ -102,7 +102,7 @@ class InheritedAccessorsSignatureTest : BaseAbstractTest() {
 
                     val property = signatures[2]
                     property.match(
-                        "val ", A("a"), ":", A("Int"), Span(),
+                        "val ", A("a"), ":", A("Int"),
                         ignoreSpanWithTokenStyle = true
                     )
                 }
@@ -113,7 +113,7 @@ class InheritedAccessorsSignatureTest : BaseAbstractTest() {
 
                     val property = signatures[1]
                     property.match(
-                        "open val ", A("a"), ":", A("Int"), Span(),
+                        "open val ", A("a"), ":", A("Int"),
                         ignoreSpanWithTokenStyle = true
                     )
                 }
@@ -149,7 +149,7 @@ class InheritedAccessorsSignatureTest : BaseAbstractTest() {
                     setterFunction.match(
                         "open fun ", A("setA"), "(", Parameters(
                             Parameter("a: ", A("Int"))
-                        ), ")", Span(),
+                        ), ")",
                         ignoreSpanWithTokenStyle = true
                     )
                 }
@@ -162,7 +162,7 @@ class InheritedAccessorsSignatureTest : BaseAbstractTest() {
                     setterFunction.match(
                         "open fun ", A("setA"), "(", Parameters(
                             Parameter("a: ", A("Int"))
-                        ), ")", Span(),
+                        ), ")",
                         ignoreSpanWithTokenStyle = true
                     )
                 }
@@ -199,7 +199,7 @@ class InheritedAccessorsSignatureTest : BaseAbstractTest() {
 
                 val getterLookalikeFunction = signatures[2]
                 getterLookalikeFunction.match(
-                    "open fun ", A("getA"), "():", A("Int"), Span(),
+                    "open fun ", A("getA"), "():", A("Int"),
                     ignoreSpanWithTokenStyle = true
                 )
 
@@ -207,13 +207,13 @@ class InheritedAccessorsSignatureTest : BaseAbstractTest() {
                 setterLookalikeFunction.match(
                     "open fun ", A("setA"), "(", Parameters(
                         Parameter("a: ", A("Int"))
-                    ), ")", Span(),
+                    ), ")",
                     ignoreSpanWithTokenStyle = true
                 )
 
                 val property = signatures[4]
                 property.match(
-                    "var ", A("a"), ":", A("Int"), Span(),
+                    "var ", A("a"), ":", A("Int"),
                     ignoreSpanWithTokenStyle = true
                 )
             }
@@ -245,7 +245,7 @@ class InheritedAccessorsSignatureTest : BaseAbstractTest() {
 
                     val property = signatures[1]
                     property.match(
-                        "open var ", A("variable"), ": ", Span("String"), Span(),
+                        "open var ", A("variable"), ": ", Span("String"),
                         ignoreSpanWithTokenStyle = true
                     )
                 }
@@ -280,7 +280,7 @@ class InheritedAccessorsSignatureTest : BaseAbstractTest() {
 
                     val property = signatures[2]
                     property.match(
-                        "var ", A("variable"), ": ", A("String"), Span(),
+                        "var ", A("variable"), ": ", A("String"),
                         ignoreSpanWithTokenStyle = true
                     )
                 }
@@ -294,7 +294,7 @@ class InheritedAccessorsSignatureTest : BaseAbstractTest() {
 
                     val getter = signatures[1]
                     getter.match(
-                        "fun ", A("getVariable"), "(): ", Span("String"), Span(),
+                        "fun ", A("getVariable"), "(): ", Span("String"),
                         ignoreSpanWithTokenStyle = true
                     )
 
@@ -302,7 +302,7 @@ class InheritedAccessorsSignatureTest : BaseAbstractTest() {
                     setter.match(
                         "fun ", A("setVariable"), "(", Parameters(
                             Parameter("value: ", Span("String"))
-                        ), ")", Span(),
+                        ), ")",
                         ignoreSpanWithTokenStyle = true
                     )
                 }
@@ -360,7 +360,7 @@ class InheritedAccessorsSignatureTest : BaseAbstractTest() {
 
                     val property = signatures[2]
                     property.match(
-                        "protected var ", A("protectedGetterAndProtectedSetter"), ":", A("Int"), Span(),
+                        "protected var ", A("protectedGetterAndProtectedSetter"), ":", A("Int"),
                         ignoreSpanWithTokenStyle = true
                     )
                 }
@@ -371,7 +371,7 @@ class InheritedAccessorsSignatureTest : BaseAbstractTest() {
 
                     val property = signatures[1]
                     property.match(
-                        "protected open var ", A("protectedGetterAndProtectedSetter"), ":", A("Int"), Span(),
+                        "protected open var ", A("protectedGetterAndProtectedSetter"), ":", A("Int"),
                         ignoreSpanWithTokenStyle = true
                     )
                 }
@@ -421,7 +421,7 @@ class InheritedAccessorsSignatureTest : BaseAbstractTest() {
 
                     val property = signatures[2]
                     property.match(
-                        "protected var ", A("protectedProperty"), ":", A("Int"), Span(),
+                        "protected var ", A("protectedProperty"), ":", A("Int"),
                         ignoreSpanWithTokenStyle = true
                     )
                 }

--- a/plugins/base/src/test/kotlin/signatures/SignatureTest.kt
+++ b/plugins/base/src/test/kotlin/signatures/SignatureTest.kt
@@ -63,7 +63,7 @@ class SignatureTest : BaseAbstractTest() {
         ) {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example/simple-fun.html").firstSignature().match(
-                    "fun ", A("simpleFun"), "(): ", A("String"), Span(),
+                    "fun ", A("simpleFun"), "(): ", A("String"),
                         ignoreSpanWithTokenStyle = true
                 )
             }
@@ -82,7 +82,7 @@ class SignatureTest : BaseAbstractTest() {
         ) {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example/simple-fun.html").firstSignature().match(
-                    "open fun ", A("simpleFun"), "(): ", A("String"), Span(),
+                    "open fun ", A("simpleFun"), "(): ", A("String"),
                         ignoreSpanWithTokenStyle = true
                 )
             }
@@ -101,7 +101,7 @@ class SignatureTest : BaseAbstractTest() {
         ) {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example/simple-fun.html").firstSignature().match(
-                    "open suspend fun ", A("simpleFun"), "(): ", A("String"), Span(),
+                    "open suspend fun ", A("simpleFun"), "(): ", A("String"),
                         ignoreSpanWithTokenStyle = true
                 )
             }
@@ -124,7 +124,7 @@ class SignatureTest : BaseAbstractTest() {
                         Parameter("a: ", A("Int"), ","),
                         Parameter("b: ", A("Boolean"), ","),
                         Parameter("c: ", A("Any")),
-                    ), "): ", A("String"), Span(),
+                    ), "): ", A("String"),
                     ignoreSpanWithTokenStyle = true
                 )
             }
@@ -145,7 +145,7 @@ class SignatureTest : BaseAbstractTest() {
                 writerPlugin.writer.renderedContent("root/example/simple-fun.html").firstSignature().match(
                     "fun ", A("simpleFun"), "(", Parameters(
                         Parameter("a: (", A("Int"), ") -> ", A("String")),
-                    ),"): ", A("String"), Span(),
+                    ),"): ", A("String"),
                     ignoreSpanWithTokenStyle = true
                 )
             }
@@ -165,7 +165,7 @@ class SignatureTest : BaseAbstractTest() {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example/simple-fun.html").firstSignature().match(
                     "fun <", A("T"), "> ", A("simpleFun"), "(): ",
-                    A("T"), Span(),
+                    A("T"),
                         ignoreSpanWithTokenStyle = true
                 )
             }
@@ -185,7 +185,7 @@ class SignatureTest : BaseAbstractTest() {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example/simple-fun.html").firstSignature().match(
                     "fun <", A("T"), " : ", A("String"), "> ", A("simpleFun"),
-                    "(): ", A("T"), Span(),
+                    "(): ", A("T"),
                         ignoreSpanWithTokenStyle = true
                 )
             }
@@ -218,7 +218,7 @@ class SignatureTest : BaseAbstractTest() {
                         Span("x: ", A("T"), ", "),
                         Span("y: ", A("T"), " & ", A("Any"))
                     ),
-                    "): ", A("T"), " & ", A("Any"), Span(),
+                    "): ", A("T"), " & ", A("Any"),
                     ignoreSpanWithTokenStyle = true
                 )
             }
@@ -240,7 +240,7 @@ class SignatureTest : BaseAbstractTest() {
                     "inline suspend fun <", A("T"), " : ", A("String"), "> ", A("simpleFun"), "(", Parameters(
                         Parameter("a: ", A("Int"), ","),
                         Parameter("b: ", A("String")),
-                    ), "): ", A("T"), Span(),
+                    ), "): ", A("T"),
                     ignoreSpanWithTokenStyle = true
                 )
             }
@@ -261,7 +261,7 @@ class SignatureTest : BaseAbstractTest() {
                 writerPlugin.writer.renderedContent("root/example/simple-fun.html").firstSignature().match(
                     "fun ", A("simpleFun"), "(", Parameters(
                         Parameter("vararg params: ", A("Int")),
-                    ), ")", Span(),
+                    ), ")",
                     ignoreSpanWithTokenStyle = true
                 )
             }
@@ -280,7 +280,7 @@ class SignatureTest : BaseAbstractTest() {
         ) {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example/-simple-class/index.html").firstSignature().match(
-                    "class ", A("SimpleClass"), Span(),
+                    "class ", A("SimpleClass"),
                         ignoreSpanWithTokenStyle = true
                 )
             }
@@ -300,7 +300,7 @@ class SignatureTest : BaseAbstractTest() {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example/-inheriting-class-from-generic-type/index.html").firstSignature().match(
                     "class ", A("InheritingClassFromGenericType"), " <", A("T"), " : ", A("Number"), ", ", A("R"), " : ", A("CharSequence"),
-                    "> : ", A("Comparable"), "<", A("T"), "> , ", A("Collection"), "<", A("R"), ">", Span(),
+                    "> : ", A("Comparable"), "<", A("T"), "> , ", A("Collection"), "<", A("R"), ">",
                         ignoreSpanWithTokenStyle = true
                 )
             }
@@ -319,7 +319,7 @@ class SignatureTest : BaseAbstractTest() {
         ) {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example/-k-runnable/index.html").firstSignature().match(
-                    "fun interface ", A("KRunnable"), Span(),
+                    "fun interface ", A("KRunnable"),
                         ignoreSpanWithTokenStyle = true
                 )
             }
@@ -352,7 +352,7 @@ class SignatureTest : BaseAbstractTest() {
                         Div("@", A("Marking"))
                     ),
                     "fun ", A("simpleFun"),
-                    "(): ", A("String"), Span(),
+                    "(): ", A("String"),
                     ignoreSpanWithTokenStyle = true
                 )
             }
@@ -387,7 +387,7 @@ class SignatureTest : BaseAbstractTest() {
                         Div("@set:", A("Marking"))
                     ),
                     "var ", A("str"),
-                    ": ", A("String"), Span(),
+                    ": ", A("String"),
                     ignoreSpanWithTokenStyle = true
                 )
             }
@@ -428,7 +428,7 @@ class SignatureTest : BaseAbstractTest() {
                            Div("@", A("Marking2"), "(", Span("int = ", Span("1")), Wbr, ")")
                         ),
                         "fun ", A("simpleFun"),
-                        "(): ", A("String"), Span(),
+                        "(): ", A("String"),
                         ignoreSpanWithTokenStyle = true
                     )
             }
@@ -469,7 +469,7 @@ class SignatureTest : BaseAbstractTest() {
                         )
                     ),
                     "fun ", A("simpleFun"),
-                    "(): ", A("String"), Span(),
+                    "(): ", A("String"),
                         ignoreSpanWithTokenStyle = true
                 )
             }
@@ -501,12 +501,12 @@ class SignatureTest : BaseAbstractTest() {
 
                 signatures[0].match(
                     "expect fun ", A("simpleFun"),
-                    "(): ", A("String"), Span(),
+                    "(): ", A("String"),
                     ignoreSpanWithTokenStyle = true
                 )
                 signatures[1].match(
                     "actual fun ", A("simpleFun"),
-                    "(): ", A("String"), Span(),
+                    "(): ", A("String"),
                     ignoreSpanWithTokenStyle = true
                 )
             }
@@ -538,13 +538,13 @@ class SignatureTest : BaseAbstractTest() {
 
                 signatures[0].match(
                     "expect val ", A("prop"),
-                    ": ", A("Int"), Span(),
+                    ": ", A("Int"),
                     ignoreSpanWithTokenStyle = true
                 )
                 signatures[1].match(
                     "actual val ", A("prop"),
                     ": ", A("Int"),
-                    " = 2", Span(),
+                    " = 2",
                     ignoreSpanWithTokenStyle = true
                 )
             }
@@ -576,11 +576,11 @@ class SignatureTest : BaseAbstractTest() {
                 val signatures = writerPlugin.writer.renderedContent("test/example/-foo/index.html").signature().toList()
 
                 signatures[0].match(
-                    "expect class ", A("Foo"), Span(),
+                    "expect class ", A("Foo"),
                     ignoreSpanWithTokenStyle = true
                 )
                 signatures[1].match(
-                    "actual typealias ", A("Foo"), " = ", A("Bar"), Span(),
+                    "actual typealias ", A("Foo"), " = ", A("Bar"),
                         ignoreSpanWithTokenStyle = true
                 )
             }
@@ -605,7 +605,7 @@ class SignatureTest : BaseAbstractTest() {
         ) {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example.html").firstSignature().match(
-                    "typealias ", A("PlainTypealias"), " = ", A("Int"), Span(),
+                    "typealias ", A("PlainTypealias"), " = ", A("Int"),
                         ignoreSpanWithTokenStyle = true
                 )
             }
@@ -640,7 +640,7 @@ class SignatureTest : BaseAbstractTest() {
                             "@", A("SomeAnnotation")
                         )
                     ),
-                    "typealias ", A("PlainTypealias"), " = ", A("Int"), Span(),
+                    "typealias ", A("PlainTypealias"), " = ", A("Int"),
                         ignoreSpanWithTokenStyle = true
                 )
             }
@@ -666,7 +666,7 @@ class SignatureTest : BaseAbstractTest() {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example.html").firstSignature().match(
                     "typealias ", A("PlainTypealias"), " = ", A("Comparable"),
-                    "<", A("Int"), ">", Span(),
+                    "<", A("Int"), ">",
                         ignoreSpanWithTokenStyle = true
                 )
             }
@@ -693,7 +693,7 @@ class SignatureTest : BaseAbstractTest() {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example.html").firstSignature().match(
                     "typealias ", A("GenericTypealias"), "<", A("T"), "> = ", A("Comparable"),
-                    "<", A("T"), ">", Span(),
+                    "<", A("T"), ">",
                         ignoreSpanWithTokenStyle = true
                 )
             }
@@ -724,7 +724,7 @@ class SignatureTest : BaseAbstractTest() {
                     .match(
                         "fun ", A("someFun"), "(", Parameters(
                             Parameter("xd: ", A("XD"), "<", A("Int"), ", ", A("String"), ">"),
-                        ), "):", A("Int"), Span(),
+                        ), "):", A("Int"),
                         ignoreSpanWithTokenStyle = true
                 )
             }
@@ -762,36 +762,36 @@ class SignatureTest : BaseAbstractTest() {
                         arrayOf(
                             "fun <", A("T"), "> ", A("GenericClass"), "(", Parameters(
                                 Parameter("x: ", A("T"))
-                            ), ")", Span()
+                            ), ")",
                         ),
                         arrayOf(
                             "fun ", A("GenericClass"), "(", Parameters(
                                 Parameter("x: ", A("Int"), ", "),
                                 Parameter("y: ", A("String"))
-                            ), ")", Span()
+                            ), ")",
                         ),
                         arrayOf(
                             "fun <", A("T"), "> ", A("GenericClass"), "(", Parameters(
                                 Parameter("x: ", A("Int"), ", "),
                                 Parameter("y: ", A("List"), "<", A("T"), ">")
-                            ), ")", Span()
+                            ), ")",
                         ),
                         arrayOf(
                             "fun ", A("GenericClass"), "(", Parameters(
                                 Parameter("x: ", A("Boolean"), ", "),
                                 Parameter("y: ", A("Int"), ", "),
                                 Parameter("z:", A("String"))
-                            ), ")", Span()
+                            ), ")",
                         ),
                         arrayOf(
                             "fun <", A("T"), "> ", A("GenericClass"), "(", Parameters(
                                 Parameter("x: ", A("List"), "<", A("Comparable"), "<", A("Lazy"), "<", A("T"), ">>>?")
-                            ), ")", Span()
+                            ), ")",
                         ),
                         arrayOf(
                             "fun ", A("GenericClass"), "(", Parameters(
                                 Parameter("x: ", A("Int"))
-                            ), ")", Span()
+                            ), ")",
                         ),
                     )
                 ).forEach {
@@ -821,7 +821,7 @@ class SignatureTest : BaseAbstractTest() {
                     Span("class "), A("PrimaryConstructorClass"), Span("<"), Span(), A("T"), Span(">"), Span("("), Parameters(
                         Parameter(Span("val "), "x", Span(": "), A("Int"), Span(",")),
                         Parameter(Span("var "), "s", Span(": "), A("String"))
-                    ), Span(")"), Span(),
+                    ), Span(")"),
                 )
             }
         }
@@ -842,7 +842,7 @@ class SignatureTest : BaseAbstractTest() {
                     "fun", A("simpleFun"), "(", Parameters(
                         Parameter("int: ", A("Int"), " = 1,"),
                         Parameter("string: ", A("String"), " = \"string\"")
-                    ), "): ", A("String"), Span(),
+                    ), "): ", A("String"),
                         ignoreSpanWithTokenStyle = true
                 )
             }
@@ -864,7 +864,7 @@ class SignatureTest : BaseAbstractTest() {
                 signature.match(
                     "fun", A("assertNoIndent"), "(", Parameters(
                         Parameter("int: ", A("Int")),
-                    ), "): ", A("String"), Span(),
+                    ), "): ", A("String"),
                     ignoreSpanWithTokenStyle = true
                 )
                 assertFalse { signature.select("span.parameters").single().hasClass("wrapped") }
@@ -889,7 +889,7 @@ class SignatureTest : BaseAbstractTest() {
                         Parameter("int: ", A("Int"), ",").withClasses("indented"),
                         Parameter("string: ", A("String"), ",").withClasses("indented"),
                         Parameter("long: ", A("Long")).withClasses("indented")
-                    ).withClasses("wrapped"), "): ", A("String"), Span(),
+                    ).withClasses("wrapped"), "): ", A("String"),
                     ignoreSpanWithTokenStyle = true
                 )
             }
@@ -908,7 +908,7 @@ class SignatureTest : BaseAbstractTest() {
         ) {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example/index.html").firstSignature().match(
-                    "const val ", A("simpleVal"), ": ", A("Int"), " = 1", Span(),
+                    "const val ", A("simpleVal"), ": ", A("Int"), " = 1",
                         ignoreSpanWithTokenStyle = true
                 )
             }
@@ -977,7 +977,7 @@ class SignatureTest : BaseAbstractTest() {
 
                     val property = signatures[2]
                     property.match(
-                        "var ", A("property"), ":", A("Int"), Span(),
+                        "var ", A("property"), ":", A("Int"),
                         ignoreSpanWithTokenStyle = true
                     )
                 }
@@ -988,7 +988,7 @@ class SignatureTest : BaseAbstractTest() {
 
                     val property = signatures[1]
                     property.match(
-                        "open var ", A("property"), ":", A("Int"), Span(),
+                        "open var ", A("property"), ":", A("Int"),
                         ignoreSpanWithTokenStyle = true
                     )
                 }

--- a/plugins/base/src/test/kotlin/signatures/VarianceSignatureTest.kt
+++ b/plugins/base/src/test/kotlin/signatures/VarianceSignatureTest.kt
@@ -38,7 +38,7 @@ class VarianceSignatureTest : BaseAbstractTest() {
         ) {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example/-generic/index.html").firstSignature().match(
-                    "class ", A("Generic"), "<in ", A("T"), ">", Span(),
+                    "class ", A("Generic"), "<in ", A("T"), ">",
                     ignoreSpanWithTokenStyle = true
                 )
             }
@@ -57,7 +57,7 @@ class VarianceSignatureTest : BaseAbstractTest() {
         ) {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example/-generic/index.html").firstSignature().match(
-                    "class ", A("Generic"), "<out ", A("T"), ">", Span(),
+                    "class ", A("Generic"), "<out ", A("T"), ">",
                     ignoreSpanWithTokenStyle = true
                 )
             }
@@ -76,7 +76,7 @@ class VarianceSignatureTest : BaseAbstractTest() {
         ) {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example/-generic/index.html").firstSignature().match(
-                    "class ", A("Generic"), "<", A("T"), ">", Span(),
+                    "class ", A("Generic"), "<", A("T"), ">",
                     ignoreSpanWithTokenStyle = true
                 )
             }
@@ -95,7 +95,7 @@ class VarianceSignatureTest : BaseAbstractTest() {
         ) {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example/-generic/index.html").firstSignature().match(
-                    "class ", A("Generic"), "<out ", A("T"), ":", A("List"), "<", A("CharSequence"), ">>", Span(),
+                    "class ", A("Generic"), "<out ", A("T"), ":", A("List"), "<", A("CharSequence"), ">>",
                     ignoreSpanWithTokenStyle = true
                 )
             }

--- a/plugins/kotlin-as-java/src/test/kotlin/KotlinAsJavaPluginTest.kt
+++ b/plugins/kotlin-as-java/src/test/kotlin/KotlinAsJavaPluginTest.kt
@@ -333,7 +333,7 @@ class KotlinAsJavaPluginTest : BaseAbstractTest() {
                 writerPlugin.writer.renderedContent("root/kotlinAsJavaPlugin/-a-b-c/some-fun.html").firstSignature().match(
                     "public final ", A("Integer"), A("someFun"), "(", Parameters(
                         Parameter(A("Integer"), "xd")
-                    ), ")", Span(), ignoreSpanWithTokenStyle = true
+                    ), ")", ignoreSpanWithTokenStyle = true
                 )
             }
         }
@@ -372,7 +372,7 @@ class KotlinAsJavaPluginTest : BaseAbstractTest() {
                 writerPlugin.writer.renderedContent("root/kotlinAsJavaPlugin/-a-b-c/some-fun.html").firstSignature().match(
                     "public final ", A("Integer"), A("someFun"), "(", Parameters(
                         Parameter(A("Map"), "<", A("String"), ", ", A("Integer"), "> xd"),
-                    ), ")", Span(), ignoreSpanWithTokenStyle = true
+                    ), ")", ignoreSpanWithTokenStyle = true
                 )
             }
         }
@@ -438,7 +438,7 @@ class KotlinAsJavaPluginTest : BaseAbstractTest() {
                 writerPlugin.writer.renderedContent("root/kotlinAsJavaPlugin/-test-kt/sample.html").firstSignature().match(
                     "public final static ", A("String"), A("sample"), "(", Parameters(
                         Parameter(A("Integer"), "a"),
-                    ), ")", Span(), ignoreSpanWithTokenStyle = true
+                    ), ")", ignoreSpanWithTokenStyle = true
                 )
             }
         }
@@ -483,7 +483,7 @@ class KotlinAsJavaPluginTest : BaseAbstractTest() {
                 writerPlugin.writer.renderedContent("root/kotlinAsJavaPlugin/-test/-test.html").firstSignature().match(
                     A("Test"), A("Test"), "(", Parameters(
                         Parameter(A("Integer"), "xd")
-                    ), ")", Span(), ignoreSpanWithTokenStyle = true
+                    ), ")", ignoreSpanWithTokenStyle = true
                 )
             }
         }
@@ -530,7 +530,7 @@ class KotlinAsJavaPluginTest : BaseAbstractTest() {
                         Parameter(A("Integer"), "xd,").withClasses("indented"),
                         Parameter(A("Long"), "l,").withClasses("indented"),
                         Parameter(A("String"), "s").withClasses("indented"),
-                    ).withClasses("wrapped"), ")", Span(), ignoreSpanWithTokenStyle = true
+                    ).withClasses("wrapped"), ")", ignoreSpanWithTokenStyle = true
                 )
             }
         }
@@ -623,7 +623,7 @@ class KotlinAsJavaPluginTest : BaseAbstractTest() {
                 writerPlugin.writer.renderedContent(methodDocumentation)
                     .firstSignature()
                     .match(
-                        "$accessModifier void ", A(methodName), "()", Span(),
+                        "$accessModifier void ", A(methodName), "()",
                         ignoreSpanWithTokenStyle = true
                     )
             }

--- a/plugins/kotlin-as-java/src/test/kotlin/KotlinAsJavaSignatureTest.kt
+++ b/plugins/kotlin-as-java/src/test/kotlin/KotlinAsJavaSignatureTest.kt
@@ -51,7 +51,7 @@ class KotlinAsJavaSignatureTest : BaseAbstractTest() {
                         Span(Span(), " x, "),
                         Span(Span(), " y")
                     ),
-                    ")", Span(),
+                    ")",
                     ignoreSpanWithTokenStyle = true
                 )
             }
@@ -106,7 +106,6 @@ class KotlinAsJavaSignatureTest : BaseAbstractTest() {
                     "public final class ", A("Clazz"),
                     // <@OnTypeParameter() T extends @OnType() Object>
                     "<", Span("@", A("OnTypeParameter"), "() "), "T extends ", Span("@", A("OnType"), "() "), A("Object"), ">",
-                    Span(),
                     ignoreSpanWithTokenStyle = true
                 )
 
@@ -124,7 +123,7 @@ class KotlinAsJavaSignatureTest : BaseAbstractTest() {
                         Span(
                             A("String"), "str2"
                         )
-                    ), ")", Span(),
+                    ), ")",
                     ignoreSpanWithTokenStyle = true
                 )
             }


### PR DESCRIPTION
Copy button itself and the script for it are still present for two scenarios:

* Copying anchor links
* Copying contents of code blocks. These are usually usage examples, so I think it could be useful

See https://github.com/Kotlin/dokka/issues/2576