### PR TITLE
Suppress useless companion for Kotlin-As-Java

### DIFF
--- a/plugins/kotlin-as-java/src/main/kotlin/converters/KotlinCompanion.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/converters/KotlinCompanion.kt
@@ -1,0 +1,48 @@
+package org.jetbrains.dokka.kotlinAsJava.converters
+
+import org.jetbrains.dokka.model.DFunction
+import org.jetbrains.dokka.model.DObject
+import org.jetbrains.dokka.model.DProperty
+
+
+internal class KotlinCompanion(private val companion: DObject?) {
+
+    fun staticFunctions(): List<DFunction> {
+        if(companion == null) return emptyList()
+        return companion.functions.filter { it.isJvmStatic }
+    }
+
+    /**
+     * @return properties that will be visible as static for java.
+     * See [Static fields](https://kotlinlang.org/docs/java-to-kotlin-interop.html#static-fields)
+     */
+    fun staticProperties(): List<DProperty> {
+        if(companion == null) return emptyList()
+        return companion.properties.filter { it.isJvmField || it.isConst || it.isLateInit}
+    }
+
+    fun asJava():DObject? {
+        if(companion == null) return null
+        if(companion.hasNothingToRender()) return null
+
+        return companion.asJava(
+            excludedProps = staticProperties(),
+            excludedFunctions = staticFunctions()
+        )
+    }
+
+    /**
+     * Hide companion object if there isn't members of parents.
+     * Properties and functions that are moved to outer class are not counted as members.
+     */
+    private fun DObject.hasNothingToRender(): Boolean{
+        val nonStaticPropsCount = properties.minus(staticProperties().toSet()).size
+        val nonStaticFunctionsCount = functions.minus(staticFunctions().toSet()).size
+        val classLikesCount = classlikes.size
+        val superTypesCount = supertypes.values.firstOrNull()?.size ?: 0
+
+        return nonStaticFunctionsCount + nonStaticPropsCount +
+                classLikesCount + superTypesCount == 0
+    }
+}
+

--- a/plugins/kotlin-as-java/src/main/kotlin/converters/KotlinCompanion.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/converters/KotlinCompanion.kt
@@ -6,73 +6,69 @@ import org.jetbrains.dokka.model.properties.PropertyContainer
 
 private const val DEFAULT_COMPANION_NAME = "Companion"
 
-internal class KotlinCompanion(private val companion: DObject?) {
-
-    fun staticFunctions(): List<DFunction> {
-        if(companion == null) return emptyList()
-        return companion.functions.filter { it.isJvmStatic }
-    }
-
-    /**
-     * @return properties that will be visible as static for java.
-     * See [Static fields](https://kotlinlang.org/docs/java-to-kotlin-interop.html#static-fields)
-     */
-    fun staticProperties(): List<DProperty> {
-        if(companion == null) return emptyList()
-        return companion.properties.filter { it.isJvmField || it.isConst || it.isLateInit}
-    }
-
-    fun companionInstancePropertyInJava(): List<DProperty>{
-        if(companion == null) return emptyList()
-        if(companion.hasNothingToRender()) return emptyList() // do not show if companion not rendered
-
-        with(companion){
-            return listOf(DProperty(
-                name = name ?: DEFAULT_COMPANION_NAME,
-                modifier = sourceSets.associateWith { JavaModifier.Final },
-                dri = dri.copy(callable = Callable(name ?: DEFAULT_COMPANION_NAME, null, emptyList())),
-                documentation = emptyMap(),
-                sources = emptyMap(),
-                visibility = companion.sourceSets.associateWith {
-                    JavaVisibility.Public
-                },
-                type = GenericTypeConstructor(dri, emptyList()),
-                setter = null,
-                getter = null,
-                sourceSets = sourceSets,
-                receiver = null,
-                generics = emptyList(),
-                expectPresentInSet = expectPresentInSet,
-                isExpectActual = false,
-                extra = PropertyContainer.withAll(sourceSets.map {
-                    mapOf(it to setOf(ExtraModifiers.JavaOnlyModifiers.Static)).toAdditionalModifiers()
-                })
-            ))
-        }
-    }
-
-    fun asJava():DObject? {
-        if(companion == null) return null
-        if(companion.hasNothingToRender()) return null
-
-        return companion.asJava(
-            excludedProps = staticProperties(),
-            excludedFunctions = staticFunctions()
-        )
-    }
-
-    /**
-     * Hide companion object if there isn't members of parents.
-     * Properties and functions that are moved to outer class are not counted as members.
-     */
-    private fun DObject.hasNothingToRender(): Boolean{
-        val nonStaticPropsCount = properties.minus(staticProperties().toSet()).size
-        val nonStaticFunctionsCount = functions.minus(staticFunctions().toSet()).size
-        val classLikesCount = classlikes.size
-        val superTypesCount = supertypes.values.firstOrNull()?.size ?: 0
-
-        return nonStaticFunctionsCount + nonStaticPropsCount +
-                classLikesCount + superTypesCount == 0
-    }
+internal fun DObject?.staticFunctionsForJava(): List<DFunction> {
+    if (this == null) return emptyList()
+    return functions.filter { it.isJvmStatic }
 }
 
+/**
+ * @return properties that will be visible as static for java.
+ * See [Static fields](https://kotlinlang.org/docs/java-to-kotlin-interop.html#static-fields)
+ */
+internal fun DObject?.staticPropertiesForJava(): List<DProperty> {
+    if (this == null) return emptyList()
+    return properties.filter { it.isJvmField || it.isConst || it.isLateInit }
+}
+
+internal fun DObject?.companionInstancePropertyForJava(): List<DProperty> {
+    if (this == null) return emptyList()
+    if (hasNothingToRender()) return emptyList() // do not show if companion not rendered
+
+    return listOf(
+        DProperty(
+            name = name ?: DEFAULT_COMPANION_NAME,
+            modifier = sourceSets.associateWith { JavaModifier.Final },
+            dri = dri.copy(callable = Callable(name ?: DEFAULT_COMPANION_NAME, null, emptyList())),
+            documentation = emptyMap(),
+            sources = emptyMap(),
+            visibility = sourceSets.associateWith {
+                JavaVisibility.Public
+            },
+            type = GenericTypeConstructor(dri, emptyList()),
+            setter = null,
+            getter = null,
+            sourceSets = sourceSets,
+            receiver = null,
+            generics = emptyList(),
+            expectPresentInSet = expectPresentInSet,
+            isExpectActual = false,
+            extra = PropertyContainer.withAll(sourceSets.map {
+                mapOf(it to setOf(ExtraModifiers.JavaOnlyModifiers.Static)).toAdditionalModifiers()
+            })
+        )
+    )
+}
+
+internal fun DObject?.companionAsJava(): DObject? {
+    if (this == null) return null
+    if (hasNothingToRender()) return null
+
+    return asJava(
+        excludedProps = staticPropertiesForJava(),
+        excludedFunctions = staticFunctionsForJava()
+    )
+}
+
+/**
+ * Hide companion object if there isn't members of parents.
+ * Properties and functions that are moved to outer class are not counted as members.
+ */
+private fun DObject.hasNothingToRender(): Boolean {
+    val nonStaticPropsCount = properties.size - staticPropertiesForJava().size
+    val nonStaticFunctionsCount = functions.size - staticFunctionsForJava().size
+    val classLikesCount = classlikes.size
+    val superTypesCount = supertypes.values.firstOrNull()?.size ?: 0
+
+    return nonStaticFunctionsCount + nonStaticPropsCount +
+            classLikesCount + superTypesCount == 0
+}

--- a/plugins/kotlin-as-java/src/main/kotlin/converters/KotlinCompanion.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/converters/KotlinCompanion.kt
@@ -20,8 +20,7 @@ internal fun DObject?.staticPropertiesForJava(): List<DProperty> {
     return properties.filter { it.isJvmField || it.isConst || it.isLateInit }
 }
 
-internal fun DObject?.companionInstancePropertyForJava(): DProperty? {
-    if (this == null) return null
+internal fun DObject.companionInstancePropertyForJava(): DProperty? {
     if (hasNothingToRender()) return null // do not show if companion not rendered
 
     return DProperty(
@@ -47,8 +46,7 @@ internal fun DObject?.companionInstancePropertyForJava(): DProperty? {
     )
 }
 
-internal fun DObject?.companionAsJava(): DObject? {
-    if (this == null) return null
+internal fun DObject.companionAsJava(): DObject? {
     if (hasNothingToRender()) return null
 
     return asJava(

--- a/plugins/kotlin-as-java/src/main/kotlin/converters/KotlinCompanion.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/converters/KotlinCompanion.kt
@@ -20,32 +20,30 @@ internal fun DObject?.staticPropertiesForJava(): List<DProperty> {
     return properties.filter { it.isJvmField || it.isConst || it.isLateInit }
 }
 
-internal fun DObject?.companionInstancePropertyForJava(): List<DProperty> {
-    if (this == null) return emptyList()
-    if (hasNothingToRender()) return emptyList() // do not show if companion not rendered
+internal fun DObject?.companionInstancePropertyForJava(): DProperty? {
+    if (this == null) return null
+    if (hasNothingToRender()) return null // do not show if companion not rendered
 
-    return listOf(
-        DProperty(
-            name = name ?: DEFAULT_COMPANION_NAME,
-            modifier = sourceSets.associateWith { JavaModifier.Final },
-            dri = dri.copy(callable = Callable(name ?: DEFAULT_COMPANION_NAME, null, emptyList())),
-            documentation = emptyMap(),
-            sources = emptyMap(),
-            visibility = sourceSets.associateWith {
-                JavaVisibility.Public
-            },
-            type = GenericTypeConstructor(dri, emptyList()),
-            setter = null,
-            getter = null,
-            sourceSets = sourceSets,
-            receiver = null,
-            generics = emptyList(),
-            expectPresentInSet = expectPresentInSet,
-            isExpectActual = false,
-            extra = PropertyContainer.withAll(sourceSets.map {
-                mapOf(it to setOf(ExtraModifiers.JavaOnlyModifiers.Static)).toAdditionalModifiers()
-            })
-        )
+    return DProperty(
+        name = name ?: DEFAULT_COMPANION_NAME,
+        modifier = sourceSets.associateWith { JavaModifier.Final },
+        dri = dri.copy(callable = Callable(name ?: DEFAULT_COMPANION_NAME, null, emptyList())),
+        documentation = emptyMap(),
+        sources = emptyMap(),
+        visibility = sourceSets.associateWith {
+            JavaVisibility.Public
+        },
+        type = GenericTypeConstructor(dri, emptyList()),
+        setter = null,
+        getter = null,
+        sourceSets = sourceSets,
+        receiver = null,
+        generics = emptyList(),
+        expectPresentInSet = expectPresentInSet,
+        isExpectActual = false,
+        extra = PropertyContainer.withAll(sourceSets.map {
+            mapOf(it to setOf(ExtraModifiers.JavaOnlyModifiers.Static)).toAdditionalModifiers()
+        })
     )
 }
 

--- a/plugins/kotlin-as-java/src/main/kotlin/converters/KotlinToJavaConverter.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/converters/KotlinToJavaConverter.kt
@@ -265,7 +265,7 @@ internal fun DClass.asJava(): DClass = copy(
     properties = propertiesInJava(),
     classlikes = classlikesInJava(),
     generics = generics.map { it.asJava() },
-    companion = companion.companionAsJava(),
+    companion = companion?.companionAsJava(),
     supertypes = supertypes.mapValues { it.value.map { it.asJava() } },
     modifier = if (modifier.all { (_, v) -> v is KotlinModifier.Empty }) sourceSets.associateWith { JavaModifier.Final }
     else sourceSets.associateWith { modifier.values.first() }
@@ -280,7 +280,7 @@ internal fun DClass.classlikesInJava(): List<DClasslike> {
         .filter { it.name != companion?.name }
         .map { it.asJava() }
 
-    val companionAsJava = companion.companionAsJava()
+    val companionAsJava = companion?.companionAsJava()
     return if (companionAsJava != null) classlikes.plus(companionAsJava) else classlikes
 }
 
@@ -299,12 +299,12 @@ internal fun DClass.propertiesInJava(): List<DProperty> {
         .staticPropertiesForJava()
         .filterNot { it.hasJvmSynthetic() }
         .map { it.asJava(isFromObjectOrCompanion = true) }
-    val companionInstanceProperty = listOfNotNull(companion.companionInstancePropertyForJava())
+    val companionInstanceProperty = companion?.companionInstancePropertyForJava()
     val ownProperties = properties
         .filterNot { it.hasJvmSynthetic() }
         .map { it.asJava() }
 
-    return propertiesFromCompanion + ownProperties + companionInstanceProperty
+    return propertiesFromCompanion + ownProperties + listOfNotNull(companionInstanceProperty)
 }
 
 private fun DTypeParameter.asJava(): DTypeParameter = copy(

--- a/plugins/kotlin-as-java/src/main/kotlin/converters/KotlinToJavaConverter.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/converters/KotlinToJavaConverter.kt
@@ -300,15 +300,18 @@ internal fun DClass.functionsInJava(): List<DFunction> =
         .flatMap { it.asJava(it.dri.classNames ?: it.name) }
 
 internal fun DClass.propertiesInJava(): List<DProperty> {
-    val propertiesFromCompanion = companion.asKotlinCompanion()
+    val companionObj = companion.asKotlinCompanion()
+
+    val propertiesFromCompanion = companionObj
         .staticProperties()
         .filterNot { it.hasJvmSynthetic() }
         .map { it.asJava(isBelongToObjectOrCompanion = true) }
+    val companionInstanceProperty = companionObj.companionInstancePropertyInJava()
     val ownProperties = properties
         .filterNot { it.hasJvmSynthetic() }
         .map { it.asJava() }
 
-    return propertiesFromCompanion + ownProperties
+    return propertiesFromCompanion + ownProperties + companionInstanceProperty
 }
 
 internal fun DObject?.asKotlinCompanion(): KotlinCompanion = KotlinCompanion(this)

--- a/plugins/kotlin-as-java/src/main/kotlin/jvmStatic.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/jvmStatic.kt
@@ -1,0 +1,12 @@
+package org.jetbrains.dokka.kotlinAsJava
+
+import org.jetbrains.dokka.model.Annotations
+import org.jetbrains.dokka.model.Documentable
+import org.jetbrains.dokka.model.properties.WithExtraProperties
+import org.jetbrains.kotlin.util.firstNotNullResult
+
+internal fun WithExtraProperties<out Documentable>.jvmStatic(): Annotations.Annotation? =
+    extra[Annotations]?.directAnnotations?.entries?.firstNotNullResult { (_, annotations) -> annotations.jvmStaticAnnotation() }
+
+internal fun List<Annotations.Annotation>.jvmStaticAnnotation(): Annotations.Annotation? =
+    firstOrNull { it.dri.packageName == "kotlin.jvm" && it.dri.classNames == "JvmStatic" }

--- a/plugins/kotlin-as-java/src/test/kotlin/CompanionAsJavaTest.kt
+++ b/plugins/kotlin-as-java/src/test/kotlin/CompanionAsJavaTest.kt
@@ -302,6 +302,76 @@ class CompanionAsJavaTest : BaseAbstractTest() {
         }
     }
 
+    @Test
+    fun `named companion instance property should be rendered if companion rendered`() {
+        testInline(
+            """
+            |/src/main/kotlin/kotlinAsJavaPlugin/sample.kt
+            |package kotlinAsJavaPlugin
+            |class MyClass {
+            |    companion object $COMPANION_NAME {
+            |       var property: String = ""
+            |    }
+            |}
+        """.trimMargin(),
+            configuration,
+        ) {
+            documentablesTransformationStage = { module ->
+                val parentClass = module.packages.flatMap { it.classlikes }
+                    .firstOrNull { it.name == "MyClass" } as DClass
+
+                assertNotNull(parentClass.properties.any {it.name == COMPANION_NAME})
+            }
+        }
+    }
+
+    @Test
+    fun `default named companion instance property should be rendered if companion rendered`() {
+        testInline(
+            """
+            |/src/main/kotlin/kotlinAsJavaPlugin/sample.kt
+            |package kotlinAsJavaPlugin
+            |class MyClass {
+            |    companion object {
+            |       var property: String = ""
+            |    }
+            |}
+        """.trimMargin(),
+            configuration,
+        ) {
+            documentablesTransformationStage = { module ->
+                val parentClass = module.packages.flatMap { it.classlikes }
+                    .firstOrNull { it.name == "MyClass" } as DClass
+
+                assertNotNull(parentClass.properties.any {it.name == "Companion"})
+            }
+        }
+    }
+
+    @Test
+    fun `companion instance property should be hidden if companion not rendered`() {
+        testInline(
+            """
+            |/src/main/kotlin/kotlinAsJavaPlugin/sample.kt
+            |package kotlinAsJavaPlugin
+            |class MyClass {
+            |    companion object $COMPANION_NAME {
+            |       const val property: String = ""
+            |    }
+            |}
+        """.trimMargin(),
+            configuration,
+        ) {
+            documentablesTransformationStage = { module ->
+                val parentClass = module.packages.flatMap { it.classlikes }
+                    .firstOrNull { it.name == "MyClass" } as DClass
+
+                assertNotNull(parentClass.properties.none {it.name == COMPANION_NAME})
+            }
+        }
+    }
+
+
 
     private fun `companion object not rendered for declaration`(declaration: String) {
         testInline(

--- a/plugins/kotlin-as-java/src/test/kotlin/CompanionAsJavaTest.kt
+++ b/plugins/kotlin-as-java/src/test/kotlin/CompanionAsJavaTest.kt
@@ -1,0 +1,312 @@
+package kotlinAsJavaPlugin
+
+import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
+import org.jetbrains.dokka.model.*
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+private const val COMPANION_NAME = "C"
+
+class CompanionAsJavaTest : BaseAbstractTest() {
+    private val configuration = dokkaConfiguration {
+        sourceSets {
+            sourceSet {
+                sourceRoots = listOf("src/")
+                classpath += jvmStdlibPath!!
+            }
+        }
+    }
+
+    @Test
+    fun `empty companion object should not be rendered`() {
+        testInline(
+            """
+            |/src/main/kotlin/kotlinAsJavaPlugin/sample.kt
+            |package kotlinAsJavaPlugin
+            |class MyClass {
+            |    companion object $COMPANION_NAME {}
+            |}
+        """.trimMargin(),
+            configuration,
+        ) {
+            documentablesTransformationStage = { module ->
+                val parentClass = module.packages.flatMap { it.classlikes }
+                    .firstOrNull { it.name == "MyClass" } as DClass
+
+                assertCompanionNotRendered(parentClass)
+            }
+        }
+    }
+
+    @Test
+    fun `companion object with only jvmField should not be rendered`() {
+        `companion object not rendered for declaration`("@JvmField val jvmFieldProp: String = \"\"")
+    }
+
+    @Test
+    fun `companion property with jvmField should be static`() {
+        `companion property is belong to outer class and static`("@JvmField val jvmFieldProp: String = \"\"", "jvmFieldProp")
+    }
+
+    @Test
+    fun `companion object with only const should not be rendered`() {
+        `companion object not rendered for declaration`("const val constProp: Int = 0")
+    }
+
+    @Test
+    fun `companion property with const should be static`() {
+        `companion property is belong to outer class and static`("const val constProp: Int = 0", "constProp")
+    }
+
+    @Test
+    fun `companion object with only lateinit not rendered`() {
+        `companion object not rendered for declaration`("lateinit var lateInitProp: String")
+    }
+
+    @Test
+    fun `companion property with lateinit should be static`() {
+        `companion property is belong to outer class and static`("lateinit var lateInitProp: String", "lateInitProp")
+    }
+
+    @Test
+    fun `companion object with only jvmStatic fun not rendered`() {
+        `companion object not rendered for declaration`("@JvmStatic fun staticFun(): String = \"\"")
+    }
+
+    @Test
+    fun `companion function with JvmStatic should be static`() {
+        `companion function is belong to outer class and static`("@JvmStatic fun staticFun(): String = \"\"", "staticFun")
+    }
+
+    @Test
+    fun `companion object with nested classes is rendered`() {
+        testInline(
+            """
+            |/src/main/kotlin/kotlinAsJavaPlugin/sample.kt
+            |package kotlinAsJavaPlugin
+            |class MyClass {
+            |    companion object $COMPANION_NAME {
+            |       @JvmStatic
+            |       fun staticFun1(): String = ""
+            |       
+            |       const val CONST_VAL: Int = 100
+            |       
+            |       class NestedClass
+            |       object NestedObject
+            |    }
+            |}
+        """.trimMargin(),
+            configuration,
+        ) {
+            documentablesTransformationStage = { module ->
+                val parentClass = module.packages.flatMap { it.classlikes }
+                    .firstOrNull { it.name == "MyClass" } as DClass
+
+                assertCompanionRendered(parentClass)
+
+                val classLikes = parentClass.companion?.classlikes
+                assertNotNull(classLikes)
+                assertEquals(2, classLikes.size,
+                    "Classlike list should contains nested class and object")
+                assertTrue(classLikes.any { it.name == "NestedClass" })
+                assertTrue(classLikes.any { it.name == "NestedObject" })
+
+            }
+        }
+    }
+
+    @Test
+    fun `companion object with supertype is rendered`() {
+        testInline(
+            """
+            |/src/main/kotlin/kotlinAsJavaPlugin/sample.kt
+            |package kotlinAsJavaPlugin
+            |
+            |class Parent
+            |interface IParent
+            |class MyClass {
+            |    companion object $COMPANION_NAME : Parent(), IParent {
+            |    }
+            |}
+        """.trimMargin(),
+            configuration,
+        ) {
+            documentablesTransformationStage = { module ->
+                val parentClass = module.packages.flatMap { it.classlikes }
+                    .firstOrNull { it.name == "MyClass" } as DClass
+
+                assertCompanionRendered(parentClass)
+            }
+        }
+    }
+
+    @Test
+    fun `companion object rendered for own properties`() {
+        testInline(
+            """
+            |/src/main/kotlin/kotlinAsJavaPlugin/sample.kt
+            |package kotlinAsJavaPlugin
+            |class MyClass {
+            |    companion object $COMPANION_NAME {
+            |       @JvmField
+            |       val jvmField: String = ""
+            |       const val contVal: Int = 0
+            |       lateinit var lateInit: String
+            |       
+            |       val rendered: Int = TODO()
+            |    }
+            |}
+        """.trimMargin(),
+            configuration,
+        ) {
+            documentablesTransformationStage = { module ->
+                val parentClass = module.packages.flatMap { it.classlikes }
+                    .firstOrNull { it.name == "MyClass" } as DClass
+
+                assertCompanionRendered(parentClass)
+
+                val properties = parentClass.companion?.properties
+
+                assertNotNull(properties)
+                assertEquals(2, properties.size) // including INSTANCE
+                assertTrue(properties.any { it.name == "rendered" })
+                assertTrue(properties.none { it.name == "jvmField1" })
+                assertTrue(properties.none { it.name == "contVal" })
+                assertTrue(properties.none { it.name == "lateInit" })
+            }
+        }
+    }
+
+    @Test
+    fun `companion object rendered for own functions`() {
+        testInline(
+            """
+            |/src/main/kotlin/kotlinAsJavaPlugin/sample.kt
+            |package kotlinAsJavaPlugin
+            |class MyClass {
+            |    companion object $COMPANION_NAME {
+            |       @JvmStatic
+            |       fun staticFun(): String = ""
+            |       
+            |       fun renderedFun(): String = ""
+            |    }
+            |}
+        """.trimMargin(),
+            configuration,
+        ) {
+            documentablesTransformationStage = { module ->
+                val parentClass = module.packages.flatMap { it.classlikes }
+                    .firstOrNull { it.name == "MyClass" } as DClass
+
+                assertCompanionRendered(parentClass)
+
+                val functions = parentClass.companion?.functions
+
+                assertNotNull(functions)
+                assertEquals(1, functions.size)
+                assertTrue(functions.any { it.name == "renderedFun" })
+                assertTrue(functions.none { it.name == "staticFun" })
+            }
+        }
+    }
+
+
+    private fun `companion object not rendered for declaration`(declaration: String) {
+        testInline(
+            """
+            |/src/main/kotlin/kotlinAsJavaPlugin/sample.kt
+            |package kotlinAsJavaPlugin
+            |class MyClass {
+            |    companion object $COMPANION_NAME {
+            |       $declaration
+            |    }
+            |}
+        """.trimMargin(),
+            configuration,
+        ) {
+            documentablesTransformationStage = { module ->
+                val parentClass = module.packages.flatMap { it.classlikes }
+                    .firstOrNull { it.name == "MyClass" } as DClass
+
+                assertCompanionNotRendered(parentClass)
+            }
+        }
+    }
+
+    private fun `companion property is belong to outer class and static`(declaration: String, name: String) {
+        testInline(
+            """
+            |/src/main/kotlin/kotlinAsJavaPlugin/sample.kt
+            |package kotlinAsJavaPlugin
+            |class MyClass {
+            |    companion object $COMPANION_NAME {
+            |       $declaration
+            |    }
+            |}
+        """.trimMargin(),
+            configuration,
+        ) {
+            documentablesTransformationStage = { module ->
+                val parentClass = module.packages.flatMap { it.classlikes }
+                    .firstOrNull { it.name == "MyClass" } as DClass
+
+                val outerClassProperty = parentClass.properties.firstOrNull{ it.name == name}
+                assertNotNull(outerClassProperty, "Outer class contains the companion property")
+                assertIsStatic(outerClassProperty)
+            }
+        }
+    }
+
+    private fun `companion function is belong to outer class and static`(declaration: String, name: String) {
+        testInline(
+            """
+            |/src/main/kotlin/kotlinAsJavaPlugin/sample.kt
+            |package kotlinAsJavaPlugin
+            |class MyClass {
+            |    companion object $COMPANION_NAME {
+            |       $declaration
+            |    }
+            |}
+        """.trimMargin(),
+            configuration,
+        ) {
+            documentablesTransformationStage = { module ->
+                val parentClass = module.packages.flatMap { it.classlikes }
+                    .firstOrNull { it.name == "MyClass" } as DClass
+
+                val outerClassFunction = parentClass.functions.firstOrNull{ it.name == name}
+                assertNotNull(outerClassFunction, "Outer class contains the companion function")
+                assertIsStatic(outerClassFunction)
+            }
+        }
+    }
+}
+
+private fun assertCompanionRendered(parentClass: DClass){
+    assertNotNull(parentClass.companion, "Companion should not be null")
+    assertTrue(parentClass.classlikes.any { it.name == COMPANION_NAME },
+        "Companion should be in classlikes list")
+}
+
+private fun assertCompanionNotRendered(parentClass: DClass){
+    assertNull(parentClass.companion, "Companion should be null")
+    assertTrue(parentClass.classlikes.none { it.name == COMPANION_NAME },
+        "Companion should not be in classlikes list")
+}
+
+private fun assertIsStatic(property: DProperty){
+    val extra = property.extra[AdditionalModifiers]
+    assertNotNull(extra, "extra for property is present")
+    assertTrue(extra.content.values.contains(setOf(ExtraModifiers.JavaOnlyModifiers.Static)),
+        "Property contains extra modifier static")
+}
+
+private fun assertIsStatic(function: DFunction){
+    val extra = function.extra[AdditionalModifiers]
+    assertNotNull(extra, "extra for property is present")
+    assertTrue(extra.content.values.contains(setOf(ExtraModifiers.JavaOnlyModifiers.Static)),
+        "Function contains extra modifier static")
+}

--- a/plugins/kotlin-as-java/src/test/kotlin/CompanionAsJavaTest.kt
+++ b/plugins/kotlin-as-java/src/test/kotlin/CompanionAsJavaTest.kt
@@ -33,8 +33,7 @@ class CompanionAsJavaTest : BaseAbstractTest() {
             configuration,
         ) {
             documentablesTransformationStage = { module ->
-                val parentClass = module.packages.flatMap { it.classlikes }
-                    .firstOrNull { it.name == "MyClass" } as DClass
+                val parentClass = module.findClass("MyClass")
 
                 assertCompanionNotRendered(parentClass)
             }
@@ -43,42 +42,186 @@ class CompanionAsJavaTest : BaseAbstractTest() {
 
     @Test
     fun `companion object with only jvmField should not be rendered`() {
-        `companion object not rendered for declaration`("@JvmField val jvmFieldProp: String = \"\"")
+        testInline(
+            """
+            |/src/main/kotlin/kotlinAsJavaPlugin/sample.kt
+            |package kotlinAsJavaPlugin
+            |class MyClass {
+            |    companion object $COMPANION_NAME {
+            |       @JvmField val jvmFieldProp: String = ""
+            |    }
+            |}
+        """.trimMargin(),
+            configuration,
+        ) {
+            documentablesTransformationStage = { module ->
+                val parentClass = module.findClass("MyClass")
+
+                assertCompanionNotRendered(parentClass)
+            }
+        }
     }
 
     @Test
     fun `companion property with jvmField should be static`() {
-        `companion property is belong to outer class and static`("@JvmField val jvmFieldProp: String = \"\"", "jvmFieldProp")
+        testInline(
+            """
+            |/src/main/kotlin/kotlinAsJavaPlugin/sample.kt
+            |package kotlinAsJavaPlugin
+            |class MyClass {
+            |    companion object $COMPANION_NAME {
+            |       @JvmField val jvmFieldProp: String = ""
+            |    }
+            |}
+        """.trimMargin(),
+            configuration,
+        ) {
+            documentablesTransformationStage = { module ->
+                val parentClass = module.findClass("MyClass")
+
+                val parentClassProperty = parentClass.properties.firstOrNull { it.name == "jvmFieldProp" }
+                assertNotNull(parentClassProperty, "Parent class should contain the companion jvmField property")
+                assertIsStatic(parentClassProperty)
+            }
+        }
     }
 
     @Test
     fun `companion object with only const should not be rendered`() {
-        `companion object not rendered for declaration`("const val constProp: Int = 0")
+        testInline(
+            """
+            |/src/main/kotlin/kotlinAsJavaPlugin/sample.kt
+            |package kotlinAsJavaPlugin
+            |class MyClass {
+            |    companion object $COMPANION_NAME {
+            |       const val constProp: Int = 0
+            |    }
+            |}
+        """.trimMargin(),
+            configuration,
+        ) {
+            documentablesTransformationStage = { module ->
+                val parentClass = module.findClass("MyClass")
+
+                assertCompanionNotRendered(parentClass)
+            }
+        }
     }
 
     @Test
     fun `companion property with const should be static`() {
-        `companion property is belong to outer class and static`("const val constProp: Int = 0", "constProp")
+        testInline(
+            """
+            |/src/main/kotlin/kotlinAsJavaPlugin/sample.kt
+            |package kotlinAsJavaPlugin
+            |class MyClass {
+            |    companion object $COMPANION_NAME {
+            |       const val constProp: Int = 0
+            |    }
+            |}
+        """.trimMargin(),
+            configuration,
+        ) {
+            documentablesTransformationStage = { module ->
+                val parentClass = module.findClass("MyClass")
+
+                val parentClassProperty = parentClass.properties.firstOrNull { it.name == "constProp" }
+                assertNotNull(parentClassProperty, "Parent class should contain the companion const property")
+                assertIsStatic(parentClassProperty)
+            }
+        }
     }
 
     @Test
     fun `companion object with only lateinit not rendered`() {
-        `companion object not rendered for declaration`("lateinit var lateInitProp: String")
+        testInline(
+            """
+            |/src/main/kotlin/kotlinAsJavaPlugin/sample.kt
+            |package kotlinAsJavaPlugin
+            |class MyClass {
+            |    companion object $COMPANION_NAME {
+            |       lateinit var lateInitProp: String
+            |    }
+            |}
+        """.trimMargin(),
+            configuration,
+        ) {
+            documentablesTransformationStage = { module ->
+                val parentClass = module.findClass("MyClass")
+
+                assertCompanionNotRendered(parentClass)
+            }
+        }
     }
 
     @Test
     fun `companion property with lateinit should be static`() {
-        `companion property is belong to outer class and static`("lateinit var lateInitProp: String", "lateInitProp")
+        testInline(
+            """
+            |/src/main/kotlin/kotlinAsJavaPlugin/sample.kt
+            |package kotlinAsJavaPlugin
+            |class MyClass {
+            |    companion object $COMPANION_NAME {
+            |       lateinit var lateInitProp: String
+            |    }
+            |}
+        """.trimMargin(),
+            configuration,
+        ) {
+            documentablesTransformationStage = { module ->
+                val parentClass = module.findClass("MyClass")
+
+                val parentClassProperty = parentClass.properties.firstOrNull { it.name == "lateInitProp" }
+                assertNotNull(parentClassProperty, "Parent class should contain the companion lateinit property")
+                assertIsStatic(parentClassProperty)
+            }
+        }
     }
 
     @Test
     fun `companion object with only jvmStatic fun not rendered`() {
-        `companion object not rendered for declaration`("@JvmStatic fun staticFun(): String = \"\"")
+        testInline(
+            """
+            |/src/main/kotlin/kotlinAsJavaPlugin/sample.kt
+            |package kotlinAsJavaPlugin
+            |class MyClass {
+            |    companion object $COMPANION_NAME {
+            |       @JvmStatic fun staticFun(): String = ""
+            |    }
+            |}
+        """.trimMargin(),
+            configuration,
+        ) {
+            documentablesTransformationStage = { module ->
+                val parentClass = module.findClass("MyClass")
+
+                assertCompanionNotRendered(parentClass)
+            }
+        }
     }
 
     @Test
     fun `companion function with JvmStatic should be static`() {
-        `companion function is belong to outer class and static`("@JvmStatic fun staticFun(): String = \"\"", "staticFun")
+        testInline(
+            """
+            |/src/main/kotlin/kotlinAsJavaPlugin/sample.kt
+            |package kotlinAsJavaPlugin
+            |class MyClass {
+            |    companion object $COMPANION_NAME {
+            |       @JvmStatic fun staticFun(): String = ""
+            |    }
+            |}
+        """.trimMargin(),
+            configuration,
+        ) {
+            documentablesTransformationStage = { module ->
+                val parentClass = module.findClass("MyClass")
+
+                val parentClassFunction = parentClass.functions.firstOrNull { it.name == "staticFun" }
+                assertNotNull(parentClassFunction, "Parent class should contains the companion jvmStatic function")
+                assertIsStatic(parentClassFunction)
+            }
+        }
     }
 
     @Test
@@ -102,8 +245,7 @@ class CompanionAsJavaTest : BaseAbstractTest() {
             configuration,
         ) {
             documentablesTransformationStage = { module ->
-                val parentClass = module.packages.flatMap { it.classlikes }
-                    .firstOrNull { it.name == "MyClass" } as DClass
+                val parentClass = module.findClass("MyClass")
 
                 assertCompanionRendered(parentClass)
 
@@ -135,8 +277,7 @@ class CompanionAsJavaTest : BaseAbstractTest() {
             configuration,
         ) {
             documentablesTransformationStage = { module ->
-                val parentClass = module.packages.flatMap { it.classlikes }
-                    .firstOrNull { it.name == "MyClass" } as DClass
+                val parentClass = module.findClass("MyClass")
 
                 assertCompanionRendered(parentClass)
             }
@@ -163,8 +304,7 @@ class CompanionAsJavaTest : BaseAbstractTest() {
             configuration,
         ) {
             documentablesTransformationStage = { module ->
-                val parentClass = module.packages.flatMap { it.classlikes }
-                    .firstOrNull { it.name == "MyClass" } as DClass
+                val parentClass = module.findClass("MyClass")
 
                 assertCompanionRendered(parentClass)
 
@@ -198,8 +338,7 @@ class CompanionAsJavaTest : BaseAbstractTest() {
             configuration,
         ) {
             documentablesTransformationStage = { module ->
-                val parentClass = module.packages.flatMap { it.classlikes }
-                    .firstOrNull { it.name == "MyClass" } as DClass
+                val parentClass = module.findClass("MyClass")
 
                 assertCompanionRendered(parentClass)
 
@@ -228,13 +367,13 @@ class CompanionAsJavaTest : BaseAbstractTest() {
             configuration,
         ) {
             documentablesTransformationStage = { module ->
-                val parentClass = module.packages.flatMap { it.classlikes }
-                    .firstOrNull { it.name == "MyClass" } as DClass
+                val parentClass = module.findClass("MyClass")
 
-                assertEquals(JavaVisibility.Public,
-                    parentClass.properties.firstOrNull()?.visibility?.values?.first())
-                assertNull(parentClass.functions.firstOrNull { it.name.contains("constProp", ignoreCase = true) },
-                    "There is no getter for the cont field")
+                assertEquals(
+                    JavaVisibility.Public,
+                    parentClass.properties.firstOrNull()?.visibility?.values?.first()
+                )
+                assertNull(parentClass.findFunction("constProp"), "There is no getter for the cont field")
             }
         }
     }
@@ -265,13 +404,13 @@ class CompanionAsJavaTest : BaseAbstractTest() {
             },
         ) {
             documentablesTransformationStage = { module ->
-                val parentClass = module.packages.flatMap { it.classlikes }
-                    .firstOrNull { it.name == "MyClass" } as DClass
+                val parentClass = module.findClass("MyClass")
 
-                assertEquals(JavaVisibility.Protected,
-                    parentClass.properties.firstOrNull()?.visibility?.values?.first())
-                assertNull(parentClass.functions.firstOrNull { it.name.contains("constProp", ignoreCase = true) },
-                    "There is no getter for the cont field")
+                assertEquals(
+                    JavaVisibility.Protected,
+                    parentClass.properties.firstOrNull()?.visibility?.values?.first()
+                )
+                assertNull(parentClass.findFunction("constProp"), "There is no getter for the cont field")
             }
         }
     }
@@ -291,13 +430,13 @@ class CompanionAsJavaTest : BaseAbstractTest() {
             configuration,
         ) {
             documentablesTransformationStage = { module ->
-                val parentClass = module.packages.flatMap { it.classlikes }
-                    .firstOrNull { it.name == "MyClass" } as DClass
+                val parentClass = module.findClass("MyClass")
 
-                assertEquals(JavaVisibility.Public,
-                    parentClass.properties.firstOrNull()?.visibility?.values?.first())
-                assertNull(parentClass.functions.firstOrNull { it.name.contains("lateInitProp", ignoreCase = true) },
-                    "There is no getter for the cont field")
+                assertEquals(
+                    JavaVisibility.Public,
+                    parentClass.properties.firstOrNull()?.visibility?.values?.first()
+                )
+                assertNull(parentClass.findFunction("lateInitProp"), "There is no getter for the cont field")
             }
         }
     }
@@ -317,10 +456,9 @@ class CompanionAsJavaTest : BaseAbstractTest() {
             configuration,
         ) {
             documentablesTransformationStage = { module ->
-                val parentClass = module.packages.flatMap { it.classlikes }
-                    .firstOrNull { it.name == "MyClass" } as DClass
+                val parentClass = module.findClass("MyClass")
 
-                assertNotNull(parentClass.properties.any {it.name == COMPANION_NAME})
+                assertNotNull(parentClass.properties.any { it.name == COMPANION_NAME })
             }
         }
     }
@@ -340,10 +478,9 @@ class CompanionAsJavaTest : BaseAbstractTest() {
             configuration,
         ) {
             documentablesTransformationStage = { module ->
-                val parentClass = module.packages.flatMap { it.classlikes }
-                    .firstOrNull { it.name == "MyClass" } as DClass
+                val parentClass = module.findClass("MyClass")
 
-                assertNotNull(parentClass.properties.any {it.name == "Companion"})
+                assertTrue(parentClass.properties.any { it.name == "Companion" })
             }
         }
     }
@@ -363,109 +500,49 @@ class CompanionAsJavaTest : BaseAbstractTest() {
             configuration,
         ) {
             documentablesTransformationStage = { module ->
-                val parentClass = module.packages.flatMap { it.classlikes }
-                    .firstOrNull { it.name == "MyClass" } as DClass
+                val parentClass = module.findClass("MyClass")
 
-                assertNotNull(parentClass.properties.none {it.name == COMPANION_NAME})
-            }
-        }
-    }
-
-
-
-    private fun `companion object not rendered for declaration`(declaration: String) {
-        testInline(
-            """
-            |/src/main/kotlin/kotlinAsJavaPlugin/sample.kt
-            |package kotlinAsJavaPlugin
-            |class MyClass {
-            |    companion object $COMPANION_NAME {
-            |       $declaration
-            |    }
-            |}
-        """.trimMargin(),
-            configuration,
-        ) {
-            documentablesTransformationStage = { module ->
-                val parentClass = module.packages.flatMap { it.classlikes }
-                    .firstOrNull { it.name == "MyClass" } as DClass
-
-                assertCompanionNotRendered(parentClass)
-            }
-        }
-    }
-
-    private fun `companion property is belong to outer class and static`(declaration: String, name: String) {
-        testInline(
-            """
-            |/src/main/kotlin/kotlinAsJavaPlugin/sample.kt
-            |package kotlinAsJavaPlugin
-            |class MyClass {
-            |    companion object $COMPANION_NAME {
-            |       $declaration
-            |    }
-            |}
-        """.trimMargin(),
-            configuration,
-        ) {
-            documentablesTransformationStage = { module ->
-                val parentClass = module.packages.flatMap { it.classlikes }
-                    .firstOrNull { it.name == "MyClass" } as DClass
-
-                val outerClassProperty = parentClass.properties.firstOrNull{ it.name == name}
-                assertNotNull(outerClassProperty, "Outer class contains the companion property")
-                assertIsStatic(outerClassProperty)
-            }
-        }
-    }
-
-    private fun `companion function is belong to outer class and static`(declaration: String, name: String) {
-        testInline(
-            """
-            |/src/main/kotlin/kotlinAsJavaPlugin/sample.kt
-            |package kotlinAsJavaPlugin
-            |class MyClass {
-            |    companion object $COMPANION_NAME {
-            |       $declaration
-            |    }
-            |}
-        """.trimMargin(),
-            configuration,
-        ) {
-            documentablesTransformationStage = { module ->
-                val parentClass = module.packages.flatMap { it.classlikes }
-                    .firstOrNull { it.name == "MyClass" } as DClass
-
-                val outerClassFunction = parentClass.functions.firstOrNull{ it.name == name}
-                assertNotNull(outerClassFunction, "Outer class contains the companion function")
-                assertIsStatic(outerClassFunction)
+                assertTrue(parentClass.properties.none { it.name == COMPANION_NAME })
             }
         }
     }
 }
 
-private fun assertCompanionRendered(parentClass: DClass){
+private fun DModule.findClass(name: String) = packages.flatMap { it.classlikes }
+    .firstOrNull { it.name == name } as DClass
+
+private fun DClass.findFunction(name: String) = functions.firstOrNull { it.name.contains(name, ignoreCase = true) }
+
+private fun assertCompanionRendered(parentClass: DClass) {
     assertNotNull(parentClass.companion, "Companion should not be null")
-    assertTrue(parentClass.classlikes.any { it.name == COMPANION_NAME },
-        "Companion should be in classlikes list")
+    assertTrue(
+        parentClass.classlikes.any { it.name == COMPANION_NAME },
+        "Companion should be in classlikes list"
+    )
 }
 
-private fun assertCompanionNotRendered(parentClass: DClass){
+private fun assertCompanionNotRendered(parentClass: DClass) {
     assertNull(parentClass.companion, "Companion should be null")
-    assertTrue(parentClass.classlikes.none { it.name == COMPANION_NAME },
-        "Companion should not be in classlikes list")
+    assertTrue(
+        parentClass.classlikes.none { it.name == COMPANION_NAME },
+        "Companion should not be in classlikes list"
+    )
 }
 
-private fun assertIsStatic(property: DProperty){
+private fun assertIsStatic(property: DProperty) {
     val extra = property.extra[AdditionalModifiers]
     assertNotNull(extra, "extra for property is present")
-    assertTrue(extra.content.values.contains(setOf(ExtraModifiers.JavaOnlyModifiers.Static)),
-        "Property contains extra modifier static")
+    assertTrue(
+        extra.content.values.contains(setOf(ExtraModifiers.JavaOnlyModifiers.Static)),
+        "Property contains extra modifier static"
+    )
 }
 
-private fun assertIsStatic(function: DFunction){
+private fun assertIsStatic(function: DFunction) {
     val extra = function.extra[AdditionalModifiers]
     assertNotNull(extra, "extra for property is present")
-    assertTrue(extra.content.values.contains(setOf(ExtraModifiers.JavaOnlyModifiers.Static)),
-        "Function contains extra modifier static")
+    assertTrue(
+        extra.content.values.contains(setOf(ExtraModifiers.JavaOnlyModifiers.Static)),
+        "Function contains extra modifier static"
+    )
 }

--- a/plugins/kotlin-as-java/src/test/kotlin/JvmFieldTest.kt
+++ b/plugins/kotlin-as-java/src/test/kotlin/JvmFieldTest.kt
@@ -110,6 +110,37 @@ class JvmFieldTest : BaseAbstractTest() {
         }
     }
 
+    @Test
+    fun `enum jvmfield property should have no getters`(){
+        testInline(
+            """
+            |/src/main/kotlin/kotlinAsJavaPlugin/sample.kt
+            |package kotlinAsJavaPlugin
+            |enum class MyEnum {
+            |    ITEM;
+            |    
+            |    @JvmField
+            |    val property: String = TODO()
+            |}
+        """.trimMargin(),
+            configuration,
+        ) {
+            documentablesTransformationStage = { module ->
+                val classLike = module.packages.flatMap { it.classlikes }.first()
+                val property = classLike.properties.singleOrNull { it.name == "property" }
+                assertNotNull(property)
+                assertEquals(
+                    emptyList(),
+                    classLike.functions
+                        .filter{ it.name.contains("property", ignoreCase = true) }
+                        .map { it.name }
+                )
+                assertNull(property.getter)
+                assertNull(property.setter)
+            }
+        }
+    }
+
 
     @Test
     fun `object jvmfield property should be static`(){

--- a/plugins/kotlin-as-java/src/test/kotlin/JvmFieldTest.kt
+++ b/plugins/kotlin-as-java/src/test/kotlin/JvmFieldTest.kt
@@ -1,11 +1,14 @@
 package kotlinAsJavaPlugin
 
 import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
+import org.jetbrains.dokka.model.AdditionalModifiers
+import org.jetbrains.dokka.model.ExtraModifiers
 import org.jetbrains.dokka.model.JavaVisibility
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class JvmFieldTest : BaseAbstractTest() {
     val configuration = dokkaConfiguration {
@@ -103,6 +106,33 @@ class JvmFieldTest : BaseAbstractTest() {
                 )
                 assertNull(property.getter)
                 assertNull(property.setter)
+            }
+        }
+    }
+
+
+    @Test
+    fun `object jvmfield property should be static`(){
+        testInline(
+            """
+            |/src/main/kotlin/kotlinAsJavaPlugin/sample.kt
+            |package kotlinAsJavaPlugin
+            |object MyObject {
+            |    @JvmField
+            |    val property: String = TODO()
+            |}
+        """.trimMargin(),
+            configuration,
+        ) {
+            documentablesTransformationStage = { module ->
+                val classLike = module.packages.flatMap { it.classlikes }.first()
+                val property = classLike.properties.singleOrNull { it.name == "property" }
+                assertNotNull(property)
+
+                val extra = property.extra[AdditionalModifiers]
+                assertNotNull(extra, "Additional modifiers for property are exist")
+                assertTrue(extra.content.values.contains(setOf(ExtraModifiers.JavaOnlyModifiers.Static)),
+                    "Extra modifiers contains static")
             }
         }
     }


### PR DESCRIPTION
* hide a companion object if it contains only `const`/`@JvmField`/`lateinit` properties or `@JvmStatic` functions
* lift the declarations to outer class from the companion
* mark lifted declarations as static
* mark `const`/`@JvmField`/`lateinit` properties as static for named objects
* remove getter/setter for `const`/`lateinit` properties in named objects/companions
* add the companion property to the outer class

Fix #200, fix #2086