### PR TITLE
Fix search bar to exclude `(source)`

### DIFF
--- a/plugins/base/src/main/kotlin/renderers/html/SearchbarDataInstaller.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/SearchbarDataInstaller.kt
@@ -106,7 +106,7 @@ private fun flattenToText(node: ContentNode): String {
             is ContentComposite -> node.children
                 .filter { sourceSetRestriction in it.sourceSets }
                 .flatMap { getContentTextNodes(it, sourceSetRestriction) }
-                .takeIf { node.dci.kind != ContentKind.Annotations }
+                .takeIf { node.dci.kind != ContentKind.Annotations && node.dci.kind != ContentKind.Source }
                 .orEmpty()
             else -> emptyList()
         }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/9636937/190632114-a012c412-ea68-4f60-8a1b-ea1229ab4bd2.png)
