### PR TITLE
enable Gradle build cache by default

### DIFF
--- a/.github/workflows/dokka-examples.yml
+++ b/.github/workflows/dokka-examples.yml
@@ -123,6 +123,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
+      - uses: gradle/gradle-build-action@v2 # provides a cache of .m2 dependencies
       - run: mvn compile dokka:dokka
         working-directory: examples/maven
         if: steps.filter.outputs.examples_changed == 'true'

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,4 @@ kotlin.code.style=official
 # Gradle settings
 org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=2g
 org.gradle.parallel=true
+org.gradle.caching=true


### PR DESCRIPTION
Enables [Gradle Build Cache](https://docs.gradle.org/current/userguide/build_cache.html). This should massively increase build speed on CI/CD as Gradle will be able to avoid doing repetitive work.

Since all of the GitHub Actions use the `gradle/gradle-build-action` action, this will automatically share the Gradle Build Cache. (I also added `gradle/gradle-build-action` in the Maven workflow, because I expect the `$USER_HOME/.m2` will be shared and re-used - if not this can be revisited later).

I expect that the GitHub Action build times will improve dramatically, especially for PRs like this where there are no code changes!

(Note that the caching won't be enabled on this PR, because by default only the master/main branch will cache. This is to avoid multiple jobs updating the cache concurrently.)