### PR TITLE
Fix NoSuchMethodError with Gradle 8.0 RC1

### DIFF
--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/TaskDependencyInternalWithAdditions.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/TaskDependencyInternalWithAdditions.kt
@@ -1,19 +1,18 @@
 package org.jetbrains.dokka.gradle
 
 import org.gradle.api.Task
-import org.gradle.api.internal.tasks.AbstractTaskDependency
+import org.gradle.api.internal.tasks.DefaultTaskDependency
 import org.gradle.api.internal.tasks.TaskDependencyInternal
-import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 
 internal operator fun TaskDependencyInternal.plus(tasks: Iterable<Task>): TaskDependencyInternal =
     TaskDependencyInternalWithAdditions(this, tasks.toSet())
 
 private class TaskDependencyInternalWithAdditions(
-    private val dependency: TaskDependencyInternal,
-    private val additionalTaskDependencies: Set<Task>
-) : AbstractTaskDependency() {
-    override fun visitDependencies(context: TaskDependencyResolveContext) {
-        dependency.visitDependencies(context)
-        additionalTaskDependencies.forEach(context::add)
+    dependency: TaskDependencyInternal,
+    additionalTaskDependencies: Set<Task>,
+) : DefaultTaskDependency() {
+
+    init {
+        add(dependency, additionalTaskDependencies)
     }
 }


### PR DESCRIPTION
An attempt to fix #2796

The `dokkaHtmlMultiModule` started failing after the change in Gradle: https://github.com/gradle/gradle/commit/7d9d6c473a0c29b6ae09b0cff307ae20a698b668#diff-8d6d587bb7323c4c8105f5616986da4d67c575f8f7fb576071e58587e17a6878 where a new constructor appeared.

1. Changed `AbstractTaskDependency` to `DefaultTaskDependency`.
The logic behind this: the message https://github.com/gradle/gradle/blob/ab07117466b9a28de41c1ec85a3fb6f4c61abbcd/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java#L102 that `AbstactTask` should be replaced with `DefaultTask`. So I apply the same for `AbstractTaskDependency` and `DefaultTaskDependency`. even they are both are in `*internal*` package. But we try to override method `public TaskDependencyInternal getTaskDependencies()` that returns an interface from the same `*internal*` package.
2.  I remove custom logic in `visitDependencies` from `TaskDependencyInternalWithAdditions` and delegate it to the default implementation of the `DefaultTaskDependency`. It seems to contain the same. And for that, I inject tasks inside the `DefaultTaskDependency`.
3. There are 2 ways to delegate tasks to the `DefaultTaskDependency` according to documentation (javadoc): in the constructor and with the `add` function. The way with the constructor is even recommended from a performance point of view.
But it requires adding a dependency to Google common collections (full guava?) and I tried to avoid it.