### PR TITLE
Make `outputDirectory` lazy in Gradle runner

### DIFF
--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/AbstractDokkaTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/AbstractDokkaTask.kt
@@ -33,7 +33,7 @@ abstract class AbstractDokkaTask : DefaultTask() {
 
     @OutputDirectory
     val outputDirectory: Property<File> = project.objects.safeProperty<File>()
-        .safeConvention(defaultDokkaOutputDirectory())
+        .safeConvention(project.provider { defaultDokkaOutputDirectory() })
 
     @Optional
     @InputDirectory

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaProperty.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaProperty.kt
@@ -13,6 +13,10 @@ internal inline fun <reified T : Any> Property<T?>.safeConvention(value: T): Pro
     return this.convention(value).cast()
 }
 
+internal inline fun <reified T : Any> Property<T?>.safeConvention(provider: Provider<T?>): Property<T> {
+    return this.convention(provider).cast()
+}
+
 @OptIn(ExperimentalStdlibApi::class)
 internal inline fun <reified T> Provider<T>.getSafe(): T =
     if (typeOf<T>().isMarkedNullable) orNull as T


### PR DESCRIPTION
#556
The bug occurs when an old Gradle API without [Configuration Avoidance](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html) is used.
New API have a lazy task configuration.