### PR TITLE
Trim four-spaces inside indented code block

### DIFF
--- a/plugins/base/src/main/kotlin/parsers/MarkdownParser.kt
+++ b/plugins/base/src/main/kotlin/parsers/MarkdownParser.kt
@@ -10,6 +10,7 @@ import org.intellij.markdown.ast.impl.ListItemCompositeNode
 import org.intellij.markdown.flavours.gfm.GFMElementTypes
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 import org.intellij.markdown.flavours.gfm.GFMTokenTypes
+import org.intellij.markdown.html.HtmlGenerator
 import org.jetbrains.dokka.base.parsers.factories.DocTagsFromIElementFactory
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.links.PointingToDeclaration
@@ -343,7 +344,7 @@ open class MarkdownParser(
         DocTagsFromIElementFactory.getInstance(node.type, children = node.children.mergeLeafASTNodes().flatMap {
             DocTagsFromIElementFactory.getInstance(
                 MarkdownTokenTypes.TEXT,
-                body = text.substring(it.startOffset, it.endOffset)
+                body = HtmlGenerator.trimIndents(text.substring(it.startOffset, it.endOffset), 4).toString()
             )
         })
 

--- a/plugins/base/src/test/kotlin/markdown/ParserTest.kt
+++ b/plugins/base/src/test/kotlin/markdown/ParserTest.kt
@@ -1340,11 +1340,11 @@ class ParserTest : KDocTest() {
                             CodeBlock(
                                 listOf(
                                     Text(
-                                        "    val x = 1\n" +
-                                                "    val y = 2\n" +
-                                                "    if (x == 1) {\n" +
-                                                "        println(y)\n" +
-                                                "    }"
+                                        "val x = 1\n" +
+                                                "val y = 2\n" +
+                                                "if (x == 1) {\n" +
+                                                "    println(y)\n" +
+                                                "}"
                                     )
                                 )
                             )

--- a/plugins/base/src/test/kotlin/model/CommentTest.kt
+++ b/plugins/base/src/test/kotlin/model/CommentTest.kt
@@ -1,6 +1,8 @@
 package model
 
+import org.jetbrains.dokka.model.DClass
 import org.jetbrains.dokka.model.DProperty
+import org.jetbrains.dokka.model.doc.CodeBlock
 import org.jetbrains.dokka.model.doc.CustomTagWrapper
 import org.jetbrains.dokka.model.doc.Text
 import org.junit.jupiter.api.Test
@@ -267,4 +269,39 @@ class CommentTest : AbstractModelTest("/src/main/kotlin/comment/Test.kt", "comme
             }
         }
     }
+
+    @Test
+    fun `should remove spaces inside indented code block`() {
+        inlineModelTest(
+            """
+            |/**
+            | * Welcome:
+            | *
+            | * ```kotlin
+            | * fun main() {
+            | *     println("Hello World!")
+            | * }
+            | * ```
+            | *
+            | *     fun thisIsACodeBlock() {
+            | *         val butWhy = "per markdown spec, because four-spaces prefix"
+            | *     }
+            | */
+            |class Foo
+        """
+        ) {
+            with((this / "comment" / "Foo").cast<DClass>()) {
+                docs()[0].children[2] equals CodeBlock(
+                    listOf(
+                        Text(
+                            "fun thisIsACodeBlock() {\n" +
+                                    "    val butWhy = \"per markdown spec, because four-spaces prefix\"\n" +
+                                    "}"
+                        )
+                    )
+                )
+            }
+        }
+    }
+
 }

--- a/plugins/base/src/test/kotlin/translators/DefaultDescriptorToDocumentableTranslatorTest.kt
+++ b/plugins/base/src/test/kotlin/translators/DefaultDescriptorToDocumentableTranslatorTest.kt
@@ -5,7 +5,6 @@ import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.model.*
 import org.jetbrains.dokka.model.doc.*
-import org.junit.Assert
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Disabled
@@ -148,15 +147,15 @@ class DefaultDescriptorToDocumentableTranslatorTest : BaseAbstractTest() {
                     CodeBlock(
                         children = listOf(
                             Text(
-                                """    val soapAttrs = attrs("soap-env" to "http://www.w3.org/2001/12/soap-envelope",
-        "soap-env:encodingStyle" to "http://www.w3.org/2001/12/soap-encoding")
-    val soapXml = node("soap-env:Envelope", soapAttrs,
-        node("soap-env:Body", attrs("xmlns:m" to "http://example"),
-            node("m:GetExample",
-                node("m:GetExampleName", "BasePair")
-            )
+                                """val soapAttrs = attrs("soap-env" to "http://www.w3.org/2001/12/soap-envelope",
+    "soap-env:encodingStyle" to "http://www.w3.org/2001/12/soap-encoding")
+val soapXml = node("soap-env:Envelope", soapAttrs,
+    node("soap-env:Body", attrs("xmlns:m" to "http://example"),
+        node("m:GetExample",
+            node("m:GetExampleName", "BasePair")
         )
-    )"""
+    )
+)"""
                             )
                         )
                     )


### PR DESCRIPTION
By [CommonMark spec](https://spec.commonmark.org/0.30/#indented-code-blocks), we should omit 4 spaces of indentation.
It should be fixed in IDEA as well:
![image](https://user-images.githubusercontent.com/9636937/189117808-b5cbba8d-96d5-4a20-964b-98acd31e30e3.png)
