### PR TITLE
Add deprecation details block to pages and strike such pages in navigation

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -3791,6 +3791,7 @@ public final class org/jetbrains/dokka/pages/ContentKind : java/lang/Enum, org/j
 	public static final field Companion Lorg/jetbrains/dokka/pages/ContentKind$Companion;
 	public static final field Constructors Lorg/jetbrains/dokka/pages/ContentKind;
 	public static final field Cover Lorg/jetbrains/dokka/pages/ContentKind;
+	public static final field Deprecation Lorg/jetbrains/dokka/pages/ContentKind;
 	public static final field Empty Lorg/jetbrains/dokka/pages/ContentKind;
 	public static final field Extensions Lorg/jetbrains/dokka/pages/ContentKind;
 	public static final field Functions Lorg/jetbrains/dokka/pages/ContentKind;
@@ -3910,6 +3911,7 @@ public final class org/jetbrains/dokka/pages/ContentResolvedLink : org/jetbrains
 
 public final class org/jetbrains/dokka/pages/ContentStyle : java/lang/Enum, org/jetbrains/dokka/pages/Style {
 	public static final field Caption Lorg/jetbrains/dokka/pages/ContentStyle;
+	public static final field Footnote Lorg/jetbrains/dokka/pages/ContentStyle;
 	public static final field InDocumentationAnchor Lorg/jetbrains/dokka/pages/ContentStyle;
 	public static final field Indented Lorg/jetbrains/dokka/pages/ContentStyle;
 	public static final field KDocTag Lorg/jetbrains/dokka/pages/ContentStyle;

--- a/core/content-matcher-test-utils/api/content-matcher-test-utils.api
+++ b/core/content-matcher-test-utils/api/content-matcher-test-utils.api
@@ -15,6 +15,8 @@ public final class matchers/content/ContentMatchersDslKt {
 	public static final fun br (Lmatchers/content/ContentMatcherBuilder;)V
 	public static final fun caption (Lmatchers/content/ContentMatcherBuilder;Lkotlin/jvm/functions/Function1;)V
 	public static final fun check (Lmatchers/content/ContentMatcherBuilder;Lkotlin/jvm/functions/Function1;)V
+	public static final fun codeBlock (Lmatchers/content/ContentMatcherBuilder;Lkotlin/jvm/functions/Function1;)V
+	public static final fun codeInline (Lmatchers/content/ContentMatcherBuilder;Lkotlin/jvm/functions/Function1;)V
 	public static final fun divergent (Lmatchers/content/ContentMatcherBuilder;Lkotlin/jvm/functions/Function1;)V
 	public static final fun divergentGroup (Lmatchers/content/ContentMatcherBuilder;Lkotlin/jvm/functions/Function1;)V
 	public static final fun divergentInstance (Lmatchers/content/ContentMatcherBuilder;Lkotlin/jvm/functions/Function1;)V

--- a/core/content-matcher-test-utils/src/main/kotlin/matchers/content/ContentMatchersDsl.kt
+++ b/core/content-matcher-test-utils/src/main/kotlin/matchers/content/ContentMatchersDsl.kt
@@ -91,6 +91,10 @@ fun ContentMatcherBuilder<*>.platformHinted(block: ContentMatcherBuilder<Content
 
 fun ContentMatcherBuilder<*>.list(block: ContentMatcherBuilder<ContentList>.() -> Unit) = composite(block)
 
+fun ContentMatcherBuilder<*>.codeBlock(block: ContentMatcherBuilder<ContentCodeBlock>.() -> Unit) = composite(block)
+
+fun ContentMatcherBuilder<*>.codeInline(block: ContentMatcherBuilder<ContentCodeInline>.() -> Unit) = composite(block)
+
 fun ContentMatcherBuilder<*>.caption(block: ContentMatcherBuilder<ContentGroup>.() -> Unit) = composite<ContentGroup> {
     block()
     check { assertThat(this::style).contains(ContentStyle.Caption) }

--- a/core/src/main/kotlin/pages/ContentNodes.kt
+++ b/core/src/main/kotlin/pages/ContentNodes.kt
@@ -333,7 +333,12 @@ enum class ContentKind : Kind {
     Symbol,
 
     Comment, Constructors, Functions, Parameters, Properties, Classlikes, Packages, Sample, Main, BriefComment,
-    Empty, Source, TypeAliases, Cover, Inheritors, SourceSetDependentHint, Extensions, Annotations;
+    Empty, Source, TypeAliases, Cover, Inheritors, SourceSetDependentHint, Extensions, Annotations,
+
+    /**
+     * Deprecation details block with related information such as message/replaceWith/level.
+     */
+    Deprecation;
 
     companion object {
         private val platformTagged =
@@ -388,7 +393,7 @@ enum class TextStyle : Style {
 
 enum class ContentStyle : Style {
     RowTitle, TabbedContent, WithExtraAttributes, RunnableSample, InDocumentationAnchor, Caption,
-    Wrapped, Indented, KDocTag
+    Wrapped, Indented, KDocTag, Footnote
 }
 
 enum class ListStyle : Style {

--- a/plugins/base/api/base.api
+++ b/plugins/base/api/base.api
@@ -403,20 +403,23 @@ public abstract class org/jetbrains/dokka/base/renderers/html/NavigationDataProv
 }
 
 public final class org/jetbrains/dokka/base/renderers/html/NavigationNode : org/jetbrains/dokka/model/WithChildren {
-	public fun <init> (Ljava/lang/String;Lorg/jetbrains/dokka/links/DRI;Ljava/util/Set;Lorg/jetbrains/dokka/base/renderers/html/NavigationNodeIcon;Ljava/util/List;)V
+	public fun <init> (Ljava/lang/String;Lorg/jetbrains/dokka/links/DRI;Ljava/util/Set;Lorg/jetbrains/dokka/base/renderers/html/NavigationNodeIcon;Ljava/util/Set;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Lorg/jetbrains/dokka/links/DRI;Ljava/util/Set;Lorg/jetbrains/dokka/base/renderers/html/NavigationNodeIcon;Ljava/util/Set;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lorg/jetbrains/dokka/links/DRI;
 	public final fun component3 ()Ljava/util/Set;
 	public final fun component4 ()Lorg/jetbrains/dokka/base/renderers/html/NavigationNodeIcon;
-	public final fun component5 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Lorg/jetbrains/dokka/links/DRI;Ljava/util/Set;Lorg/jetbrains/dokka/base/renderers/html/NavigationNodeIcon;Ljava/util/List;)Lorg/jetbrains/dokka/base/renderers/html/NavigationNode;
-	public static synthetic fun copy$default (Lorg/jetbrains/dokka/base/renderers/html/NavigationNode;Ljava/lang/String;Lorg/jetbrains/dokka/links/DRI;Ljava/util/Set;Lorg/jetbrains/dokka/base/renderers/html/NavigationNodeIcon;Ljava/util/List;ILjava/lang/Object;)Lorg/jetbrains/dokka/base/renderers/html/NavigationNode;
+	public final fun component5 ()Ljava/util/Set;
+	public final fun component6 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Lorg/jetbrains/dokka/links/DRI;Ljava/util/Set;Lorg/jetbrains/dokka/base/renderers/html/NavigationNodeIcon;Ljava/util/Set;Ljava/util/List;)Lorg/jetbrains/dokka/base/renderers/html/NavigationNode;
+	public static synthetic fun copy$default (Lorg/jetbrains/dokka/base/renderers/html/NavigationNode;Ljava/lang/String;Lorg/jetbrains/dokka/links/DRI;Ljava/util/Set;Lorg/jetbrains/dokka/base/renderers/html/NavigationNodeIcon;Ljava/util/Set;Ljava/util/List;ILjava/lang/Object;)Lorg/jetbrains/dokka/base/renderers/html/NavigationNode;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
 	public final fun getDri ()Lorg/jetbrains/dokka/links/DRI;
 	public final fun getIcon ()Lorg/jetbrains/dokka/base/renderers/html/NavigationNodeIcon;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getSourceSets ()Ljava/util/Set;
+	public final fun getStyles ()Ljava/util/Set;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -909,6 +912,7 @@ public abstract class org/jetbrains/dokka/base/signatures/AtStrategy {
 
 public abstract interface class org/jetbrains/dokka/base/signatures/JvmSignatureUtils {
 	public abstract fun annotations (Lorg/jetbrains/dokka/model/DProperty;)Ljava/util/Map;
+	public abstract fun annotations (Lorg/jetbrains/dokka/model/Documentable;)Ljava/util/Map;
 	public abstract fun annotations (Lorg/jetbrains/dokka/model/properties/WithExtraProperties;)Ljava/util/Map;
 	public abstract fun annotationsBlock (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;)V
 	public abstract fun annotationsBlockWithIgnored (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;Ljava/util/Set;Lorg/jetbrains/dokka/base/signatures/AtStrategy;Lkotlin/Pair;Ljava/lang/String;)V
@@ -925,6 +929,7 @@ public abstract interface class org/jetbrains/dokka/base/signatures/JvmSignature
 
 public final class org/jetbrains/dokka/base/signatures/JvmSignatureUtils$DefaultImpls {
 	public static fun annotations (Lorg/jetbrains/dokka/base/signatures/JvmSignatureUtils;Lorg/jetbrains/dokka/model/DProperty;)Ljava/util/Map;
+	public static fun annotations (Lorg/jetbrains/dokka/base/signatures/JvmSignatureUtils;Lorg/jetbrains/dokka/model/Documentable;)Ljava/util/Map;
 	public static fun annotations (Lorg/jetbrains/dokka/base/signatures/JvmSignatureUtils;Lorg/jetbrains/dokka/model/properties/WithExtraProperties;)Ljava/util/Map;
 	public static fun annotationsBlockWithIgnored (Lorg/jetbrains/dokka/base/signatures/JvmSignatureUtils;Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;Ljava/util/Set;Lorg/jetbrains/dokka/base/signatures/AtStrategy;Lkotlin/Pair;Ljava/lang/String;)V
 	public static fun annotationsInlineWithIgnored (Lorg/jetbrains/dokka/base/signatures/JvmSignatureUtils;Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;Ljava/util/Set;Lorg/jetbrains/dokka/base/signatures/AtStrategy;Lkotlin/Pair;Ljava/lang/String;)V
@@ -940,6 +945,7 @@ public final class org/jetbrains/dokka/base/signatures/KotlinSignatureProvider :
 	public fun <init> (Lorg/jetbrains/dokka/base/transformers/pages/comments/CommentsToContentConverter;Lorg/jetbrains/dokka/utilities/DokkaLogger;)V
 	public fun <init> (Lorg/jetbrains/dokka/plugability/DokkaContext;)V
 	public fun annotations (Lorg/jetbrains/dokka/model/DProperty;)Ljava/util/Map;
+	public fun annotations (Lorg/jetbrains/dokka/model/Documentable;)Ljava/util/Map;
 	public fun annotations (Lorg/jetbrains/dokka/model/properties/WithExtraProperties;)Ljava/util/Map;
 	public fun annotationsBlock (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;)V
 	public fun annotationsBlockWithIgnored (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;Ljava/util/Set;Lorg/jetbrains/dokka/base/signatures/AtStrategy;Lkotlin/Pair;Ljava/lang/String;)V
@@ -958,6 +964,7 @@ public final class org/jetbrains/dokka/base/signatures/KotlinSignatureProvider :
 public final class org/jetbrains/dokka/base/signatures/KotlinSignatureUtils : org/jetbrains/dokka/base/signatures/JvmSignatureUtils {
 	public static final field INSTANCE Lorg/jetbrains/dokka/base/signatures/KotlinSignatureUtils;
 	public fun annotations (Lorg/jetbrains/dokka/model/DProperty;)Ljava/util/Map;
+	public fun annotations (Lorg/jetbrains/dokka/model/Documentable;)Ljava/util/Map;
 	public fun annotations (Lorg/jetbrains/dokka/model/properties/WithExtraProperties;)Ljava/util/Map;
 	public fun annotationsBlock (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;)V
 	public fun annotationsBlockWithIgnored (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;Ljava/util/Set;Lorg/jetbrains/dokka/base/signatures/AtStrategy;Lkotlin/Pair;Ljava/lang/String;)V
@@ -1266,6 +1273,7 @@ public final class org/jetbrains/dokka/base/transformers/documentables/Suppresse
 
 public final class org/jetbrains/dokka/base/transformers/documentables/UtilsKt {
 	public static final fun getDeprecatedAnnotation (Lorg/jetbrains/dokka/model/properties/WithExtraProperties;)Lorg/jetbrains/dokka/model/Annotations$Annotation;
+	public static final fun isDeprecated (Lorg/jetbrains/dokka/model/Annotations$Annotation;)Z
 	public static final fun isDeprecated (Lorg/jetbrains/dokka/model/properties/WithExtraProperties;)Z
 	public static final fun isException (Lorg/jetbrains/dokka/model/properties/WithExtraProperties;)Z
 }
@@ -1519,6 +1527,8 @@ public class org/jetbrains/dokka/base/translators/documentables/PageContentBuild
 	public final fun block (Ljava/lang/String;ILorg/jetbrains/dokka/pages/Kind;Ljava/lang/Iterable;Ljava/util/Set;Ljava/util/Set;Lorg/jetbrains/dokka/model/properties/PropertyContainer;ZZLjava/util/List;ZLkotlin/jvm/functions/Function2;)V
 	public static synthetic fun block$default (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Ljava/lang/String;ILorg/jetbrains/dokka/pages/Kind;Ljava/lang/Iterable;Ljava/util/Set;Ljava/util/Set;Lorg/jetbrains/dokka/model/properties/PropertyContainer;ZZLjava/util/List;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 	public final fun booleanLiteral (Z)V
+	public final fun breakLine (Ljava/util/Set;)V
+	public static synthetic fun breakLine$default (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Ljava/util/Set;ILjava/lang/Object;)V
 	public final fun build (Ljava/util/Set;Lorg/jetbrains/dokka/pages/Kind;Ljava/util/Set;Lorg/jetbrains/dokka/model/properties/PropertyContainer;)Lorg/jetbrains/dokka/pages/ContentGroup;
 	public final fun buildGroup (Ljava/util/Set;Ljava/util/Set;Lorg/jetbrains/dokka/pages/Kind;Ljava/util/Set;Lorg/jetbrains/dokka/model/properties/PropertyContainer;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/dokka/pages/ContentGroup;
 	public static synthetic fun buildGroup$default (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Ljava/util/Set;Ljava/util/Set;Lorg/jetbrains/dokka/pages/Kind;Ljava/util/Set;Lorg/jetbrains/dokka/model/properties/PropertyContainer;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/dokka/pages/ContentGroup;

--- a/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
@@ -94,6 +94,7 @@ open class HtmlRenderer(
                 childrenCallback()
             }
             node.hasStyle(ContentStyle.KDocTag) -> span("kdoc-tag") { childrenCallback() }
+            node.hasStyle(ContentStyle.Footnote) -> div("footnote") { childrenCallback() }
             node.hasStyle(TextStyle.BreakableAfter) -> {
                 span { childrenCallback() }
                 wbr { }
@@ -123,10 +124,12 @@ open class HtmlRenderer(
             node.dci.kind == ContentKind.Cover -> div("cover $additionalClasses") { //TODO this can be removed
                 childrenCallback()
             }
+            node.dci.kind == ContentKind.Deprecation -> div("deprecation-block") { childrenCallback() }
             node.hasStyle(TextStyle.Paragraph) -> p(additionalClasses) { childrenCallback() }
             node.hasStyle(TextStyle.Block) -> div(additionalClasses) { childrenCallback() }
             node.hasStyle(TextStyle.Quotation) -> blockQuote(additionalClasses) { childrenCallback() }
             node.hasStyle(TextStyle.FloatingRight) -> span("clearfix") { span("floating-right") { childrenCallback() } }
+            node.hasStyle(TextStyle.Strikethrough) -> strike { childrenCallback() }
             node.isAnchorable -> buildAnchor(
                 node.anchor!!,
                 node.anchorLabel!!,

--- a/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
@@ -124,7 +124,7 @@ open class HtmlRenderer(
             node.dci.kind == ContentKind.Cover -> div("cover $additionalClasses") { //TODO this can be removed
                 childrenCallback()
             }
-            node.dci.kind == ContentKind.Deprecation -> div("deprecation-block") { childrenCallback() }
+            node.dci.kind == ContentKind.Deprecation -> div("deprecation-content") { childrenCallback() }
             node.hasStyle(TextStyle.Paragraph) -> p(additionalClasses) { childrenCallback() }
             node.hasStyle(TextStyle.Block) -> div(additionalClasses) { childrenCallback() }
             node.hasStyle(TextStyle.Quotation) -> blockQuote(additionalClasses) { childrenCallback() }

--- a/plugins/base/src/main/kotlin/renderers/html/NavigationDataProvider.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/NavigationDataProvider.kt
@@ -34,8 +34,8 @@ abstract class NavigationDataProvider {
             name
         }
 
-    private fun chooseNavigationIcon(contentPage: ContentPage): NavigationNodeIcon? {
-        return if (contentPage is WithDocumentables) {
+    private fun chooseNavigationIcon(contentPage: ContentPage): NavigationNodeIcon? =
+        if (contentPage is WithDocumentables) {
             val documentable = contentPage.documentables.firstOrNull()
             val isJava = documentable?.hasAnyJavaSources() ?: false
 
@@ -64,20 +64,17 @@ abstract class NavigationDataProvider {
         } else {
             null
         }
-    }
 
     private fun Documentable.hasAnyJavaSources(): Boolean {
         val withSources = this as? WithSources ?: return false
         return this.sourceSets.any { withSources.documentableLanguage(it) == DocumentableLanguage.JAVA }
     }
 
-    private fun DClass.isAbstract(): Boolean {
-        return modifier.values.all { it is KotlinModifier.Abstract || it is JavaModifier.Abstract }
-    }
+    private fun DClass.isAbstract() =
+        modifier.values.all { it is KotlinModifier.Abstract || it is JavaModifier.Abstract }
 
-    private fun chooseStyles(page: ContentPage): Set<Style> {
-        return if (page.containsOnlyDeprecatedDocumentables()) setOf(TextStyle.Strikethrough) else emptySet()
-    }
+    private fun chooseStyles(page: ContentPage): Set<Style> =
+        if (page.containsOnlyDeprecatedDocumentables()) setOf(TextStyle.Strikethrough) else emptySet()
 
     private fun ContentPage.containsOnlyDeprecatedDocumentables(): Boolean {
         if (this !is WithDocumentables) {
@@ -93,16 +90,15 @@ abstract class NavigationDataProvider {
         }
     }
 
-    private fun ContentPage.navigableChildren(): List<NavigationNode> {
-        return if (this is ClasslikePage) {
-            return this.navigableChildren()
+    private fun ContentPage.navigableChildren() =
+        if (this is ClasslikePage) {
+            this.navigableChildren()
         } else {
             children
                 .filterIsInstance<ContentPage>()
                 .map { visit(it) }
                 .sortedBy { it.name.toLowerCase() }
         }
-    }
 
     private fun ClasslikePage.navigableChildren(): List<NavigationNode> {
         // Classlikes should only have other classlikes as navigable children

--- a/plugins/base/src/main/kotlin/renderers/html/NavigationDataProvider.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/NavigationDataProvider.kt
@@ -1,6 +1,8 @@
 package org.jetbrains.dokka.base.renderers.html
 
 import org.jetbrains.dokka.base.renderers.sourceSets
+import org.jetbrains.dokka.base.signatures.KotlinSignatureUtils.annotations
+import org.jetbrains.dokka.base.transformers.documentables.isDeprecated
 import org.jetbrains.dokka.base.transformers.documentables.isException
 import org.jetbrains.dokka.base.translators.documentables.DocumentableLanguage
 import org.jetbrains.dokka.base.translators.documentables.documentableLanguage
@@ -17,6 +19,7 @@ abstract class NavigationDataProvider {
             dri = page.dri.first(),
             sourceSets = page.sourceSets(),
             icon = chooseNavigationIcon(page),
+            styles = chooseStyles(page),
             children = page.navigableChildren()
         )
 
@@ -70,6 +73,24 @@ abstract class NavigationDataProvider {
 
     private fun DClass.isAbstract(): Boolean {
         return modifier.values.all { it is KotlinModifier.Abstract || it is JavaModifier.Abstract }
+    }
+
+    private fun chooseStyles(page: ContentPage): Set<Style> {
+        return if (page.containsOnlyDeprecatedDocumentables()) setOf(TextStyle.Strikethrough) else emptySet()
+    }
+
+    private fun ContentPage.containsOnlyDeprecatedDocumentables(): Boolean {
+        if (this !is WithDocumentables) {
+            return false
+        }
+        return this.documentables.isNotEmpty() && this.documentables.all { it.isDeprecatedForAllSourceSets() }
+    }
+
+    private fun Documentable.isDeprecatedForAllSourceSets(): Boolean {
+        val sourceSetAnnotations = this.annotations()
+        return sourceSetAnnotations.isNotEmpty() && sourceSetAnnotations.all { (_, annotations) ->
+            annotations.any { it.isDeprecated() }
+        }
     }
 
     private fun ContentPage.navigableChildren(): List<NavigationNode> {

--- a/plugins/base/src/main/kotlin/renderers/html/NavigationPage.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/NavigationPage.kt
@@ -57,17 +57,27 @@ class NavigationPage(
                             span("nav-link-grid") {
                                 span("nav-link-child ${node.icon?.style()}")
                                 span("nav-link-child") {
-                                    buildBreakableText(node.name)
+                                    nodeText(node)
                                 }
                             }
                         } else {
-                            buildBreakableText(node.name)
+                            nodeText(node)
                         }
                     }
                 }
                 node.children.withIndex().forEach { (n, p) -> visit(p, "$navId-$n", renderer) }
             }
         }
+
+    private fun FlowContent.nodeText(node: NavigationNode) {
+        if (node.styles.contains(TextStyle.Strikethrough)) {
+            strike {
+                buildBreakableText(node.name)
+            }
+        } else {
+            buildBreakableText(node.name)
+        }
+    }
 }
 
 data class NavigationNode(
@@ -75,6 +85,7 @@ data class NavigationNode(
     val dri: DRI,
     val sourceSets: Set<DisplaySourceSet>,
     val icon: NavigationNodeIcon?,
+    val styles: Set<Style> = emptySet(),
     override val children: List<NavigationNode>
 ) : WithChildren<NavigationNode>
 
@@ -108,4 +119,4 @@ fun NavigationPage.transform(block: (NavigationNode) -> NavigationNode) =
     NavigationPage(root.transform(block), moduleName, context)
 
 fun NavigationNode.transform(block: (NavigationNode) -> NavigationNode) =
-    run(block).let { NavigationNode(it.name, it.dri, it.sourceSets, it.icon, it.children.map(block)) }
+    run(block).let { NavigationNode(it.name, it.dri, it.sourceSets, it.icon, it.styles, it.children.map(block)) }

--- a/plugins/base/src/main/kotlin/signatures/JvmSignatureUtils.kt
+++ b/plugins/base/src/main/kotlin/signatures/JvmSignatureUtils.kt
@@ -20,6 +20,9 @@ interface JvmSignatureUtils {
     fun Collection<ExtraModifiers>.toSignatureString(): String =
         joinToString("") { it.name.toLowerCase() + " " }
 
+    @Suppress("UNCHECKED_CAST")
+    fun Documentable.annotations() = (this as? WithExtraProperties<Documentable>)?.annotations() ?: emptyMap()
+
     fun <T : AnnotationTarget> WithExtraProperties<T>.annotations(): SourceSetDependent<List<Annotations.Annotation>> =
         extra[Annotations]?.directAnnotations ?: emptyMap()
 

--- a/plugins/base/src/main/kotlin/signatures/KotlinSignatureUtils.kt
+++ b/plugins/base/src/main/kotlin/signatures/KotlinSignatureUtils.kt
@@ -1,6 +1,8 @@
 package org.jetbrains.dokka.base.signatures
 
 import org.jetbrains.dokka.base.translators.documentables.PageContentBuilder
+import org.jetbrains.dokka.base.transformers.pages.annotations.SinceKotlinTransformer
+import org.jetbrains.dokka.pages.ContentKind
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.links.DriOfAny
 import org.jetbrains.dokka.links.DriOfUnit
@@ -10,12 +12,21 @@ import org.jetbrains.dokka.model.properties.WithExtraProperties
 
 object KotlinSignatureUtils : JvmSignatureUtils {
 
+    private const val classExtension = "::class"
     private val strategy = OnlyOnce
     private val listBrackets = Pair('[', ']')
-    private val classExtension = "::class"
     private val ignoredAnnotations = setOf(
+        /**
+         * Rendered separately, see [SinceKotlinTransformer]
+         */
         Annotations.Annotation(DRI("kotlin", "SinceKotlin"), emptyMap()),
-        Annotations.Annotation(DRI("kotlin", "Deprecated"), emptyMap())
+
+        /**
+         * Rendered separately as its own block, see usage of [ContentKind.Deprecation]
+         */
+        Annotations.Annotation(DRI("kotlin", "Deprecated"), emptyMap()),
+        Annotations.Annotation(DRI("kotlin", "DeprecatedSinceKotlin"), emptyMap()),
+        Annotations.Annotation(DRI("java.lang", "Deprecated"), emptyMap()), // could be used as well for interop
     )
 
 

--- a/plugins/base/src/main/kotlin/transformers/documentables/utils.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/utils.kt
@@ -5,16 +5,28 @@ import org.jetbrains.dokka.model.Documentable
 import org.jetbrains.dokka.model.ExceptionInSupertypes
 import org.jetbrains.dokka.model.properties.WithExtraProperties
 
+/**
+ * @return true if [T] has [kotlin.Deprecated] or [java.lang.Deprecated]
+ *         annotation for **any** source set
+ */
 fun <T> T.isDeprecated() where T : WithExtraProperties<out Documentable> =
     deprecatedAnnotation != null
+
 
 val <T> T.deprecatedAnnotation where T : WithExtraProperties<out Documentable>
     get() = extra[Annotations]?.let { annotations ->
         annotations.directAnnotations.values.flatten().firstOrNull {
-            it.dri.toString() == "kotlin/Deprecated///PointingToDeclaration/" ||
-                    it.dri.toString() == "java.lang/Deprecated///PointingToDeclaration/"
+            it.isDeprecated()
         }
     }
+
+/**
+ * @return true for [kotlin.Deprecated] and [java.lang.Deprecated]
+ */
+fun Annotations.Annotation.isDeprecated(): Boolean {
+    return (this.dri.packageName == "kotlin" && this.dri.classNames == "Deprecated") ||
+            (this.dri.packageName == "java.lang" && this.dri.classNames == "Deprecated")
+}
 
 val <T : WithExtraProperties<out Documentable>> T.isException: Boolean
     get() = extra[ExceptionInSupertypes] != null

--- a/plugins/base/src/main/kotlin/transformers/documentables/utils.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/utils.kt
@@ -5,12 +5,8 @@ import org.jetbrains.dokka.model.Documentable
 import org.jetbrains.dokka.model.ExceptionInSupertypes
 import org.jetbrains.dokka.model.properties.WithExtraProperties
 
-/**
- * @return true if [T] has [kotlin.Deprecated] or [java.lang.Deprecated]
- *         annotation for **any** source set
- */
-fun <T> T.isDeprecated() where T : WithExtraProperties<out Documentable> =
-    deprecatedAnnotation != null
+val <T : WithExtraProperties<out Documentable>> T.isException: Boolean
+    get() = extra[ExceptionInSupertypes] != null
 
 
 val <T> T.deprecatedAnnotation where T : WithExtraProperties<out Documentable>
@@ -21,12 +17,14 @@ val <T> T.deprecatedAnnotation where T : WithExtraProperties<out Documentable>
     }
 
 /**
+ * @return true if [T] has [kotlin.Deprecated] or [java.lang.Deprecated]
+ *         annotation for **any** source set
+ */
+fun <T> T.isDeprecated() where T : WithExtraProperties<out Documentable> = deprecatedAnnotation != null
+
+/**
  * @return true for [kotlin.Deprecated] and [java.lang.Deprecated]
  */
-fun Annotations.Annotation.isDeprecated(): Boolean {
-    return (this.dri.packageName == "kotlin" && this.dri.classNames == "Deprecated") ||
+fun Annotations.Annotation.isDeprecated() =
+    (this.dri.packageName == "kotlin" && this.dri.classNames == "Deprecated") ||
             (this.dri.packageName == "java.lang" && this.dri.classNames == "Deprecated")
-}
-
-val <T : WithExtraProperties<out Documentable>> T.isException: Boolean
-    get() = extra[ExceptionInSupertypes] != null

--- a/plugins/base/src/main/kotlin/transformers/pages/merger/SameMethodNamePageMergerStrategy.kt
+++ b/plugins/base/src/main/kotlin/transformers/pages/merger/SameMethodNamePageMergerStrategy.kt
@@ -1,8 +1,11 @@
 package org.jetbrains.dokka.base.transformers.pages.merger
 
 import org.jetbrains.dokka.base.renderers.sourceSets
+import org.jetbrains.dokka.base.transformers.documentables.isDeprecated
 import org.jetbrains.dokka.model.DisplaySourceSet
+import org.jetbrains.dokka.model.Documentable
 import org.jetbrains.dokka.model.dfs
+import org.jetbrains.dokka.model.properties.WithExtraProperties
 import org.jetbrains.dokka.pages.*
 import org.jetbrains.dokka.utilities.DokkaLogger
 
@@ -12,7 +15,12 @@ import org.jetbrains.dokka.utilities.DokkaLogger
  */
 class SameMethodNamePageMergerStrategy(val logger: DokkaLogger) : PageMergerStrategy {
     override fun tryMerge(pages: List<PageNode>, path: List<String>): List<PageNode> {
-        val members = pages.filterIsInstance<MemberPageNode>().takeIf { it.isNotEmpty() } ?: return pages
+        val members = pages
+            .filterIsInstance<MemberPageNode>()
+            .takeIf { it.isNotEmpty() }
+            ?.sortedBy { it.containsDeprecatedDocumentables() } // non-deprecated first
+            ?: return pages
+
         val name = pages.first().name.also {
             if (pages.any { page -> page.name != it }) { // Is this even possible?
                 logger.error("Page names for $it do not match!")
@@ -31,6 +39,11 @@ class SameMethodNamePageMergerStrategy(val logger: DokkaLogger) : PageMergerStra
         )
 
         return (pages - members) + listOf(merged)
+    }
+
+    private fun MemberPageNode.containsDeprecatedDocumentables(): Boolean {
+        @Suppress("UNCHECKED_CAST")
+        return this.documentables.any { (it as? WithExtraProperties<Documentable>)?.isDeprecated() == true }
     }
 
     private fun List<MemberPageNode>.allSourceSets(): Set<DisplaySourceSet> =

--- a/plugins/base/src/main/kotlin/transformers/pages/merger/SameMethodNamePageMergerStrategy.kt
+++ b/plugins/base/src/main/kotlin/transformers/pages/merger/SameMethodNamePageMergerStrategy.kt
@@ -41,10 +41,9 @@ class SameMethodNamePageMergerStrategy(val logger: DokkaLogger) : PageMergerStra
         return (pages - members) + listOf(merged)
     }
 
-    private fun MemberPageNode.containsDeprecatedDocumentables(): Boolean {
-        @Suppress("UNCHECKED_CAST")
-        return this.documentables.any { (it as? WithExtraProperties<Documentable>)?.isDeprecated() == true }
-    }
+    @Suppress("UNCHECKED_CAST")
+    private fun MemberPageNode.containsDeprecatedDocumentables() =
+        this.documentables.any { (it as? WithExtraProperties<Documentable>)?.isDeprecated() == true }
 
     private fun List<MemberPageNode>.allSourceSets(): Set<DisplaySourceSet> =
         fold(emptySet()) { acc, e -> acc + e.sourceSets() }

--- a/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
@@ -452,6 +452,8 @@ open class DefaultPageCreator(
         val platforms = d.sourceSets.toSet()
 
         return contentBuilder.contentFor(d, styles = setOf(TextStyle.Block)) {
+            deprecatedSection(d, platforms)
+
             val descriptions = d.descriptions
             if (descriptions.any { it.value.root.children.isNotEmpty() }) {
                 platforms.forEach { platform ->

--- a/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
@@ -452,7 +452,7 @@ open class DefaultPageCreator(
         val platforms = d.sourceSets.toSet()
 
         return contentBuilder.contentFor(d, styles = setOf(TextStyle.Block)) {
-            deprecatedSection(d, platforms)
+            deprecatedSectionContent(d, platforms)
 
             val descriptions = d.descriptions
             if (descriptions.any { it.value.root.children.isNotEmpty() }) {

--- a/plugins/base/src/main/kotlin/translators/documentables/DeprecationSectionCreator.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DeprecationSectionCreator.kt
@@ -20,13 +20,7 @@ private const val DEPRECATED_HEADER_LEVEL = 3
  */
 private const val DIRECT_PARAM_HEADER_LEVEL = 4
 
-/**
- * Header for a nested param of [Deprecated],
- * such as [ReplaceWith.expression] and [ReplaceWith.imports]
- */
-private const val NESTED_PARAM_HEADER_LEVEL = 5
-
-internal fun PageContentBuilder.DocumentableContentBuilder.deprecatedSection(
+internal fun PageContentBuilder.DocumentableContentBuilder.deprecatedSectionContent(
     documentable: Documentable,
     platforms: Set<DokkaConfiguration.DokkaSourceSet>
 ) {
@@ -48,9 +42,9 @@ internal fun PageContentBuilder.DocumentableContentBuilder.deprecatedSection(
                 // contains more useful information, and Java's annotation is probably there
                 // for interop with Java callers, so it should be OK to ignore it
                 if (kotlinAnnotation != null) {
-                    createKotlinDeprecatedSection(kotlinAnnotation, platformAnnotations)
+                    createKotlinDeprecatedSectionContent(kotlinAnnotation, platformAnnotations)
                 } else if (javaAnnotation != null) {
-                    createJavaDeprecatedSection(javaAnnotation)
+                    createJavaDeprecatedSectionContent(javaAnnotation)
                 }
             }
         }
@@ -69,7 +63,7 @@ private fun findDeprecatedSinceKotlinAnnotation(annotations: List<Annotations.An
 /**
  * Section with details for Kotlin's [kotlin.Deprecated] annotation
  */
-private fun DocumentableContentBuilder.createKotlinDeprecatedSection(
+private fun DocumentableContentBuilder.createKotlinDeprecatedSectionContent(
     deprecatedAnnotation: Annotations.Annotation,
     allAnnotations: List<Annotations.Annotation>
 ) {
@@ -80,7 +74,7 @@ private fun DocumentableContentBuilder.createKotlinDeprecatedSection(
     )
 
     deprecatedSinceKotlinAnnotation?.let {
-        createDeprecatedSinceKotlinFootnote(it)
+        createDeprecatedSinceKotlinFootnoteContent(it)
     }
 
     deprecatedAnnotation.takeStringParam("message")?.let {
@@ -89,7 +83,7 @@ private fun DocumentableContentBuilder.createKotlinDeprecatedSection(
         }
     }
 
-    createReplaceWithSection(deprecatedAnnotation)
+    createReplaceWithSectionContent(deprecatedAnnotation)
 }
 
 private fun createKotlinDeprecatedHeaderText(
@@ -115,7 +109,7 @@ private fun createKotlinDeprecatedHeaderText(
  *
  * Notice that values are empty by default, so it's not guaranteed that all three will be set
  */
-private fun DocumentableContentBuilder.createDeprecatedSinceKotlinFootnote(
+private fun DocumentableContentBuilder.createDeprecatedSinceKotlinFootnoteContent(
     deprecatedSinceKotlinAnnotation: Annotations.Annotation
 ) {
     group(styles = setOf(ContentStyle.Footnote)) {
@@ -140,7 +134,7 @@ private fun DocumentableContentBuilder.createDeprecatedSinceKotlinFootnote(
 /**
  * Section for [ReplaceWith] parameter of [kotlin.Deprecated] annotation
  */
-private fun DocumentableContentBuilder.createReplaceWithSection(kotlinDeprecatedAnnotation: Annotations.Annotation) {
+private fun DocumentableContentBuilder.createReplaceWithSectionContent(kotlinDeprecatedAnnotation: Annotations.Annotation) {
     val replaceWithAnnotation = (kotlinDeprecatedAnnotation.params["replaceWith"] as? AnnotationValue)?.annotation
         ?: return
 
@@ -174,7 +168,7 @@ private fun DocumentableContentBuilder.createReplaceWithSection(kotlinDeprecated
 /**
  * Section with details for Java's [java.lang.Deprecated] annotation
  */
-private fun DocumentableContentBuilder.createJavaDeprecatedSection(
+private fun DocumentableContentBuilder.createJavaDeprecatedSectionContent(
     deprecatedAnnotation: Annotations.Annotation,
 ) {
     val isForRemoval = deprecatedAnnotation.takeBooleanParam("forRemoval", default = false)
@@ -189,10 +183,8 @@ private fun DocumentableContentBuilder.createJavaDeprecatedSection(
     }
 }
 
-private fun Annotations.Annotation.takeBooleanParam(name: String, default: Boolean): Boolean {
-    return (this.params[name] as? BooleanValue)?.value ?: default
-}
+private fun Annotations.Annotation.takeBooleanParam(name: String, default: Boolean): Boolean =
+    (this.params[name] as? BooleanValue)?.value ?: default
 
-private fun Annotations.Annotation.takeStringParam(name: String): String? {
-    return (this.params[name] as? StringValue)?.takeIf { it.value.isNotEmpty() }?.value
-}
+private fun Annotations.Annotation.takeStringParam(name: String): String? =
+    (this.params[name] as? StringValue)?.takeIf { it.value.isNotEmpty() }?.value

--- a/plugins/base/src/main/kotlin/translators/documentables/DeprecationSectionCreator.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DeprecationSectionCreator.kt
@@ -1,0 +1,190 @@
+package org.jetbrains.dokka.base.translators.documentables
+
+import org.jetbrains.dokka.DokkaConfiguration
+import org.jetbrains.dokka.base.signatures.KotlinSignatureUtils.annotations
+import org.jetbrains.dokka.base.transformers.documentables.isDeprecated
+import org.jetbrains.dokka.model.*
+import org.jetbrains.dokka.pages.ContentKind
+import org.jetbrains.dokka.pages.ContentStyle
+import org.jetbrains.dokka.pages.TextStyle
+import org.jetbrains.dokka.base.translators.documentables.PageContentBuilder.DocumentableContentBuilder
+
+/**
+ * Main header for [Deprecated] section
+ */
+private const val DEPRECATED_HEADER_LEVEL = 3
+
+/**
+ * Header for a direct parameter of [Deprecated] annotation,
+ * such as [Deprecated.message] and [Deprecated.replaceWith]
+ */
+private const val DIRECT_PARAM_HEADER_LEVEL = 4
+
+/**
+ * Header for a nested param of [Deprecated],
+ * such as [ReplaceWith.expression] and [ReplaceWith.imports]
+ */
+private const val NESTED_PARAM_HEADER_LEVEL = 5
+
+internal fun PageContentBuilder.DocumentableContentBuilder.deprecatedSection(
+    documentable: Documentable,
+    platforms: Set<DokkaConfiguration.DokkaSourceSet>
+) {
+    val allAnnotations = documentable.annotations()
+    if (allAnnotations.isEmpty()) {
+        return
+    }
+
+    platforms.forEach { platform ->
+        val platformAnnotations = allAnnotations[platform] ?: emptyList()
+        val deprecatedPlatformAnnotations = platformAnnotations.filter { it.isDeprecated() }
+
+        if (deprecatedPlatformAnnotations.isNotEmpty()) {
+            group(kind = ContentKind.Deprecation, sourceSets = setOf(platform), styles = emptySet()) {
+                val kotlinAnnotation = deprecatedPlatformAnnotations.find { it.dri.packageName == "kotlin" }
+                val javaAnnotation = deprecatedPlatformAnnotations.find { it.dri.packageName == "java.lang" }
+
+                // If both annotations are present, priority is given to Kotlin's annotation since it
+                // contains more useful information, and Java's annotation is probably there
+                // for interop with Java callers, so it should be OK to ignore it
+                if (kotlinAnnotation != null) {
+                    createKotlinDeprecatedSection(kotlinAnnotation, platformAnnotations)
+                } else if (javaAnnotation != null) {
+                    createJavaDeprecatedSection(javaAnnotation)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * @see [DeprecatedSinceKotlin]
+ */
+private fun findDeprecatedSinceKotlinAnnotation(annotations: List<Annotations.Annotation>): Annotations.Annotation? {
+    return annotations.firstOrNull {
+        it.dri.packageName == "kotlin" && it.dri.classNames == "DeprecatedSinceKotlin"
+    }
+}
+
+/**
+ * Section with details for Kotlin's [kotlin.Deprecated] annotation
+ */
+private fun DocumentableContentBuilder.createKotlinDeprecatedSection(
+    deprecatedAnnotation: Annotations.Annotation,
+    allAnnotations: List<Annotations.Annotation>
+) {
+    val deprecatedSinceKotlinAnnotation = findDeprecatedSinceKotlinAnnotation(allAnnotations)
+    header(
+        level = DEPRECATED_HEADER_LEVEL,
+        text = createKotlinDeprecatedHeaderText(deprecatedAnnotation, deprecatedSinceKotlinAnnotation)
+    )
+
+    deprecatedSinceKotlinAnnotation?.let {
+        createDeprecatedSinceKotlinFootnote(it)
+    }
+
+    deprecatedAnnotation.takeStringParam("message")?.let {
+        group(styles = setOf(TextStyle.Paragraph)) {
+            text(it)
+        }
+    }
+
+    createReplaceWithSection(deprecatedAnnotation)
+}
+
+private fun createKotlinDeprecatedHeaderText(
+    kotlinDeprecatedAnnotation: Annotations.Annotation,
+    deprecatedSinceKotlinAnnotation: Annotations.Annotation?
+): String {
+    if (deprecatedSinceKotlinAnnotation != null) {
+        // In this case there's no single level, it's dynamic based on api version,
+        // so there should be a footnote with levels and their respective versions
+        return "Deprecated"
+    }
+
+    val deprecationLevel = kotlinDeprecatedAnnotation.params["level"]?.let { (it as? EnumValue)?.enumName }
+    return when (deprecationLevel) {
+        "DeprecationLevel.ERROR" -> "Deprecated (with error)"
+        "DeprecationLevel.HIDDEN" -> "Deprecated (hidden)"
+        else -> "Deprecated"
+    }
+}
+
+/**
+ * Footnote for [DeprecatedSinceKotlin] annotation used in stdlib
+ */
+private fun DocumentableContentBuilder.createDeprecatedSinceKotlinFootnote(
+    deprecatedSinceKotlinAnnotation: Annotations.Annotation
+) {
+    group(styles = setOf(ContentStyle.Footnote)) {
+        deprecatedSinceKotlinAnnotation.takeStringParam("warningSince")?.let { text("Warning since $it") }
+        breakLine()
+        deprecatedSinceKotlinAnnotation.takeStringParam("errorSince")?.let { text("Error since $it") }
+        breakLine()
+        deprecatedSinceKotlinAnnotation.takeStringParam("hiddenSince")?.let { text("Hidden since $it") }
+    }
+}
+
+/**
+ * Section for [ReplaceWith] parameter of [kotlin.Deprecated] annotation
+ */
+private fun DocumentableContentBuilder.createReplaceWithSection(kotlinDeprecatedAnnotation: Annotations.Annotation) {
+    val replaceWithAnnotation = (kotlinDeprecatedAnnotation.params["replaceWith"] as? AnnotationValue)?.annotation
+        ?: return
+
+    header(
+        level = DIRECT_PARAM_HEADER_LEVEL,
+        text = "Replace with"
+    )
+
+    replaceWithAnnotation.takeStringParam("expression")?.let {
+        codeBlock(language = "kotlin", styles = setOf(TextStyle.Monospace)) {
+            text(it)
+        }
+    }
+
+    // Signature: vararg val imports: String
+    val imports = (replaceWithAnnotation.params["imports"] as? ArrayValue)
+        ?.value
+        ?.mapNotNull { (it as? StringValue)?.value }
+        ?: emptyList()
+
+    if (imports.isNotEmpty()) {
+        header(
+            level = NESTED_PARAM_HEADER_LEVEL,
+            text = "Imports"
+        )
+        codeBlock(language = "kotlin", styles = setOf(TextStyle.Monospace)) {
+            imports.forEach {
+                text(it)
+                breakLine()
+            }
+        }
+    }
+}
+
+/**
+ * Section with details for Java's [java.lang.Deprecated] annotation
+ */
+private fun DocumentableContentBuilder.createJavaDeprecatedSection(
+    deprecatedAnnotation: Annotations.Annotation,
+) {
+    val isForRemoval = deprecatedAnnotation.takeBooleanParam("forRemoval", default = false)
+    header(
+        level = DEPRECATED_HEADER_LEVEL,
+        text = if (isForRemoval) "Deprecated (for removal)" else "Deprecated"
+    )
+    deprecatedAnnotation.takeStringParam("since")?.let {
+        group(styles = setOf(ContentStyle.Footnote)) {
+            text("Since version $it")
+        }
+    }
+}
+
+private fun Annotations.Annotation.takeBooleanParam(name: String, default: Boolean): Boolean {
+    return (this.params[name] as? BooleanValue)?.value ?: default
+}
+
+private fun Annotations.Annotation.takeStringParam(name: String): String? {
+    return (this.params[name] as? StringValue)?.takeIf { it.value.isNotEmpty() }?.value
+}

--- a/plugins/base/src/main/kotlin/translators/documentables/DeprecationSectionCreator.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DeprecationSectionCreator.kt
@@ -149,12 +149,6 @@ private fun DocumentableContentBuilder.createReplaceWithSection(kotlinDeprecated
         text = "Replace with"
     )
 
-    replaceWithAnnotation.takeStringParam("expression")?.removeSurrounding("`")?.let {
-        codeBlock(language = "kotlin", styles = setOf(TextStyle.Monospace)) {
-            text(it)
-        }
-    }
-
     // Signature: vararg val imports: String
     val imports = (replaceWithAnnotation.params["imports"] as? ArrayValue)
         ?.value
@@ -162,15 +156,17 @@ private fun DocumentableContentBuilder.createReplaceWithSection(kotlinDeprecated
         ?: emptyList()
 
     if (imports.isNotEmpty()) {
-        header(
-            level = NESTED_PARAM_HEADER_LEVEL,
-            text = "Imports"
-        )
         codeBlock(language = "kotlin", styles = setOf(TextStyle.Monospace)) {
             imports.forEach {
-                text(it)
+                text("import $it")
                 breakLine()
             }
+        }
+    }
+
+    replaceWithAnnotation.takeStringParam("expression")?.removeSurrounding("`")?.let {
+        codeBlock(language = "kotlin", styles = setOf(TextStyle.Monospace)) {
+            text(it)
         }
     }
 }

--- a/plugins/base/src/main/kotlin/translators/documentables/DeprecationSectionCreator.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DeprecationSectionCreator.kt
@@ -112,16 +112,28 @@ private fun createKotlinDeprecatedHeaderText(
 
 /**
  * Footnote for [DeprecatedSinceKotlin] annotation used in stdlib
+ *
+ * Notice that values are empty by default, so it's not guaranteed that all three will be set
  */
 private fun DocumentableContentBuilder.createDeprecatedSinceKotlinFootnote(
     deprecatedSinceKotlinAnnotation: Annotations.Annotation
 ) {
     group(styles = setOf(ContentStyle.Footnote)) {
-        deprecatedSinceKotlinAnnotation.takeStringParam("warningSince")?.let { text("Warning since $it") }
-        breakLine()
-        deprecatedSinceKotlinAnnotation.takeStringParam("errorSince")?.let { text("Error since $it") }
-        breakLine()
-        deprecatedSinceKotlinAnnotation.takeStringParam("hiddenSince")?.let { text("Hidden since $it") }
+        deprecatedSinceKotlinAnnotation.takeStringParam("warningSince")?.let {
+            group(styles = setOf(TextStyle.Paragraph)) {
+                text("Warning since $it")
+            }
+        }
+        deprecatedSinceKotlinAnnotation.takeStringParam("errorSince")?.let {
+            group(styles = setOf(TextStyle.Paragraph)) {
+                text("Error since $it")
+            }
+        }
+        deprecatedSinceKotlinAnnotation.takeStringParam("hiddenSince")?.let {
+            group(styles = setOf(TextStyle.Paragraph)) {
+                text("Hidden since $it")
+            }
+        }
     }
 }
 
@@ -137,7 +149,7 @@ private fun DocumentableContentBuilder.createReplaceWithSection(kotlinDeprecated
         text = "Replace with"
     )
 
-    replaceWithAnnotation.takeStringParam("expression")?.let {
+    replaceWithAnnotation.takeStringParam("expression")?.removeSurrounding("`")?.let {
         codeBlock(language = "kotlin", styles = setOf(TextStyle.Monospace)) {
             text(it)
         }

--- a/plugins/base/src/main/kotlin/translators/documentables/PageContentBuilder.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/PageContentBuilder.kt
@@ -139,6 +139,10 @@ open class PageContentBuilder(
             contents += createText(text, kind, sourceSets, styles, extra)
         }
 
+        fun breakLine(sourceSets: Set<DokkaSourceSet> = mainSourcesetData) {
+            contents += ContentBreakLine(sourceSets.toDisplaySourceSets())
+        }
+
         fun buildSignature(d: Documentable) = signatureProvider.signature(d)
 
         fun table(

--- a/plugins/base/src/main/resources/dokka/styles/style.css
+++ b/plugins/base/src/main/resources/dokka/styles/style.css
@@ -778,6 +778,10 @@ small {
     display: block;
 }
 
+.deprecation-block .footnote > p {
+    margin: 0;
+}
+
 .platform-tag {
     display: flex;
     flex-direction: row;

--- a/plugins/base/src/main/resources/dokka/styles/style.css
+++ b/plugins/base/src/main/resources/dokka/styles/style.css
@@ -743,36 +743,36 @@ small {
     font-size: 11px;
 }
 
-.deprecation-block {
+.deprecation-content {
     margin: 20px 10px;
     border:1px solid var(--border-color);
     padding: 13px 15px 16px 15px;
 }
 
-.deprecation-block > h3 {
+.deprecation-content > h3 {
     margin-top: 0;
     margin-bottom: 0;
 }
 
-.deprecation-block > h4 {
+.deprecation-content > h4 {
     font-size: 16px;
     margin-top: 15px;
     margin-bottom: 0;
 }
 
-.deprecation-block code.block {
+.deprecation-content code.block {
     padding: 5px 10px;
     display: inline-block;
 }
 
-.deprecation-block .footnote {
+.deprecation-content .footnote {
     margin-left: 25px;
     font-size: 13px;
     font-weight: bold;
     display: block;
 }
 
-.deprecation-block .footnote > p {
+.deprecation-content .footnote > p {
     margin: 0;
 }
 

--- a/plugins/base/src/main/resources/dokka/styles/style.css
+++ b/plugins/base/src/main/resources/dokka/styles/style.css
@@ -760,12 +760,6 @@ small {
     margin-bottom: 0;
 }
 
-.deprecation-block > h5 {
-    font-size: 15px;
-    margin-top: 10px;
-    margin-bottom: 0;
-}
-
 .deprecation-block code.block {
     padding: 5px 10px;
     display: inline-block;

--- a/plugins/base/src/main/resources/dokka/styles/style.css
+++ b/plugins/base/src/main/resources/dokka/styles/style.css
@@ -743,6 +743,41 @@ small {
     font-size: 11px;
 }
 
+.deprecation-block {
+    margin: 20px 10px;
+    border:1px solid var(--border-color);
+    padding: 13px 15px 16px 15px;
+}
+
+.deprecation-block > h3 {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.deprecation-block > h4 {
+    font-size: 16px;
+    margin-top: 15px;
+    margin-bottom: 0;
+}
+
+.deprecation-block > h5 {
+    font-size: 15px;
+    margin-top: 10px;
+    margin-bottom: 0;
+}
+
+.deprecation-block code.block {
+    padding: 5px 10px;
+    display: inline-block;
+}
+
+.deprecation-block .footnote {
+    margin-left: 25px;
+    font-size: 13px;
+    font-weight: bold;
+    display: block;
+}
+
 .platform-tag {
     display: flex;
     flex-direction: row;

--- a/plugins/base/src/test/kotlin/content/annotations/JavaDeprecatedTest.kt
+++ b/plugins/base/src/test/kotlin/content/annotations/JavaDeprecatedTest.kt
@@ -1,0 +1,139 @@
+package content.annotations
+
+import matchers.content.*
+import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
+import org.jetbrains.dokka.base.transformers.documentables.deprecatedAnnotation
+import org.jetbrains.dokka.base.transformers.documentables.isDeprecated
+import org.jetbrains.dokka.model.Documentable
+import org.jetbrains.dokka.model.properties.WithExtraProperties
+import org.jetbrains.dokka.pages.ContentPage
+import org.jetbrains.dokka.pages.ContentStyle
+import org.junit.jupiter.api.Test
+import utils.pWrapped
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class JavaDeprecatedTest : BaseAbstractTest() {
+
+    private val testConfiguration = dokkaConfiguration {
+        sourceSets {
+            sourceSet {
+                sourceRoots = listOf("src/")
+                analysisPlatform = "jvm"
+            }
+        }
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    fun `should assert util functions for deprecation`() {
+        testInline(
+            """
+            |/src/main/kotlin/deprecated/DeprecatedJavaClass.java
+            |package deprecated
+            |
+            |@Deprecated(forRemoval = true)
+            |public class DeprecatedJavaClass {}
+            """.trimIndent(),
+            testConfiguration
+        ) {
+            documentablesTransformationStage = { module ->
+                val deprecatedClass = module.children
+                    .single { it.name == "deprecated" }.children
+                    .single { it.name == "DeprecatedJavaClass" }
+
+                val isDeprecated = (deprecatedClass as WithExtraProperties<out Documentable>).isDeprecated()
+                assertTrue(isDeprecated)
+
+                val deprecatedAnnotation = (deprecatedClass as WithExtraProperties<out Documentable>).deprecatedAnnotation
+                checkNotNull(deprecatedAnnotation)
+
+                assertTrue(deprecatedAnnotation.isDeprecated())
+                assertEquals("java.lang", deprecatedAnnotation.dri.packageName)
+                assertEquals("Deprecated", deprecatedAnnotation.dri.classNames)
+            }
+        }
+    }
+
+    @Test
+    fun `should change deprecated header if marked for removal`() {
+        testInline(
+            """
+            |/src/main/kotlin/deprecated/DeprecatedJavaClass.java
+            |package deprecated
+            |
+            |/**
+            | * Average function description
+            | */
+            |@Deprecated(forRemoval = true)
+            |public class DeprecatedJavaClass {}
+            """.trimIndent(),
+            testConfiguration
+        ) {
+            pagesTransformationStage = { module ->
+                val deprecatedJavaClass = module.children
+                    .single { it.name == "deprecated" }.children
+                    .single { it.name == "DeprecatedJavaClass" } as ContentPage
+
+                deprecatedJavaClass.content.assertNode {
+                    group {
+                        header(1) { +"DeprecatedJavaClass" }
+                        platformHinted {
+                            skipAllNotMatching()
+                            group {
+                                header(3) {
+                                    +"Deprecated (for removal)"
+                                }
+                            }
+                            group { pWrapped("Average function description") }
+                        }
+                    }
+                    skipAllNotMatching()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should add footnote for 'since' param`() {
+        testInline(
+            """
+            |/src/main/kotlin/deprecated/DeprecatedJavaClass.java
+            |package deprecated
+            |
+            |/**
+            | * Average function description
+            | */
+            |@Deprecated(since = "11")
+            |public class DeprecatedJavaClass {}
+            """.trimIndent(),
+            testConfiguration
+        ) {
+            pagesTransformationStage = { module ->
+                val deprecatedJavaClass = module.children
+                    .single { it.name == "deprecated" }.children
+                    .single { it.name == "DeprecatedJavaClass" } as ContentPage
+
+                deprecatedJavaClass.content.assertNode {
+                    group {
+                        header(1) { +"DeprecatedJavaClass" }
+                        platformHinted {
+                            skipAllNotMatching()
+                            group {
+                                header(3) {
+                                    +"Deprecated"
+                                }
+                                group {
+                                    check { assertEquals(ContentStyle.Footnote, this.style.firstOrNull()) }
+                                    +"Since version 11"
+                                }
+                            }
+                            group { pWrapped("Average function description") }
+                        }
+                    }
+                    skipAllNotMatching()
+                }
+            }
+        }
+    }
+}

--- a/plugins/base/src/test/kotlin/content/annotations/KotlinDeprecatedTest.kt
+++ b/plugins/base/src/test/kotlin/content/annotations/KotlinDeprecatedTest.kt
@@ -192,18 +192,15 @@ class KotlinDeprecatedTest : BaseAbstractTest() {
                                         +"Replace with"
                                     }
                                     codeBlock {
-                                        +"newShinyFunction(typedParam, someLiteral, SomeNewType())"
-                                    }
-                                    header(5) {
-                                        +"Imports"
+                                        +"import com.example.dokka.debug.newShinyFunction"
+                                        br()
+                                        +"import com.example.dokka.debug.SomeOldType"
+                                        br()
+                                        +"import com.example.dokka.debug.SomeNewType"
+                                        br()
                                     }
                                     codeBlock {
-                                        +"com.example.dokka.debug.newShinyFunction"
-                                        br()
-                                        +"com.example.dokka.debug.SomeOldType"
-                                        br()
-                                        +"com.example.dokka.debug.SomeNewType"
-                                        br()
+                                        +"newShinyFunction(typedParam, someLiteral, SomeNewType())"
                                     }
                                 }
                                 group { pWrapped("Average function description") }
@@ -376,18 +373,15 @@ class KotlinDeprecatedTest : BaseAbstractTest() {
                                         +"Replace with"
                                     }
                                     codeBlock {
-                                        +"newShinyFunction(typedParam, someLiteral, SomeNewType())"
-                                    }
-                                    header(5) {
-                                        +"Imports"
+                                        +"import com.example.dokka.debug.newShinyFunction"
+                                        br()
+                                        +"import com.example.dokka.debug.SomeOldType"
+                                        br()
+                                        +"import com.example.dokka.debug.SomeNewType"
+                                        br()
                                     }
                                     codeBlock {
-                                        +"com.example.dokka.debug.newShinyFunction"
-                                        br()
-                                        +"com.example.dokka.debug.SomeOldType"
-                                        br()
-                                        +"com.example.dokka.debug.SomeNewType"
-                                        br()
+                                        +"newShinyFunction(typedParam, someLiteral, SomeNewType())"
                                     }
                                 }
                                 group { pWrapped("Average function description") }

--- a/plugins/base/src/test/kotlin/content/annotations/KotlinDeprecatedTest.kt
+++ b/plugins/base/src/test/kotlin/content/annotations/KotlinDeprecatedTest.kt
@@ -273,12 +273,15 @@ class KotlinDeprecatedTest : BaseAbstractTest() {
                                     }
                                     group {
                                         check { assertEquals(ContentStyle.Footnote, this.style.firstOrNull()) }
-
-                                        +"Warning since 1.4"
-                                        br()
-                                        +"Error since 1.5"
-                                        br()
-                                        +"Hidden since 1.6"
+                                        p {
+                                            +"Warning since 1.4"
+                                        }
+                                        p {
+                                            +"Error since 1.5"
+                                        }
+                                        p {
+                                            +"Hidden since 1.6"
+                                        }
                                     }
                                     p {
                                         +"Deprecation reason bla bla"

--- a/plugins/base/src/test/kotlin/content/annotations/KotlinDeprecatedTest.kt
+++ b/plugins/base/src/test/kotlin/content/annotations/KotlinDeprecatedTest.kt
@@ -1,0 +1,398 @@
+package content.annotations
+
+import matchers.content.*
+import org.jetbrains.dokka.pages.ContentPage
+import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
+import org.jetbrains.dokka.base.transformers.documentables.deprecatedAnnotation
+import org.jetbrains.dokka.pages.ContentStyle
+import org.jetbrains.dokka.base.transformers.documentables.isDeprecated
+import org.jetbrains.dokka.model.Documentable
+import org.jetbrains.dokka.model.properties.WithExtraProperties
+import org.junit.jupiter.api.Test
+import utils.ParamAttributes
+import utils.bareSignature
+import utils.pWrapped
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+
+class KotlinDeprecatedTest : BaseAbstractTest() {
+
+    private val testConfiguration = dokkaConfiguration {
+        sourceSets {
+            sourceSet {
+                sourceRoots = listOf("src/")
+                analysisPlatform = "jvm"
+            }
+        }
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    fun `should assert util functions for deprecation`() {
+        testInline(
+            """
+            |/src/main/kotlin/kotlin/KotlinFile.kt
+            |package kotlin
+            |
+            |@Deprecated(
+            |    message = "Fancy message"
+            |)
+            |fun simpleFunction() {} 
+            """.trimIndent(),
+            testConfiguration
+        ) {
+            documentablesTransformationStage = { module ->
+                val deprecatedFunction = module.children
+                    .single { it.name == "kotlin" }.children
+                    .single { it.name == "simpleFunction" }
+
+                val isDeprecated = (deprecatedFunction as WithExtraProperties<out Documentable>).isDeprecated()
+                assertTrue(isDeprecated)
+
+                val deprecatedAnnotation = (deprecatedFunction as WithExtraProperties<out Documentable>).deprecatedAnnotation
+                checkNotNull(deprecatedAnnotation)
+
+                assertTrue(deprecatedAnnotation.isDeprecated())
+                assertEquals("kotlin", deprecatedAnnotation.dri.packageName)
+                assertEquals("Deprecated", deprecatedAnnotation.dri.classNames)
+            }
+        }
+    }
+
+    @Test
+    fun `should change header if deprecation level is not default`() {
+        testInline(
+            """
+            |/src/main/kotlin/kotlin/DeprecatedKotlin.kt
+            |package kotlin
+            |
+            |/**
+            | * Average function description
+            | */
+            |@Deprecated(
+            |    message = "Reason for deprecation bla bla",
+            |    level = DeprecationLevel.ERROR
+            |)
+            |fun oldLegacyFunction(typedParam: SomeOldType, someLiteral: String): String {}
+            |
+            |fun newShinyFunction(typedParam: SomeOldType, someLiteral: String, newTypedParam: SomeNewType): String {}
+            |class SomeOldType {}
+            |class SomeNewType {}
+            """.trimIndent(),
+            testConfiguration
+        ) {
+            pagesTransformationStage = { module ->
+                val functionWithDeprecatedFunction = module.children
+                    .single { it.name == "kotlin" }.children
+                    .single { it.name == "oldLegacyFunction" } as ContentPage
+
+                functionWithDeprecatedFunction.content.assertNode {
+                    group {
+                        header(1) { +"oldLegacyFunction" }
+                    }
+                    divergentGroup {
+                        divergentInstance {
+                            divergent {
+                                bareSignature(
+                                    annotations = emptyMap(),
+                                    visibility = "",
+                                    modifier = "",
+                                    keywords = emptySet(),
+                                    name = "oldLegacyFunction",
+                                    returnType = "String",
+                                    params = arrayOf(
+                                        "typedParam" to ParamAttributes(emptyMap(), emptySet(), "SomeOldType"),
+                                        "someLiteral" to ParamAttributes(emptyMap(), emptySet(), "String"),
+                                    )
+                                )
+                            }
+                            after {
+                                group {
+                                    header(3) {
+                                        +"Deprecated (with error)"
+                                    }
+                                    p {
+                                        +"Reason for deprecation bla bla"
+                                    }
+                                }
+                                group { pWrapped("Average function description") }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should display repalceWith param with imports as code blocks`() {
+        testInline(
+            """
+            |/src/main/kotlin/kotlin/DeprecatedKotlin.kt
+            |package kotlin
+            |
+            |/**
+            | * Average function description
+            | */
+            |@Deprecated(
+            |    message = "Reason for deprecation bla bla",
+            |    replaceWith = ReplaceWith(
+            |        "newShinyFunction(typedParam, someLiteral, SomeNewType())",
+            |        imports = [
+            |            "com.example.dokka.debug.newShinyFunction",
+            |            "com.example.dokka.debug.SomeOldType",
+            |            "com.example.dokka.debug.SomeNewType",
+            |        ]
+            |    ),
+            |)
+            |fun oldLegacyFunction(typedParam: SomeOldType, someLiteral: String): String {}
+            |
+            |fun newShinyFunction(typedParam: SomeOldType, someLiteral: String, newTypedParam: SomeNewType): String {}
+            |class SomeOldType {}
+            |class SomeNewType {}
+            """.trimIndent(),
+            testConfiguration
+        ) {
+            pagesTransformationStage = { module ->
+                val functionWithDeprecatedFunction = module.children
+                    .single { it.name == "kotlin" }.children
+                    .single { it.name == "oldLegacyFunction" } as ContentPage
+
+                functionWithDeprecatedFunction.content.assertNode {
+                    group {
+                        header(1) { +"oldLegacyFunction" }
+                    }
+                    divergentGroup {
+                        divergentInstance {
+                            divergent {
+                                bareSignature(
+                                    annotations = emptyMap(),
+                                    visibility = "",
+                                    modifier = "",
+                                    keywords = emptySet(),
+                                    name = "oldLegacyFunction",
+                                    returnType = "String",
+                                    params = arrayOf(
+                                        "typedParam" to ParamAttributes(emptyMap(), emptySet(), "SomeOldType"),
+                                        "someLiteral" to ParamAttributes(emptyMap(), emptySet(), "String"),
+                                    )
+                                )
+                            }
+                            after {
+                                group {
+                                    header(3) {
+                                        +"Deprecated"
+                                    }
+                                    p {
+                                        +"Reason for deprecation bla bla"
+                                    }
+
+                                    header(4) {
+                                        +"Replace with"
+                                    }
+                                    codeBlock {
+                                        +"newShinyFunction(typedParam, someLiteral, SomeNewType())"
+                                    }
+                                    header(5) {
+                                        +"Imports"
+                                    }
+                                    codeBlock {
+                                        +"com.example.dokka.debug.newShinyFunction"
+                                        br()
+                                        +"com.example.dokka.debug.SomeOldType"
+                                        br()
+                                        +"com.example.dokka.debug.SomeNewType"
+                                        br()
+                                    }
+                                }
+                                group { pWrapped("Average function description") }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should add footnote for DeprecatedSinceKotlin annotation`() {
+        testInline(
+            """
+            |/src/main/kotlin/kotlin/DeprecatedKotlin.kt
+            |package kotlin
+            |
+            |/**
+            | * Average function description
+            | */
+            |@DeprecatedSinceKotlin(
+            |    warningSince = "1.4",
+            |    errorSince = "1.5",
+            |    hiddenSince = "1.6"
+            |)
+            |@Deprecated(
+            |    message = "Deprecation reason bla bla"
+            |)
+            |fun oldLegacyFunction(typedParam: SomeOldType, someLiteral: String): String {}
+            |
+            |fun newShinyFunction(typedParam: SomeOldType, someLiteral: String, newTypedParam: SomeNewType): String {}
+            |class SomeOldType {}
+            |class SomeNewType {}
+            """.trimIndent(),
+            testConfiguration
+        ) {
+            pagesTransformationStage = { module ->
+                val functionWithDeprecatedFunction = module.children
+                    .single { it.name == "kotlin" }.children
+                    .single { it.name == "oldLegacyFunction" } as ContentPage
+
+                functionWithDeprecatedFunction.content.assertNode {
+                    group {
+                        header(1) { +"oldLegacyFunction" }
+                    }
+                    divergentGroup {
+                        divergentInstance {
+                            divergent {
+                                bareSignature(
+                                    annotations = emptyMap(),
+                                    visibility = "",
+                                    modifier = "",
+                                    keywords = emptySet(),
+                                    name = "oldLegacyFunction",
+                                    returnType = "String",
+                                    params = arrayOf(
+                                        "typedParam" to ParamAttributes(emptyMap(), emptySet(), "SomeOldType"),
+                                        "someLiteral" to ParamAttributes(emptyMap(), emptySet(), "String"),
+                                    )
+                                )
+                            }
+                            after {
+                                group {
+                                    header(3) {
+                                        +"Deprecated"
+                                    }
+                                    group {
+                                        check { assertEquals(ContentStyle.Footnote, this.style.firstOrNull()) }
+
+                                        +"Warning since 1.4"
+                                        br()
+                                        +"Error since 1.5"
+                                        br()
+                                        +"Hidden since 1.6"
+                                    }
+                                    p {
+                                        +"Deprecation reason bla bla"
+                                    }
+                                }
+                                group { pWrapped("Average function description") }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should generate deprecation block with all parameters present and long description`() {
+        testInline(
+            """
+            |/src/main/kotlin/kotlin/DeprecatedKotlin.kt
+            |package kotlin
+            |
+            |/**
+            | * Average function description
+            | */
+            |@Deprecated(
+            |    message = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas vel vulputate risus. " +
+            |            "Etiam dictum odio vel vulputate auctor.Nulla facilisi. Duis ullamcorper ullamcorper lectus " +
+            |            "nec rutrum. Quisque eu risus eu purus bibendum ultricies. Maecenas tincidunt dui in sodales " +
+            |            "faucibus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin id sem felis. " +
+            |            "Praesent et libero lacinia, egestas libero in, ultrices lectus. Suspendisse eget volutpat " +
+            |            "velit. Phasellus laoreet mi eu egestas mattis.",
+            |    replaceWith = ReplaceWith(
+            |        "newShinyFunction(typedParam, someLiteral, SomeNewType())",
+            |        imports = [
+            |            "com.example.dokka.debug.newShinyFunction",
+            |            "com.example.dokka.debug.SomeOldType",
+            |            "com.example.dokka.debug.SomeNewType",
+            |        ]
+            |    ),
+            |    level = DeprecationLevel.ERROR
+            |)
+            |fun oldLegacyFunction(typedParam: SomeOldType, someLiteral: String): String {}
+            |
+            |fun newShinyFunction(typedParam: SomeOldType, someLiteral: String, newTypedParam: SomeNewType): String {}
+            |class SomeOldType {}
+            |class SomeNewType {}
+            """.trimIndent(),
+            testConfiguration
+        ) {
+            pagesTransformationStage = { module ->
+                val functionWithDeprecatedFunction = module.children
+                    .single { it.name == "kotlin" }.children
+                    .single { it.name == "oldLegacyFunction" } as ContentPage
+
+                functionWithDeprecatedFunction.content.assertNode {
+                    group {
+                        header(1) { +"oldLegacyFunction" }
+                    }
+                    divergentGroup {
+                        divergentInstance {
+                            divergent {
+                                bareSignature(
+                                    annotations = emptyMap(),
+                                    visibility = "",
+                                    modifier = "",
+                                    keywords = emptySet(),
+                                    name = "oldLegacyFunction",
+                                    returnType = "String",
+                                    params = arrayOf(
+                                        "typedParam" to ParamAttributes(emptyMap(), emptySet(), "SomeOldType"),
+                                        "someLiteral" to ParamAttributes(emptyMap(), emptySet(), "String"),
+                                    )
+                                )
+                            }
+                            after {
+                                group {
+                                    header(3) {
+                                        +"Deprecated (with error)"
+                                    }
+                                    p {
+                                        +("Lorem ipsum dolor sit amet, consectetur adipiscing elit. " +
+                                                "Maecenas vel vulputate risus. Etiam dictum odio vel " +
+                                                "vulputate auctor.Nulla facilisi. Duis ullamcorper " +
+                                                "ullamcorper lectus nec rutrum. Quisque eu risus eu " +
+                                                "purus bibendum ultricies. Maecenas tincidunt dui in sodales faucibus. " +
+                                                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. " +
+                                                "Proin id sem felis. Praesent et libero lacinia, egestas " +
+                                                "libero in, ultrices lectus. Suspendisse eget volutpat velit. " +
+                                                "Phasellus laoreet mi eu egestas mattis.")
+                                    }
+                                    header(4) {
+                                        +"Replace with"
+                                    }
+                                    codeBlock {
+                                        +"newShinyFunction(typedParam, someLiteral, SomeNewType())"
+                                    }
+                                    header(5) {
+                                        +"Imports"
+                                    }
+                                    codeBlock {
+                                        +"com.example.dokka.debug.newShinyFunction"
+                                        br()
+                                        +"com.example.dokka.debug.SomeOldType"
+                                        br()
+                                        +"com.example.dokka.debug.SomeNewType"
+                                        br()
+                                    }
+                                }
+                                group { pWrapped("Average function description") }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/plugins/base/src/test/kotlin/content/annotations/SinceKotlinTest.kt
+++ b/plugins/base/src/test/kotlin/content/annotations/SinceKotlinTest.kt
@@ -1,61 +1,19 @@
 package content.annotations
 
-
 import matchers.content.*
-import org.jetbrains.dokka.pages.ContentPage
 import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
+import org.jetbrains.dokka.pages.ContentPage
 import org.junit.jupiter.api.Test
 import utils.ParamAttributes
 import utils.bareSignature
 
-
-class DepredatedAndSinceKotlinTest : BaseAbstractTest() {
+class SinceKotlinTest : BaseAbstractTest() {
 
     private val testConfiguration = dokkaConfiguration {
         sourceSets {
             sourceSet {
                 sourceRoots = listOf("src/")
                 analysisPlatform = "jvm"
-            }
-        }
-    }
-
-    @Test
-    fun `function with deprecated annotation`() {
-        testInline(
-            """
-            |/src/main/kotlin/test/source.kt
-            |package test
-            |
-            |@Deprecated("And some things that should not have been forgotten were lost. History became legend. Legend became myth.")
-            |fun ring(abc: String): String {
-            |    return "My precious " + abc
-            |}
-        """.trimIndent(), testConfiguration
-        ) {
-            pagesTransformationStage = { module ->
-                val page = module.children.single { it.name == "test" }
-                    .children.single { it.name == "ring" } as ContentPage
-                page.content.assertNode {
-                    group {
-                        header(1) { +"ring" }
-                    }
-                    divergentGroup {
-                        divergentInstance {
-                            divergent {
-                                bareSignature(
-                                    emptyMap(),
-                                    "",
-                                    "",
-                                    emptySet(),
-                                    "ring",
-                                    "String",
-                                    "abc" to ParamAttributes(emptyMap(), emptySet(), "String")
-                                )
-                            }
-                        }
-                    }
-                }
             }
         }
     }

--- a/plugins/base/src/test/kotlin/utils/contentUtils.kt
+++ b/plugins/base/src/test/kotlin/utils/contentUtils.kt
@@ -208,7 +208,9 @@ fun ContentMatcherBuilder<*>.typealiasSignature(name: String, expressionTarget: 
                                         group {
                                             +"typealias "
                                             group {
-                                                link { +name }
+                                                group {
+                                                    link { +name }
+                                                }
                                                 skipAllNotMatching()
                                             }
                                             +" = "

--- a/plugins/gfm/src/main/kotlin/org/jetbrains/dokka/gfm/renderer/CommonmarkRenderer.kt
+++ b/plugins/gfm/src/main/kotlin/org/jetbrains/dokka/gfm/renderer/CommonmarkRenderer.kt
@@ -32,6 +32,16 @@ open class CommonmarkRenderer(
                 childrenCallback()
                 buildParagraph()
             }
+            node.dci.kind == ContentKind.Deprecation -> {
+                append("---")
+                childrenCallback()
+                append("---")
+                buildNewLine()
+            }
+            node.hasStyle(ContentStyle.Footnote) -> {
+                childrenCallback()
+                buildParagraph()
+            }
             else -> childrenCallback()
         }
     }

--- a/plugins/javadoc/api/javadoc.api
+++ b/plugins/javadoc/api/javadoc.api
@@ -649,6 +649,7 @@ public final class org/jetbrains/dokka/javadoc/signatures/JavadocSignatureProvid
 	public fun <init> (Lorg/jetbrains/dokka/base/transformers/pages/comments/CommentsToContentConverter;Lorg/jetbrains/dokka/utilities/DokkaLogger;)V
 	public fun <init> (Lorg/jetbrains/dokka/plugability/DokkaContext;)V
 	public fun annotations (Lorg/jetbrains/dokka/model/DProperty;)Ljava/util/Map;
+	public fun annotations (Lorg/jetbrains/dokka/model/Documentable;)Ljava/util/Map;
 	public fun annotations (Lorg/jetbrains/dokka/model/properties/WithExtraProperties;)Ljava/util/Map;
 	public fun annotationsBlock (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;)V
 	public fun annotationsBlockWithIgnored (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;Ljava/util/Set;Lorg/jetbrains/dokka/base/signatures/AtStrategy;Lkotlin/Pair;Ljava/lang/String;)V

--- a/plugins/kotlin-as-java/api/kotlin-as-java.api
+++ b/plugins/kotlin-as-java/api/kotlin-as-java.api
@@ -22,6 +22,7 @@ public final class org/jetbrains/dokka/kotlinAsJava/converters/KotlinToJavaConve
 public final class org/jetbrains/dokka/kotlinAsJava/signatures/JavaSignatureProvider : org/jetbrains/dokka/base/signatures/JvmSignatureUtils, org/jetbrains/dokka/base/signatures/SignatureProvider {
 	public fun <init> (Lorg/jetbrains/dokka/plugability/DokkaContext;)V
 	public fun annotations (Lorg/jetbrains/dokka/model/DProperty;)Ljava/util/Map;
+	public fun annotations (Lorg/jetbrains/dokka/model/Documentable;)Ljava/util/Map;
 	public fun annotations (Lorg/jetbrains/dokka/model/properties/WithExtraProperties;)Ljava/util/Map;
 	public fun annotationsBlock (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;)V
 	public fun annotationsBlockWithIgnored (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;Ljava/util/Set;Lorg/jetbrains/dokka/base/signatures/AtStrategy;Lkotlin/Pair;Ljava/lang/String;)V
@@ -40,6 +41,7 @@ public final class org/jetbrains/dokka/kotlinAsJava/signatures/JavaSignatureProv
 public final class org/jetbrains/dokka/kotlinAsJava/signatures/JavaSignatureUtils : org/jetbrains/dokka/base/signatures/JvmSignatureUtils {
 	public static final field INSTANCE Lorg/jetbrains/dokka/kotlinAsJava/signatures/JavaSignatureUtils;
 	public fun annotations (Lorg/jetbrains/dokka/model/DProperty;)Ljava/util/Map;
+	public fun annotations (Lorg/jetbrains/dokka/model/Documentable;)Ljava/util/Map;
 	public fun annotations (Lorg/jetbrains/dokka/model/properties/WithExtraProperties;)Ljava/util/Map;
 	public fun annotationsBlock (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;)V
 	public fun annotationsBlockWithIgnored (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;Ljava/util/Set;Lorg/jetbrains/dokka/base/signatures/AtStrategy;Lkotlin/Pair;Ljava/lang/String;)V

--- a/plugins/kotlin-as-java/src/main/kotlin/signatures/JavaSignatureProvider.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/signatures/JavaSignatureProvider.kt
@@ -44,10 +44,10 @@ class JavaSignatureProvider internal constructor(ctcc: CommentsToContentConverte
             contentBuilder.contentFor(
                 e,
                 ContentKind.Symbol,
-                setOf(TextStyle.Monospace) + e.stylesIfDeprecated(it),
+                setOf(TextStyle.Monospace),
                 sourceSets = setOf(it)
             ) {
-                link(e.name, e.dri)
+                link(e.name, e.dri, styles = mainStyles + e.stylesIfDeprecated(it))
             }
         }
 
@@ -61,7 +61,7 @@ class JavaSignatureProvider internal constructor(ctcc: CommentsToContentConverte
             contentBuilder.contentFor(
                 c,
                 ContentKind.Symbol,
-                setOf(TextStyle.Monospace) + deprecationStyles,
+                setOf(TextStyle.Monospace),
                 sourceSets = setOf(sourceSet)
             ) {
                 annotationsBlock(c)
@@ -79,7 +79,7 @@ class JavaSignatureProvider internal constructor(ctcc: CommentsToContentConverte
                     is DObject -> keyword("class ")
                     is DAnnotation -> keyword("@interface ")
                 }
-                link(c.name!!, c.dri)
+                link(c.name!!, c.dri, styles = mainStyles + deprecationStyles)
                 if (c is WithGenerics) {
                     list(c.generics, prefix = "<", suffix = ">",
                         separatorStyles = mainStyles + TokenStyle.Punctuation,
@@ -110,7 +110,7 @@ class JavaSignatureProvider internal constructor(ctcc: CommentsToContentConverte
             contentBuilder.contentFor(
                 p,
                 ContentKind.Symbol,
-                setOf(TextStyle.Monospace, TextStyle.Block) + p.stylesIfDeprecated(it),
+                setOf(TextStyle.Monospace, TextStyle.Block),
                 sourceSets = setOf(it)
             ) {
                 annotationsBlock(p)
@@ -119,7 +119,7 @@ class JavaSignatureProvider internal constructor(ctcc: CommentsToContentConverte
                 p.modifiers()[it]?.toSignatureString()?.let { keyword(it) }
                 signatureForProjection(p.type)
                 text(nbsp.toString())
-                link(p.name, p.dri)
+                link(p.name, p.dri, styles = mainStyles + p.stylesIfDeprecated(it))
             }
         }
 
@@ -128,7 +128,7 @@ class JavaSignatureProvider internal constructor(ctcc: CommentsToContentConverte
             contentBuilder.contentFor(
                 f,
                 ContentKind.Symbol,
-                setOf(TextStyle.Monospace, TextStyle.Block) + f.stylesIfDeprecated(sourceSet),
+                setOf(TextStyle.Monospace, TextStyle.Block),
                 sourceSets = setOf(sourceSet)
             ) {
                 annotationsBlock(f)
@@ -138,7 +138,7 @@ class JavaSignatureProvider internal constructor(ctcc: CommentsToContentConverte
                 val returnType = f.type
                 signatureForProjection(returnType)
                 text(nbsp.toString())
-                link(f.name, f.dri, styles = mainStyles + TokenStyle.Function)
+                link(f.name, f.dri, styles = mainStyles + TokenStyle.Function + f.stylesIfDeprecated(sourceSet))
                 val usedGenerics = if (f.isConstructor) f.generics.filter { f uses it } else f.generics
                 list(usedGenerics, prefix = "<", suffix = ">",
                     separatorStyles = mainStyles + TokenStyle.Punctuation,
@@ -161,12 +161,15 @@ class JavaSignatureProvider internal constructor(ctcc: CommentsToContentConverte
 
     private fun signature(t: DTypeParameter) =
         t.sourceSets.map {
-            contentBuilder.contentFor(t, styles = t.stylesIfDeprecated(it), sourceSets = setOf(it)) {
+            contentBuilder.contentFor(t, sourceSets = setOf(it)) {
                 annotationsInline(t)
-                text(t.name.substringAfterLast("."))
-                list(t.bounds, prefix = " extends ",
+                text(t.name.substringAfterLast("."), styles = mainStyles + t.stylesIfDeprecated(it))
+                list(
+                    elements = t.bounds,
+                    prefix = " extends ",
                     separatorStyles = mainStyles + TokenStyle.Punctuation,
-                    surroundingCharactersStyle = mainStyles + TokenStyle.Keyword) {
+                    surroundingCharactersStyle = mainStyles + TokenStyle.Keyword
+                ) {
                     signatureForProjection(it)
                 }
             }


### PR DESCRIPTION
* Deprecation details on pages, both for Kotlin and Java `Deprecated` annotations
* Strikethrough only declaration names and not for the whole signature as before (so should only be class name, function name, etc)
* Add text strikethrough for navigation pages where all documentables are deprecated (all and in all source sets)
* Integrate `@DeprecatedSinceKotlin` into the block
* Deprecated declarations are always last on the merged pages, but not on package overview page (as it's sorted by name)

Part of #2576