### PR TITLE
Fix anchor copy button popup

### DIFF
--- a/plugins/base/src/main/resources/dokka/styles/style.css
+++ b/plugins/base/src/main/resources/dokka/styles/style.css
@@ -427,6 +427,7 @@ code.paragraph {
     left: -15em;
 }
 
+.table-row:hover .copy-popup-wrapper.active-popup,
 .sample-container:hover .copy-popup-wrapper.active-popup {
     display: flex !important;
 }


### PR DESCRIPTION
See #2576

Apparently, when adding more styles for code blocks, it was simply forgotten that copy button is used for anchors too