### PR TITLE
Update Kotlin to 1.7.20

### DIFF
--- a/examples/gradle/dokka-customFormat-example/build.gradle.kts
+++ b/examples/gradle/dokka-customFormat-example/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.dokka.gradle.DokkaTask
 
 plugins {
-    kotlin("jvm") version "1.7.20-RC"
+    kotlin("jvm") version "1.7.20"
     id("org.jetbrains.dokka") version ("1.7.10")
 }
 

--- a/examples/gradle/dokka-gradle-example/build.gradle.kts
+++ b/examples/gradle/dokka-gradle-example/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.dokka.gradle.DokkaTask
 import java.net.URL
 
 plugins {
-    kotlin("jvm") version "1.7.20-RC"
+    kotlin("jvm") version "1.7.20"
     id("org.jetbrains.dokka") version ("1.7.10")
 }
 

--- a/examples/gradle/dokka-kotlinAsJava-example/build.gradle.kts
+++ b/examples/gradle/dokka-kotlinAsJava-example/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.7.20-RC"
+    kotlin("jvm") version "1.7.20"
     id("org.jetbrains.dokka") version ("1.7.10")
 }
 

--- a/examples/gradle/dokka-library-publishing-example/build.gradle.kts
+++ b/examples/gradle/dokka-library-publishing-example/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.7.20-RC"
+    kotlin("jvm") version "1.7.20"
     id("org.jetbrains.dokka") version ("1.7.10")
     `java-library`
     `maven-publish`

--- a/examples/gradle/dokka-multimodule-example/settings.gradle.kts
+++ b/examples/gradle/dokka-multimodule-example/settings.gradle.kts
@@ -1,6 +1,6 @@
 pluginManagement {
     plugins {
-        kotlin("jvm") version "1.7.20-RC"
+        kotlin("jvm") version "1.7.20"
         id("org.jetbrains.dokka") version ("1.7.10")
     }
 }

--- a/examples/gradle/dokka-multiplatform-example/build.gradle.kts
+++ b/examples/gradle/dokka-multiplatform-example/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.dokka.Platform
 
 plugins {
-    kotlin("multiplatform") version "1.7.20-RC"
+    kotlin("multiplatform") version "1.7.20"
     id("org.jetbrains.dokka") version "1.7.10"
 }
 

--- a/examples/gradle/dokka-versioning-multimodule-example/build.gradle.kts
+++ b/examples/gradle/dokka-versioning-multimodule-example/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.7.20-RC"
+    kotlin("jvm") version "1.7.20"
     id("org.jetbrains.dokka") version ("1.7.10") apply false
 }
 

--- a/examples/maven/pom.xml
+++ b/examples/maven/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>kotlin-maven-example</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <kotlin.version>1.7.20-RC</kotlin.version>
+        <kotlin.version>1.7.20</kotlin.version>
         <dokka.version>1.7.10</dokka.version>
     </properties>
 

--- a/examples/plugin/hide-internal-api/build.gradle.kts
+++ b/examples/plugin/hide-internal-api/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.net.URI
 
 plugins {
-    kotlin("jvm") version "1.7.20-RC"
+    kotlin("jvm") version "1.7.20"
     id("org.jetbrains.dokka") version "1.7.10"
     `maven-publish`
     signing

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 dokka_version=1.8.0-SNAPSHOT
 dokka_integration_test_parallelism=2
 # Versions
-kotlin_version=1.7.20-RC
+kotlin_version=1.7.20
 coroutines_version=1.6.3
 kotlinx_html_version=0.7.5
 kotlin_plugin_version=213-1.7.20-199-IJ6777.52

--- a/integration-tests/gradle/projects/it-android-0/gradle.properties
+++ b/integration-tests/gradle/projects/it-android-0/gradle.properties
@@ -1,3 +1,3 @@
-dokka_it_kotlin_version=1.7.20-RC
+dokka_it_kotlin_version=1.7.20
 dokka_it_android_gradle_plugin_version=4.0.0
 android.useAndroidX=true

--- a/integration-tests/gradle/projects/it-basic-groovy/gradle.properties
+++ b/integration-tests/gradle/projects/it-basic-groovy/gradle.properties
@@ -1,1 +1,1 @@
-dokka_it_kotlin_version=1.7.20-RC
+dokka_it_kotlin_version=1.7.20

--- a/integration-tests/gradle/projects/it-basic/build.gradle.kts
+++ b/integration-tests/gradle/projects/it-basic/build.gradle.kts
@@ -16,7 +16,7 @@ buildscript {
     }
 }
 
-version = "1.7.10-SNAPSHOT"
+version = "1.7.20-SNAPSHOT"
 
 apply(from = "../template.root.gradle.kts")
 

--- a/integration-tests/gradle/projects/it-basic/gradle.properties
+++ b/integration-tests/gradle/projects/it-basic/gradle.properties
@@ -1,1 +1,1 @@
-dokka_it_kotlin_version=1.7.20-RC
+dokka_it_kotlin_version=1.7.20

--- a/integration-tests/gradle/projects/it-collector-0/gradle.properties
+++ b/integration-tests/gradle/projects/it-collector-0/gradle.properties
@@ -1,1 +1,1 @@
-dokka_it_kotlin_version=1.7.20-RC
+dokka_it_kotlin_version=1.7.20

--- a/integration-tests/gradle/projects/it-js-ir-0/gradle.properties
+++ b/integration-tests/gradle/projects/it-js-ir-0/gradle.properties
@@ -1,2 +1,2 @@
-dokka_it_kotlin_version=1.7.20-RC
+dokka_it_kotlin_version=1.7.20
 react_version=18.1.0-pre.345

--- a/integration-tests/gradle/projects/it-multimodule-0/gradle.properties
+++ b/integration-tests/gradle/projects/it-multimodule-0/gradle.properties
@@ -1,1 +1,1 @@
-dokka_it_kotlin_version=1.7.20-RC
+dokka_it_kotlin_version=1.7.20

--- a/integration-tests/gradle/projects/it-multimodule-1/gradle.properties
+++ b/integration-tests/gradle/projects/it-multimodule-1/gradle.properties
@@ -1,1 +1,1 @@
-dokka_it_kotlin_version=1.7.20-RC
+dokka_it_kotlin_version=1.7.20

--- a/integration-tests/gradle/projects/it-multimodule-versioning-0/gradle.properties
+++ b/integration-tests/gradle/projects/it-multimodule-versioning-0/gradle.properties
@@ -1,2 +1,2 @@
-dokka_it_kotlin_version=1.7.20-RC
+dokka_it_kotlin_version=1.7.20
 

--- a/integration-tests/gradle/projects/it-multiplatform-0/gradle.properties
+++ b/integration-tests/gradle/projects/it-multiplatform-0/gradle.properties
@@ -1,4 +1,4 @@
-dokka_it_kotlin_version=1.7.20-RC
+dokka_it_kotlin_version=1.7.20
 #these flags are enabled by default since 1.6.20.
 #remove when this test is executed with Kotlin >= 1.6.20
 kotlin.mpp.enableGranularSourceSetsMetadata=true

--- a/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/BasicGradleIntegrationTest.kt
+++ b/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/BasicGradleIntegrationTest.kt
@@ -156,7 +156,7 @@ class BasicGradleIntegrationTest(override val versions: BuildVersions) : Abstrac
         val indexFile = File(this, "index.html")
         assertTrue(indexFile.isFile, "Missing index.html")
         assertTrue(
-            """<title>Basic Project 1.7.10-SNAPSHOT API </title>""" in indexFile.readText(),
+            """<title>Basic Project 1.7.20-SNAPSHOT API </title>""" in indexFile.readText(),
             "Header with version number not present in index.html"
         )
 

--- a/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/TestedVersions.kt
+++ b/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/TestedVersions.kt
@@ -5,7 +5,7 @@ internal object TestedVersions {
     val BASE =
         BuildVersions.permutations(
             gradleVersions = listOf("7.4.2", "6.9"),
-            kotlinVersions = listOf("1.7.20-RC", "1.6.21", "1.5.31", "1.4.32"),
+            kotlinVersions = listOf("1.7.20", "1.6.21", "1.5.31", "1.4.32"),
         ) + BuildVersions.permutations(
             gradleVersions = listOf(*ifExhaustive("7.0", "6.1.1")),
             kotlinVersions = listOf(*ifExhaustive("1.6.0", "1.5.0", "1.4.0"))
@@ -18,11 +18,11 @@ internal object TestedVersions {
     val ANDROID =
         BuildVersions.permutations(
             gradleVersions = listOf("7.4.2", *ifExhaustive("7.0")),
-            kotlinVersions = listOf("1.7.20-RC", "1.6.21", "1.5.31", "1.4.32"),
+            kotlinVersions = listOf("1.7.20", "1.6.21", "1.5.31", "1.4.32"),
             androidGradlePluginVersions = listOf("7.2.0")
         ) + BuildVersions.permutations(
             gradleVersions = listOf("6.9", *ifExhaustive("6.1.1", "5.6.4")),
-            kotlinVersions = listOf("1.7.20-RC", "1.6.21", "1.5.31", "1.4.32"),
+            kotlinVersions = listOf("1.7.20", "1.6.21", "1.5.31", "1.4.32"),
             androidGradlePluginVersions = listOf("4.0.0", *ifExhaustive("3.6.3"))
         )
 
@@ -32,6 +32,6 @@ internal object TestedVersions {
         "1.6.0" to "17.0.2-pre.280-kotlin-1.6.0",
         "1.5.31" to "17.0.2-pre.265-kotlin-1.5.31",
         "1.6.21" to "18.0.0-pre.332-kotlin-1.6.21",
-        "1.7.20-RC" to "18.2.0-pre.391",
+        "1.7.20" to "18.2.0-pre.391",
     )
 }

--- a/integration-tests/maven/projects/it-maven/pom.xml
+++ b/integration-tests/maven/projects/it-maven/pom.xml
@@ -7,7 +7,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <kotlin.version>1.7.20-RC</kotlin.version>
+        <kotlin.version>1.7.20</kotlin.version>
     </properties>
     <build>
         <plugins>


### PR DESCRIPTION
Current Kotlin plugins version (`213-1.7.20-199-IJ6777.52`) is already the latest. It was built a week before the release, and the only difference between this version and the release version is the changelog, which should not affect us in any way.