### PR TITLE
Move inheritors, params, see also and samples tabs to description for classlikes

### DIFF
--- a/plugins/base/api/base.api
+++ b/plugins/base/api/base.api
@@ -1443,20 +1443,15 @@ public class org/jetbrains/dokka/base/translators/documentables/DefaultPageCreat
 	public synthetic fun <init> (Lorg/jetbrains/dokka/base/DokkaBaseConfiguration;Lorg/jetbrains/dokka/base/transformers/pages/comments/CommentsToContentConverter;Lorg/jetbrains/dokka/base/signatures/SignatureProvider;Lorg/jetbrains/dokka/utilities/DokkaLogger;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	protected fun contentForBrief (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/Documentable;)V
 	protected fun contentForClasslikesAndEntries (Ljava/util/List;)Lorg/jetbrains/dokka/pages/ContentGroup;
-	protected fun contentForComments (Ljava/util/List;Z)Ljava/util/List;
-	protected fun contentForComments (Lorg/jetbrains/dokka/links/DRI;Ljava/util/Set;Ljava/util/Map;Z)Ljava/util/List;
-	protected fun contentForComments (Lorg/jetbrains/dokka/model/Documentable;Z)Ljava/util/List;
-	public static synthetic fun contentForComments$default (Lorg/jetbrains/dokka/base/translators/documentables/DefaultPageCreator;Ljava/util/List;ZILjava/lang/Object;)Ljava/util/List;
-	public static synthetic fun contentForComments$default (Lorg/jetbrains/dokka/base/translators/documentables/DefaultPageCreator;Lorg/jetbrains/dokka/links/DRI;Ljava/util/Set;Ljava/util/Map;ZILjava/lang/Object;)Ljava/util/List;
-	public static synthetic fun contentForComments$default (Lorg/jetbrains/dokka/base/translators/documentables/DefaultPageCreator;Lorg/jetbrains/dokka/model/Documentable;ZILjava/lang/Object;)Ljava/util/List;
 	protected fun contentForDescription (Lorg/jetbrains/dokka/model/Documentable;)Ljava/util/List;
 	protected fun contentForFunction (Lorg/jetbrains/dokka/model/DFunction;)Lorg/jetbrains/dokka/pages/ContentGroup;
+	protected fun contentForInheritors (Lorg/jetbrains/dokka/model/Documentable;Ljava/util/List;)Ljava/util/List;
 	protected fun contentForMember (Lorg/jetbrains/dokka/model/Documentable;)Lorg/jetbrains/dokka/pages/ContentGroup;
 	protected fun contentForMembers (Ljava/util/List;)Lorg/jetbrains/dokka/pages/ContentGroup;
 	protected fun contentForModule (Lorg/jetbrains/dokka/model/DModule;)Lorg/jetbrains/dokka/pages/ContentGroup;
 	protected fun contentForPackage (Lorg/jetbrains/dokka/model/DPackage;)Lorg/jetbrains/dokka/pages/ContentGroup;
 	protected fun contentForProperty (Lorg/jetbrains/dokka/model/DProperty;)Lorg/jetbrains/dokka/pages/ContentGroup;
-	protected fun contentForScope (Ljava/util/Set;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;)Lorg/jetbrains/dokka/pages/ContentGroup;
+	protected fun contentForScope (Ljava/util/Set;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lorg/jetbrains/dokka/pages/ContentGroup;
 	protected fun contentForScope (Lorg/jetbrains/dokka/model/WithScope;Lorg/jetbrains/dokka/links/DRI;Ljava/util/Set;)Lorg/jetbrains/dokka/pages/ContentGroup;
 	protected fun contentForScopes (Ljava/util/List;Ljava/util/Set;)Lorg/jetbrains/dokka/pages/ContentGroup;
 	protected fun divergentBlock (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Ljava/lang/String;Ljava/util/Collection;Lorg/jetbrains/dokka/pages/ContentKind;Lorg/jetbrains/dokka/model/properties/PropertyContainer;)V

--- a/plugins/base/api/base.api
+++ b/plugins/base/api/base.api
@@ -1445,7 +1445,6 @@ public class org/jetbrains/dokka/base/translators/documentables/DefaultPageCreat
 	protected fun contentForClasslikesAndEntries (Ljava/util/List;)Lorg/jetbrains/dokka/pages/ContentGroup;
 	protected fun contentForDescription (Lorg/jetbrains/dokka/model/Documentable;)Ljava/util/List;
 	protected fun contentForFunction (Lorg/jetbrains/dokka/model/DFunction;)Lorg/jetbrains/dokka/pages/ContentGroup;
-	protected fun contentForInheritors (Lorg/jetbrains/dokka/model/Documentable;Ljava/util/List;)Ljava/util/List;
 	protected fun contentForMember (Lorg/jetbrains/dokka/model/Documentable;)Lorg/jetbrains/dokka/pages/ContentGroup;
 	protected fun contentForMembers (Ljava/util/List;)Lorg/jetbrains/dokka/pages/ContentGroup;
 	protected fun contentForModule (Lorg/jetbrains/dokka/model/DModule;)Lorg/jetbrains/dokka/pages/ContentGroup;

--- a/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
@@ -312,7 +312,6 @@ open class DefaultPageCreator(
                     documentables.forEach {
                         +buildSignature(it)
                         +contentForDescription(it)
-                        +contentForInheritors(it, documentables)
                     }
                 }
             }
@@ -406,12 +405,8 @@ open class DefaultPageCreator(
             seeAlsoSectionContent(tags)
             throwsSectionContent(tags)
             samplesSectionContent(tags)
-        }.children
-    }
 
-    protected open fun contentForInheritors(d: Documentable, documentables: List<Documentable>): List<ContentNode> {
-        return contentBuilder.contentFor(d, styles = setOf(TextStyle.Block)) {
-            inheritorsSectionContent(documentables, logger)
+            inheritorsSectionContent(d, logger)
         }.children
     }
 

--- a/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
@@ -6,28 +6,21 @@ import org.jetbrains.dokka.base.resolvers.anchors.SymbolAnchorHint
 import org.jetbrains.dokka.base.signatures.SignatureProvider
 import org.jetbrains.dokka.base.transformers.documentables.CallableExtensions
 import org.jetbrains.dokka.base.transformers.documentables.ClashingDriIdentifier
-import org.jetbrains.dokka.base.transformers.documentables.InheritorsInfo
 import org.jetbrains.dokka.base.transformers.pages.comments.CommentsToContentConverter
 import org.jetbrains.dokka.base.transformers.pages.tags.CustomTagContentProvider
 import org.jetbrains.dokka.base.translators.documentables.PageContentBuilder.DocumentableContentBuilder
 import org.jetbrains.dokka.links.DRI
-import org.jetbrains.dokka.links.PointingToDeclaration
 import org.jetbrains.dokka.model.*
 import org.jetbrains.dokka.model.doc.*
 import org.jetbrains.dokka.model.properties.PropertyContainer
 import org.jetbrains.dokka.model.properties.WithExtraProperties
 import org.jetbrains.dokka.pages.*
 import org.jetbrains.dokka.utilities.DokkaLogger
-import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 import kotlin.reflect.KClass
-import kotlin.reflect.full.isSubclassOf
 
 internal const val KDOC_TAG_HEADER_LEVEL = 4
 
-private typealias GroupedTags = Map<KClass<out TagWrapper>, List<Pair<DokkaSourceSet?, TagWrapper>>>
-
-private val specialTags: Set<KClass<out TagWrapper>> =
-    setOf(Property::class, Description::class, Constructor::class, Param::class, See::class)
+internal typealias GroupedTags = Map<KClass<out TagWrapper>, List<Pair<DokkaSourceSet?, TagWrapper>>>
 
 open class DefaultPageCreator(
     configuration: DokkaBaseConfiguration?,
@@ -203,7 +196,6 @@ open class DefaultPageCreator(
                 }
             }
         }
-        +contentForComments(m)
 
         block(
             "Packages",
@@ -244,7 +236,6 @@ open class DefaultPageCreator(
             }
         }
         group(styles = setOf(ContentStyle.TabbedContent)) {
-            +contentForComments(p)
             +contentForScope(p, p.dri, p.sourceSets)
         }
     }
@@ -254,25 +245,13 @@ open class DefaultPageCreator(
         sourceSets: Set<DokkaSourceSet>
     ): ContentGroup {
         val types = scopes.flatMap { it.classlikes } + scopes.filterIsInstance<DPackage>().flatMap { it.typealiases }
-        val inheritors = scopes.fold(mutableMapOf<DokkaSourceSet, List<DRI>>()) { acc, scope ->
-            val inheritorsForScope =
-                scope.safeAs<WithExtraProperties<Documentable>>()?.let { it.extra[InheritorsInfo] }?.let { inheritors ->
-                    inheritors.value.filter { it.value.isNotEmpty() }
-                }.orEmpty()
-            inheritorsForScope.forEach { (k, v) ->
-                acc.compute(k) { _, value -> value?.plus(v) ?: v }
-            }
-            acc
-        }
-
         return contentForScope(
             @Suppress("UNCHECKED_CAST")
             (scopes as List<Documentable>).dri,
             sourceSets,
             types,
             scopes.flatMap { it.functions },
-            scopes.flatMap { it.properties },
-            inheritors
+            scopes.flatMap { it.properties }
         )
     }
 
@@ -285,12 +264,7 @@ open class DefaultPageCreator(
             s.classlikes,
             (s as? DPackage)?.typealiases ?: emptyList()
         ).flatten()
-        val inheritors =
-            s.safeAs<WithExtraProperties<Documentable>>()?.let { it.extra[InheritorsInfo] }?.let { inheritors ->
-                inheritors.value.filter { it.value.isNotEmpty() }
-            }.orEmpty()
-
-        return contentForScope(setOf(dri), sourceSets, types, s.functions, s.properties, inheritors)
+        return contentForScope(setOf(dri), sourceSets, types, s.functions, s.properties)
     }
 
     protected open fun contentForScope(
@@ -298,8 +272,7 @@ open class DefaultPageCreator(
         sourceSets: Set<DokkaSourceSet>,
         types: List<Documentable>,
         functions: List<DFunction>,
-        properties: List<DProperty>,
-        inheritors: SourceSetDependent<List<DRI>>
+        properties: List<DProperty>
     ) = contentBuilder.contentFor(dri, sourceSets) {
         divergentBlock("Types", types, ContentKind.Classlikes, extra = mainExtra + SimpleAttr.header("Types"))
         if (separateInheritedMembers) {
@@ -312,31 +285,6 @@ open class DefaultPageCreator(
         } else {
             functionsBlock("Functions", functions)
             propertiesBlock("Properties", properties, sourceSets)
-        }
-        if (inheritors.values.any()) {
-            header(2, "Inheritors") { }
-            +ContentTable(
-                header = listOf(contentBuilder.contentFor(mainDRI, mainSourcesetData) {
-                    text("Name")
-                }),
-                children = inheritors.entries.flatMap { entry -> entry.value.map { Pair(entry.key, it) } }
-                    .groupBy({ it.second }, { it.first }).map { (classlike, platforms) ->
-                        val label = classlike.classNames?.substringAfterLast(".") ?: classlike.toString()
-                            .also { logger.warn("No class name found for DRI $classlike") }
-                        buildGroup(
-                            setOf(classlike),
-                            platforms.toSet(),
-                            ContentKind.Inheritors,
-                            extra = mainExtra + SymbolAnchorHint(label, ContentKind.Inheritors)
-                        ) {
-                            link(label, classlike)
-                        }
-                    },
-                dci = DCI(dri, ContentKind.Inheritors),
-                sourceSets = sourceSets.toDisplaySourceSets(),
-                style = emptySet(),
-                extra = mainExtra + SimpleAttr.header("Inheritors")
-            )
         }
     }
 
@@ -364,12 +312,11 @@ open class DefaultPageCreator(
                     documentables.forEach {
                         +buildSignature(it)
                         +contentForDescription(it)
+                        +contentForInheritors(it, documentables)
                     }
                 }
             }
-
             group(styles = setOf(ContentStyle.TabbedContent), sourceSets = mainSourcesetData + extensions.sourceSets) {
-                +contentForComments(documentables)
                 val csWithConstructor = classlikes.filterIsInstance<WithConstructors>()
                 if (csWithConstructor.isNotEmpty() && documentables.shouldRenderConstructors()) {
                     val constructorsToDocumented = csWithConstructor.flatMap { it.constructors }
@@ -442,271 +389,31 @@ open class DefaultPageCreator(
     // and instantiated directly under normal circumstances, so constructors should not be rendered.
     private fun List<Documentable>.shouldRenderConstructors() = !this.any { it is DAnnotation }
 
-    @Suppress("UNCHECKED_CAST")
-    private inline fun <reified T : TagWrapper> GroupedTags.withTypeUnnamed(): SourceSetDependent<T> =
-        (this[T::class] as List<Pair<DokkaSourceSet, T>>?)?.toMap().orEmpty()
-
-    @Suppress("UNCHECKED_CAST")
-    private inline fun <reified T : NamedTagWrapper> GroupedTags.withTypeNamed(): Map<String, SourceSetDependent<T>> =
-        (this[T::class] as List<Pair<DokkaSourceSet, T>>?)
-            ?.groupByTo(linkedMapOf()) { it.second.name }
-            ?.mapValues { (_, v) -> v.toMap() }
-            .orEmpty()
-
-    private inline fun <reified T : TagWrapper> GroupedTags.isNotEmptyForTag(): Boolean =
-        this[T::class]?.isNotEmpty() ?: false
-
     protected open fun contentForDescription(
         d: Documentable
     ): List<ContentNode> {
-        val tags: GroupedTags = d.groupedTags
         val platforms = d.sourceSets.toSet()
+        val tags = d.groupedTags
 
-        return contentBuilder.contentFor(d, styles = setOf(TextStyle.Block)) {
+        return contentBuilder.contentFor(d) {
             deprecatedSectionContent(d, platforms)
 
-            val descriptions = d.descriptions
-            if (descriptions.any { it.value.root.children.isNotEmpty() }) {
-                platforms.forEach { platform ->
-                    descriptions[platform]?.also {
-                        group(sourceSets = setOf(platform), styles = emptySet()) {
-                            comment(it.root)
-                        }
-                    }
-                }
-            }
+            descriptionSectionContent(d, platforms)
+            customTagSectionContent(d, platforms, customTagContentProviders)
+            unnamedTagSectionContent(d, platforms) { toHeaderString() }
 
-            val customTags = d.customTags
-            if (customTags.isNotEmpty()) {
-                platforms.forEach { platform ->
-                    customTags.forEach { (_, sourceSetTag) ->
-                        sourceSetTag[platform]?.let { tag ->
-                            customTagContentProviders.filter { it.isApplicable(tag) }.forEach { provider ->
-                                group(sourceSets = setOf(platform), styles = setOf(ContentStyle.KDocTag)) {
-                                    with(provider) {
-                                        contentForDescription(platform, tag)
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            val unnamedTags = tags.filterNot { (k, _) -> k.isSubclassOf(NamedTagWrapper::class) || k in specialTags }
-                .values.flatten().groupBy { it.first }.mapValues { it.value.map { it.second } }
-            if (unnamedTags.isNotEmpty()) {
-                platforms.forEach { platform ->
-                    unnamedTags[platform]?.let { tags ->
-                        if (tags.isNotEmpty()) {
-                            tags.groupBy { it::class }.forEach { (_, sameCategoryTags) ->
-                                group(sourceSets = setOf(platform), styles = setOf(ContentStyle.KDocTag)) {
-                                    header(
-                                        level = KDOC_TAG_HEADER_LEVEL,
-                                        text = sameCategoryTags.first().toHeaderString(),
-                                        styles = setOf()
-                                    )
-                                    sameCategoryTags.forEach { comment(it.root, styles = setOf()) }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            paramsSectionContent(tags)
+            seeAlsoSectionContent(tags)
+            throwsSectionContent(tags)
+            samplesSectionContent(tags)
         }.children
     }
 
-    private fun Set<DokkaSourceSet>.getPossibleFallbackSourcesets(sourceSet: DokkaSourceSet) =
-        this.filter { it.sourceSetID in sourceSet.dependentSourceSets }
-
-    private fun <V> Map<DokkaSourceSet, V>.fallback(sourceSets: List<DokkaSourceSet>): V? =
-        sourceSets.firstOrNull { it in this.keys }.let { this[it] }
-
-    protected open fun contentForComments(
-        d: Documentable,
-        isPlatformHintedContent: Boolean = true
-    ) = contentForComments(d.dri, d.sourceSets, d.groupedTags, isPlatformHintedContent)
-
-    protected open fun contentForComments(
-        d: List<Documentable>,
-        isPlatformHintedContent: Boolean = true
-    ) = contentForComments(d.first().dri, d.sourceSets, d.groupedTags, isPlatformHintedContent)
-
-    protected open fun contentForComments(
-        dri: DRI,
-        sourceSets: Set<DokkaSourceSet>,
-        tags: GroupedTags,
-        isPlatformHintedContent: Boolean = true
-    ): List<ContentNode> {
-
-        fun DocumentableContentBuilder.buildContent(
-            platforms: Set<DokkaSourceSet>,
-            contentBuilder: DocumentableContentBuilder.() -> Unit
-        ) = if (isPlatformHintedContent)
-            sourceSetDependentHint(
-                sourceSets = platforms,
-                kind = ContentKind.SourceSetDependentHint,
-                block = contentBuilder
-            )
-        else
-            contentBuilder()
-
-        fun DocumentableContentBuilder.contentForParams() {
-            if (tags.isNotEmptyForTag<Param>()) {
-                val params = tags.withTypeNamed<Param>()
-                val availablePlatforms = params.values.flatMap { it.keys }.toSet()
-
-                header(KDOC_TAG_HEADER_LEVEL, "Parameters", kind = ContentKind.Parameters, sourceSets = availablePlatforms)
-                group(
-                    extra = mainExtra + SimpleAttr.header("Parameters"),
-                    styles = setOf(ContentStyle.WithExtraAttributes),
-                    sourceSets = availablePlatforms
-                ) {
-                    buildContent(availablePlatforms) {
-                        table(kind = ContentKind.Parameters, sourceSets = availablePlatforms) {
-                            availablePlatforms.forEach { platform ->
-                                val possibleFallbacks = sourceSets.getPossibleFallbackSourcesets(platform)
-                                params.mapNotNull { (_, param) ->
-                                    (param[platform] ?: param.fallback(possibleFallbacks))?.let {
-                                        row(sourceSets = setOf(platform), kind = ContentKind.Parameters) {
-                                            text(
-                                                it.name,
-                                                kind = ContentKind.Parameters,
-                                                styles = mainStyles + setOf(ContentStyle.RowTitle, TextStyle.Underlined)
-                                            )
-                                            if (it.isNotEmpty()) {
-                                                comment(it.root)
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        fun DocumentableContentBuilder.contentForSeeAlso() {
-            if (tags.isNotEmptyForTag<See>()) {
-                val seeAlsoTags = tags.withTypeNamed<See>()
-                val availablePlatforms = seeAlsoTags.values.flatMap { it.keys }.toSet()
-
-                header(KDOC_TAG_HEADER_LEVEL, "See also", kind = ContentKind.Comment, sourceSets = availablePlatforms)
-                group(
-                    extra = mainExtra + SimpleAttr.header("See also"),
-                    styles = setOf(ContentStyle.WithExtraAttributes),
-                    sourceSets = availablePlatforms
-                ) {
-                    buildContent(availablePlatforms) {
-                        table(kind = ContentKind.Sample) {
-                            availablePlatforms.forEach { platform ->
-                                val possibleFallbacks = sourceSets.getPossibleFallbackSourcesets(platform)
-                                seeAlsoTags.forEach { (_, see) ->
-                                    (see[platform] ?: see.fallback(possibleFallbacks))?.let { seeTag ->
-                                        row(
-                                            sourceSets = setOf(platform),
-                                            kind = ContentKind.Comment,
-                                            styles = this@group.mainStyles,
-                                        ) {
-                                            seeTag.address?.let { dri ->
-                                                link(
-                                                    text = seeTag.name.removePrefix("${dri.packageName}."),
-                                                    address = dri,
-                                                    kind = ContentKind.Comment,
-                                                    styles = mainStyles + ContentStyle.RowTitle
-                                                )
-                                            } ?: text(
-                                                text = seeTag.name,
-                                                kind = ContentKind.Comment,
-                                                styles = mainStyles + ContentStyle.RowTitle
-                                            )
-                                            if (seeTag.isNotEmpty()) {
-                                                comment(seeTag.root)
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        fun DocumentableContentBuilder.contentForThrows() {
-            val throws = tags.withTypeNamed<Throws>()
-            if (throws.isNotEmpty()) {
-                val availablePlatforms = throws.values.flatMap { it.keys }.toSet()
-
-                header(KDOC_TAG_HEADER_LEVEL, "Throws", sourceSets = availablePlatforms)
-                buildContent(availablePlatforms) {
-                    availablePlatforms.forEach { sourceset ->
-                        table(
-                            kind = ContentKind.Main,
-                            sourceSets = setOf(sourceset),
-                            extra = mainExtra + SimpleAttr.header("Throws")
-                        ) {
-                            throws.entries.forEach { entry ->
-                                entry.value[sourceset]?.let { throws ->
-                                    row(sourceSets = setOf(sourceset)) {
-                                        group(styles = mainStyles + ContentStyle.RowTitle) {
-                                            throws.exceptionAddress?.let {
-                                                val className = it.takeIf { it.target is PointingToDeclaration }?.classNames
-                                                link(text = className ?: entry.key, address = it)
-                                            } ?: text(entry.key)
-                                        }
-                                        if (throws.isNotEmpty()) {
-                                            comment(throws.root)
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        fun DocumentableContentBuilder.contentForSamples() {
-            val samples = tags.withTypeNamed<Sample>()
-            if (samples.isNotEmpty()) {
-                val availablePlatforms = samples.values.flatMap { it.keys }.toSet()
-                header(KDOC_TAG_HEADER_LEVEL, "Samples", kind = ContentKind.Sample, sourceSets = availablePlatforms)
-                group(
-                    extra = mainExtra + SimpleAttr.header("Samples"),
-                    styles = emptySet(),
-                    sourceSets = availablePlatforms
-                ) {
-                    buildContent(availablePlatforms) {
-                        availablePlatforms.map { platformData ->
-                            val content = samples.filter { it.value.isEmpty() || platformData in it.value }
-                            group(
-                                sourceSets = setOf(platformData),
-                                kind = ContentKind.Sample,
-                                styles = setOf(TextStyle.Monospace, ContentStyle.RunnableSample)
-                            ) {
-                                content.forEach {
-                                    text(it.key)
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        return contentBuilder.contentFor(dri, sourceSets) {
-            if (tags.isNotEmpty()) {
-                contentForSamples()
-                contentForSeeAlso()
-                contentForParams()
-                contentForThrows()
-            }
+    protected open fun contentForInheritors(d: Documentable, documentables: List<Documentable>): List<ContentNode> {
+        return contentBuilder.contentFor(d, styles = setOf(TextStyle.Block)) {
+            inheritorsSectionContent(documentables, logger)
         }.children
     }
-
-    private fun TagWrapper.isNotEmpty() = this.children.isNotEmpty()
 
     protected open fun DocumentableContentBuilder.contentForBrief(documentable: Documentable) {
         documentable.sourceSets.forEach { sourceSet ->
@@ -761,7 +468,6 @@ open class DefaultPageCreator(
                         }
                         after {
                             +contentForDescription(d)
-                            +contentForComments(d, isPlatformHintedContent = false)
                         }
                     }
                 }
@@ -872,8 +578,7 @@ open class DefaultPageCreator(
     }
 
     private fun DocumentableContentBuilder.contentForCustomTagsBrief(documentable: Documentable) {
-        val customTags = documentable.customTags
-        if (customTags.isEmpty()) return
+        val customTags = documentable.customTags ?: return
 
         documentable.sourceSets.forEach { sourceSet ->
             customTags.forEach { (_, sourceSetTag) ->
@@ -889,35 +594,38 @@ open class DefaultPageCreator(
     }
 
     protected open fun TagWrapper.toHeaderString() = this.javaClass.toGenericString().split('.').last()
-
-    private val List<Documentable>.sourceSets: Set<DokkaSourceSet>
-        get() = flatMap { it.sourceSets }.toSet()
-
-    private val List<Documentable>.dri: Set<DRI>
-        get() = map { it.dri }.toSet()
-
-    private val Documentable.groupedTags: GroupedTags
-        get() = documentation.flatMap { (pd, doc) ->
-            doc.children.map { pd to it }.toList()
-        }.groupBy { it.second::class }
-
-    private val List<Documentable>.groupedTags: GroupedTags
-        get() = this.flatMap {
-            it.documentation.flatMap { (pd, doc) ->
-                doc.children.map { pd to it }.toList()
-            }
-        }.groupBy { it.second::class }
-
-    private val Documentable.descriptions: SourceSetDependent<Description>
-        get() = groupedTags.withTypeUnnamed()
-
-    private val Documentable.customTags: Map<String, SourceSetDependent<CustomTagWrapper>>
-        get() = groupedTags.withTypeNamed()
-
-    private val Documentable.hasSeparatePage: Boolean
-        get() = this !is DTypeAlias
-
-    @Suppress("UNCHECKED_CAST")
-    private fun <T : Documentable> T.nameAfterClash(): String =
-        ((this as? WithExtraProperties<out Documentable>)?.extra?.get(DriClashAwareName)?.value ?: name).orEmpty()
 }
+
+internal val List<Documentable>.sourceSets: Set<DokkaSourceSet>
+    get() = flatMap { it.sourceSets }.toSet()
+
+internal val List<Documentable>.dri: Set<DRI>
+    get() = map { it.dri }.toSet()
+
+internal val Documentable.groupedTags: GroupedTags
+    get() = documentation.flatMap { (pd, doc) ->
+        doc.children.map { pd to it }.toList()
+    }.groupBy { it.second::class }
+
+internal val Documentable.descriptions: SourceSetDependent<Description>
+    get() = groupedTags.withTypeUnnamed()
+
+internal val Documentable.customTags: Map<String, SourceSetDependent<CustomTagWrapper>>?
+    get() = groupedTags.withTypeNamed()
+
+private val Documentable.hasSeparatePage: Boolean
+    get() = this !is DTypeAlias
+
+@Suppress("UNCHECKED_CAST")
+private fun <T : Documentable> T.nameAfterClash(): String =
+    ((this as? WithExtraProperties<out Documentable>)?.extra?.get(DriClashAwareName)?.value ?: name).orEmpty()
+
+@Suppress("UNCHECKED_CAST")
+internal inline fun <reified T : TagWrapper> GroupedTags.withTypeUnnamed(): SourceSetDependent<T> =
+    (this[T::class] as List<Pair<DokkaSourceSet, T>>?)?.toMap().orEmpty()
+
+@Suppress("UNCHECKED_CAST")
+internal inline fun <reified T : NamedTagWrapper> GroupedTags.withTypeNamed(): Map<String, SourceSetDependent<T>>? =
+    (this[T::class] as List<Pair<DokkaSourceSet, T>>?)
+        ?.groupByTo(linkedMapOf()) { it.second.name }
+        ?.mapValues { (_, v) -> v.toMap() }

--- a/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
@@ -391,15 +391,15 @@ open class DefaultPageCreator(
     protected open fun contentForDescription(
         d: Documentable
     ): List<ContentNode> {
-        val platforms = d.sourceSets.toSet()
+        val sourceSets = d.sourceSets.toSet()
         val tags = d.groupedTags
 
         return contentBuilder.contentFor(d) {
-            deprecatedSectionContent(d, platforms)
+            deprecatedSectionContent(d, sourceSets)
 
-            descriptionSectionContent(d, platforms)
-            customTagSectionContent(d, platforms, customTagContentProviders)
-            unnamedTagSectionContent(d, platforms) { toHeaderString() }
+            descriptionSectionContent(d, sourceSets)
+            customTagSectionContent(d, sourceSets, customTagContentProviders)
+            unnamedTagSectionContent(d, sourceSets) { toHeaderString() }
 
             paramsSectionContent(tags)
             seeAlsoSectionContent(tags)

--- a/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
@@ -18,8 +18,6 @@ import org.jetbrains.dokka.pages.*
 import org.jetbrains.dokka.utilities.DokkaLogger
 import kotlin.reflect.KClass
 
-internal const val KDOC_TAG_HEADER_LEVEL = 4
-
 internal typealias GroupedTags = Map<KClass<out TagWrapper>, List<Pair<DokkaSourceSet?, TagWrapper>>>
 
 open class DefaultPageCreator(
@@ -573,7 +571,8 @@ open class DefaultPageCreator(
     }
 
     private fun DocumentableContentBuilder.contentForCustomTagsBrief(documentable: Documentable) {
-        val customTags = documentable.customTags ?: return
+        val customTags = documentable.customTags
+        if (customTags.isEmpty()) return
 
         documentable.sourceSets.forEach { sourceSet ->
             customTags.forEach { (_, sourceSetTag) ->
@@ -605,7 +604,7 @@ internal val Documentable.groupedTags: GroupedTags
 internal val Documentable.descriptions: SourceSetDependent<Description>
     get() = groupedTags.withTypeUnnamed()
 
-internal val Documentable.customTags: Map<String, SourceSetDependent<CustomTagWrapper>>?
+internal val Documentable.customTags: Map<String, SourceSetDependent<CustomTagWrapper>>
     get() = groupedTags.withTypeNamed()
 
 private val Documentable.hasSeparatePage: Boolean
@@ -620,7 +619,8 @@ internal inline fun <reified T : TagWrapper> GroupedTags.withTypeUnnamed(): Sour
     (this[T::class] as List<Pair<DokkaSourceSet, T>>?)?.toMap().orEmpty()
 
 @Suppress("UNCHECKED_CAST")
-internal inline fun <reified T : NamedTagWrapper> GroupedTags.withTypeNamed(): Map<String, SourceSetDependent<T>>? =
+internal inline fun <reified T : NamedTagWrapper> GroupedTags.withTypeNamed(): Map<String, SourceSetDependent<T>> =
     (this[T::class] as List<Pair<DokkaSourceSet, T>>?)
         ?.groupByTo(linkedMapOf()) { it.second.name }
         ?.mapValues { (_, v) -> v.toMap() }
+        .orEmpty()

--- a/plugins/base/src/main/kotlin/translators/documentables/DescriptionSections.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DescriptionSections.kt
@@ -1,0 +1,273 @@
+package org.jetbrains.dokka.base.translators.documentables
+
+import org.jetbrains.dokka.DokkaConfiguration
+import org.jetbrains.dokka.base.transformers.documentables.InheritorsInfo
+import org.jetbrains.dokka.base.transformers.pages.tags.CustomTagContentProvider
+import org.jetbrains.dokka.links.DRI
+import org.jetbrains.dokka.links.PointingToDeclaration
+import org.jetbrains.dokka.model.Documentable
+import org.jetbrains.dokka.model.SourceSetDependent
+import org.jetbrains.dokka.model.WithScope
+import org.jetbrains.dokka.model.doc.*
+import org.jetbrains.dokka.model.orEmpty
+import org.jetbrains.dokka.model.properties.WithExtraProperties
+import org.jetbrains.dokka.pages.ContentKind
+import org.jetbrains.dokka.pages.ContentStyle
+import org.jetbrains.dokka.pages.SimpleAttr
+import org.jetbrains.dokka.pages.TextStyle
+import org.jetbrains.dokka.utilities.DokkaLogger
+import org.jetbrains.kotlin.utils.addToStdlib.safeAs
+import kotlin.reflect.KClass
+import kotlin.reflect.full.isSubclassOf
+
+
+internal fun PageContentBuilder.DocumentableContentBuilder.descriptionSectionContent(
+    documentable: Documentable,
+    platforms: Set<DokkaConfiguration.DokkaSourceSet>
+) {
+    val descriptions = documentable.descriptions
+    if (descriptions.any { it.value.root.children.isNotEmpty() }) {
+        platforms.forEach { platform ->
+            descriptions[platform]?.also {
+                group(sourceSets = setOf(platform), styles = emptySet()) {
+                    comment(it.root)
+                }
+            }
+        }
+    }
+}
+
+internal fun PageContentBuilder.DocumentableContentBuilder.customTagSectionContent(
+    documentable: Documentable,
+    platforms: Set<DokkaConfiguration.DokkaSourceSet>,
+    customTagContentProviders: List<CustomTagContentProvider>
+) {
+    val customTags = documentable.customTags ?: return
+
+    platforms.forEach { platform ->
+        customTags.forEach { (_, sourceSetTag) ->
+            sourceSetTag[platform]?.let { tag ->
+                customTagContentProviders.filter { it.isApplicable(tag) }.forEach { provider ->
+                    group(sourceSets = setOf(platform), styles = setOf(ContentStyle.KDocTag)) {
+                        with(provider) {
+                            contentForDescription(platform, tag)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+internal fun PageContentBuilder.DocumentableContentBuilder.unnamedTagSectionContent(
+    documentable: Documentable,
+    platforms: Set<DokkaConfiguration.DokkaSourceSet>,
+    toHeaderString: TagWrapper.() -> String
+) {
+    val unnamedTags = documentable.groupedTags
+        .filterNot { (k, _) -> k.isSubclassOf(NamedTagWrapper::class) || k in specialTags }
+        .values.flatten().groupBy { it.first }.mapValues { it.value.map { it.second } }
+    if (unnamedTags.isEmpty()) return
+    platforms.forEach { platform ->
+        unnamedTags[platform]?.let { tags ->
+            if (tags.isNotEmpty()) {
+                tags.groupBy { it::class }.forEach { (_, sameCategoryTags) ->
+                    group(sourceSets = setOf(platform), styles = setOf(ContentStyle.KDocTag)) {
+                        header(
+                            level = KDOC_TAG_HEADER_LEVEL,
+                            text = sameCategoryTags.first().toHeaderString(),
+                            styles = setOf()
+                        )
+                        sameCategoryTags.forEach { comment(it.root, styles = setOf()) }
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+internal fun PageContentBuilder.DocumentableContentBuilder.paramsSectionContent(tags: GroupedTags) {
+    val params = tags.withTypeNamed<Param>() ?: return
+
+    val availablePlatforms = params.availablePlatforms()
+    availablePlatforms.forEach { platform ->
+        header(KDOC_TAG_HEADER_LEVEL, "Parameters", kind = ContentKind.Parameters, sourceSets = setOf(platform))
+        table(
+            kind = ContentKind.Parameters,
+            extra = mainExtra + SimpleAttr.header("Parameters"),
+            sourceSets = setOf(platform)
+        )
+        {
+            val possibleFallbacks = availablePlatforms.getPossibleFallbackSourcesets(platform)
+            params.mapNotNull { (_, param) ->
+                (param[platform] ?: param.fallback(possibleFallbacks))?.let {
+                    row(sourceSets = setOf(platform), kind = ContentKind.Parameters) {
+                        text(
+                            it.name,
+                            kind = ContentKind.Parameters,
+                            styles = mainStyles + setOf(ContentStyle.RowTitle, TextStyle.Underlined)
+                        )
+                        if (it.isNotEmpty()) {
+                            comment(it.root)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+internal fun PageContentBuilder.DocumentableContentBuilder.seeAlsoSectionContent(tags: GroupedTags) {
+    val seeAlsoTags = tags.withTypeNamed<See>() ?: return
+
+    val availablePlatforms = seeAlsoTags.availablePlatforms()
+    availablePlatforms.forEach { platform ->
+        header(KDOC_TAG_HEADER_LEVEL, "See also", kind = ContentKind.Comment, sourceSets = setOf(platform))
+
+        table(
+            kind = ContentKind.Comment,
+            extra = mainExtra + SimpleAttr.header("See also")
+        )
+        {
+            val possibleFallbacks = availablePlatforms.getPossibleFallbackSourcesets(platform)
+            seeAlsoTags.forEach { (_, see) ->
+                (see[platform] ?: see.fallback(possibleFallbacks))?.let { seeTag ->
+                    row(
+                        sourceSets = setOf(platform),
+                        kind = ContentKind.Comment
+                    ) {
+                        seeTag.address?.let { dri ->
+                            link(
+                                text = seeTag.name.removePrefix("${dri.packageName}."),
+                                address = dri,
+                                kind = ContentKind.Comment,
+                                styles = mainStyles + ContentStyle.RowTitle
+                            )
+                        } ?: text(
+                            text = seeTag.name,
+                            kind = ContentKind.Comment,
+                            styles = mainStyles + ContentStyle.RowTitle
+                        )
+                        if (seeTag.isNotEmpty()) {
+                            comment(seeTag.root)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+internal fun PageContentBuilder.DocumentableContentBuilder.throwsSectionContent(
+    tags: GroupedTags
+) {
+    val throws = tags.withTypeNamed<Throws>() ?: return
+
+    val availablePlatforms = throws.values.flatMap { it.keys }.toSet()
+    availablePlatforms.forEach { platform ->
+        header(KDOC_TAG_HEADER_LEVEL, "Throws", sourceSets = setOf(platform))
+        table(
+            kind = ContentKind.Main,
+            sourceSets = setOf(platform),
+            extra = mainExtra + SimpleAttr.header("Throws")
+        ) {
+            throws.entries.forEach { entry ->
+                entry.value[platform]?.let { throws ->
+                    row(sourceSets = setOf(platform)) {
+                        group(styles = mainStyles + ContentStyle.RowTitle) {
+                            throws.exceptionAddress?.let {
+                                val className = it.takeIf { it.target is PointingToDeclaration }?.classNames
+                                link(text = className ?: entry.key, address = it)
+                            } ?: text(entry.key)
+                        }
+                        if (throws.isNotEmpty()) {
+                            comment(throws.root)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+internal fun PageContentBuilder.DocumentableContentBuilder.samplesSectionContent(tags: GroupedTags) {
+    val samples = tags.withTypeNamed<Sample>() ?: return
+
+    samples.availablePlatforms().forEach { platformData ->
+        val content = samples.filter { it.value.isEmpty() || platformData in it.value }
+        header(KDOC_TAG_HEADER_LEVEL, "Samples", kind = ContentKind.Sample, sourceSets = setOf(platformData))
+        group(
+            sourceSets = setOf(platformData),
+            kind = ContentKind.Sample,
+            styles = setOf(TextStyle.Monospace, ContentStyle.RunnableSample),
+            extra = mainExtra + SimpleAttr.header("Samples")
+        ) {
+            content.forEach {
+                text(it.key)
+            }
+        }
+    }
+}
+
+internal fun PageContentBuilder.DocumentableContentBuilder.inheritorsSectionContent(
+    documentables: List<Documentable>,
+    logger: DokkaLogger
+) {
+    val inheritors = documentables.filterIsInstance<WithScope>().inheritors()
+    if (inheritors.values.none()) return
+
+    val availablePlatforms = inheritors.keys.toSet()
+    availablePlatforms.forEach { platform ->
+        header(KDOC_TAG_HEADER_LEVEL, "Inheritors", sourceSets = setOf(platform))
+        table(
+            kind = ContentKind.Inheritors,
+            sourceSets = setOf(platform),
+            extra = mainExtra + SimpleAttr.header("Inheritors")
+        ) {
+            inheritors[platform]?.forEach { classlike ->
+                row {
+                    link(
+                        text = classlike.friendlyClassName()
+                            ?: classlike.toString().also { logger.warn("No class name found for DRI $classlike") },
+                        address = classlike
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun List<WithScope>.inheritors() =
+    fold(mutableMapOf<DokkaConfiguration.DokkaSourceSet, List<DRI>>()) { acc, scope ->
+        val inheritorsForScope =
+            scope.safeAs<WithExtraProperties<Documentable>>()?.let { it.extra[InheritorsInfo] }?.let { inheritors ->
+                inheritors.value.filter { it.value.isNotEmpty() }
+            }.orEmpty()
+        inheritorsForScope.forEach { (k, v) ->
+            acc.compute(k) { _, value -> value?.plus(v) ?: v }
+        }
+        acc
+    }
+
+private fun DRI.friendlyClassName() = classNames?.substringAfterLast(".")
+
+private fun TagWrapper.isNotEmpty() = this.children.isNotEmpty()
+
+private fun <V> Map<DokkaConfiguration.DokkaSourceSet, V>.fallback(sourceSets: List<DokkaConfiguration.DokkaSourceSet>): V? =
+    sourceSets.firstOrNull { it in this.keys }.let { this[it] }
+
+/**
+ * Used for multi-value tags (e.g. params) when values are missed on some platforms.
+ * It this case description is inherited from parent platform.
+ * E.g. if param hasn't description in JVM, the description is taken from common.
+ */
+private fun Set<DokkaConfiguration.DokkaSourceSet>.getPossibleFallbackSourcesets(sourceSet: DokkaConfiguration.DokkaSourceSet) =
+    this.filter { it.sourceSetID in sourceSet.dependentSourceSets }
+
+private val specialTags: Set<KClass<out TagWrapper>> =
+    setOf(Property::class, Description::class, Constructor::class, Param::class, See::class)
+
+private fun <T> Map<String, SourceSetDependent<T>>.availablePlatforms() = values.flatMap { it.keys }.toSet()
+
+

--- a/plugins/base/src/main/kotlin/translators/documentables/DescriptionSections.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DescriptionSections.kt
@@ -159,13 +159,10 @@ internal fun PageContentBuilder.DocumentableContentBuilder.seeAlsoSectionContent
     }
 }
 
-internal fun PageContentBuilder.DocumentableContentBuilder.throwsSectionContent(
-    tags: GroupedTags
-) {
+internal fun PageContentBuilder.DocumentableContentBuilder.throwsSectionContent(tags: GroupedTags) {
     val throws = tags.withTypeNamed<Throws>() ?: return
 
-    val availablePlatforms = throws.values.flatMap { it.keys }.toSet()
-    availablePlatforms.forEach { platform ->
+    throws.availablePlatforms().forEach { platform ->
         header(KDOC_TAG_HEADER_LEVEL, "Throws", sourceSets = setOf(platform))
         table(
             kind = ContentKind.Main,
@@ -193,12 +190,12 @@ internal fun PageContentBuilder.DocumentableContentBuilder.throwsSectionContent(
 
 internal fun PageContentBuilder.DocumentableContentBuilder.samplesSectionContent(tags: GroupedTags) {
     val samples = tags.withTypeNamed<Sample>() ?: return
+    samples.availablePlatforms().forEach { platform ->
+        val content = samples.filter { it.value.isEmpty() || platform in it.value }
+        header(KDOC_TAG_HEADER_LEVEL, "Samples", kind = ContentKind.Sample, sourceSets = setOf(platform))
 
-    samples.availablePlatforms().forEach { platformData ->
-        val content = samples.filter { it.value.isEmpty() || platformData in it.value }
-        header(KDOC_TAG_HEADER_LEVEL, "Samples", kind = ContentKind.Sample, sourceSets = setOf(platformData))
         group(
-            sourceSets = setOf(platformData),
+            sourceSets = setOf(platform),
             kind = ContentKind.Sample,
             styles = setOf(TextStyle.Monospace, ContentStyle.RunnableSample),
             extra = mainExtra + SimpleAttr.header("Samples")

--- a/plugins/base/src/main/kotlin/translators/documentables/DescriptionSections.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DescriptionSections.kt
@@ -92,13 +92,11 @@ internal fun PageContentBuilder.DocumentableContentBuilder.paramsSectionContent(
     val params = tags.withTypeNamed<Param>() ?: return
 
     val availableSourceSets = params.availableSourceSets()
-    header(KDOC_TAG_HEADER_LEVEL, "Parameters", kind = ContentKind.Parameters, sourceSets = availableSourceSets)
-    table(
+    tableSectionContentBlock(
+        blockName = "Parameters",
         kind = ContentKind.Parameters,
-        extra = mainExtra + SimpleAttr.header("Parameters"),
         sourceSets = availableSourceSets
-    )
-    {
+    ) {
         availableSourceSets.forEach { sourceSet ->
             val possibleFallbacks = availableSourceSets.getPossibleFallback(sourceSet)
             params.mapNotNull { (_, param) ->
@@ -123,14 +121,11 @@ internal fun PageContentBuilder.DocumentableContentBuilder.seeAlsoSectionContent
     val seeAlsoTags = tags.withTypeNamed<See>() ?: return
 
     val availableSourceSets = seeAlsoTags.availableSourceSets()
-    header(KDOC_TAG_HEADER_LEVEL, "See also", kind = ContentKind.Comment, sourceSets = availableSourceSets)
-
-    table(
+    tableSectionContentBlock(
+        blockName = "See also",
         kind = ContentKind.Comment,
-        extra = mainExtra + SimpleAttr.header("See also"),
         sourceSets = availableSourceSets
-    )
-    {
+    ) {
         availableSourceSets.forEach { sourceSet ->
             val possibleFallbacks = availableSourceSets.getPossibleFallback(sourceSet)
             seeAlsoTags.forEach { (_, see) ->
@@ -165,11 +160,10 @@ internal fun PageContentBuilder.DocumentableContentBuilder.throwsSectionContent(
     val throwsTags = tags.withTypeNamed<Throws>() ?: return
     val availableSourceSets = throwsTags.availableSourceSets()
 
-    header(KDOC_TAG_HEADER_LEVEL, "Throws", sourceSets = availableSourceSets)
-    table(
+    tableSectionContentBlock(
+        blockName = "Throws",
         kind = ContentKind.Main,
-        sourceSets = availableSourceSets,
-        extra = mainExtra + SimpleAttr.header("Throws")
+        sourceSets = availableSourceSets
     ) {
         throwsTags.forEach { (throwsName, throwsPerSourceSet) ->
             throwsPerSourceSet.forEach { (sourceSet, throws) ->
@@ -249,7 +243,11 @@ private fun PageContentBuilder.DocumentableContentBuilder.multiplatformInheritor
     // intersect is used for removing duplication in case of merged classlikes from different platforms
     val availableSourceSets = inheritors.keys.toSet().intersect(documentable.sourceSets)
 
-    inheritorsBlock(sourceSets = availableSourceSets) {
+    tableSectionContentBlock(
+        blockName = "Inheritors",
+        kind = ContentKind.Inheritors,
+        sourceSets = availableSourceSets
+    ) {
         availableSourceSets.forEach { sourceSet ->
             inheritors[sourceSet]?.forEach { classlike: DRI ->
                 inheritorRow(classlike, logger, sourceSet)
@@ -263,22 +261,27 @@ private fun PageContentBuilder.DocumentableContentBuilder.sharedSourceSetOnlyInh
     logger: DokkaLogger,
 ) {
     val uniqueInheritors = inheritors.values.flatten().toSet()
-    inheritorsBlock {
+    tableSectionContentBlock(
+        blockName = "Inheritors",
+        kind = ContentKind.Inheritors,
+    ) {
         uniqueInheritors.forEach { classlike ->
             inheritorRow(classlike, logger)
         }
     }
 }
 
-private fun PageContentBuilder.DocumentableContentBuilder.inheritorsBlock(
+private fun PageContentBuilder.DocumentableContentBuilder.tableSectionContentBlock(
+    blockName: String,
+    kind: ContentKind,
     sourceSets: Set<DokkaConfiguration.DokkaSourceSet> = mainSourcesetData,
     body: PageContentBuilder.TableBuilder.() -> Unit,
 ) {
-    header(KDOC_TAG_HEADER_LEVEL, "Inheritors", sourceSets = sourceSets)
+    header(KDOC_TAG_HEADER_LEVEL, text = blockName, kind = kind, sourceSets = sourceSets)
     table(
-        kind = ContentKind.Inheritors,
+        kind = kind,
         sourceSets = sourceSets,
-        extra = mainExtra + SimpleAttr.header("Inheritors")
+        extra = mainExtra + SimpleAttr.header(blockName)
     ) {
         body()
     }

--- a/plugins/base/src/main/resources/dokka/styles/style.css
+++ b/plugins/base/src/main/resources/dokka/styles/style.css
@@ -946,9 +946,10 @@ td.content {
     display: none;
 }
 
-/*Work around an issue: https://github.com/JetBrains/kotlin-playground/issues/91*/
-.platform-hinted[data-togglable="Samples"] > .content:not([data-active]),
-.tabs-section-body > *[data-togglable="Samples"]:not([data-active]) {
+/* Work around an issue: https://github.com/JetBrains/kotlin-playground/issues/91
+Applies for main description blocks with platform tabs.
+Just in case of possible performance degradation it excluding tabs with briefs on classlike page */
+#content > div:not(.tabbedcontent) .sourceset-dependent-content:not([data-active]) {
     display: block !important;
     visibility: hidden;
     height: 0;

--- a/plugins/base/src/test/kotlin/content/exceptions/ContentForExceptions.kt
+++ b/plugins/base/src/test/kotlin/content/exceptions/ContentForExceptions.kt
@@ -1,0 +1,434 @@
+package content.exceptions
+
+import matchers.content.*
+import org.jetbrains.dokka.DokkaConfiguration
+import org.jetbrains.dokka.PluginConfigurationImpl
+import org.jetbrains.dokka.base.DokkaBase
+import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
+import org.jetbrains.dokka.model.DisplaySourceSet
+import org.jetbrains.kotlin.utils.addIfNotNull
+import org.junit.jupiter.api.Test
+import utils.ParamAttributes
+import utils.bareSignature
+import utils.findTestType
+import kotlin.test.assertEquals
+
+class ContentForExceptions : BaseAbstractTest() {
+    private val testConfiguration = dokkaConfiguration {
+        sourceSets {
+            sourceSet {
+                sourceRoots = listOf("src/")
+                analysisPlatform = "jvm"
+            }
+        }
+    }
+
+    private val mppTestConfiguration = dokkaConfiguration {
+        moduleName = "example"
+        sourceSets {
+            val common = sourceSet {
+                name = "common"
+                displayName = "common"
+                analysisPlatform = "common"
+                sourceRoots = listOf("src/commonMain/kotlin/pageMerger/Test.kt")
+            }
+            sourceSet {
+                name = "jvm"
+                displayName = "jvm"
+                analysisPlatform = "jvm"
+                dependentSourceSets = setOf(common.value.sourceSetID)
+                sourceRoots = listOf("src/jvmMain/kotlin/pageMerger/Test.kt")
+            }
+            sourceSet {
+                name = "linuxX64"
+                displayName = "linuxX64"
+                analysisPlatform = "native"
+                dependentSourceSets = setOf(common.value.sourceSetID)
+                sourceRoots = listOf("src/linuxX64Main/kotlin/pageMerger/Test.kt")
+            }
+        }
+        pluginsConfigurations.addIfNotNull(
+            PluginConfigurationImpl(
+                DokkaBase::class.qualifiedName!!,
+                DokkaConfiguration.SerializationFormat.JSON,
+                """{ "mergeImplicitExpectActualDeclarations": true }""",
+            )
+        )
+    }
+
+    @Test
+    fun `function with navigatable thrown exception`() {
+        testInline(
+            """
+            |/src/main/kotlin/test/source.kt
+            |package test
+            |
+            |/**
+            |* @throws Exception
+            |*/
+            |fun function(abc: String) {
+            |    println(abc)
+            |}
+        """.trimIndent(), testConfiguration
+        ) {
+            pagesTransformationStage = { module ->
+                val page = module.findTestType("test", "function")
+                page.content.assertNode {
+                    group {
+                        header(1) { +"function" }
+                    }
+                    divergentGroup {
+                        divergentInstance {
+                            divergent {
+                                bareSignature(
+                                    emptyMap(),
+                                    "",
+                                    "",
+                                    emptySet(),
+                                    "function",
+                                    null,
+                                    "abc" to ParamAttributes(emptyMap(), emptySet(), "String")
+                                )
+                            }
+                            after {
+                                header(4) { +"Throws" }
+                                table {
+                                    group {
+                                        group {
+                                            link { +"Exception" }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `function with non-navigatable thrown exception`() {
+        testInline(
+            """
+            |/src/main/kotlin/test/source.kt
+            |package test
+            |
+            |/**
+            |* @throws UnavailableException
+            |*/
+            |fun function(abc: String) {
+            |    println(abc)
+            |}
+        """.trimIndent(), testConfiguration
+        ) {
+            pagesTransformationStage = { module ->
+                val page = module.findTestType("test", "function")
+                page.content.assertNode {
+                    group {
+                        header(1) { +"function" }
+                    }
+                    divergentGroup {
+                        divergentInstance {
+                            divergent {
+                                bareSignature(
+                                    emptyMap(),
+                                    "",
+                                    "",
+                                    emptySet(),
+                                    "function",
+                                    null,
+                                    "abc" to ParamAttributes(emptyMap(), emptySet(), "String")
+                                )
+                            }
+                            after {
+                                header(4) { +"Throws" }
+                                table {
+                                    group {
+                                        group {
+                                            +"UnavailableException"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `multiplatofrm class with throws`() {
+        testInline(
+            """
+                |/src/commonMain/kotlin/pageMerger/Test.kt
+                |package pageMerger
+                |
+                |/**
+                |* @throws CommonException
+                |*/
+                |expect open class Parent
+                |
+                |/src/jvmMain/kotlin/pageMerger/Test.kt
+                |package pageMerger
+                |
+                |/**
+                |* @throws JvmException
+                |*/
+                |actual open class Parent
+                |
+                |/src/linuxX64Main/kotlin/pageMerger/Test.kt
+                |package pageMerger
+                |
+                |/**
+                |* @throws LinuxException
+                |*/
+                |actual open class Parent
+                |
+            """.trimMargin(),
+            mppTestConfiguration
+        ) {
+            pagesTransformationStage = { module ->
+                val page = module.findTestType("pageMerger", "Parent")
+                page.content.assertNode {
+                    group {
+                        header(1) { +"Parent" }
+                        platformHinted {
+                            group {
+                                +"expect open class "
+                                link {
+                                    +"Parent"
+                                }
+                            }
+                            group {
+                                +"actual open class "
+                                link {
+                                    +"Parent"
+                                }
+                            }
+                            group {
+                                +"actual open class "
+                                link {
+                                    +"Parent"
+                                }
+                            }
+                            header(4) { +"Throws" }
+                            table {
+                                group {
+                                    group {
+                                        +"CommonException"
+                                    }
+                                    check {
+                                        assertEquals(1, sourceSets.size)
+                                        assertEquals(
+                                            "common",
+                                            this.sourceSets.first().name
+                                        )
+                                    }
+                                }
+                                group {
+                                    group {
+                                        +"JvmException"
+                                    }
+                                    check {
+                                        sourceSets.assertSourceSet("jvm")
+                                    }
+                                }
+                                group {
+                                    group {
+                                        +"LinuxException"
+                                    }
+                                    check {
+                                        sourceSets.assertSourceSet("linuxX64")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    skipAllNotMatching()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `multiplatofrm class with throws in few platforms`() {
+        testInline(
+            """
+                |/src/commonMain/kotlin/pageMerger/Test.kt
+                |package pageMerger
+                |
+                |/**
+                |* @throws CommonException
+                |*/
+                |expect open class Parent
+                |
+                |/src/jvmMain/kotlin/pageMerger/Test.kt
+                |package pageMerger
+                |
+                |/**
+                |* @throws JvmException
+                |*/
+                |actual open class Parent
+                |
+                |/src/linuxX64Main/kotlin/pageMerger/Test.kt
+                |package pageMerger
+                |
+                |actual open class Parent
+                |
+            """.trimMargin(),
+            mppTestConfiguration
+        ) {
+            pagesTransformationStage = { module ->
+                val page = module.findTestType("pageMerger", "Parent")
+                page.content.assertNode {
+                    group {
+                        header(1) { +"Parent" }
+                        platformHinted {
+                            group {
+                                +"expect open class "
+                                link {
+                                    +"Parent"
+                                }
+                            }
+                            group {
+                                +"actual open class "
+                                link {
+                                    +"Parent"
+                                }
+                            }
+                            group {
+                                +"actual open class "
+                                link {
+                                    +"Parent"
+                                }
+                            }
+                            header(4) { +"Throws" }
+                            table {
+                                group {
+                                    group {
+                                        +"CommonException"
+                                    }
+                                    check {
+                                        sourceSets.assertSourceSet("common")
+                                    }
+                                }
+                                group {
+                                    group {
+                                        +"JvmException"
+                                    }
+                                    check {
+                                        sourceSets.assertSourceSet("jvm")
+                                    }
+                                }
+                                check {
+                                    assertEquals(2, sourceSets.size)
+                                }
+                            }
+                        }
+                    }
+                    skipAllNotMatching()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `throws in merged functions`() {
+        testInline(
+            """
+                |/src/linuxX64Main/kotlin/pageMerger/Test.kt
+                |package pageMerger
+                |
+                |/**
+                |* @throws LinuxException
+                |*/
+                |fun function() {
+                |    println()
+                |}
+                |
+                |/src/jvmMain/kotlin/pageMerger/Test.kt
+                |package pageMerger
+                |
+                |/**
+                |* @throws JvmException
+                |*/
+                |fun function() {
+                |    println()
+                |}
+                |
+            """.trimMargin(),
+            mppTestConfiguration
+        ) {
+            pagesTransformationStage = { module ->
+                val page = module.findTestType("pageMerger", "function")
+                page.content.assertNode {
+                    group {
+                        header(1) { +"function" }
+                    }
+                    divergentGroup {
+                        divergentInstance {
+                            divergent {
+                                bareSignature(
+                                    emptyMap(),
+                                    "",
+                                    "",
+                                    emptySet(),
+                                    "function",
+                                    null,
+                                )
+                            }
+                            after {
+                                header(4) { +"Throws" }
+                                table {
+                                    group {
+                                        group {
+                                            +"JvmException"
+                                        }
+                                    }
+                                    check {
+                                        sourceSets.assertSourceSet("jvm")
+                                    }
+                                }
+                            }
+                            check {
+                                sourceSets.assertSourceSet("jvm")
+                            }
+                        }
+                        divergentInstance {
+                            divergent {
+                                bareSignature(
+                                    emptyMap(),
+                                    "",
+                                    "",
+                                    emptySet(),
+                                    "function",
+                                    null,
+                                )
+                            }
+                            after {
+                                header(4) { +"Throws" }
+                                table {
+                                    group {
+                                        group {
+                                            +"LinuxException"
+                                        }
+                                    }
+                                }
+                            }
+                            check {
+                                sourceSets.assertSourceSet("linuxX64")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun Set<DisplaySourceSet>.assertSourceSet(expectedName: String) {
+    assertEquals(1, this.size)
+    assertEquals(expectedName, this.first().name)
+}

--- a/plugins/base/src/test/kotlin/content/inheritors/ContentForInheritorsTest.kt
+++ b/plugins/base/src/test/kotlin/content/inheritors/ContentForInheritorsTest.kt
@@ -16,6 +16,32 @@ class ContentForInheritorsTest : BaseAbstractTest() {
         }
     }
 
+    private val mppTestConfiguration = dokkaConfiguration {
+        moduleName = "example"
+        sourceSets {
+            val common = sourceSet {
+                name = "common"
+                displayName = "common"
+                analysisPlatform = "common"
+                sourceRoots = listOf("src/commonMain/kotlin/pageMerger/Test.kt")
+            }
+            sourceSet {
+                name = "jvm"
+                displayName = "jvm"
+                analysisPlatform = "jvm"
+                dependentSourceSets = setOf(common.value.sourceSetID)
+                sourceRoots = listOf("src/jvmMain/kotlin/pageMerger/Test.kt")
+            }
+            sourceSet {
+                name = "linuxX64"
+                displayName = "linuxX64"
+                analysisPlatform = "native"
+                dependentSourceSets = setOf(common.value.sourceSetID)
+                sourceRoots = listOf("src/linuxX64Main/kotlin/pageMerger/Test.kt")
+            }
+        }
+    }
+
     @Test
     fun `class with one inheritor has table in description`() {
         testInline(
@@ -71,7 +97,6 @@ class ContentForInheritorsTest : BaseAbstractTest() {
         ) {
             pagesTransformationStage = { module ->
                 val page = module.findTestType("test", "Parent")
-                println(page.content)
                 page.content.assertNode {
                     group {
                         header(1) { +"Parent" }
@@ -89,6 +114,110 @@ class ContentForInheritorsTest : BaseAbstractTest() {
                                 }
                                 group {
                                     link { +"Bar" }
+                                }
+                            }
+                        }
+                    }
+                    skipAllNotMatching()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `inherit from one of multiplatoforms actuals`() {
+        testInline(
+            """
+                |/src/commonMain/kotlin/pageMerger/Test.kt
+                |package pageMerger
+                |
+                |expect open class Parent
+                |
+                |/src/jvmMain/kotlin/pageMerger/Test.kt
+                |package pageMerger
+                |
+                |actual open class Parent
+                |
+                |/src/linuxX64Main/kotlin/pageMerger/Test.kt
+                |package pageMerger
+                |
+                |actual open class Parent
+                |class Child: Parent()
+                |
+            """.trimMargin(),
+            mppTestConfiguration
+        ) {
+            pagesTransformationStage = { module ->
+                val page = module.findTestType("pageMerger", "Parent")
+                page.content.assertNode {
+                    group {
+                        header(1) { +"Parent" }
+                        platformHinted {
+                            group {
+                                +"expect open class "
+                                link {
+                                    +"Parent"
+                                }
+                            }
+                            group {
+                                +"actual open class "
+                                link {
+                                    +"Parent"
+                                }
+                            }
+                            group {
+                                +"actual open class "
+                                link {
+                                    +"Parent"
+                                }
+                            }
+                            header(4) { +"Inheritors" }
+                            table {
+                                group {
+                                    link { +"Child" }
+                                }
+                            }
+                        }
+                    }
+                    skipAllNotMatching()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `inherit from class in common code`() {
+        testInline(
+            """
+                |/src/commonMain/kotlin/pageMerger/Test.kt
+                |package pageMerger
+                |
+                |open class Parent
+                |
+                |/src/jvmMain/kotlin/pageMerger/Test.kt
+                |package pageMerger
+                |
+                |class Child : Parent()
+                |
+            """.trimMargin(),
+            mppTestConfiguration
+        ) {
+            pagesTransformationStage = { module ->
+                val page = module.findTestType("pageMerger", "Parent")
+                page.content.assertNode {
+                    group {
+                        header(1) { +"Parent" }
+                        platformHinted {
+                            group {
+                                +"open class "
+                                link {
+                                    +"Parent"
+                                }
+                            }
+                            header(4) { +"Inheritors" }
+                            table {
+                                group {
+                                    link { +"Child" }
                                 }
                             }
                         }

--- a/plugins/base/src/test/kotlin/content/inheritors/ContentForInheritorsTest.kt
+++ b/plugins/base/src/test/kotlin/content/inheritors/ContentForInheritorsTest.kt
@@ -1,0 +1,101 @@
+package content.inheritors
+
+import matchers.content.*
+import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
+import org.junit.jupiter.api.Test
+import utils.classSignature
+import utils.findTestType
+
+class ContentForInheritorsTest : BaseAbstractTest() {
+    private val testConfiguration = dokkaConfiguration {
+        sourceSets {
+            sourceSet {
+                sourceRoots = listOf("src/")
+                analysisPlatform = "jvm"
+            }
+        }
+    }
+
+    @Test
+    fun `class with one inheritor has table in description`() {
+        testInline(
+            """
+            |/src/main/kotlin/test/source.kt
+            |package test
+            |
+            |class Parent
+            |
+            |class Foo : Parent()
+        """.trimIndent(), testConfiguration
+        ) {
+            pagesTransformationStage = { module ->
+                val page = module.findTestType("test", "Parent")
+                println(page.content)
+                page.content.assertNode {
+                    group {
+                        header(1) { +"Parent" }
+                        platformHinted {
+                            classSignature(
+                                emptyMap(),
+                                "",
+                                "",
+                                emptySet(),
+                                "Parent"
+                            )
+                            header(4) { +"Inheritors" }
+                            table {
+                                group {
+                                    link { +"Foo" }
+                                }
+                            }
+                        }
+                    }
+                    skipAllNotMatching()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `interface with few inheritors has table in description`() {
+        testInline(
+            """
+            |/src/main/kotlin/test/source.kt
+            |package test
+            |
+            |interface Parent
+            | 
+            |class Foo : Parent()
+            |class Bar : Parent()
+        """.trimIndent(), testConfiguration
+        ) {
+            pagesTransformationStage = { module ->
+                val page = module.findTestType("test", "Parent")
+                println(page.content)
+                page.content.assertNode {
+                    group {
+                        header(1) { +"Parent" }
+                        platformHinted {
+                            group {
+                                +"interface "
+                                link {
+                                    +"Parent"
+                                }
+                            }
+                            header(4) { +"Inheritors" }
+                            table {
+                                group {
+                                    link { +"Foo" }
+                                }
+                                group {
+                                    link { +"Bar" }
+                                }
+                            }
+                        }
+                    }
+                    skipAllNotMatching()
+                }
+            }
+        }
+    }
+}

--- a/plugins/base/src/test/kotlin/content/params/ContentForParamsTest.kt
+++ b/plugins/base/src/test/kotlin/content/params/ContentForParamsTest.kt
@@ -2,12 +2,12 @@ package content.params
 
 import matchers.content.*
 import org.jetbrains.dokka.Platform
+import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
 import org.jetbrains.dokka.model.DFunction
 import org.jetbrains.dokka.model.dfs
 import org.jetbrains.dokka.model.doc.DocumentationNode
 import org.jetbrains.dokka.model.doc.Param
 import org.jetbrains.dokka.model.doc.Text
-import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
 import org.jetbrains.dokka.pages.*
 import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
 import org.junit.jupiter.api.Test
@@ -763,14 +763,12 @@ class ContentForParamsTest : BaseAbstractTest() {
                                     }
                                 }
                                 header(4) { +"Parameters" }
-                                group {
-                                    table {
-                                        group {
-                                            +"testParam"
-                                            comment {
-                                                +"Sample description for test param that has a type of "
-                                                link { +"String" }
-                                            }
+                                table {
+                                    group {
+                                        +"testParam"
+                                        comment {
+                                            +"Sample description for test param that has a type of "
+                                            link { +"String" }
                                         }
                                     }
                                 }
@@ -1051,16 +1049,14 @@ class ContentForParamsTest : BaseAbstractTest() {
                             after {
                                 group { pWrapped("comment to function") }
                                 header(4) { +"Parameters" }
-                                group {
-                                    table {
-                                        group {
-                                            +"abc"
-                                            check {
-                                                val textStyles = children.single { it is ContentText }.style
-                                                assertContains(textStyles, TextStyle.Underlined)
-                                            }
-                                            group { group { +"comment to param" } }
+                                table {
+                                    group {
+                                        +"abc"
+                                        check {
+                                            val textStyles = children.single { it is ContentText }.style
+                                            assertContains(textStyles, TextStyle.Underlined)
                                         }
+                                        group { group { +"comment to param" } }
                                     }
                                 }
                             }
@@ -1108,32 +1104,30 @@ class ContentForParamsTest : BaseAbstractTest() {
                             after {
                                 group { group { group { +"comment to function" } } }
                                 header(4) { +"Parameters" }
-                                group {
-                                    table {
-                                        group {
-                                            +"first"
-                                            check {
-                                                val textStyles = children.single { it is ContentText }.style
-                                                assertContains(textStyles, TextStyle.Underlined)
-                                            }
-                                            group { group { +"comment to first param" } }
+                                table {
+                                    group {
+                                        +"first"
+                                        check {
+                                            val textStyles = children.single { it is ContentText }.style
+                                            assertContains(textStyles, TextStyle.Underlined)
                                         }
-                                        group {
-                                            +"second"
-                                            check {
-                                                val textStyles = children.single { it is ContentText }.style
-                                                assertContains(textStyles, TextStyle.Underlined)
-                                            }
-                                            group { group { +"comment to second param" } }
+                                        group { group { +"comment to first param" } }
+                                    }
+                                    group {
+                                        +"second"
+                                        check {
+                                            val textStyles = children.single { it is ContentText }.style
+                                            assertContains(textStyles, TextStyle.Underlined)
                                         }
-                                        group {
-                                            +"third"
-                                            check {
-                                                val textStyles = children.single { it is ContentText }.style
-                                                assertContains(textStyles, TextStyle.Underlined)
-                                            }
-                                            group { group { +"comment to third param" } }
+                                        group { group { +"comment to second param" } }
+                                    }
+                                    group {
+                                        +"third"
+                                        check {
+                                            val textStyles = children.single { it is ContentText }.style
+                                            assertContains(textStyles, TextStyle.Underlined)
                                         }
+                                        group { group { +"comment to third param" } }
                                     }
                                 }
                             }
@@ -1182,22 +1176,21 @@ class ContentForParamsTest : BaseAbstractTest() {
                             after {
                                 group { group { group { +"comment to function" } } }
                                 header(4) { +"Parameters" }
-                                group {
-                                    table {
-                                        group {
-                                            +"c"
-                                            group { group { +"comment to c param" } }
-                                        }
-                                        group {
-                                            +"b"
-                                            group { group { +"comment to b param" } }
-                                        }
-                                        group {
-                                            +"a"
-                                            group { group { +"comment to a param" } }
-                                        }
+                                table {
+                                    group {
+                                        +"c"
+                                        group { group { +"comment to c param" } }
+                                    }
+                                    group {
+                                        +"b"
+                                        group { group { +"comment to b param" } }
+                                    }
+                                    group {
+                                        +"a"
+                                        group { group { +"comment to a param" } }
                                     }
                                 }
+
                             }
                         }
                     }
@@ -1241,20 +1234,18 @@ class ContentForParamsTest : BaseAbstractTest() {
                             }
                             after {
                                 header(4) { +"Parameters" }
-                                group {
-                                    table {
-                                        group {
-                                            +"first"
-                                            group { group { +"comment to first param" } }
-                                        }
-                                        group {
-                                            +"second"
-                                            group { group { +"comment to second param" } }
-                                        }
-                                        group {
-                                            +"third"
-                                            group { group { +"comment to third param" } }
-                                        }
+                                table {
+                                    group {
+                                        +"first"
+                                        group { group { +"comment to first param" } }
+                                    }
+                                    group {
+                                        +"second"
+                                        group { group { +"comment to second param" } }
+                                    }
+                                    group {
+                                        +"third"
+                                        group { group { +"comment to third param" } }
                                     }
                                 }
                             }
@@ -1309,14 +1300,13 @@ class ContentForParamsTest : BaseAbstractTest() {
                                     pWrapped("comment to receiver")
                                 }
                                 header(4) { +"Parameters" }
-                                group {
-                                    table {
-                                        group {
-                                            +"abc"
-                                            group { group { +"comment to param" } }
-                                        }
+                                table {
+                                    group {
+                                        +"abc"
+                                        group { group { +"comment to param" } }
                                     }
                                 }
+
                             }
                         }
                     }
@@ -1361,16 +1351,14 @@ class ContentForParamsTest : BaseAbstractTest() {
                             after {
                                 group { group { group { +"comment to function" } } }
                                 header(4) { +"Parameters" }
-                                group {
-                                    table {
-                                        group {
-                                            +"first"
-                                            group { group { +"comment to first param" } }
-                                        }
-                                        group {
-                                            +"third"
-                                            group { group { +"comment to third param" } }
-                                        }
+                                table {
+                                    group {
+                                        +"first"
+                                        group { group { +"comment to first param" } }
+                                    }
+                                    group {
+                                        +"third"
+                                        group { group { +"comment to third param" } }
                                     }
                                 }
                             }
@@ -1423,20 +1411,18 @@ class ContentForParamsTest : BaseAbstractTest() {
                                 unnamedTag("Since") { comment { +"0.11" } }
                                 header(4) { +"Parameters" }
 
-                                group {
-                                    table {
-                                        group {
-                                            +"first"
-                                            group { group { +"comment to first param" } }
-                                        }
-                                        group {
-                                            +"second"
-                                            group { group { +"comment to second param" } }
-                                        }
-                                        group {
-                                            +"third"
-                                            group { group { +"comment to third param" } }
-                                        }
+                                table {
+                                    group {
+                                        +"first"
+                                        group { group { +"comment to first param" } }
+                                    }
+                                    group {
+                                        +"second"
+                                        group { group { +"comment to second param" } }
+                                    }
+                                    group {
+                                        +"third"
+                                        group { group { +"comment to third param" } }
                                     }
                                 }
                             }

--- a/plugins/base/src/test/kotlin/content/params/ContentForParamsTest.kt
+++ b/plugins/base/src/test/kotlin/content/params/ContentForParamsTest.kt
@@ -37,8 +37,7 @@ class ContentForParamsTest : BaseAbstractTest() {
         """.trimIndent(), testConfiguration
         ) {
             pagesTransformationStage = { module ->
-                val page = module.children.single { it.name == "test" }
-                    .children.single { it.name == "function" } as ContentPage
+                val page = module.findTestType("test", "function")
                 page.content.assertNode {
                     group {
                         header(1) { +"function" }
@@ -76,8 +75,7 @@ class ContentForParamsTest : BaseAbstractTest() {
         """.trimIndent(), testConfiguration
         ) {
             pagesTransformationStage = { module ->
-                val page = module.children.single { it.name == "test" }
-                    .children.single { it.name == "function" } as ContentPage
+                val page = module.findTestType("test", "function")
                 page.content.assertNode {
                     group {
                         header(1) { +"function" }
@@ -122,8 +120,7 @@ class ContentForParamsTest : BaseAbstractTest() {
         """.trimIndent(), testConfiguration
         ) {
             pagesTransformationStage = { module ->
-                val page = module.children.single { it.name == "test" }
-                    .children.single { it.name == "function" } as ContentPage
+                val page = module.findTestType("test", "function")
                 page.content.assertNode {
                     group {
                         header(1) { +"function" }
@@ -175,8 +172,7 @@ class ContentForParamsTest : BaseAbstractTest() {
             """.trimIndent(), testConfiguration
         ) {
             pagesTransformationStage = { module ->
-                val classPage =
-                    module.children.single { it.name == "sample" }.children.single { it.name == "DocGenProcessor" } as ContentPage
+                val classPage = module.findTestType("sample", "DocGenProcessor")
                 classPage.content.assertNode {
                     group {
                         header { +"DocGenProcessor" }
@@ -219,8 +215,7 @@ class ContentForParamsTest : BaseAbstractTest() {
             """.trimIndent(), testConfiguration
         ) {
             pagesTransformationStage = { module ->
-                val classPage =
-                    module.children.single { it.name == "sample" }.children.single { it.name == "DocGenProcessor" } as ContentPage
+                val classPage = module.findTestType("sample", "DocGenProcessor")
                 classPage.content.assertNode {
                     group {
                         header { +"DocGenProcessor" }
@@ -274,7 +269,7 @@ class ContentForParamsTest : BaseAbstractTest() {
         ) {
             pagesTransformationStage = { module ->
                 val classPage =
-                    module.children.single { it.name == "sample" }.children.single { it.name == "DocGenProcessor" } as ContentPage
+                    module.findTestType("sample", "DocGenProcessor")
                 classPage.content.assertNode {
                     group {
                         header { +"DocGenProcessor" }
@@ -327,7 +322,7 @@ class ContentForParamsTest : BaseAbstractTest() {
         ) {
             pagesTransformationStage = { module ->
                 val classPage =
-                    module.children.single { it.name == "sample" }.children.single { it.name == "DocGenProcessor" } as ContentPage
+                    module.findTestType("sample", "DocGenProcessor")
                 classPage.content.assertNode {
                     group {
                         header { +"DocGenProcessor" }
@@ -375,7 +370,7 @@ class ContentForParamsTest : BaseAbstractTest() {
         ) {
             pagesTransformationStage = { module ->
                 val classPage =
-                    module.children.single { it.name == "sample" }.children.single { it.name == "DocGenProcessor" } as ContentPage
+                    module.findTestType("sample", "DocGenProcessor")
                 classPage.content.assertNode {
                     group {
                         header { +"DocGenProcessor" }
@@ -436,7 +431,10 @@ class ContentForParamsTest : BaseAbstractTest() {
         ) {
             pagesTransformationStage = { module ->
                 val functionPage =
-                    module.children.single { it.name == "sample" }.children.single { it.name == "DocGenProcessor" }.children.single { it.name == "sample" } as ContentPage
+                    module.findTestType(
+                        "sample",
+                        "DocGenProcessor"
+                    ).children.single { it.name == "sample" } as ContentPage
                 functionPage.content.assertNode {
                     group {
                         header(1) { +"sample" }
@@ -492,8 +490,7 @@ class ContentForParamsTest : BaseAbstractTest() {
             """.trimIndent(), testConfiguration
         ) {
             pagesTransformationStage = { module ->
-                val functionPage =
-                    module.children.single { it.name == "sample" }.children.single { it.name == "sample" } as ContentPage
+                val functionPage = module.findTestType("sample", "sample")
                 functionPage.content.assertNode {
                     group {
                         header(1) { +"sample" }
@@ -564,7 +561,7 @@ class ContentForParamsTest : BaseAbstractTest() {
         ) {
             pagesTransformationStage = { module ->
                 val functionPage =
-                    module.children.single { it.name == "sample" }.children.single { it.name == "sample" } as ContentPage
+                    module.findTestType("sample", "sample")
                 functionPage.content.assertNode {
                     group {
                         header(1) { +"sample" }
@@ -616,7 +613,10 @@ class ContentForParamsTest : BaseAbstractTest() {
         ) {
             pagesTransformationStage = { module ->
                 val functionPage =
-                    module.children.single { it.name == "sample" }.children.single { it.name == "DocGenProcessor" }.children.single { it.name == "sample" } as ContentPage
+                    module.findTestType(
+                        "sample",
+                        "DocGenProcessor"
+                    ).children.single { it.name == "sample" } as ContentPage
                 functionPage.content.assertNode {
                     group {
                         header(1) { +"sample" }
@@ -693,7 +693,7 @@ class ContentForParamsTest : BaseAbstractTest() {
         ) {
             pagesTransformationStage = { module ->
                 val classPage =
-                    module.children.single { it.name == "sample" }.children.single { it.name == "DocGenProcessor" } as ContentPage
+                    module.findTestType("sample", "DocGenProcessor")
                 classPage.content.assertNode {
                     group {
                         header { +"DocGenProcessor" }
@@ -742,7 +742,10 @@ class ContentForParamsTest : BaseAbstractTest() {
         ) {
             pagesTransformationStage = { module ->
                 val functionPage =
-                    module.children.single { it.name == "sample" }.children.single { it.name == "DocGenProcessor" }.children.single { it.name == "sample" } as ContentPage
+                    module.findTestType(
+                        "sample",
+                        "DocGenProcessor"
+                    ).children.single { it.name == "sample" } as ContentPage
                 functionPage.content.assertNode {
                     group {
                         header(1) { +"sample" }
@@ -799,8 +802,7 @@ class ContentForParamsTest : BaseAbstractTest() {
             """.trimIndent(), testConfiguration
         ) {
             pagesTransformationStage = { module ->
-                val functionPage =
-                    module.children.single { it.name == "sample" }.children.single { it.name == "sample" } as ContentPage
+                val functionPage = module.findTestType("sample", "sample")
                 functionPage.content.assertNode {
                     group {
                         header(1) { +"sample" }
@@ -853,8 +855,7 @@ class ContentForParamsTest : BaseAbstractTest() {
             """.trimIndent(), testConfiguration
         ) {
             pagesTransformationStage = { module ->
-                val classPage =
-                    module.children.single { it.name == "sample" }.children.single { it.name == "DocGenProcessor" } as ContentPage
+                val classPage = module.findTestType("sample", "DocGenProcessor")
                 classPage.content.assertNode {
                     group {
                         header { +"DocGenProcessor" }
@@ -919,7 +920,7 @@ class ContentForParamsTest : BaseAbstractTest() {
         ) {
             pagesTransformationStage = { module ->
                 val classPage =
-                    module.children.single { it.name == "sample" }.children.single { it.name == "DocGenProcessor" } as ContentPage
+                    module.findTestType("sample", "DocGenProcessor")
                 classPage.content.assertNode {
                     group {
                         header { +"DocGenProcessor" }
@@ -980,8 +981,7 @@ class ContentForParamsTest : BaseAbstractTest() {
         """.trimIndent(), testConfiguration
         ) {
             pagesTransformationStage = { module ->
-                val page = module.children.single { it.name == "test" }
-                    .children.single { it.name == "function" } as ContentPage
+                val page = module.findTestType("test", "function")
                 page.content.assertNode {
                     group {
                         header(1) { +"function" }
@@ -1027,8 +1027,7 @@ class ContentForParamsTest : BaseAbstractTest() {
         """.trimIndent(), testConfiguration
         ) {
             pagesTransformationStage = { module ->
-                val page = module.children.single { it.name == "test" }
-                    .children.single { it.name == "function" } as ContentPage
+                val page = module.findTestType("test", "function")
                 page.content.assertNode {
                     group {
                         header(1) { +"function" }
@@ -1068,6 +1067,56 @@ class ContentForParamsTest : BaseAbstractTest() {
     }
 
     @Test
+    fun `single parameter in class`() {
+        testInline(
+            """
+            |/src/main/kotlin/test/source.kt
+            |package test
+            | /**
+            |  * comment to class
+            |  * @param abc comment to param
+            |  */
+            |class Foo(abc: String)
+        """.trimIndent(), testConfiguration
+        ) {
+            pagesTransformationStage = { module ->
+                val page = module.findTestType("test", "Foo")
+                println(page.content)
+                page.content.assertNode {
+                    group {
+                        header(1) { +"Foo" }
+                        platformHinted {
+                            classSignature(
+                                emptyMap(),
+                                "",
+                                "",
+                                emptySet(),
+                                "Foo",
+                                "abc" to ParamAttributes(emptyMap(), emptySet(), "String")
+                            )
+                            group {
+                                pWrapped("comment to class")
+                            }
+                            header(4) { +"Parameters" }
+                            table {
+                                group {
+                                    +"abc"
+                                    check {
+                                        val textStyles = children.single { it is ContentText }.style
+                                        assertContains(textStyles, TextStyle.Underlined)
+                                    }
+                                    group { group { +"comment to param" } }
+                                }
+                            }
+                        }
+                    }
+                    skipAllNotMatching()
+                }
+            }
+        }
+    }
+
+    @Test
     fun `multiple parameters`() {
         testInline(
             """
@@ -1085,8 +1134,7 @@ class ContentForParamsTest : BaseAbstractTest() {
         """.trimIndent(), testConfiguration
         ) {
             pagesTransformationStage = { module ->
-                val page = module.children.single { it.name == "test" }
-                    .children.single { it.name == "function" } as ContentPage
+                val page = module.findTestType("test", "function")
                 page.content.assertNode {
                     group {
                         header(1) { +"function" }
@@ -1157,8 +1205,7 @@ class ContentForParamsTest : BaseAbstractTest() {
         """.trimIndent(), testConfiguration
         ) {
             pagesTransformationStage = { module ->
-                val page = module.children.single { it.name == "test" }
-                    .children.single { it.name == "function" } as ContentPage
+                val page = module.findTestType("test", "function")
                 page.content.assertNode {
                     group {
                         header(1) { +"function" }
@@ -1216,8 +1263,7 @@ class ContentForParamsTest : BaseAbstractTest() {
         """.trimIndent(), testConfiguration
         ) {
             pagesTransformationStage = { module ->
-                val page = module.children.single { it.name == "test" }
-                    .children.single { it.name == "function" } as ContentPage
+                val page = module.findTestType("test", "function")
                 page.content.assertNode {
                     group {
                         header(1) { +"function" }
@@ -1273,8 +1319,7 @@ class ContentForParamsTest : BaseAbstractTest() {
         """.trimIndent(), testConfiguration
         ) {
             pagesTransformationStage = { module ->
-                val page = module.children.single { it.name == "test" }
-                    .children.single { it.name == "function" } as ContentPage
+                val page = module.findTestType("test", "function")
                 page.content.assertNode {
                     group {
                         header(1) { +"function" }
@@ -1332,8 +1377,7 @@ class ContentForParamsTest : BaseAbstractTest() {
         """.trimIndent(), testConfiguration
         ) {
             pagesTransformationStage = { module ->
-                val page = module.children.single { it.name == "test" }
-                    .children.single { it.name == "function" } as ContentPage
+                val page = module.findTestType("test", "function")
                 page.content.assertNode {
                     group {
                         header(1) { +"function" }
@@ -1389,8 +1433,7 @@ class ContentForParamsTest : BaseAbstractTest() {
         """.trimIndent(), testConfiguration
         ) {
             pagesTransformationStage = { module ->
-                val page = module.children.single { it.name == "test" }
-                    .children.single { it.name == "function" } as ContentPage
+                val page = module.findTestType("test", "function")
                 page.content.assertNode {
                     group {
                         header(1) { +"function" }

--- a/plugins/base/src/test/kotlin/content/samples/ContentForSamplesTest.kt
+++ b/plugins/base/src/test/kotlin/content/samples/ContentForSamplesTest.kt
@@ -37,7 +37,6 @@ class ContentForSamplesTest : BaseAbstractTest() {
         ) {
             pagesTransformationStage = { module ->
                 val page = module.findTestType("test", "Foo")
-                println(page.content)
                 page.content.assertNode {
                     group {
                         header(1) { +"Foo" }

--- a/plugins/base/src/test/kotlin/content/samples/ContentForSamplesTest.kt
+++ b/plugins/base/src/test/kotlin/content/samples/ContentForSamplesTest.kt
@@ -1,0 +1,70 @@
+package content.samples
+
+import matchers.content.*
+import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
+import org.junit.jupiter.api.Test
+import utils.classSignature
+import utils.findTestType
+import java.nio.file.Paths
+
+class ContentForSamplesTest : BaseAbstractTest() {
+    private val testDataDir = getTestDataDir("content/samples").toAbsolutePath()
+
+    private val testConfiguration = dokkaConfiguration {
+        sourceSets {
+            sourceSet {
+                sourceRoots = listOf("src/")
+                analysisPlatform = "jvm"
+                samples = listOf(
+                    Paths.get("$testDataDir/samples.kt").toString(),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `samples block is rendered in the description`() {
+        testInline(
+            """
+            |/src/main/kotlin/test/source.kt
+            |package test
+            |
+            | /**
+            | * @sample [test.sampleForClassDescription]
+            | */
+            |class Foo
+        """.trimIndent(), testConfiguration
+        ) {
+            pagesTransformationStage = { module ->
+                val page = module.findTestType("test", "Foo")
+                println(page.content)
+                page.content.assertNode {
+                    group {
+                        header(1) { +"Foo" }
+                        platformHinted {
+                            classSignature(
+                                emptyMap(),
+                                "",
+                                "",
+                                emptySet(),
+                                "Foo"
+                            )
+                            header(4) { +"Samples" }
+                            group {
+                                codeBlock {
+                                    +"""|
+                                    |fun main() { 
+                                    |   //sampleStart 
+                                    |   print("Hello") 
+                                    |   //sampleEnd
+                                    |}""".trimMargin()
+                                }
+                            }
+                        }
+                    }
+                    skipAllNotMatching()
+                }
+            }
+        }
+    }
+}

--- a/plugins/base/src/test/kotlin/content/samples/ContentForSamplesTest.kt
+++ b/plugins/base/src/test/kotlin/content/samples/ContentForSamplesTest.kt
@@ -2,10 +2,12 @@ package content.samples
 
 import matchers.content.*
 import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
+import org.jetbrains.dokka.model.DisplaySourceSet
 import org.junit.jupiter.api.Test
 import utils.classSignature
 import utils.findTestType
 import java.nio.file.Paths
+import kotlin.test.assertEquals
 
 class ContentForSamplesTest : BaseAbstractTest() {
     private val testDataDir = getTestDataDir("content/samples").toAbsolutePath()
@@ -15,6 +17,41 @@ class ContentForSamplesTest : BaseAbstractTest() {
             sourceSet {
                 sourceRoots = listOf("src/")
                 analysisPlatform = "jvm"
+                samples = listOf(
+                    Paths.get("$testDataDir/samples.kt").toString(),
+                )
+            }
+        }
+    }
+
+    private val mppTestConfiguration = dokkaConfiguration {
+        moduleName = "example"
+        sourceSets {
+            val common = sourceSet {
+                name = "common"
+                displayName = "common"
+                analysisPlatform = "common"
+                sourceRoots = listOf("src/commonMain/kotlin/pageMerger/Test.kt")
+                samples = listOf(
+                    Paths.get("$testDataDir/samples.kt").toString(),
+                )
+            }
+            sourceSet {
+                name = "jvm"
+                displayName = "jvm"
+                analysisPlatform = "jvm"
+                dependentSourceSets = setOf(common.value.sourceSetID)
+                sourceRoots = listOf("src/jvmMain/kotlin/pageMerger/Test.kt")
+                samples = listOf(
+                    Paths.get("$testDataDir/samples.kt").toString(),
+                )
+            }
+            sourceSet {
+                name = "linuxX64"
+                displayName = "linuxX64"
+                analysisPlatform = "native"
+                dependentSourceSets = setOf(common.value.sourceSetID)
+                sourceRoots = listOf("src/linuxX64Main/kotlin/pageMerger/Test.kt")
                 samples = listOf(
                     Paths.get("$testDataDir/samples.kt").toString(),
                 )
@@ -66,4 +103,90 @@ class ContentForSamplesTest : BaseAbstractTest() {
             }
         }
     }
+
+    @Test
+    fun `multiplatofrm class with samples in few platforms`() {
+        testInline(
+            """
+                |/src/commonMain/kotlin/pageMerger/Test.kt
+                |package pageMerger
+                |
+                |/**
+                |* @sample [test.sampleForClassDescription]
+                |*/
+                |expect open class Parent
+                |
+                |/src/jvmMain/kotlin/pageMerger/Test.kt
+                |package pageMerger
+                |
+                |/**
+                |* @sample unresolved
+                |*/
+                |actual open class Parent
+                |
+                |/src/linuxX64Main/kotlin/pageMerger/Test.kt
+                |package pageMerger
+                |
+                |actual open class Parent
+                |
+            """.trimMargin(),
+            mppTestConfiguration
+        ) {
+            pagesTransformationStage = { module ->
+                val page = module.findTestType("pageMerger", "Parent")
+                page.content.assertNode {
+                    group {
+                        header(1) { +"Parent" }
+                        platformHinted {
+                            group {
+                                +"expect open class "
+                                link {
+                                    +"Parent"
+                                }
+                            }
+                            group {
+                                +"actual open class "
+                                link {
+                                    +"Parent"
+                                }
+                            }
+                            group {
+                                +"actual open class "
+                                link {
+                                    +"Parent"
+                                }
+                            }
+                            header(4) { +"Samples" }
+                            group {
+                                codeBlock {
+                                    +"""|
+                                    |fun main() { 
+                                    |   //sampleStart 
+                                    |   print("Hello") 
+                                    |   //sampleEnd
+                                    |}""".trimMargin()
+                                }
+                                check {
+                                    sourceSets.assertSourceSet("common")
+                                }
+                            }
+                            group {
+                                +"unresolved"
+                                check {
+                                    sourceSets.assertSourceSet("jvm")
+                                }
+                            }
+                        }
+                    }
+                    skipAllNotMatching()
+                }
+            }
+        }
+    }
+}
+
+
+private fun Set<DisplaySourceSet>.assertSourceSet(expectedName: String) {
+    assertEquals(1, this.size)
+    assertEquals(expectedName, this.first().name)
 }

--- a/plugins/base/src/test/kotlin/content/seealso/ContentForSeeAlsoTest.kt
+++ b/plugins/base/src/test/kotlin/content/seealso/ContentForSeeAlsoTest.kt
@@ -1,16 +1,14 @@
 package content.seealso
 
 import matchers.content.*
+import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
 import org.jetbrains.dokka.pages.ContentDRILink
 import org.jetbrains.dokka.pages.ContentPage
-import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
-import org.jetbrains.dokka.links.Callable
-import org.jetbrains.dokka.links.DRI
-import org.jetbrains.dokka.links.JavaClassReference
-import org.jetbrains.dokka.model.doc.See
-import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
 import org.junit.jupiter.api.Test
-import utils.*
+import utils.ParamAttributes
+import utils.bareSignature
+import utils.comment
+import utils.unnamedTag
 import kotlin.test.assertEquals
 
 class ContentForSeeAlsoTest : BaseAbstractTest() {
@@ -98,12 +96,10 @@ class ContentForSeeAlsoTest : BaseAbstractTest() {
                             }
                             after {
                                 header(4) { +"See also" }
-                                group {
-                                    table {
-                                        group {
-                                            //DRI should be "test//abc/#/-1/"
-                                            link { +"abc" }
-                                        }
+                                table {
+                                    group {
+                                        //DRI should be "test//abc/#/-1/"
+                                        link { +"abc" }
                                     }
                                 }
                             }
@@ -150,14 +146,12 @@ class ContentForSeeAlsoTest : BaseAbstractTest() {
                             }
                             after {
                                 header(4) { +"See also" }
-                                group {
-                                    table {
+                                table {
+                                    group {
+                                        //DRI should be "test//abc/#/-1/"
+                                        link { +"abc" }
                                         group {
-                                            //DRI should be "test//abc/#/-1/"
-                                            link { +"abc" }
-                                            group {
-                                                group { +"Comment to abc" }
-                                            }
+                                            group { +"Comment to abc" }
                                         }
                                     }
                                 }
@@ -205,13 +199,11 @@ class ContentForSeeAlsoTest : BaseAbstractTest() {
                             }
                             after {
                                 header(4) { +"See also" }
-                                group {
-                                    table {
+                                table {
+                                    group {
+                                        +"com.example.NonExistingClass"
                                         group {
-                                            +"com.example.NonExistingClass"
-                                            group {
-                                                group { +"description for non-existing" }
-                                            }
+                                            group { +"description for non-existing" }
                                         }
                                     }
                                 }
@@ -259,21 +251,20 @@ class ContentForSeeAlsoTest : BaseAbstractTest() {
                             }
                             after {
                                 header(4) { +"See also" }
-                                group {
-                                    table {
-                                        group {
-                                            link {
-                                                check {
-                                                    assertEquals(
-                                                        "kotlin.collections/Collection///PointingToDeclaration/",
-                                                        (this as ContentDRILink).address.toString()
-                                                    )
-                                                }
-                                                +"Collection"
+                                table {
+                                    group {
+                                        link {
+                                            check {
+                                                assertEquals(
+                                                    "kotlin.collections/Collection///PointingToDeclaration/",
+                                                    (this as ContentDRILink).address.toString()
+                                                )
                                             }
+                                            +"Collection"
                                         }
                                     }
                                 }
+
                             }
                         }
                     }
@@ -318,16 +309,15 @@ class ContentForSeeAlsoTest : BaseAbstractTest() {
                             }
                             after {
                                 header(4) { +"See also" }
-                                group {
-                                    table {
+                                table {
+                                    group {
+                                        //DRI should be "test//abc/#/-1/"
+                                        link { +"Collection" }
                                         group {
-                                            //DRI should be "test//abc/#/-1/"
-                                            link { +"Collection" }
-                                            group {
-                                                group { +"Comment to stdliblink" }
-                                            }
+                                            group { +"Comment to stdliblink" }
                                         }
                                     }
+
                                 }
                             }
                         }
@@ -380,17 +370,16 @@ class ContentForSeeAlsoTest : BaseAbstractTest() {
                                 unnamedTag("Since") { comment { +"0.11" } }
 
                                 header(4) { +"See also" }
-                                group {
-                                    table {
+                                table {
+                                    group {
+                                        //DRI should be "test//abc/#/-1/"
+                                        link { +"Collection" }
                                         group {
-                                            //DRI should be "test//abc/#/-1/"
-                                            link { +"Collection" }
-                                            group {
-                                                group { +"Comment to stdliblink" }
-                                            }
+                                            group { +"Comment to stdliblink" }
                                         }
                                     }
                                 }
+
                             }
                         }
                     }
@@ -436,17 +425,16 @@ class ContentForSeeAlsoTest : BaseAbstractTest() {
                             }
                             after {
                                 header(4) { +"See also" }
-                                group {
-                                    table {
+                                table {
+                                    group {
+                                        //DRI should be "test//abc/#/-1/"
+                                        link { +"abc" }
                                         group {
-                                            //DRI should be "test//abc/#/-1/"
-                                            link { +"abc" }
-                                            group {
-                                                group { +"Comment to abc2" }
-                                            }
+                                            group { +"Comment to abc2" }
                                         }
                                     }
                                 }
+
                             }
                         }
                     }
@@ -492,20 +480,18 @@ class ContentForSeeAlsoTest : BaseAbstractTest() {
                             }
                             after {
                                 header(4) { +"See also" }
-                                group {
-                                    table {
+                                table {
+                                    group {
+                                        //DRI should be "test//abc/#/-1/"
+                                        link { +"abc" }
                                         group {
-                                            //DRI should be "test//abc/#/-1/"
-                                            link { +"abc" }
-                                            group {
-                                                group { +"Comment to abc1" }
-                                            }
+                                            group { +"Comment to abc1" }
                                         }
-                                        group {
-                                            //DRI should be "test//abc/#/-1/"
-                                            link { +"Collection" }
-                                            group { group { +"Comment to collection" } }
-                                        }
+                                    }
+                                    group {
+                                        //DRI should be "test//abc/#/-1/"
+                                        link { +"Collection" }
+                                        group { group { +"Comment to collection" } }
                                     }
                                 }
                             }
@@ -564,19 +550,17 @@ class ContentForSeeAlsoTest : BaseAbstractTest() {
                             }
                             after {
                                 header(4) { +"See also" }
-                                group {
-                                    table {
+                                table {
+                                    group {
+                                        link { +"CollectionExtensions.property" }
                                         group {
-                                            link { +"CollectionExtensions.property" }
-                                            group {
-                                                group { +"static property" }
-                                            }
+                                            group { +"static property" }
                                         }
+                                    }
+                                    group {
+                                        link { +"CollectionExtensions.emptyList" }
                                         group {
-                                            link { +"CollectionExtensions.emptyList" }
-                                            group {
-                                                group { +"static emptyList" }
-                                            }
+                                            group { +"static emptyList" }
                                         }
                                     }
                                 }

--- a/plugins/base/src/test/kotlin/content/seealso/ContentForSeeAlsoTest.kt
+++ b/plugins/base/src/test/kotlin/content/seealso/ContentForSeeAlsoTest.kt
@@ -752,7 +752,7 @@ class ContentForSeeAlsoTest : BaseAbstractTest() {
     }
 
     @Test
-    fun `multiplatofrm class with seealso in few platforms`() {
+    fun `multiplatform class with seealso in few platforms`() {
         testInline(
             """
                 |/src/commonMain/kotlin/pageMerger/Test.kt

--- a/plugins/base/src/test/kotlin/linkableContent/LinkableContentTest.kt
+++ b/plugins/base/src/test/kotlin/linkableContent/LinkableContentTest.kt
@@ -1,13 +1,13 @@
 package linkableContent
 
 import org.jetbrains.dokka.SourceLinkDefinitionImpl
+import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
 import org.jetbrains.dokka.base.transformers.pages.samples.DefaultSamplesTransformer
 import org.jetbrains.dokka.base.transformers.pages.sourcelinks.SourceLinksTransformer
 import org.jetbrains.dokka.model.WithGenerics
 import org.jetbrains.dokka.model.dfs
 import org.jetbrains.dokka.model.doc.Text
 import org.jetbrains.dokka.pages.*
-import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
 import org.jetbrains.kotlin.utils.addToStdlib.cast
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 import org.junit.jupiter.api.Assertions
@@ -199,7 +199,6 @@ class LinkableContentTest : BaseAbstractTest() {
                     val text = function.cast<MemberPageNode>().content.cast<ContentGroup>().children.last()
                         .cast<ContentDivergentGroup>().children.single()
                         .cast<ContentDivergentInstance>().after
-                        .cast<ContentGroup>().children.last()
                         .cast<ContentGroup>().children.last()
                         .cast<ContentGroup>().children.single()
                         .cast<ContentCodeBlock>().children.single().cast<ContentText>().text

--- a/plugins/base/src/test/kotlin/utils/contentUtils.kt
+++ b/plugins/base/src/test/kotlin/utils/contentUtils.kt
@@ -1,9 +1,9 @@
 package utils
 
 import matchers.content.*
-import org.jetbrains.dokka.model.*
 import org.jetbrains.dokka.pages.ContentGroup
-import kotlin.text.Typography.nbsp
+import org.jetbrains.dokka.pages.ContentPage
+import org.jetbrains.dokka.pages.RootPageNode
 
 //TODO: Try to unify those functions after update to 1.4
 fun ContentMatcherBuilder<*>.functionSignature(
@@ -64,6 +64,53 @@ fun ContentMatcherBuilder<*>.bareSignature(
             link {
                 +(returnType)
             }
+        }
+    }
+}
+
+fun ContentMatcherBuilder<*>.classSignature(
+    annotations: Map<String, Set<String>>,
+    visibility: String,
+    modifier: String,
+    keywords: Set<String>,
+    name: String,
+    vararg params: Pair<String, ParamAttributes>,
+    parent: String? = null
+) = group {
+    annotations.entries.forEach {
+        group {
+            unwrapAnnotation(it)
+        }
+    }
+    if (visibility.isNotBlank()) +"$visibility "
+    if (modifier.isNotBlank()) +"$modifier "
+    +("${keywords.joinToString("") { "$it " }}class ")
+    link { +name }
+    if (params.isNotEmpty()) {
+        +"("
+        group {
+            params.forEachIndexed { id, (n, t) ->
+                group {
+                    t.annotations.forEach {
+                        unwrapAnnotation(it)
+                    }
+                    t.keywords.forEach {
+                        +it
+                    }
+
+                    +"$n: "
+                    group { link { +(t.type) } }
+                    if (id != params.lastIndex)
+                        +", "
+                }
+            }
+        }
+        +")"
+    }
+    if (parent != null) {
+        +(" : ")
+        link {
+            +(parent)
         }
     }
 }
@@ -272,3 +319,6 @@ data class ParamAttributes(
     val keywords: Set<String>,
     val type: String
 )
+
+fun RootPageNode.findTestType(packageName: String, name: String) =
+    children.single { it.name == packageName }.children.single { it.name == name } as ContentPage

--- a/plugins/base/src/test/resources/content/samples/samples.kt
+++ b/plugins/base/src/test/resources/content/samples/samples.kt
@@ -1,0 +1,5 @@
+package test
+
+fun sampleForClassDescription() {
+    print("Hello")
+}


### PR DESCRIPTION
Migrate params, seealso, samples, and inheritors to the description
* remove `contentForComments` API, those tags will be handled in the `contentForDescription`
* change API for `contentForScopes`: remove inheritors parameter in the method
* remove inheritors from the package list: I didn't find a way to show them there. mat be something with markdown but I don't see a reason to keep that.


Fix #2688