### PR TITLE
Fixes "The following documentation URLs were checked" message in Android Studio (IntelliJ)

### DIFF
--- a/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/pages/utils.kt
+++ b/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/pages/utils.kt
@@ -5,7 +5,7 @@ import org.jetbrains.dokka.model.*
 internal fun JavadocFunctionNode.getAnchor(): String =
     "$name(${parameters.joinToString(",") {
         when (val bound = if (it.typeBound is Nullable) it.typeBound.inner else it.typeBound) {
-            is TypeConstructor -> bound.dri.classNames.orEmpty()
+            is TypeConstructor -> listOf(bound.dri.packageName, bound.dri.classNames).joinToString(".")
             is TypeParameter -> bound.name
             is PrimitiveJavaType -> bound.name
             is UnresolvedBound -> bound.name

--- a/plugins/javadoc/src/main/resources/views/class.korte
+++ b/plugins/javadoc/src/main/resources/views/class.korte
@@ -3,7 +3,7 @@
 
 <main role="main">
     <div class="header">
-        <div class="subTitle"><span class="packageLabelInType">Package</span>&nbsp;<a href="package-summary.html">{{ package }}</a></div>
+        <div class="subTitle"><span class="packageLabelInType">Package</span>&nbsp;<a href="package-summary.html">{{ packageName }}</a></div>
         <h2 title="{{ kind|capitalize }} {{ name }}" class="title">{{ kind|capitalize }} {{ name }}</h2>
     </div>
     <div class="contentContainer">

--- a/plugins/javadoc/src/test/kotlin/org/jetbrains/dokka/javadoc/location/JavadocLocationTest.kt
+++ b/plugins/javadoc/src/test/kotlin/org/jetbrains/dokka/javadoc/location/JavadocLocationTest.kt
@@ -95,7 +95,7 @@ class JavadocLocationTest : BaseAbstractTest() {
                 .firstChildOfType<JavadocClasslikePageNode> { it.name == "Test" }
             val testFunctionNode = testClassNode.methods.first { it.name == "test2" }
             assertEquals(
-                """<a href=Test.html#test2(String)>test2</a>(<a href=https://docs.oracle.com/javase/8/docs/api/java/lang/String.html>String</a> s)""",
+                """<a href=Test.html#test2(java.lang.String)>test2</a>(<a href=https://docs.oracle.com/javase/8/docs/api/java/lang/String.html>String</a> s)""",
                 transformer.htmlForContentNode(
                     testFunctionNode.signature.signatureWithoutModifiers,
                     testClassNode


### PR DESCRIPTION
### Fixed wrong Javadoc links in Android Studio (IntelliJ)

Before:
<img width="461" alt="Screen Shot 2022-11-01 at 23 27 52" src="https://user-images.githubusercontent.com/3813595/199357619-59c7f033-1f35-4a0a-bfd2-b2126a71a7a4.png">

After:
<img width="409" alt="Screen Shot 2022-11-02 at 00 03 20" src="https://user-images.githubusercontent.com/3813595/199358796-719e14e6-b678-40e3-b971-682c39878181.png">

---
  
### Fixed missing package name in rendered html pages

Before:
<img width="465" alt="Screen Shot 2022-11-01 at 23 56 33 2" src="https://user-images.githubusercontent.com/3813595/199358891-e1013ac0-5fd9-429b-b854-d0eb73b9fae1.png">

After:
<img width="465" alt="Screen Shot 2022-11-01 at 23 56 33" src="https://user-images.githubusercontent.com/3813595/199357634-8cfc8ee5-4696-4a9c-b0ff-b783f6be27d2.png">
