### PR TITLE
Update Qodana GitHub action

### DIFF
--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -6,22 +6,20 @@ on:
   push:
     branches:
       - master
+
 jobs:
-  inspection:
+  qodana:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Qodana - Code Inspection
-        id: qodana
-        uses: JetBrains/qodana-action@v2022.2.1
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: 'Qodana Scan'
+        uses: JetBrains/qodana-action@v2022.2.3
         with:
           args: --baseline,qodana.sarif.json,--fail-threshold,0,--linter,jetbrains/qodana-jvm
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
-  clone-finder:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Qodana - Clone Finder
-        uses: JetBrains/qodana-clone-finder-action@v2.0-eap
+      - uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -8,7 +8,7 @@ on:
       - master
 
 jobs:
-  qodana:
+  inspection:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
* Builds started [failing](https://github.com/Kotlin/dokka/actions/runs/3475913847/jobs/5810645460) due to [qodana-clone-finder](https://github.com/JetBrains/qodana-clone-finder-action) being archived. 
* Updated configuration to closer match [examples](https://github.com/jetbrains/qodana-action).