### PR TITLE
[ci/cd] GitHub Actions - enabled setup-java Maven caching

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
+          cache: 'maven'
       - uses: gradle/gradle-build-action@v2
         with:
           arguments: apiCheck --stacktrace

--- a/.github/workflows/dokka-examples.yml
+++ b/.github/workflows/dokka-examples.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
+          cache: 'maven'
       - uses: gradle/gradle-build-action@v2
       - run: ./gradlew build --no-daemon --stacktrace
         working-directory: ${{ matrix.projects }}
@@ -55,6 +56,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
+          cache: 'maven'
       - uses: gradle/gradle-build-action@v2
       - run: ./gradlew dokkaHtml --no-daemon --stacktrace
         working-directory: ${{ matrix.projects }}
@@ -77,6 +79,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
+          cache: 'maven'
       - uses: gradle/gradle-build-action@v2
       - run: ./gradlew ${{ matrix.tasks }} --no-daemon --stacktrace
         working-directory: examples/gradle/dokka-library-publishing-example
@@ -103,6 +106,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
+          cache: 'maven'
       - uses: gradle/gradle-build-action@v2
       - run: ./gradlew ${{ matrix.task }} --no-daemon --stacktrace
         working-directory: ${{ matrix.dir }}
@@ -123,6 +127,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
+          cache: 'maven'
       - run: mvn compile dokka:dokka
         working-directory: examples/maven
         if: steps.filter.outputs.examples_changed == 'true'

--- a/.github/workflows/gh-actions-artifacts-snapshots.yml
+++ b/.github/workflows/gh-actions-artifacts-snapshots.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 12
+          cache: 'maven'
       - name: Document coroutines
         uses: gradle/gradle-build-action@v2
         with:
@@ -44,6 +45,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 12
+          cache: 'maven'
       - name: Document serialization
         uses: gradle/gradle-build-action@v2
         with:
@@ -69,6 +71,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 12
+          cache: 'maven'
       - name: Document biojava-core
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/gh-pages-examples.yml
+++ b/.github/workflows/gh-pages-examples.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
+          cache: 'maven'
       - uses: gradle/gradle-build-action@v2
       - name: Build html
         run: ./gradlew dokkaHtml --no-daemon --stacktrace
@@ -60,6 +61,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
+          cache: 'maven'
       - uses: gradle/gradle-build-action@v2
       - name: Build html
         run: ./gradlew dokkaHtmlMultiModule --no-daemon --stacktrace

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
+          cache: 'maven'
       - uses: gradle/gradle-build-action@v2
       - name: Get current dokka version
         run: echo "DOKKA_VERSION=`./gradlew :properties | grep '^version:.*' | cut -d ' ' -f 2`" >> $GITHUB_ENV

--- a/.github/workflows/gradle-test.pr.yml
+++ b/.github/workflows/gradle-test.pr.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.version }}
+          cache: 'maven'
       - uses: gradle/gradle-build-action@v2
         with:
           arguments: clean test --stacktrace
@@ -30,6 +31,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.version }}
+          cache: 'maven'
       - uses: gradle/gradle-build-action@v2
         with:
           arguments: clean test --stacktrace --no-daemon --parallel --max-workers=1

--- a/.github/workflows/s3-snapshots.yml
+++ b/.github/workflows/s3-snapshots.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 12
+          cache: 'maven'
       - name: Document stdlib
         uses: gradle/gradle-build-action@v2
         with:
@@ -48,6 +49,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 12
+          cache: 'maven'
       - name: Document coroutines
         uses: gradle/gradle-build-action@v2
         with:
@@ -77,6 +79,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 12
+          cache: 'maven'
       - name: Document serialization
         uses: gradle/gradle-build-action@v2
         with:
@@ -106,6 +109,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 12
+          cache: 'maven'
       - name: Document biojava-core
         uses: gradle/gradle-build-action@v2
         with:


### PR DESCRIPTION
Enable caching of Maven dependencies using https://github.com/actions/setup-java#caching-maven-dependencies

I expect that this will improve the build times for GitHub Actions, because Dokka uses Maven in the Maven plugin, and in the integration tests. I've enabled the cache for all usages for consistency, and because the GHA cache is fast there's no real disadvantage to caching, even if it isn't needed.

Related to #2711 