### PR TITLE
Use OS color scheme to init light/dark mode (#2591)

### DIFF
--- a/plugins/base/src/main/resources/dokka/scripts/platform-content-handler.js
+++ b/plugins/base/src/main/resources/dokka/scripts/platform-content-handler.js
@@ -32,15 +32,12 @@ const darkModeSwitch = () => {
     const localStorageKey = "dokka-dark-mode"
     const storage = localStorage.getItem(localStorageKey)
     const osDarkSchemePreferred = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
-    const savedDarkMode = storage ? JSON.parse(storage) : osDarkSchemePreferred
+    const darkModeEnabled = storage ? JSON.parse(storage) : osDarkSchemePreferred
     const element = document.getElementById("theme-toggle-button")
-    const enabledClasses = document.getElementsByTagName("html")[0].classList
-    initPlayground(savedDarkMode ? samplesDarkThemeName : samplesLightThemeName)
-    if (savedDarkMode != enabledClasses.contains('theme-dark')) {
-        enabledClasses.toggle("theme-dark");
-    }
+    initPlayground(darkModeEnabled ? samplesDarkThemeName : samplesLightThemeName)
 
     element.addEventListener('click', () => {
+        const enabledClasses = document.getElementsByTagName("html")[0].classList
         enabledClasses.toggle("theme-dark")
 
         //if previously we had saved dark theme then we set it to light as this is what we save in local storage

--- a/plugins/base/src/main/resources/dokka/scripts/platform-content-handler.js
+++ b/plugins/base/src/main/resources/dokka/scripts/platform-content-handler.js
@@ -31,12 +31,16 @@ window.addEventListener('load', () => {
 const darkModeSwitch = () => {
     const localStorageKey = "dokka-dark-mode"
     const storage = localStorage.getItem(localStorageKey)
-    const savedDarkMode = storage ? JSON.parse(storage) : false
+    const osDarkSchemePreferred = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+    const savedDarkMode = storage ? JSON.parse(storage) : osDarkSchemePreferred
     const element = document.getElementById("theme-toggle-button")
+    const enabledClasses = document.getElementsByTagName("html")[0].classList
     initPlayground(savedDarkMode ? samplesDarkThemeName : samplesLightThemeName)
+    if (savedDarkMode != enabledClasses.contains('theme-dark')) {
+        enabledClasses.toggle("theme-dark");
+    }
 
     element.addEventListener('click', () => {
-        const enabledClasses = document.getElementsByTagName("html")[0].classList
         enabledClasses.toggle("theme-dark")
 
         //if previously we had saved dark theme then we set it to light as this is what we save in local storage

--- a/plugins/base/src/main/resources/dokka/templates/base.ftl
+++ b/plugins/base/src/main/resources/dokka/templates/base.ftl
@@ -12,10 +12,18 @@
     <#-- This script doesn't need to be there but it is nice to have
     since app in dark mode doesn't 'blink' (class is added before it is rendered) -->
     <script>const storage = localStorage.getItem("dokka-dark-mode")
-const savedDarkMode = storage ? JSON.parse(storage) : false
-if(savedDarkMode === true){
-    document.getElementsByTagName("html")[0].classList.add("theme-dark")
-}</script>
+    if (storage == null) {
+        const osDarkSchemePreferred = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+        if (osDarkSchemePreferred === true) {
+            document.getElementsByTagName("html")[0].classList.add("theme-dark")
+        }
+    } else {
+        const savedDarkMode = JSON.parse(storage)
+        if(savedDarkMode === true) {
+            document.getElementsByTagName("html")[0].classList.add("theme-dark")
+        }
+    }
+    </script>
     <#-- Resources (scripts, stylesheets) are handled by Dokka.
     Use customStyleSheets and customAssets to change them. -->
     <@resources/>


### PR DESCRIPTION
Closes #2591

I tried to implement what mentioned in the issue:

> I think if you open up Dokka for the first time, it could choose light/dark mode based on OS theme, and then if the person decides to switch it to something else - remember that choice.
