### PR TITLE
Add a distinct divider between function overloads

### DIFF
--- a/core/src/main/kotlin/pages/ContentNodes.kt
+++ b/core/src/main/kotlin/pages/ContentNodes.kt
@@ -36,7 +36,6 @@ data class ContentText(
     override fun hasAnyContent(): Boolean = text.isNotBlank()
 }
 
-// TODO: Remove
 data class ContentBreakLine(
     override val sourceSets: Set<DisplaySourceSet>,
     override val dci: DCI = DCI(emptySet(), ContentKind.Empty),

--- a/plugins/base/api/base.api
+++ b/plugins/base/api/base.api
@@ -243,6 +243,7 @@ public abstract class org/jetbrains/dokka/base/renderers/DefaultRenderer : org/j
 	public fun buildHeader (Ljava/lang/Object;Lorg/jetbrains/dokka/pages/ContentHeader;Lorg/jetbrains/dokka/pages/ContentPage;Ljava/util/Set;)V
 	public static synthetic fun buildHeader$default (Lorg/jetbrains/dokka/base/renderers/DefaultRenderer;Ljava/lang/Object;Lorg/jetbrains/dokka/pages/ContentHeader;Lorg/jetbrains/dokka/pages/ContentPage;Ljava/util/Set;ILjava/lang/Object;)V
 	public abstract fun buildLineBreak (Ljava/lang/Object;)V
+	public fun buildLineBreak (Ljava/lang/Object;Lorg/jetbrains/dokka/pages/ContentBreakLine;Lorg/jetbrains/dokka/pages/ContentPage;)V
 	public abstract fun buildLink (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun buildList (Ljava/lang/Object;Lorg/jetbrains/dokka/pages/ContentList;Lorg/jetbrains/dokka/pages/ContentPage;Ljava/util/Set;)V
 	public static synthetic fun buildList$default (Lorg/jetbrains/dokka/base/renderers/DefaultRenderer;Ljava/lang/Object;Lorg/jetbrains/dokka/pages/ContentList;Lorg/jetbrains/dokka/pages/ContentPage;Ljava/util/Set;ILjava/lang/Object;)V
@@ -359,7 +360,9 @@ public class org/jetbrains/dokka/base/renderers/html/HtmlRenderer : org/jetbrain
 	public fun buildHeader (Lkotlinx/html/FlowContent;ILorg/jetbrains/dokka/pages/ContentHeader;Lkotlin/jvm/functions/Function1;)V
 	public fun buildHtml (Lorg/jetbrains/dokka/pages/PageNode;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Ljava/lang/String;
 	public synthetic fun buildLineBreak (Ljava/lang/Object;)V
+	public synthetic fun buildLineBreak (Ljava/lang/Object;Lorg/jetbrains/dokka/pages/ContentBreakLine;Lorg/jetbrains/dokka/pages/ContentPage;)V
 	public fun buildLineBreak (Lkotlinx/html/FlowContent;)V
+	public fun buildLineBreak (Lkotlinx/html/FlowContent;Lorg/jetbrains/dokka/pages/ContentBreakLine;Lorg/jetbrains/dokka/pages/ContentPage;)V
 	public synthetic fun buildLink (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public fun buildLink (Lkotlinx/html/FlowContent;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public final fun buildLink (Lkotlinx/html/FlowContent;Lorg/jetbrains/dokka/links/DRI;Ljava/util/List;Lorg/jetbrains/dokka/pages/PageNode;Lkotlin/jvm/functions/Function1;)V

--- a/plugins/base/src/main/kotlin/renderers/DefaultRenderer.kt
+++ b/plugins/base/src/main/kotlin/renderers/DefaultRenderer.kt
@@ -36,6 +36,8 @@ abstract class DefaultRenderer<T>(
     )
 
     abstract fun T.buildLineBreak()
+    open fun T.buildLineBreak(node: ContentBreakLine, pageContext: ContentPage) = buildLineBreak()
+
     abstract fun T.buildResource(node: ContentEmbeddedResource, pageContext: ContentPage)
     abstract fun T.buildTable(
         node: ContentTable,
@@ -116,7 +118,7 @@ abstract class DefaultRenderer<T>(
                 is ContentList -> buildList(node, pageContext, sourceSetRestriction)
                 is ContentTable -> buildTable(node, pageContext, sourceSetRestriction)
                 is ContentGroup -> buildGroup(node, pageContext, sourceSetRestriction)
-                is ContentBreakLine -> buildLineBreak()
+                is ContentBreakLine -> buildLineBreak(node, pageContext)
                 is PlatformHintedContent -> buildPlatformDependent(node, pageContext, sourceSetRestriction)
                 is ContentDivergentGroup -> buildDivergent(node, pageContext)
                 is ContentDivergentInstance -> buildDivergentInstance(node, pageContext)

--- a/plugins/base/src/main/kotlin/renderers/html/HtmlContent.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/HtmlContent.kt
@@ -1,0 +1,14 @@
+package org.jetbrains.dokka.base.renderers.html
+
+import org.jetbrains.dokka.pages.ContentBreakLine
+import org.jetbrains.dokka.pages.Style
+
+
+/**
+ * Html-specific style that represents <hr> tag if used in conjunction with [ContentBreakLine]
+ */
+internal object HorizontalBreakLineStyle : Style {
+    // this exists as a simple internal solution to avoid introducing unnecessary public API on content level.
+    // If you have the need to implement proper horizontal divider (i.e to support `---` markdown element),
+    // consider removing this and providing proper API for all formats and levels
+}

--- a/plugins/base/src/main/kotlin/transformers/pages/merger/SameMethodNamePageMergerStrategy.kt
+++ b/plugins/base/src/main/kotlin/transformers/pages/merger/SameMethodNamePageMergerStrategy.kt
@@ -6,6 +6,10 @@ import org.jetbrains.dokka.model.dfs
 import org.jetbrains.dokka.pages.*
 import org.jetbrains.dokka.utilities.DokkaLogger
 
+/**
+ * Merges [MemberPage] elements that have the same name.
+ * That includes **both** properties and functions.
+ */
 class SameMethodNamePageMergerStrategy(val logger: DokkaLogger) : PageMergerStrategy {
     override fun tryMerge(pages: List<PageNode>, path: List<String>): List<PageNode> {
         val members = pages.filterIsInstance<MemberPageNode>().takeIf { it.isNotEmpty() } ?: return pages

--- a/plugins/base/src/main/resources/dokka/styles/style.css
+++ b/plugins/base/src/main/resources/dokka/styles/style.css
@@ -115,6 +115,11 @@ html ::-webkit-scrollbar-thumb {
     margin-right: var(--horizontal-spacing-for-content);
 }
 
+.main-content .content > hr {
+    margin: 30px 0;
+    border-top: 3px double #8c8b8b;
+}
+
 .navigation-wrapper {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
By far not the best solution, but I found no other _reliable_ way to add a divider for function overloads especially considering different sourcesets. This adds no new public API, so I think it's not a big deal - will probably have to redesign this down the road anyway. 

See https://github.com/Kotlin/dokka/issues/2576

#  For function overloads with some description

![2022-07-25_20-25-05](https://user-images.githubusercontent.com/22685910/180827893-4dac5aca-a8cf-4cb8-bac1-774a506d5815.png)

___

# For function overloads with the same description

![2022-07-25_20-25-25](https://user-images.githubusercontent.com/22685910/180827889-731723d6-b85b-45ea-8869-8ce7a5699724.png)