### PR TITLE
Introduce jackson-databind constraint for 2.12.7.1

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -15,6 +15,12 @@ dependencies {
     val jackson_version: String by project
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jackson_version")
+    val jackson_databind_version: String by project
+    constraints {
+        implementation("com.fasterxml.jackson.core:jackson-databind:$jackson_databind_version") {
+            because("CVE-2022-42003")
+        }
+    }
 
     val coroutines_version: String by project
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version")

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,9 @@ jsoup_version=1.14.3
 idea_version=213.6777.52
 language_version=1.4
 # jackson 2.13.X does not support kotlin language version 1.4, check before updating
-jackson_version=2.12.7.1
+jackson_version=2.12.7
+# fixes CVE-2022-42003
+jackson_databind_version=2.12.7.1
 freemarker_version=2.3.31
 # Code style
 kotlin.code.style=official

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ jsoup_version=1.14.3
 idea_version=213.6777.52
 language_version=1.4
 # jackson 2.13.X does not support kotlin language version 1.4, check before updating
-jackson_version=2.12.7
+jackson_version=2.12.7.1
 freemarker_version=2.3.31
 # Code style
 kotlin.code.style=official

--- a/plugins/all-modules-page/build.gradle.kts
+++ b/plugins/all-modules-page/build.gradle.kts
@@ -18,6 +18,12 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version")
     val jackson_version: String by project
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
+    val jackson_databind_version: String by project
+    constraints {
+        implementation("com.fasterxml.jackson.core:jackson-databind:$jackson_databind_version") {
+            because("CVE-2022-42003")
+        }
+    }
     val kotlinx_html_version: String by project
     implementation("org.jetbrains.kotlinx:kotlinx-html-jvm:$kotlinx_html_version")
 

--- a/plugins/base/build.gradle.kts
+++ b/plugins/base/build.gradle.kts
@@ -11,6 +11,12 @@ dependencies {
 
     val jackson_version: String by project
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
+    val jackson_databind_version: String by project
+    constraints {
+        implementation("com.fasterxml.jackson.core:jackson-databind:$jackson_databind_version") {
+            because("CVE-2022-42003")
+        }
+    }
 
     val freemarker_version: String by project
     implementation("org.freemarker:freemarker:$freemarker_version")

--- a/plugins/gfm/build.gradle.kts
+++ b/plugins/gfm/build.gradle.kts
@@ -6,6 +6,12 @@ dependencies {
     testImplementation(project(":plugins:base:base-test-utils"))
     val jackson_version: String by project
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
+    val jackson_databind_version: String by project
+    constraints {
+        implementation("com.fasterxml.jackson.core:jackson-databind:$jackson_databind_version") {
+            because("CVE-2022-42003")
+        }
+    }
 }
 
 registerDokkaArtifactPublication("gfmPlugin") {

--- a/plugins/templating/build.gradle.kts
+++ b/plugins/templating/build.gradle.kts
@@ -11,6 +11,12 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version")
     val jackson_version: String by project
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
+    val jackson_databind_version: String by project
+    constraints {
+        implementation("com.fasterxml.jackson.core:jackson-databind:$jackson_databind_version") {
+            because("CVE-2022-42003")
+        }
+    }
     val kotlinx_html_version: String by project
     implementation("org.jetbrains.kotlinx:kotlinx-html-jvm:$kotlinx_html_version")
 

--- a/plugins/versioning/build.gradle.kts
+++ b/plugins/versioning/build.gradle.kts
@@ -12,6 +12,12 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version")
     val jackson_version: String by project
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
+    val jackson_databind_version: String by project
+    constraints {
+        implementation("com.fasterxml.jackson.core:jackson-databind:$jackson_databind_version") {
+            because("CVE-2022-42003")
+        }
+    }
     val kotlinx_html_version: String by project
     implementation("org.jetbrains.kotlinx:kotlinx-html-jvm:$kotlinx_html_version")
 


### PR DESCRIPTION
Fixes [CVE-2022-42003](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42003) without going to 2.13.X branch.