### PR TITLE
Fix configure version eagerly

### DIFF
--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/AbstractDokkaTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/AbstractDokkaTask.kt
@@ -29,7 +29,7 @@ abstract class AbstractDokkaTask : DefaultTask() {
 
     @Input
     val moduleVersion: Property<String> = project.objects.safeProperty<String>()
-        .safeConvention(project.version.toString())
+        .safeConvention(project.provider { project.version.toString() })
 
     @OutputDirectory
     val outputDirectory: Property<File> = project.objects.safeProperty<File>()


### PR DESCRIPTION
A typical approach in some version plugins is using an object which uses internally a `Property<String>`, and the `toString()` method unwraps it.

With `provider { … }` unwrapping it too soon is avoided.