### PR TITLE
Fixed documentation for Gradle multiplatform projects

### DIFF
--- a/docs/src/doc/docs/user_guide/applying/gradle.md
+++ b/docs/src/doc/docs/user_guide/applying/gradle.md
@@ -241,7 +241,7 @@ kotlin {  // Kotlin Multiplatform plugin configuration
     js("customName")
 }
 
-tasks.withType<DokkaTask>().configureEach {
+tasks.withType<DokkaTaskPartial>().configureEach {
     // custom output directory
     outputDirectory.set(buildDir.resolve("dokka"))
 


### PR DESCRIPTION
If you have this structure:
```
root/
  module1/
    module1.md
    build.gradle.kts
  build.gradle.kts
```

Problem:
- add the configuration for `includes.from("module1.md")` in `module1/build.gradle.kts`,
- run `./gradlew dokkaHtmlMultiModule`
- the markdown file is not included, in fact the whole configuration block is ignored

This is because `dokkaHtmlMultiModule` executes `module1:dokkaHtmlPartial`, but no `module1:dokkaHtml`.
By switching the task type, the documentation is properly taken into account.