### PR TITLE
Default Java constructor

### DIFF
--- a/plugins/base/src/main/kotlin/translators/psi/DefaultPsiToDocumentableTranslator.kt
+++ b/plugins/base/src/main/kotlin/translators/psi/DefaultPsiToDocumentableTranslator.kt
@@ -485,13 +485,11 @@ class DefaultPsiToDocumentableTranslator(
             )
         }
 
-        /**
-         * `isPhysical` detects the virtual declarations without real sources.
-         * Otherwise, [PsiDocumentableSource] initialization will fail: non-physical declarations doesn't have `virtualFile`.
-         * The check is required since in [parseConstructors] we create a virtual method for default constructor.
-         */
         private fun PsiNamedElement.parseSources(): SourceSetDependent<DocumentableSource> {
             return when {
+                // `isPhysical` detects the virtual declarations without real sources.
+                // Otherwise, `PsiDocumentableSource` initialization will fail: non-physical declarations doesn't have `virtualFile`.
+                // This check protects from accidentally requesting sources for synthetic / virtual declarations.
                 isPhysical -> PsiDocumentableSource(this).toSourceSetDependent()
                 else -> emptyMap()
             }

--- a/plugins/base/src/test/kotlin/model/JavaTest.kt
+++ b/plugins/base/src/test/kotlin/model/JavaTest.kt
@@ -13,7 +13,6 @@ import utils.AbstractModelTest
 import utils.assertNotNull
 import utils.name
 import kotlin.test.assertEquals
-import  org.jetbrains.dokka.links.Callable as DRICallable
 
 class JavaTest : AbstractModelTest("/src/main/kotlin/java/Test.java", "java") {
     val configuration = dokkaConfiguration {
@@ -48,7 +47,7 @@ class JavaTest : AbstractModelTest("/src/main/kotlin/java/Test.java", "java") {
         ) {
             with((this / "java" / "Test").cast<DClass>()) {
                 name equals "Test"
-                children counts 1
+                children counts 2 // default constructor and function
                 with((this / "fn").cast<DFunction>()) {
                     name equals "fn"
                     val params = parameters.map { it.documentation.values.first().children.first() as Param }
@@ -118,7 +117,7 @@ class JavaTest : AbstractModelTest("/src/main/kotlin/java/Test.java", "java") {
         ) {
             with((this / "java" / "Test").cast<DClass>()) {
                 name equals "Test"
-                children counts 1
+                children counts 2 // default constructor and function
 
                 with((this / "arrayToString").cast<DFunction>()) {
                     name equals "arrayToString"
@@ -219,10 +218,10 @@ class JavaTest : AbstractModelTest("/src/main/kotlin/java/Test.java", "java") {
             """, configuration = configuration
         ) {
             with((this / "java" / "InnerClass").cast<DClass>()) {
-                children counts 1
+                children counts 2 // default constructor and inner class
                 with((this / "D").cast<DClass>()) {
                     name equals "D"
-                    children counts 0
+                    children counts 1 // default constructor
                 }
             }
         }
@@ -239,7 +238,7 @@ class JavaTest : AbstractModelTest("/src/main/kotlin/java/Test.java", "java") {
         ) {
             with((this / "java" / "Foo").cast<DClass>()) {
                 name equals "Foo"
-                children counts 1
+                children counts 2 // default constructor and function
 
                 with((this / "bar").cast<DFunction>()) {
                     name equals "bar"
@@ -263,7 +262,7 @@ class JavaTest : AbstractModelTest("/src/main/kotlin/java/Test.java", "java") {
             """, configuration = configuration
         ) {
             with((this / "java" / "Test").cast<DClass>()) {
-                children counts 2
+                children counts 3 // default constructor + 2 props
 
                 with((this / "i").cast<DProperty>()) {
                     getter equals null

--- a/plugins/base/src/test/kotlin/signatures/InheritedAccessorsSignatureTest.kt
+++ b/plugins/base/src/test/kotlin/signatures/InheritedAccessorsSignatureTest.kt
@@ -62,11 +62,11 @@ class InheritedAccessorsSignatureTest : BaseAbstractTest() {
                 writerPlugin.writer.renderedContent("root/test/-a/index.html").let { javaClassContent ->
                     val signatures = javaClassContent.signature().toList()
                     assertEquals(
-                        2, signatures.size,
-                        "Expected 2 signatures: class signature and property"
+                        3, signatures.size,
+                        "Expected 3 signatures: class signature, default constructor and property"
                     )
 
-                    val property = signatures[1]
+                    val property = signatures[2]
                     property.match(
                         "open var ", A("a"), ":", A("Int"),
                         ignoreSpanWithTokenStyle = true
@@ -109,9 +109,13 @@ class InheritedAccessorsSignatureTest : BaseAbstractTest() {
 
                 writerPlugin.writer.renderedContent("root/test/-a/index.html").let { javaClassContent ->
                     val signatures = javaClassContent.signature().toList()
-                    assertEquals(2, signatures.size, "Expected 2 signatures: class signature and property")
+                    assertEquals(
+                        3,
+                        signatures.size,
+                        "Expected 3 signatures: class signature, default constructor and property"
+                    )
 
-                    val property = signatures[1]
+                    val property = signatures[2]
                     property.match(
                         "open val ", A("a"), ":", A("Int"),
                         ignoreSpanWithTokenStyle = true
@@ -156,9 +160,13 @@ class InheritedAccessorsSignatureTest : BaseAbstractTest() {
 
                 writerPlugin.writer.renderedContent("root/test/-a/index.html").let { javaClassContent ->
                     val signatures = javaClassContent.signature().toList()
-                    assertEquals(2, signatures.size, "Expected 2 signatures: class signature and setter")
+                    assertEquals(
+                        3,
+                        signatures.size,
+                        "Expected 3 signatures: class signature, default constructor and setter"
+                    )
 
-                    val setterFunction = signatures[1]
+                    val setterFunction = signatures[2]
                     setterFunction.match(
                         "open fun ", A("setA"), "(", Parameters(
                             Parameter("a: ", A("Int"))
@@ -241,9 +249,13 @@ class InheritedAccessorsSignatureTest : BaseAbstractTest() {
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/test/-java-class/index.html").let { kotlinClassContent ->
                     val signatures = kotlinClassContent.signature().toList()
-                    assertEquals(2, signatures.size, "Expected to find two signatures: class and property")
+                    assertEquals(
+                        3,
+                        signatures.size,
+                        "Expected to find 3 signatures: class, default constructor and property"
+                    )
 
-                    val property = signatures[1]
+                    val property = signatures[2]
                     property.match(
                         "open var ", A("variable"), ": ", Span("String"),
                         ignoreSpanWithTokenStyle = true
@@ -290,15 +302,19 @@ class InheritedAccessorsSignatureTest : BaseAbstractTest() {
                 // test added to control changes
                 writerPlugin.writer.renderedContent("root/test/-java-class/index.html").let { javaClassContent ->
                     val signatures = javaClassContent.signature().toList()
-                    assertEquals(3, signatures.size, "Expected to find 3 signatures: class and two accessors")
+                    assertEquals(
+                        4,
+                        signatures.size,
+                        "Expected to find 4 signatures: class, default constructor and two accessors"
+                    )
 
-                    val getter = signatures[1]
+                    val getter = signatures[2]
                     getter.match(
                         "fun ", A("getVariable"), "(): ", Span("String"),
                         ignoreSpanWithTokenStyle = true
                     )
 
-                    val setter = signatures[2]
+                    val setter = signatures[3]
                     setter.match(
                         "fun ", A("setVariable"), "(", Parameters(
                             Parameter("value: ", Span("String"))
@@ -367,9 +383,13 @@ class InheritedAccessorsSignatureTest : BaseAbstractTest() {
 
                 writerPlugin.writer.renderedContent("root/test/-java-class/index.html").let { javaClassContent ->
                     val signatures = javaClassContent.signature().toList()
-                    assertEquals(2, signatures.size, "Expected 2 signatures: class signature and property")
+                    assertEquals(
+                        3,
+                        signatures.size,
+                        "Expected 2 signatures: class signature, default constructor and property"
+                    )
 
-                    val property = signatures[1]
+                    val property = signatures[2]
                     property.match(
                         "protected open var ", A("protectedGetterAndProtectedSetter"), ":", A("Int"),
                         ignoreSpanWithTokenStyle = true

--- a/plugins/base/src/test/kotlin/signatures/InheritedAccessorsSignatureTest.kt
+++ b/plugins/base/src/test/kotlin/signatures/InheritedAccessorsSignatureTest.kt
@@ -386,7 +386,7 @@ class InheritedAccessorsSignatureTest : BaseAbstractTest() {
                     assertEquals(
                         3,
                         signatures.size,
-                        "Expected 2 signatures: class signature, default constructor and property"
+                        "Expected 3 signatures: class signature, default constructor and property"
                     )
 
                     val property = signatures[2]

--- a/plugins/base/src/test/kotlin/signatures/SignatureTest.kt
+++ b/plugins/base/src/test/kotlin/signatures/SignatureTest.kt
@@ -979,7 +979,7 @@ class SignatureTest : BaseAbstractTest() {
                     assertEquals(
                         3,
                         signatures.size,
-                        "Expected 2 signatures: class signature, default constructor and property"
+                        "Expected 3 signatures: class signature, default constructor and property"
                     )
 
                     val property = signatures[2]

--- a/plugins/base/src/test/kotlin/signatures/SignatureTest.kt
+++ b/plugins/base/src/test/kotlin/signatures/SignatureTest.kt
@@ -976,9 +976,13 @@ class SignatureTest : BaseAbstractTest() {
 
                 writerPlugin.writer.renderedContent("root/test/-java-class/index.html").let { kotlinClassContent ->
                     val signatures = kotlinClassContent.signature().toList()
-                    assertEquals(2, signatures.size, "Expected 2 signatures: class signature and property")
+                    assertEquals(
+                        3,
+                        signatures.size,
+                        "Expected 2 signatures: class signature, default constructor and property"
+                    )
 
-                    val property = signatures[1]
+                    val property = signatures[2]
                     property.match(
                         "open var ", A("property"), ":", A("Int"),
                         ignoreSpanWithTokenStyle = true

--- a/plugins/base/src/test/kotlin/translators/DefaultPsiToDocumentableTranslatorTest.kt
+++ b/plugins/base/src/test/kotlin/translators/DefaultPsiToDocumentableTranslatorTest.kt
@@ -1,6 +1,5 @@
 package translators
 
-import com.jetbrains.rd.util.first
 import org.jetbrains.dokka.DokkaConfiguration
 import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
@@ -761,7 +760,7 @@ class DefaultPsiToDocumentableTranslatorTest : BaseAbstractTest() {
                     testedClass.constructors.first().parameters.isEmpty(),
                     "Expect default constructor doesn't have params"
                 )
-                assertEquals(JavaVisibility.Public, testedClass.constructors.first().constructorVisibility())
+                assertEquals(JavaVisibility.Public, testedClass.constructors.first().visibility())
             }
         }
     }
@@ -781,7 +780,7 @@ class DefaultPsiToDocumentableTranslatorTest : BaseAbstractTest() {
                 val testedClass = module.findClasslike(packageName = "test", "A") as DClass
 
                 assertEquals(1, testedClass.constructors.size, "Expect 1 default constructor")
-                assertEquals(JavaVisibility.Default, testedClass.constructors.first().constructorVisibility())
+                assertEquals(JavaVisibility.Default, testedClass.constructors.first().visibility())
             }
         }
     }
@@ -803,7 +802,7 @@ class DefaultPsiToDocumentableTranslatorTest : BaseAbstractTest() {
                 val testedClass = parentClass.classlikes.single { it.name == "PrivateNested" } as DClass
 
                 assertEquals(1, testedClass.constructors.size, "Expect 1 default constructor")
-                assertEquals(JavaVisibility.Private, testedClass.constructors.first().constructorVisibility())
+                assertEquals(JavaVisibility.Private, testedClass.constructors.first().visibility())
             }
         }
     }
@@ -824,10 +823,10 @@ class DefaultPsiToDocumentableTranslatorTest : BaseAbstractTest() {
                 val testedClass = module.findClasslike(packageName = "test", "A") as DClass
 
                 assertEquals(1, testedClass.constructors.size, "Expect 1 declared constructor")
-                assertEquals(JavaVisibility.Private, testedClass.constructors.first().constructorVisibility())
+                assertEquals(JavaVisibility.Private, testedClass.constructors.first().visibility())
             }
         }
     }
 }
 
-private fun DFunction.constructorVisibility() = visibility.first().value
+private fun DFunction.visibility() = visibility.values.first()

--- a/plugins/javadoc/src/test/kotlin/org/jetbrains/dokka/javadoc/search/JavadocIndexSearchTest.kt
+++ b/plugins/javadoc/src/test/kotlin/org/jetbrains/dokka/javadoc/search/JavadocIndexSearchTest.kt
@@ -1,9 +1,9 @@
 package org.jetbrains.dokka.javadoc.search
 
 import org.jetbrains.dokka.javadoc.AbstractJavadocTemplateMapTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import utils.TestOutputWriterPlugin
-import org.junit.jupiter.api.Assertions.*
 
 internal class JavadocIndexSearchTest : AbstractJavadocTemplateMapTest() {
     @Test
@@ -47,9 +47,12 @@ internal class JavadocIndexSearchTest : AbstractJavadocTemplateMapTest() {
             pluginsOverride = listOf(writerPlugin)
         ) {
             val contents = writerPlugin.writer.contents
-            val expectedPackageJson = """var packageSearchIndex = [{"l":"package0","url":"package0/package-summary.html"}, {"l":"All packages","url":"index.html"}]"""
-            val expectedClassesJson = """var typeSearchIndex = [{"p":"package0","l":"ClassA","url":"package0/ClassA.html"}, {"l":"All classes","url":"allclasses.html"}]"""
-            val expectedMembersJson = """var memberSearchIndex = [{"p":"package0","c":"ClassA","l":"sampleFunction()","url":"package0/ClassA.html#sampleFunction()"}, {"p":"package0","c":"ClassA","l":"propertyOfClassA","url":"package0/ClassA.html#propertyOfClassA"}]"""
+            val expectedPackageJson =
+                """var packageSearchIndex = [{"l":"package0","url":"package0/package-summary.html"}, {"l":"All packages","url":"index.html"}]"""
+            val expectedClassesJson =
+                """var typeSearchIndex = [{"p":"package0","l":"ClassA","url":"package0/ClassA.html"}, {"l":"All classes","url":"allclasses.html"}]"""
+            val expectedMembersJson =
+                """var memberSearchIndex = [{"p":"package0","c":"ClassA","l":"ClassA()","url":"package0/ClassA.html#ClassA()"}, {"p":"package0","c":"ClassA","l":"sampleFunction()","url":"package0/ClassA.html#sampleFunction()"}, {"p":"package0","c":"ClassA","l":"propertyOfClassA","url":"package0/ClassA.html#propertyOfClassA"}]"""
 
             assertEquals(expectedPackageJson, contents["package-search-index.js"])
             assertEquals(expectedClassesJson, contents["type-search-index.js"])

--- a/plugins/kotlin-as-java/src/test/kotlin/KotlinAsJavaPluginTest.kt
+++ b/plugins/kotlin-as-java/src/test/kotlin/KotlinAsJavaPluginTest.kt
@@ -13,8 +13,13 @@ import org.jetbrains.kotlin.utils.addToStdlib.cast
 import org.junit.Assert
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-import signatures.*
-import utils.*
+import signatures.Parameter
+import signatures.Parameters
+import signatures.firstSignature
+import signatures.renderedContent
+import utils.A
+import utils.TestOutputWriterPlugin
+import utils.match
 import kotlin.test.assertEquals
 
 class KotlinAsJavaPluginTest : BaseAbstractTest() {
@@ -134,9 +139,18 @@ class KotlinAsJavaPluginTest : BaseAbstractTest() {
                 }
 
                 classes["TestJ"].let {
-                    it?.children.orEmpty().assertCount(1, "(Java) TestJ members: ")
-                    it!!.children.first()
-                        .let { assert(it.name == "testF") { "(Java) Expected method name: testF, got: ${it.name}" } }
+                    it?.children.orEmpty().assertCount(2, "(Java) TestJ members: ") // constructor + method
+                    it!!.children.map { it.name }
+                        .let {
+                            assert(
+                                it.containsAll(
+                                    setOf(
+                                        "testF",
+                                        "TestJ"
+                                    )
+                                )
+                            ) { "(Java) Expected method name: testF, got: $it" }
+                        }
                 }
             }
         }
@@ -220,8 +234,9 @@ class KotlinAsJavaPluginTest : BaseAbstractTest() {
                 val testClass = root.dfs { it.name == "TestJ" } as? ClasslikePageNode
                 assert(testClass != null)
                 (testClass!!.content as ContentGroup).children.last().assertNode {
+                    skipAllNotMatching()
                     group {
-                        header(2){
+                        header(2) {
                             +"Properties"
                         }
                         table {


### PR DESCRIPTION
Fix #2765

If a class doesn't have an explicit constructor (with any visibility), a default synthetic one will be provided.
Affects only `DClass`.