### PR TITLE
Update dokka-customFormat-example to use up-to-date logo styles

### DIFF
--- a/examples/gradle/dokka-customFormat-example/README.md
+++ b/examples/gradle/dokka-customFormat-example/README.md
@@ -1,0 +1,24 @@
+## Dokka custom format example
+
+This example demonstrates a few things:
+
+1. How to override css styles and add custom images.
+2. How to change logo used in the header.
+3. How to register a custom `Dokka` task with its own independent configuration.
+
+### Running
+
+`dokkaCustomFormat` task has been created in the buildscript of this example project with a few configuration changes.
+
+In order to see the full effect of these changes, run `dokkaCustomFormat` task from your IDE or execute
+the following command:
+
+```bash
+./gradlew clean dokkaCustomFormat
+```
+
+---
+
+If you run any other `Dokka` task, such as `dokkaHtml`, you'll see vanilla `Dokka` without any alterations.
+This is because changes to configuration are applied only within `dokkaCustomFormat` task. This can be useful
+if you want to generate multiple versions of documentation with different configuration settings.

--- a/examples/gradle/dokka-customFormat-example/build.gradle.kts
+++ b/examples/gradle/dokka-customFormat-example/build.gradle.kts
@@ -20,6 +20,9 @@ repositories {
  */
 tasks.register<DokkaTask>("dokkaCustomFormat") {
     pluginConfiguration<org.jetbrains.dokka.base.DokkaBase, org.jetbrains.dokka.base.DokkaBaseConfiguration> {
+        // Dokka's stylesheets and assets with conflicting names will be overriden.
+        // In this particular case, logo-styles.css will be overriden and ktor-logo.png will
+        // be added as an additional image asset
         customStyleSheets = listOf(file("logo-styles.css"))
         customAssets = listOf(file("ktor-logo.png"))
     }

--- a/examples/gradle/dokka-customFormat-example/logo-styles.css
+++ b/examples/gradle/dokka-customFormat-example/logo-styles.css
@@ -14,7 +14,7 @@
     background-size: 125px 50px;
     position: absolute;
     width: 52px;
-    height: 150px;
+    height: 50px;
     top: -18px;
     left: -62px;
 }

--- a/examples/gradle/dokka-customFormat-example/logo-styles.css
+++ b/examples/gradle/dokka-customFormat-example/logo-styles.css
@@ -1,6 +1,20 @@
-#logo {
+/*
+ * All Margins and sizes are custom for the ktor-logo.png file.
+ * You may need to modify it and find what works best for your case.
+ */
+.library-name a {
+    position: relative;
+    margin-left: 55px;
+}
+
+.library-name a::before {
+    content: '';
     background-image: url('../images/ktor-logo.png');
+    background-repeat: no-repeat;
     background-size: 125px 50px;
-    padding-top: 12px;
-    height: 65px;
+    position: absolute;
+    width: 52px;
+    height: 150px;
+    top: -18px;
+    left: -62px;
 }


### PR DESCRIPTION
Seems like it had styles of pre-1.6 Dokka. 

Fixes #2605

Not sure how it looked before, but now it looks like this:

![2022-08-04_15-49-00](https://user-images.githubusercontent.com/22685910/182864322-557f7007-d7a0-420a-af7a-0d1688b116ae.png)