### PR TITLE
Change log level to INFO for messages about alpha plugin versions

### DIFF
--- a/plugins/gfm/src/main/kotlin/org/jetbrains/dokka/gfm/GfmPlugin.kt
+++ b/plugins/gfm/src/main/kotlin/org/jetbrains/dokka/gfm/GfmPlugin.kt
@@ -43,7 +43,7 @@ class GfmPlugin : DokkaPlugin() {
     internal val alphaVersionNotifier by extending {
         CoreExtensions.postActions providing { ctx ->
             PostAction {
-                ctx.logger.warn("GFM output format is in Alpha version, use at your own risk, expect bugs and migration issues")
+                ctx.logger.info("GFM output format is in Alpha version, use at your own risk, expect bugs and migration issues")
             }
         }
     }

--- a/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/JavadocPlugin.kt
+++ b/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/JavadocPlugin.kt
@@ -86,7 +86,7 @@ class JavadocPlugin : DokkaPlugin() {
     internal val alphaVersionNotifier by extending {
         CoreExtensions.postActions providing { ctx ->
             PostAction {
-                ctx.logger.warn("Javadoc output format is in Alpha version, use at your own risk, expect bugs and migration issues")
+                ctx.logger.info("Javadoc output format is in Alpha version, use at your own risk, expect bugs and migration issues")
             }
         }
     }

--- a/plugins/jekyll/src/main/kotlin/JekyllPlugin.kt
+++ b/plugins/jekyll/src/main/kotlin/JekyllPlugin.kt
@@ -52,7 +52,7 @@ class JekyllPlugin : DokkaPlugin() {
     internal val alphaVersionNotifier by extending {
         CoreExtensions.postActions providing { ctx ->
             PostAction {
-                ctx.logger.warn("Jekyll output format is in Alpha version, use at your own risk, expect bugs and migration issues")
+                ctx.logger.info("Jekyll output format is in Alpha version, use at your own risk, expect bugs and migration issues")
             }
         }
     }

--- a/plugins/kotlin-as-java/src/main/kotlin/KotlinAsJavaPlugin.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/KotlinAsJavaPlugin.kt
@@ -34,7 +34,7 @@ class KotlinAsJavaPlugin : DokkaPlugin() {
     internal val alphaVersionNotifier by extending {
         CoreExtensions.postActions providing { ctx ->
             PostAction {
-                ctx.logger.warn("KotlinAsJava plugin is in Alpha version, use at your own risk, expect bugs and migration issues")
+                ctx.logger.info("KotlinAsJava plugin is in Alpha version, use at your own risk, expect bugs and migration issues")
             }
         }
     }


### PR DESCRIPTION
Otherwise it fails the build if `failOnWarning` configuration property is enabled, and there's nothing the user can do

Steps to reproduce:
1. Enable `failOnWarning`
2. Run gfm/javadoc/jekyll/KaJ task
3. Observe failed build

I think printing this message with `info` level is slightly better anyway, since there's nothing the user can do about the warning, there's nothing to fix on their end
