### PR TITLE
Move Gradle tasks into task package

### DIFF
--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/AbstractDokkaLeafTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/AbstractDokkaLeafTask.kt
@@ -1,3 +1,5 @@
+@file:Suppress("PackageDirectoryMismatch")
+
 package org.jetbrains.dokka.gradle
 
 import org.gradle.api.NamedDomainObjectContainer

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/AbstractDokkaParentTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/AbstractDokkaParentTask.kt
@@ -1,3 +1,5 @@
+@file:Suppress("PackageDirectoryMismatch")
+
 package org.jetbrains.dokka.gradle
 
 import org.gradle.api.Project
@@ -99,4 +101,3 @@ abstract class AbstractDokkaParentTask : AbstractDokkaTask() {
         )
     }
 }
-

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/AbstractDokkaTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/AbstractDokkaTask.kt
@@ -1,3 +1,5 @@
+@file:Suppress("PackageDirectoryMismatch")
+
 package org.jetbrains.dokka.gradle
 
 import groovy.lang.Closure

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/DokkaCollectorTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/DokkaCollectorTask.kt
@@ -1,3 +1,5 @@
+@file:Suppress("PackageDirectoryMismatch")
+
 package org.jetbrains.dokka.gradle
 
 import org.gradle.api.tasks.CacheableTask

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/DokkaMultiModuleTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/DokkaMultiModuleTask.kt
@@ -1,3 +1,5 @@
+@file:Suppress("PackageDirectoryMismatch")
+
 package org.jetbrains.dokka.gradle
 
 import org.gradle.api.file.ConfigurableFileCollection
@@ -100,4 +102,3 @@ abstract class DokkaMultiModuleTask : AbstractDokkaParentTask() {
         includes = includes.toSet(),
     )
 }
-

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/DokkaTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/DokkaTask.kt
@@ -1,3 +1,5 @@
+@file:Suppress("PackageDirectoryMismatch")
+
 package org.jetbrains.dokka.gradle
 
 import org.jetbrains.dokka.DokkaConfigurationImpl

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/DokkaTaskPartial.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/DokkaTaskPartial.kt
@@ -1,3 +1,5 @@
+@file:Suppress("PackageDirectoryMismatch")
+
 package org.jetbrains.dokka.gradle
 
 import org.jetbrains.dokka.DokkaConfigurationImpl

--- a/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/tasks/DokkaMultiModuleTaskTest.kt
+++ b/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/tasks/DokkaMultiModuleTaskTest.kt
@@ -1,4 +1,4 @@
-@file:Suppress("UnstableApiUsage", "DEPRECATION")
+@file:Suppress("UnstableApiUsage", "DEPRECATION", "PackageDirectoryMismatch")
 
 package org.jetbrains.dokka.gradle
 

--- a/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/tasks/DokkaTaskTest.kt
+++ b/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/tasks/DokkaTaskTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("PackageDirectoryMismatch")
+
 package org.jetbrains.dokka.gradle
 
 import org.gradle.kotlin.dsl.create


### PR DESCRIPTION
part of #2700 

depends on 

* #2701 
* #2702 

This helps organise the package to make it a little more understandable. All the Gradle tasks are stored in one package.

