### PR TITLE
Avoid snapshotting sourceLink.localDirectory input

### DIFF
--- a/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/BasicCachingIntegrationTest.kt
+++ b/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/BasicCachingIntegrationTest.kt
@@ -24,6 +24,25 @@ class BasicCachingIntegrationTest(override val versions: BuildVersions) : Abstra
         runAndAssertOutcome(TaskOutcome.FROM_CACHE)
     }
 
+    @Test
+    fun localDirectoryPointingToRoot() {
+        fun String.findAndReplace(oldValue: String, newValue: String): String {
+            assertTrue(oldValue in this, "Expected to replace '$oldValue'")
+            return replace(oldValue, newValue)
+        }
+        val projectKts = projectDir.resolve("build.gradle.kts")
+        val projectKtsText = projectKts.readText()
+            .findAndReplace("localDirectory.set(file(\"src/main\"))", "localDirectory.set(projectDir)")
+            .findAndReplace("integration-tests/gradle/projects/it-basic/src/main", "integration-tests/gradle/projects/it-basic")
+        projectKts.writeText(projectKtsText)
+
+        runAndAssertOutcome(TaskOutcome.SUCCESS)
+        projectDir.resolve("unrelated.txt").writeText("modified")
+        // despite projectDir is used as an input in localDirectory, changing its contents shouldn't invalidate the cache
+        runAndAssertOutcome(TaskOutcome.FROM_CACHE)
+    }
+
+
     private fun runAndAssertOutcome(expectedOutcome: TaskOutcome) {
         val result = createGradleRunner(
             "clean",

--- a/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/GradleRelocatedCachingIntegrationTest.kt
+++ b/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/GradleRelocatedCachingIntegrationTest.kt
@@ -21,11 +21,11 @@ class GradleRelocatedCachingIntegrationTest(override val versions: BuildVersions
 
     @Test
     fun execute() {
-        runAndAssertOutcome(projectFolder(1), TaskOutcome.SUCCESS)
-        runAndAssertOutcome(projectFolder(2), TaskOutcome.FROM_CACHE)
+        runAndAssertOutcomeAndContents(projectFolder(1), TaskOutcome.SUCCESS)
+        runAndAssertOutcomeAndContents(projectFolder(2), TaskOutcome.FROM_CACHE)
     }
 
-    private fun runAndAssertOutcome(project: File, expectedOutcome: TaskOutcome) {
+    private fun runAndAssertOutcomeAndContents(project: File, expectedOutcome: TaskOutcome) {
         val result = createGradleRunner("clean", "dokkaHtml", "-i", "-s", "-Dorg.gradle.caching.debug=true", "--build-cache")
             .withProjectDir(project)
             .buildRelaxed()

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/GradleSourceLinkBuilder.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/GradleSourceLinkBuilder.kt
@@ -2,6 +2,7 @@ package org.jetbrains.dokka.gradle
 
 import org.gradle.api.Project
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.*
 import org.jetbrains.dokka.DokkaConfigurationBuilder
 import org.jetbrains.dokka.SourceLinkDefinitionImpl
@@ -36,9 +37,13 @@ class GradleSourceLinkBuilder(
      * projectDir.resolve("src")
      * ```
      */
-    @InputDirectory
-    @PathSensitive(PathSensitivity.RELATIVE)
+    @Internal
     val localDirectory: Property<File?> = project.objects.safeProperty()
+
+    @Suppress("unused")
+    @get:Input
+    internal val localDirectoryPath: Provider<String?> =
+        localDirectory.map { it.relativeToOrSelf(project.projectDir).invariantSeparatorsPath }
 
     /**
      * URL of source code hosting service that can be accessed by documentation readers,

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/GradleSourceLinkBuilder.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/GradleSourceLinkBuilder.kt
@@ -41,9 +41,13 @@ class GradleSourceLinkBuilder(
      * projectDir.resolve("src")
      * ```
      */
-    @Internal
+    @Internal // changing contents of the directory should not invalidate the task
     val localDirectory: Property<File?> = project.objects.safeProperty()
-
+    
+    /**
+     * The relative path to [localDirectory] from the project directory. Declared as an input to invalidate the task if that path changes.
+     * Should not be used anywhere directly.
+     */
     @Suppress("unused")
     @get:Input
     internal val localDirectoryPath: Provider<String?> =

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/GradleSourceLinkBuilder.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/GradleSourceLinkBuilder.kt
@@ -31,6 +31,10 @@ class GradleSourceLinkBuilder(
     /**
      * Path to the local source directory. The path must be relative to the root of current project.
      *
+     * This path is used to find relative paths of the source files from which the documentation is built.
+     * These relative paths are then combined with the base url of a source code hosting service specified with
+     * the [remoteUrl] property to create source links for each declaration.
+     *
      * Example:
      *
      * ```kotlin


### PR DESCRIPTION
A typical use case in a project with complex source root setup is to set `sourceLink.localDirectory` to the root of the project checkout dir and remoteUrl to the root of the project VCS url respectively.
However, since this property was marked as `InputDirectory`, in that case Gradle snapshotted hashes of all files in this entire project directory before running the Dokka task (including for example .git and .gradle directories). This could be very slow in big projects and also result in various Gradle warnings.

Now `localDirectory` is not an input property, but its relativized path is stored in another read-only input string property. Therefore, it invalidates task outputs when its value changes, but not when any content inside it.