### PR TITLE
Make implementations of DokkaLogger thread-safe

### DIFF
--- a/core/src/main/kotlin/DokkaBootstrapImpl.kt
+++ b/core/src/main/kotlin/DokkaBootstrapImpl.kt
@@ -1,7 +1,7 @@
 package org.jetbrains.dokka
 
 import org.jetbrains.dokka.utilities.DokkaLogger
-import java.util.concurrent.atomic.LongAdder
+import java.util.concurrent.atomic.AtomicInteger
 
 import java.util.function.BiConsumer
 
@@ -12,11 +12,16 @@ import java.util.function.BiConsumer
 class DokkaBootstrapImpl : DokkaBootstrap {
 
     class DokkaProxyLogger(val consumer: BiConsumer<String, String>) : DokkaLogger {
-        private val warningsCounter = LongAdder()
-        private val errorsCounter = LongAdder()
+        private val warningsCounter = AtomicInteger()
+        private val errorsCounter = AtomicInteger()
 
-        override var warningsCount: Int = warningsCounter.toInt()
-        override var errorsCount: Int = errorsCounter.toInt()
+        override var warningsCount: Int
+            get() = warningsCounter.get()
+            set(value) = warningsCounter.set(value)
+
+        override var errorsCount: Int
+            get() = errorsCounter.get()
+            set(value) = errorsCounter.set(value)
 
         override fun debug(message: String) {
             consumer.accept("debug", message)
@@ -31,11 +36,11 @@ class DokkaBootstrapImpl : DokkaBootstrap {
         }
 
         override fun warn(message: String) {
-            consumer.accept("warn", message).also { warningsCounter.increment() }
+            consumer.accept("warn", message).also { warningsCounter.incrementAndGet() }
         }
 
         override fun error(message: String) {
-            consumer.accept("error", message).also { errorsCounter.increment() }
+            consumer.accept("error", message).also { errorsCounter.incrementAndGet() }
         }
     }
 

--- a/core/src/main/kotlin/DokkaBootstrapImpl.kt
+++ b/core/src/main/kotlin/DokkaBootstrapImpl.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.dokka
 
 import org.jetbrains.dokka.utilities.DokkaLogger
+import java.util.concurrent.atomic.LongAdder
 
 import java.util.function.BiConsumer
 
@@ -11,8 +12,11 @@ import java.util.function.BiConsumer
 class DokkaBootstrapImpl : DokkaBootstrap {
 
     class DokkaProxyLogger(val consumer: BiConsumer<String, String>) : DokkaLogger {
-        override var warningsCount: Int = 0
-        override var errorsCount: Int = 0
+        private val warningsCounter = LongAdder()
+        private val errorsCounter = LongAdder()
+
+        override var warningsCount: Int = warningsCounter.toInt()
+        override var errorsCount: Int = errorsCounter.toInt()
 
         override fun debug(message: String) {
             consumer.accept("debug", message)
@@ -27,11 +31,11 @@ class DokkaBootstrapImpl : DokkaBootstrap {
         }
 
         override fun warn(message: String) {
-            consumer.accept("warn", message).also { warningsCount++ }
+            consumer.accept("warn", message).also { warningsCounter.increment() }
         }
 
         override fun error(message: String) {
-            consumer.accept("error", message).also { errorsCount++ }
+            consumer.accept("error", message).also { errorsCounter.increment() }
         }
     }
 

--- a/core/src/main/kotlin/utilities/DokkaLogging.kt
+++ b/core/src/main/kotlin/utilities/DokkaLogging.kt
@@ -1,5 +1,7 @@
 package org.jetbrains.dokka.utilities
 
+import java.util.concurrent.atomic.LongAdder
+
 interface DokkaLogger {
     var warningsCount: Int
     var errorsCount: Int
@@ -40,8 +42,11 @@ class DokkaConsoleLogger(
     val minLevel: LoggingLevel = LoggingLevel.DEBUG,
     private val emitter: MessageEmitter = MessageEmitter.consoleEmitter
 ) : DokkaLogger {
-    override var warningsCount: Int = 0
-    override var errorsCount: Int = 0
+    private val warningsCounter = LongAdder()
+    private val errorsCounter = LongAdder()
+
+    override var warningsCount: Int = warningsCounter.toInt()
+    override var errorsCount: Int = errorsCounter.toInt()
 
     override fun debug(message: String) {
         if (shouldBeDisplayed(LoggingLevel.DEBUG)) emitter(message)
@@ -59,14 +64,14 @@ class DokkaConsoleLogger(
         if (shouldBeDisplayed(LoggingLevel.WARN)) {
             emitter("WARN: $message")
         }
-        warningsCount++
+        warningsCounter.increment()
     }
 
     override fun error(message: String) {
         if (shouldBeDisplayed(LoggingLevel.ERROR)) {
             emitter("ERROR: $message")
         }
-        errorsCount++
+        errorsCounter.increment()
     }
 
     private fun shouldBeDisplayed(messageLevel: LoggingLevel): Boolean = messageLevel.index >= minLevel.index

--- a/core/src/main/kotlin/utilities/DokkaLogging.kt
+++ b/core/src/main/kotlin/utilities/DokkaLogging.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.dokka.utilities
 
-import java.util.concurrent.atomic.LongAdder
+import java.util.concurrent.atomic.AtomicInteger
 
 interface DokkaLogger {
     var warningsCount: Int
@@ -42,11 +42,16 @@ class DokkaConsoleLogger(
     val minLevel: LoggingLevel = LoggingLevel.DEBUG,
     private val emitter: MessageEmitter = MessageEmitter.consoleEmitter
 ) : DokkaLogger {
-    private val warningsCounter = LongAdder()
-    private val errorsCounter = LongAdder()
+    private val warningsCounter = AtomicInteger()
+    private val errorsCounter = AtomicInteger()
 
-    override var warningsCount: Int = warningsCounter.toInt()
-    override var errorsCount: Int = errorsCounter.toInt()
+    override var warningsCount: Int
+        get() = warningsCounter.get()
+        set(value) = warningsCounter.set(value)
+
+    override var errorsCount: Int
+        get() = errorsCounter.get()
+        set(value) = errorsCounter.set(value)
 
     override fun debug(message: String) {
         if (shouldBeDisplayed(LoggingLevel.DEBUG)) emitter(message)
@@ -64,14 +69,14 @@ class DokkaConsoleLogger(
         if (shouldBeDisplayed(LoggingLevel.WARN)) {
             emitter("WARN: $message")
         }
-        warningsCounter.increment()
+        warningsCounter.incrementAndGet()
     }
 
     override fun error(message: String) {
         if (shouldBeDisplayed(LoggingLevel.ERROR)) {
             emitter("ERROR: $message")
         }
-        errorsCounter.increment()
+        errorsCounter.incrementAndGet()
     }
 
     private fun shouldBeDisplayed(messageLevel: LoggingLevel): Boolean = messageLevel.index >= minLevel.index

--- a/core/test-api/src/main/kotlin/testApi/logger/TestLogger.kt
+++ b/core/test-api/src/main/kotlin/testApi/logger/TestLogger.kt
@@ -1,24 +1,28 @@
 package org.jetbrains.dokka.testApi.logger
 
 import org.jetbrains.dokka.utilities.DokkaLogger
+import java.util.Collections
 
+/*
+ * Even in tests it be used in a concurrent environment, so needs to be thread safe
+ */
 class TestLogger(private val logger: DokkaLogger) : DokkaLogger {
     override var warningsCount: Int by logger::warningsCount
     override var errorsCount: Int by logger::errorsCount
 
-    private var _debugMessages = mutableListOf<String>()
+    private var _debugMessages = synchronizedMutableListOf<String>()
     val debugMessages: List<String> get() = _debugMessages.toList()
 
-    private var _infoMessages = mutableListOf<String>()
+    private var _infoMessages = synchronizedMutableListOf<String>()
     val infoMessages: List<String> get() = _infoMessages.toList()
 
-    private var _progressMessages = mutableListOf<String>()
+    private var _progressMessages = synchronizedMutableListOf<String>()
     val progressMessages: List<String> get() = _progressMessages.toList()
 
-    private var _warnMessages = mutableListOf<String>()
+    private var _warnMessages = synchronizedMutableListOf<String>()
     val warnMessages: List<String> get() = _warnMessages.toList()
 
-    private var _errorMessages = mutableListOf<String>()
+    private var _errorMessages = synchronizedMutableListOf<String>()
     val errorMessages: List<String> get() = _errorMessages.toList()
 
     override fun debug(message: String) {
@@ -45,4 +49,6 @@ class TestLogger(private val logger: DokkaLogger) : DokkaLogger {
         _errorMessages.add(message)
         logger.error(message)
     }
+
+    private fun <T> synchronizedMutableListOf(): MutableList<T> = Collections.synchronizedList(mutableListOf())
 }

--- a/runners/maven-plugin/src/main/kotlin/MavenDokkaLogger.kt
+++ b/runners/maven-plugin/src/main/kotlin/MavenDokkaLogger.kt
@@ -2,18 +2,23 @@ package org.jetbrains.dokka.maven
 
 import org.apache.maven.plugin.logging.Log
 import org.jetbrains.dokka.utilities.DokkaLogger
-import java.util.concurrent.atomic.LongAdder
+import java.util.concurrent.atomic.AtomicInteger
 
 class MavenDokkaLogger(val log: Log) : DokkaLogger {
-    private val warningsCounter = LongAdder()
-    private val errorsCounter = LongAdder()
+    private val warningsCounter = AtomicInteger()
+    private val errorsCounter = AtomicInteger()
 
-    override var warningsCount: Int = warningsCounter.toInt()
-    override var errorsCount: Int = errorsCounter.toInt()
+    override var warningsCount: Int
+        get() = warningsCounter.get()
+        set(value) = warningsCounter.set(value)
+
+    override var errorsCount: Int
+        get() = errorsCounter.get()
+        set(value) = errorsCounter.set(value)
 
     override fun debug(message: String) = log.debug(message)
     override fun info(message: String) = log.info(message)
     override fun progress(message: String) = log.info(message)
-    override fun warn(message: String) = log.warn(message).also { warningsCounter.increment() }
-    override fun error(message: String) = log.error(message).also { errorsCounter.increment() }
+    override fun warn(message: String) = log.warn(message).also { warningsCounter.incrementAndGet() }
+    override fun error(message: String) = log.error(message).also { errorsCounter.incrementAndGet() }
 }

--- a/runners/maven-plugin/src/main/kotlin/MavenDokkaLogger.kt
+++ b/runners/maven-plugin/src/main/kotlin/MavenDokkaLogger.kt
@@ -2,14 +2,18 @@ package org.jetbrains.dokka.maven
 
 import org.apache.maven.plugin.logging.Log
 import org.jetbrains.dokka.utilities.DokkaLogger
+import java.util.concurrent.atomic.LongAdder
 
 class MavenDokkaLogger(val log: Log) : DokkaLogger {
-    override var warningsCount: Int = 0
-    override var errorsCount: Int = 0
+    private val warningsCounter = LongAdder()
+    private val errorsCounter = LongAdder()
+
+    override var warningsCount: Int = warningsCounter.toInt()
+    override var errorsCount: Int = errorsCounter.toInt()
 
     override fun debug(message: String) = log.debug(message)
     override fun info(message: String) = log.info(message)
     override fun progress(message: String) = log.info(message)
-    override fun warn(message: String) = log.warn(message).also { warningsCount++ }
-    override fun error(message: String) = log.error(message).also { errorsCount++ }
+    override fun warn(message: String) = log.warn(message).also { warningsCounter.increment() }
+    override fun error(message: String) = log.error(message).also { errorsCounter.increment() }
 }


### PR DESCRIPTION
It was reported that `TestLogger` sometimes throws `ArrayIndexOutOfBoundsException`. While at it, made sure other implementations are OK as well.
