### PR TITLE
Disable caching of Dokka's integration tests

### DIFF
--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -23,9 +23,11 @@ subprojects {
 
     /**
      * Dokka's integration test task is not cacheable because the HTML outputs
-     * it produces when running the tests are used for showcasing resulting documentation.
+     * it produces when running the tests are used for showcasing resulting documentation,
+     * which does not work well with caching.
      *
      * At the moment there are two problems that do not allow to make it cacheable:
+     *
      * 1. The task's inputs are such that changes in Dokka's code do not invalidate the cache,
      *    because it is run with the same version of Dokka ("DOKKA_VERSION") on the same
      *    test project inputs.
@@ -37,7 +39,7 @@ subprojects {
      *
      * @see [org.jetbrains.dokka.it.TestOutputCopier] for more details on showcasing documentation
      */
-    @DisableCachingByDefault
+    @DisableCachingByDefault(because = "Contains incorrect inputs/outputs configuration, see the KDoc for details")
     abstract class NonCacheableIntegrationTest : Test()
 
     val integrationTest by tasks.register<NonCacheableIntegrationTest>("integrationTest") {

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -21,7 +21,26 @@ subprojects {
         implementation(project(":integration-tests"))
     }
 
-    val integrationTest by tasks.register<Test>("integrationTest") {
+    /**
+     * Dokka's integration test task is not cacheable because the HTML outputs
+     * it produces when running the tests are used for showcasing resulting documentation.
+     *
+     * At the moment there are two problems that do not allow to make it cacheable:
+     * 1. The task's inputs are such that changes in Dokka's code do not invalidate the cache,
+     *    because it is run with the same version of Dokka ("DOKKA_VERSION") on the same
+     *    test project inputs.
+     * 2. The tests generate HTML output which is then used to showcase documentation.
+     *    The outputs are usually copied to a location from which it will be served.
+     *    However, if the test is cacheable, it produces no outputs, so no documentation
+     *    to showcase. It needs to be broken into two separate tasks: one cacheable for running
+     *    the tests and producing HTML output, and another non-cacheable for copying the output.
+     *
+     * @see [org.jetbrains.dokka.it.TestOutputCopier] for more details on showcasing documentation
+     */
+    @DisableCachingByDefault
+    abstract class NonCacheableIntegrationTest : Test()
+
+    val integrationTest by tasks.register<NonCacheableIntegrationTest>("integrationTest") {
         maxHeapSize = "2G"
         description = "Runs integration tests."
         group = "verification"


### PR DESCRIPTION
Because integration tests are cached by default, it produces no output for showcasing documentation through S3 or GitHub artifacts.

Tried to explain what needs to be done in the comment. I tried, but it takes too much time to implement and test it properly, and I'd like to restore the demo functionality sooner, so proposing to just disable it for now.

Regression from #2711