### PR TITLE
Gradle Plugin: update custom Gradle utils to use Gradle Kotlin DSL

### DIFF
--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaMultiModuleFileLayout.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaMultiModuleFileLayout.kt
@@ -23,7 +23,7 @@ fun interface DokkaMultiModuleFileLayout {
      */
     object NoCopy : DokkaMultiModuleFileLayout {
         override fun targetChildOutputDirectory(parent: DokkaMultiModuleTask, child: AbstractDokkaTask): File =
-            child.outputDirectory.getSafe()
+            child.outputDirectory.get()
     }
 
     /**
@@ -38,7 +38,7 @@ fun interface DokkaMultiModuleFileLayout {
             val relativeProjectPath = parent.project.relativeProjectPath(child.project.path)
             val relativeFilePath = relativeProjectPath.replace(":", File.separator)
             check(!File(relativeFilePath).isAbsolute) { "Unexpected absolute path $relativeFilePath" }
-            return parent.outputDirectory.getSafe().resolve(relativeFilePath)
+            return parent.outputDirectory.get().resolve(relativeFilePath)
         }
     }
 }
@@ -56,7 +56,7 @@ internal fun DokkaMultiModuleTask.copyChildOutputDirectories() {
 
 internal fun DokkaMultiModuleTask.copyChildOutputDirectory(child: AbstractDokkaTask) {
     val targetChildOutputDirectory = project.file(fileLayout.get().targetChildOutputDirectory(this, child))
-    val sourceChildOutputDirectory = child.outputDirectory.getSafe()
+    val sourceChildOutputDirectory = child.outputDirectory.get()
 
     /* Pointing to the same directory -> No copy necessary */
     if (sourceChildOutputDirectory.absoluteFile == targetChildOutputDirectory.absoluteFile) {
@@ -79,4 +79,3 @@ internal fun DokkaMultiModuleTask.copyChildOutputDirectory(child: AbstractDokkaT
 
     sourceChildOutputDirectory.copyRecursively(targetChildOutputDirectory, overwrite = true)
 }
-

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaProperty.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaProperty.kt
@@ -1,26 +1,6 @@
 package org.jetbrains.dokka.gradle
 
-import org.gradle.api.model.ObjectFactory
-import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
-import org.gradle.kotlin.dsl.property
-import org.jetbrains.dokka.utilities.cast
-import kotlin.reflect.typeOf
 
-internal inline fun <reified T : Any> ObjectFactory.safeProperty() = property<T?>()
-
-internal inline fun <reified T : Any> Property<T?>.safeConvention(value: T): Property<T> {
-    return this.convention(value).cast()
-}
-
-internal inline fun <reified T : Any> Property<T?>.safeConvention(provider: Provider<T?>): Property<T> {
-    return this.convention(provider).cast()
-}
-
-@OptIn(ExperimentalStdlibApi::class)
-internal inline fun <reified T> Provider<T>.getSafe(): T =
-    if (typeOf<T>().isMarkedNullable) orNull as T
-    else get()
 
 internal fun Provider<String>.getValidVersionOrNull() = orNull?.takeIf { it != "unspecified" }
-

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaSourceSetMapper.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaSourceSetMapper.kt
@@ -9,28 +9,28 @@ internal fun GradleDokkaSourceSetBuilder.toDokkaSourceSetImpl(): DokkaSourceSetI
     displayName = displayNameOrDefault(),
     sourceSetID = sourceSetID,
     sourceRoots = sourceRoots.toSet(),
-    dependentSourceSets = dependentSourceSets.getSafe().toSet(),
+    dependentSourceSets = dependentSourceSets.get().toSet(),
     samples = samples.toSet(),
     includes = includes.toSet(),
-    includeNonPublic = includeNonPublic.getSafe(),
-    documentedVisibilities = documentedVisibilities.getSafe(),
-    reportUndocumented = reportUndocumented.getSafe(),
-    skipEmptyPackages = skipEmptyPackages.getSafe(),
-    skipDeprecated = skipDeprecated.getSafe(),
-    jdkVersion = jdkVersion.getSafe(),
-    sourceLinks = sourceLinks.getSafe().build().toSet(),
-    perPackageOptions = perPackageOptions.getSafe().build(),
+    includeNonPublic = includeNonPublic.get(),
+    documentedVisibilities = documentedVisibilities.get(),
+    reportUndocumented = reportUndocumented.get(),
+    skipEmptyPackages = skipEmptyPackages.get(),
+    skipDeprecated = skipDeprecated.get(),
+    jdkVersion = jdkVersion.get(),
+    sourceLinks = sourceLinks.get().build().toSet(),
+    perPackageOptions = perPackageOptions.get().build(),
     externalDocumentationLinks = externalDocumentationLinksWithDefaults(),
-    languageVersion = languageVersion.getSafe(),
-    apiVersion = apiVersion.getSafe(),
-    noStdlibLink = noStdlibLink.getSafe(),
-    noJdkLink = noJdkLink.getSafe(),
+    languageVersion = languageVersion.orNull,
+    apiVersion = apiVersion.orNull,
+    noStdlibLink = noStdlibLink.get(),
+    noJdkLink = noJdkLink.get(),
     suppressedFiles = suppressedFilesWithDefaults(),
-    analysisPlatform = platform.getSafe()
+    analysisPlatform = platform.get()
 )
 
 private fun GradleDokkaSourceSetBuilder.displayNameOrDefault(): String {
-    displayName.getSafe()?.let { return it }
+    displayName.orNull?.let { return it }
     if (name.endsWith("Main") && name != "Main") {
         return name.removeSuffix("Main")
     }
@@ -39,17 +39,17 @@ private fun GradleDokkaSourceSetBuilder.displayNameOrDefault(): String {
 }
 
 private fun GradleDokkaSourceSetBuilder.externalDocumentationLinksWithDefaults(): Set<ExternalDocumentationLinkImpl> {
-    return externalDocumentationLinks.getSafe().build()
+    return externalDocumentationLinks.get().build()
         .run {
-            if (noJdkLink.getSafe()) this
-            else this + ExternalDocumentationLink.jdk(jdkVersion.getSafe())
+            if (noJdkLink.get()) this
+            else this + ExternalDocumentationLink.jdk(jdkVersion.get())
         }
         .run {
-            if (noStdlibLink.getSafe()) this
+            if (noStdlibLink.get()) this
             else this + ExternalDocumentationLink.kotlinStdlib()
         }
         .run {
-            if (noAndroidSdkLink.getSafe() || !project.isAndroidProject()) this
+            if (noAndroidSdkLink.get() || !project.isAndroidProject()) this
             else this +
                     ExternalDocumentationLink.androidSdk() +
                     ExternalDocumentationLink.androidX()
@@ -58,7 +58,7 @@ private fun GradleDokkaSourceSetBuilder.externalDocumentationLinksWithDefaults()
 }
 
 private fun GradleDokkaSourceSetBuilder.suppressedFilesWithDefaults(): Set<File> {
-    val suppressedGeneratedFiles = if (suppressGeneratedFiles.getSafe()) {
+    val suppressedGeneratedFiles = if (suppressGeneratedFiles.get()) {
         val generatedRoot = project.buildDir.resolve("generated").absoluteFile
         sourceRoots
             .filter { it.startsWith(generatedRoot) }

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/GradleDokkaSourceSetBuilder.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/GradleDokkaSourceSetBuilder.kt
@@ -8,6 +8,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.*
 import org.gradle.kotlin.dsl.listProperty
+import org.gradle.kotlin.dsl.property
 import org.gradle.kotlin.dsl.setProperty
 import org.jetbrains.dokka.*
 import java.io.File
@@ -51,8 +52,8 @@ open class GradleDokkaSourceSetBuilder(
      * Default is `false`.
      */
     @Input
-    val suppress: Property<Boolean> = project.objects.safeProperty<Boolean>()
-        .safeConvention(false)
+    val suppress: Property<Boolean> = project.objects.property<Boolean>()
+        .convention(false)
 
     /**
      * Display name used to refer to the source set.
@@ -64,7 +65,7 @@ open class GradleDokkaSourceSetBuilder(
      */
     @Input
     @Optional
-    val displayName: Property<String?> = project.objects.safeProperty()
+    val displayName: Property<String?> = project.objects.property()
 
     /**
      * List of Markdown files that contain
@@ -108,8 +109,9 @@ open class GradleDokkaSourceSetBuilder(
      * Default is [DokkaConfiguration.Visibility.PUBLIC].
      */
     @Input
-    val documentedVisibilities: SetProperty<DokkaConfiguration.Visibility> = project.objects.setProperty<DokkaConfiguration.Visibility>()
-        .convention(DokkaDefaults.documentedVisibilities)
+    val documentedVisibilities: SetProperty<DokkaConfiguration.Visibility> =
+        project.objects.setProperty<DokkaConfiguration.Visibility>()
+            .convention(DokkaDefaults.documentedVisibilities)
 
     /**
      * Specifies source sets that current source set depends on.
@@ -169,8 +171,8 @@ open class GradleDokkaSourceSetBuilder(
      * Default is `false`.
      */
     @Input
-    val reportUndocumented: Property<Boolean> = project.objects.safeProperty<Boolean>()
-        .safeConvention(DokkaDefaults.reportUndocumented)
+    val reportUndocumented: Property<Boolean> = project.objects.property<Boolean>()
+        .convention(DokkaDefaults.reportUndocumented)
 
     /**
      * Specifies the location of the project source code on the Web. If provided, Dokka generates
@@ -209,8 +211,8 @@ open class GradleDokkaSourceSetBuilder(
      */
     @Input
     @Optional
-    val platform: Property<Platform> = project.objects.safeProperty<Platform>()
-        .safeConvention(Platform.DEFAULT)
+    val platform: Property<Platform> = project.objects.property<Platform>()
+        .convention(Platform.DEFAULT)
 
     /**
      * Whether to skip packages that contain no visible declarations after
@@ -222,8 +224,8 @@ open class GradleDokkaSourceSetBuilder(
      * Default is `true`.
      */
     @Input
-    val skipEmptyPackages: Property<Boolean> = project.objects.safeProperty<Boolean>()
-        .safeConvention(DokkaDefaults.skipEmptyPackages)
+    val skipEmptyPackages: Property<Boolean> = project.objects.property<Boolean>()
+        .convention(DokkaDefaults.skipEmptyPackages)
 
     /**
      * Whether to document declarations annotated with [Deprecated].
@@ -233,8 +235,8 @@ open class GradleDokkaSourceSetBuilder(
      * Default is `false`.
      */
     @Input
-    val skipDeprecated: Property<Boolean> = project.objects.safeProperty<Boolean>()
-        .safeConvention(DokkaDefaults.skipDeprecated)
+    val skipDeprecated: Property<Boolean> = project.objects.property<Boolean>()
+        .convention(DokkaDefaults.skipDeprecated)
 
     /**
      * Directories or individual files that should be suppressed, meaning declarations from them
@@ -256,8 +258,8 @@ open class GradleDokkaSourceSetBuilder(
      * Default is `true`.
      */
     @Input
-    val suppressGeneratedFiles: Property<Boolean> = project.objects.safeProperty<Boolean>()
-        .safeConvention(DokkaDefaults.suppressGeneratedFiles)
+    val suppressGeneratedFiles: Property<Boolean> = project.objects.property<Boolean>()
+        .convention(DokkaDefaults.suppressGeneratedFiles)
 
     /**
      * Whether to generate external documentation links that lead to API reference
@@ -266,8 +268,8 @@ open class GradleDokkaSourceSetBuilder(
      * Default is `false`, meaning links will be generated.
      */
     @Input
-    val noStdlibLink: Property<Boolean> = project.objects.safeProperty<Boolean>()
-        .safeConvention(DokkaDefaults.noStdlibLink)
+    val noStdlibLink: Property<Boolean> = project.objects.property<Boolean>()
+        .convention(DokkaDefaults.noStdlibLink)
 
     /**
      * Whether to generate external documentation links to JDK's Javadocs
@@ -278,8 +280,8 @@ open class GradleDokkaSourceSetBuilder(
      * Default is `false`, meaning links will be generated.
      */
     @Input
-    val noJdkLink: Property<Boolean> = project.objects.safeProperty<Boolean>()
-        .safeConvention(DokkaDefaults.noJdkLink)
+    val noJdkLink: Property<Boolean> = project.objects.property<Boolean>()
+        .convention(DokkaDefaults.noJdkLink)
 
     /**
      * Whether to generate external documentation links for Android SDK API reference
@@ -290,8 +292,8 @@ open class GradleDokkaSourceSetBuilder(
      * Default is `false`, meaning links will be generated.
      */
     @Input
-    val noAndroidSdkLink: Property<Boolean> = project.objects.safeProperty<Boolean>()
-        .safeConvention(DokkaDefaults.noAndroidSdkLink)
+    val noAndroidSdkLink: Property<Boolean> = project.objects.property<Boolean>()
+        .convention(DokkaDefaults.noAndroidSdkLink)
 
     /**
      * [Kotlin language version](https://kotlinlang.org/docs/compatibility-modes.html)
@@ -302,7 +304,7 @@ open class GradleDokkaSourceSetBuilder(
      */
     @Input
     @Optional
-    val languageVersion: Property<String?> = project.objects.safeProperty()
+    val languageVersion: Property<String?> = project.objects.property()
 
     /**
      * [Kotlin API version](https://kotlinlang.org/docs/compatibility-modes.html)
@@ -313,7 +315,7 @@ open class GradleDokkaSourceSetBuilder(
      */
     @Input
     @Optional
-    val apiVersion: Property<String?> = project.objects.safeProperty()
+    val apiVersion: Property<String?> = project.objects.property()
 
     /**
      * JDK version to use when generating external documentation links for Java types.
@@ -325,15 +327,15 @@ open class GradleDokkaSourceSetBuilder(
      * Default is JDK 8.
      */
     @Input
-    val jdkVersion: Property<Int> = project.objects.safeProperty<Int>()
-        .safeConvention(DokkaDefaults.jdkVersion)
+    val jdkVersion: Property<Int> = project.objects.property<Int>()
+        .convention(DokkaDefaults.jdkVersion)
 
     /**
      * Deprecated. Use [documentedVisibilities] instead.
      */
     @Input
-    val includeNonPublic: Property<Boolean> = project.objects.safeProperty<Boolean>()
-        .safeConvention(DokkaDefaults.includeNonPublic)
+    val includeNonPublic: Property<Boolean> = project.objects.property<Boolean>()
+        .convention(DokkaDefaults.includeNonPublic)
 
     fun DokkaSourceSetID(sourceSetName: String): DokkaSourceSetID = sourceSetIdFactory.create(sourceSetName)
 

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/GradleExternalDocumentationLinkBuilder.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/GradleExternalDocumentationLinkBuilder.kt
@@ -5,6 +5,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
+import org.gradle.kotlin.dsl.property
 import org.jetbrains.dokka.DokkaConfigurationBuilder
 import org.jetbrains.dokka.ExternalDocumentationLink
 import org.jetbrains.dokka.ExternalDocumentationLinkImpl
@@ -52,7 +53,7 @@ class GradleExternalDocumentationLinkBuilder(
      * ```
      */
     @Input
-    val url: Property<URL?> = project.objects.safeProperty()
+    val url: Property<URL> = project.objects.property()
 
     /**
      * Specifies the exact location of a `package-list` instead of relying on Dokka
@@ -66,10 +67,10 @@ class GradleExternalDocumentationLinkBuilder(
      */
     @Optional
     @Input
-    val packageListUrl: Property<URL?> = project.objects.safeProperty()
+    val packageListUrl: Property<URL> = project.objects.property()
 
     override fun build(): ExternalDocumentationLinkImpl = ExternalDocumentationLink(
-        url = checkNotNull(url.getSafe()) { "url not specified " },
-        packageListUrl = packageListUrl.getSafe()
+        url = checkNotNull(url.get()) { "url not specified " },
+        packageListUrl = packageListUrl.orNull,
     )
 }

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/GradlePackageOptionsBuilder.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/GradlePackageOptionsBuilder.kt
@@ -7,7 +7,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
-import org.gradle.kotlin.dsl.setProperty
+import org.gradle.kotlin.dsl.*
 import org.jetbrains.dokka.DokkaConfiguration
 import org.jetbrains.dokka.DokkaConfigurationBuilder
 import org.jetbrains.dokka.DokkaDefaults
@@ -40,8 +40,8 @@ class GradlePackageOptionsBuilder(
      * Default is any string: `.*`.
      */
     @Input
-    val matchingRegex: Property<String> = project.objects.safeProperty<String>()
-        .safeConvention(".*")
+    val matchingRegex: Property<String> = project.objects.property<String>()
+        .convention(".*")
 
     /**
      * Whether this package should be skipped when generating documentation.
@@ -49,8 +49,8 @@ class GradlePackageOptionsBuilder(
      * Default is `false`.
      */
     @Input
-    val suppress: Property<Boolean> = project.objects.safeProperty<Boolean>()
-        .safeConvention(DokkaDefaults.suppress)
+    val suppress: Property<Boolean> = project.objects.property<Boolean>()
+        .convention(DokkaDefaults.suppress)
 
     /**
      * Set of visibility modifiers that should be documented.
@@ -63,8 +63,9 @@ class GradlePackageOptionsBuilder(
      * Default is [DokkaConfiguration.Visibility.PUBLIC].
      */
     @Input
-    val documentedVisibilities: SetProperty<DokkaConfiguration.Visibility> = project.objects.setProperty<DokkaConfiguration.Visibility>()
-        .convention(DokkaDefaults.documentedVisibilities)
+    val documentedVisibilities: SetProperty<DokkaConfiguration.Visibility> =
+        project.objects.setProperty<DokkaConfiguration.Visibility>()
+            .convention(DokkaDefaults.documentedVisibilities)
 
     /**
      * Whether to document declarations annotated with [Deprecated].
@@ -74,8 +75,8 @@ class GradlePackageOptionsBuilder(
      * Default is `false`.
      */
     @Input
-    val skipDeprecated: Property<Boolean> = project.objects.safeProperty<Boolean>()
-        .safeConvention(DokkaDefaults.skipDeprecated)
+    val skipDeprecated: Property<Boolean> = project.objects.property<Boolean>()
+        .convention(DokkaDefaults.skipDeprecated)
 
     /**
      * Whether to emit warnings about visible undocumented declarations, that is declarations from
@@ -88,23 +89,23 @@ class GradlePackageOptionsBuilder(
      * Default is `false`.
      */
     @Input
-    val reportUndocumented: Property<Boolean> = project.objects.safeProperty<Boolean>()
-        .safeConvention(DokkaDefaults.reportUndocumented)
+    val reportUndocumented: Property<Boolean> = project.objects.property<Boolean>()
+        .convention(DokkaDefaults.reportUndocumented)
 
     /**
      * Deprecated. Use [documentedVisibilities] instead.
      */
     @Input
-    val includeNonPublic: Property<Boolean> = project.objects.safeProperty<Boolean>()
-        .safeConvention(DokkaDefaults.includeNonPublic)
+    val includeNonPublic: Property<Boolean> = project.objects.property<Boolean>()
+        .convention(DokkaDefaults.includeNonPublic)
 
 
     override fun build(): PackageOptionsImpl = PackageOptionsImpl(
-        matchingRegex = checkNotNull(matchingRegex.getSafe()) { "prefix not specified" },
-        includeNonPublic = includeNonPublic.getSafe(),
-        documentedVisibilities = documentedVisibilities.getSafe(),
-        reportUndocumented = reportUndocumented.getSafe(),
-        skipDeprecated = skipDeprecated.getSafe(),
-        suppress = suppress.getSafe()
+        matchingRegex = matchingRegex.get(),
+        includeNonPublic = includeNonPublic.get(),
+        documentedVisibilities = documentedVisibilities.get(),
+        reportUndocumented = reportUndocumented.get(),
+        skipDeprecated = skipDeprecated.get(),
+        suppress = suppress.get()
     )
 }

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/GradleSourceLinkBuilder.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/GradleSourceLinkBuilder.kt
@@ -4,6 +4,7 @@ import org.gradle.api.Project
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.*
+import org.gradle.kotlin.dsl.property
 import org.jetbrains.dokka.DokkaConfigurationBuilder
 import org.jetbrains.dokka.SourceLinkDefinitionImpl
 import java.io.File
@@ -42,8 +43,8 @@ class GradleSourceLinkBuilder(
      * ```
      */
     @Internal // changing contents of the directory should not invalidate the task
-    val localDirectory: Property<File?> = project.objects.safeProperty()
-    
+    val localDirectory: Property<File?> = project.objects.property()
+
     /**
      * The relative path to [localDirectory] from the project directory. Declared as an input to invalidate the task if that path changes.
      * Should not be used anywhere directly.
@@ -65,7 +66,7 @@ class GradleSourceLinkBuilder(
      * ```
      */
     @Input
-    val remoteUrl: Property<URL?> = project.objects.safeProperty()
+    val remoteUrl: Property<URL> = project.objects.property()
 
     /**
      * Suffix used to append source code line number to the URL. This will help readers navigate
@@ -84,14 +85,14 @@ class GradleSourceLinkBuilder(
      */
     @Optional
     @Input
-    val remoteLineSuffix: Property<String> = project.objects.safeProperty<String>()
-        .safeConvention("#L")
+    val remoteLineSuffix: Property<String> = project.objects.property<String>()
+        .convention("#L")
 
     override fun build(): SourceLinkDefinitionImpl {
         return SourceLinkDefinitionImpl(
-            localDirectory = localDirectory.getSafe()?.canonicalPath ?: project.projectDir.canonicalPath,
-            remoteUrl = checkNotNull(remoteUrl.getSafe()) { "missing remoteUrl on source link" },
-            remoteLineSuffix = remoteLineSuffix.getSafe()
+            localDirectory = localDirectory.orNull?.canonicalPath ?: project.projectDir.canonicalPath,
+            remoteUrl = remoteUrl.get(),
+            remoteLineSuffix = remoteLineSuffix.get(),
         )
     }
 }

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/checkDependentSourceSets.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/checkDependentSourceSets.kt
@@ -8,12 +8,12 @@ internal fun checkSourceSetDependencies(sourceSets: List<GradleDokkaSourceSetBui
 
 private fun checkSourceSetDependencies(sourceSets: Map<DokkaSourceSetID, GradleDokkaSourceSetBuilder>) {
     sourceSets.values.forEach { sourceSet ->
-        sourceSet.dependentSourceSets.getSafe().forEach { dependentSourceSetID ->
+        sourceSet.dependentSourceSets.get().forEach { dependentSourceSetID ->
             val dependentSourceSet = requireNotNull(sourceSets[dependentSourceSetID]) {
                 "Dokka source set \"${sourceSet.name}\": Cannot find dependent source set \"$dependentSourceSetID\""
             }
 
-            if (sourceSet.suppress.getSafe().not() && dependentSourceSet.suppress.getSafe()) {
+            if (sourceSet.suppress.get().not() && dependentSourceSet.suppress.get()) {
                 throw IllegalArgumentException(
                     "Dokka source set: \"${sourceSet.name}\": " +
                             "Unsuppressed source set cannot depend on suppressed source set \"$dependentSourceSetID\""

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/AbstractDokkaLeafTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/AbstractDokkaLeafTask.kt
@@ -33,5 +33,5 @@ abstract class AbstractDokkaLeafTask : AbstractDokkaTask() {
         get() = dokkaSourceSets
             .toList()
             .also(::checkSourceSetDependencies)
-            .filterNot { it.suppress.getSafe() }
+            .filterNot { it.suppress.get() }
 }

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/AbstractDokkaTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/AbstractDokkaTask.kt
@@ -14,6 +14,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import org.gradle.kotlin.dsl.listProperty
 import org.gradle.kotlin.dsl.mapProperty
+import org.gradle.kotlin.dsl.property
 import org.gradle.work.DisableCachingByDefault
 import org.jetbrains.dokka.*
 import org.jetbrains.dokka.plugability.ConfigurableBlock
@@ -33,8 +34,8 @@ abstract class AbstractDokkaTask : DefaultTask() {
      * Default is Gradle project name.
      */
     @Input
-    val moduleName: Property<String> = project.objects.safeProperty<String>()
-        .safeConvention(project.name)
+    val moduleName: Property<String> = project.objects.property<String>()
+        .convention(project.name)
 
     /**
      * Module version.
@@ -45,8 +46,8 @@ abstract class AbstractDokkaTask : DefaultTask() {
      * Default is Gradle project version.
      */
     @Input
-    val moduleVersion: Property<String> = project.objects.safeProperty<String>()
-        .safeConvention(project.provider { project.version.toString() })
+    val moduleVersion: Property<String> = project.objects.property<String>()
+        .convention(project.provider { project.version.toString() })
 
     /**
      * Directory to which documentation will be generated, regardless of format.
@@ -56,8 +57,8 @@ abstract class AbstractDokkaTask : DefaultTask() {
      * for `dokkaHtmlMultiModule` task it will be `project/buildDir/htmlMultiModule`
      */
     @OutputDirectory
-    val outputDirectory: Property<File> = project.objects.safeProperty<File>()
-        .safeConvention(project.provider { defaultDokkaOutputDirectory() })
+    val outputDirectory: Property<File> = project.objects.property<File>()
+        .convention(project.provider { defaultDokkaOutputDirectory() })
 
     /**
      * Configuration for Dokka plugins. This property is not expected to be used directly - if possible, use
@@ -103,8 +104,8 @@ abstract class AbstractDokkaTask : DefaultTask() {
      * Default is `true`
      */
     @Input
-    val suppressObviousFunctions: Property<Boolean> = project.objects.safeProperty<Boolean>()
-        .safeConvention(DokkaDefaults.suppressObviousFunctions)
+    val suppressObviousFunctions: Property<Boolean> = project.objects.property<Boolean>()
+        .convention(DokkaDefaults.suppressObviousFunctions)
 
     /**
      * Whether to suppress inherited members that aren't explicitly overridden in a given class.
@@ -116,8 +117,8 @@ abstract class AbstractDokkaTask : DefaultTask() {
      * Default is `false`.
      */
     @Input
-    val suppressInheritedMembers: Property<Boolean> = project.objects.safeProperty<Boolean>()
-        .safeConvention(DokkaDefaults.suppressInheritedMembers)
+    val suppressInheritedMembers: Property<Boolean> = project.objects.property<Boolean>()
+        .convention(DokkaDefaults.suppressInheritedMembers)
 
     /**
      * Whether to resolve remote files/links over network.
@@ -135,8 +136,8 @@ abstract class AbstractDokkaTask : DefaultTask() {
      * Default is `false`.
      */
     @Input
-    val offlineMode: Property<Boolean> = project.objects.safeProperty<Boolean>()
-        .safeConvention(DokkaDefaults.offlineMode)
+    val offlineMode: Property<Boolean> = project.objects.property<Boolean>()
+        .convention(DokkaDefaults.offlineMode)
 
     /**
      * Whether to fail documentation generation if Dokka has emitted a warning or an error.
@@ -147,13 +148,13 @@ abstract class AbstractDokkaTask : DefaultTask() {
      * Default is `false`.
      */
     @Input
-    val failOnWarning: Property<Boolean> = project.objects.safeProperty<Boolean>()
-        .safeConvention(DokkaDefaults.failOnWarning)
+    val failOnWarning: Property<Boolean> = project.objects.property<Boolean>()
+        .convention(DokkaDefaults.failOnWarning)
 
     @Optional
     @InputDirectory
     @PathSensitive(PathSensitivity.RELATIVE)
-    val cacheRoot: Property<File?> = project.objects.safeProperty()
+    val cacheRoot: Property<File?> = project.objects.property()
 
     /**
      * Type-safe configuration for a Dokka plugin.
@@ -231,13 +232,13 @@ abstract class AbstractDokkaTask : DefaultTask() {
     }
 
     internal fun buildPluginsConfiguration(): List<PluginConfigurationImpl> {
-        val manuallyConfigured = pluginsMapConfiguration.getSafe().entries.map { entry ->
+        val manuallyConfigured = pluginsMapConfiguration.get().entries.map { entry ->
             PluginConfigurationImpl(
                 entry.key,
                 DokkaConfiguration.SerializationFormat.JSON,
                 entry.value
             )
         }
-        return pluginsConfiguration.getSafe().mapNotNull { it as? PluginConfigurationImpl } + manuallyConfigured
+        return pluginsConfiguration.get().mapNotNull { it as? PluginConfigurationImpl } + manuallyConfigured
     }
 }

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/DokkaCollectorTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/DokkaCollectorTask.kt
@@ -15,15 +15,15 @@ abstract class DokkaCollectorTask : AbstractDokkaParentTask() {
 
     override fun buildDokkaConfiguration(): DokkaConfigurationImpl {
         val initialDokkaConfiguration = DokkaConfigurationImpl(
-            moduleName = moduleName.getSafe(),
-            outputDir = outputDirectory.getSafe(),
-            cacheRoot = cacheRoot.getSafe(),
-            failOnWarning = failOnWarning.getSafe(),
-            offlineMode = offlineMode.getSafe(),
+            moduleName = moduleName.get(),
+            outputDir = outputDirectory.get(),
+            cacheRoot = cacheRoot.get(),
+            failOnWarning = failOnWarning.get(),
+            offlineMode = offlineMode.get(),
             pluginsClasspath = plugins.resolve().toList(),
             pluginsConfiguration = buildPluginsConfiguration(),
-            suppressObviousFunctions = suppressObviousFunctions.getSafe(),
-            suppressInheritedMembers = suppressInheritedMembers.getSafe(),
+            suppressObviousFunctions = suppressObviousFunctions.get(),
+            suppressInheritedMembers = suppressInheritedMembers.get(),
         )
 
         val subprojectDokkaConfigurations = childDokkaTasks.map { dokkaTask -> dokkaTask.buildDokkaConfiguration() }

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/DokkaCollectorTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/DokkaCollectorTask.kt
@@ -17,7 +17,7 @@ abstract class DokkaCollectorTask : AbstractDokkaParentTask() {
         val initialDokkaConfiguration = DokkaConfigurationImpl(
             moduleName = moduleName.get(),
             outputDir = outputDirectory.get(),
-            cacheRoot = cacheRoot.get(),
+            cacheRoot = cacheRoot.orNull,
             failOnWarning = failOnWarning.get(),
             offlineMode = offlineMode.get(),
             pluginsClasspath = plugins.resolve().toList(),

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/DokkaMultiModuleTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/DokkaMultiModuleTask.kt
@@ -6,6 +6,7 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.internal.tasks.TaskDependencyInternal
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
+import org.gradle.kotlin.dsl.property
 import org.jetbrains.dokka.DokkaConfigurationImpl
 import org.jetbrains.dokka.DokkaModuleDescriptionImpl
 import java.io.File
@@ -51,13 +52,13 @@ abstract class DokkaMultiModuleTask : AbstractDokkaParentTask() {
     val includes: ConfigurableFileCollection = project.files()
 
     @Internal
-    val fileLayout: Property<DokkaMultiModuleFileLayout> = project.objects.safeProperty<DokkaMultiModuleFileLayout>()
-        .safeConvention(DokkaMultiModuleFileLayout.CompactInParent)
+    val fileLayout: Property<DokkaMultiModuleFileLayout> = project.objects.property<DokkaMultiModuleFileLayout>()
+        .convention(DokkaMultiModuleFileLayout.CompactInParent)
 
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
     internal val sourceChildOutputDirectories: Iterable<File>
-        get() = childDokkaTasks.map { task -> task.outputDirectory.getSafe() }
+        get() = childDokkaTasks.map { task -> task.outputDirectory.get() }
 
     @get:OutputDirectories
     internal val targetChildOutputDirectories: Iterable<File>
@@ -83,20 +84,20 @@ abstract class DokkaMultiModuleTask : AbstractDokkaParentTask() {
     }
 
     override fun buildDokkaConfiguration(): DokkaConfigurationImpl = DokkaConfigurationImpl(
-        moduleName = moduleName.getSafe(),
+        moduleName = moduleName.get(),
         moduleVersion = moduleVersion.getValidVersionOrNull(),
-        outputDir = outputDirectory.getSafe(),
-        cacheRoot = cacheRoot.getSafe(),
+        outputDir = outputDirectory.get(),
+        cacheRoot = cacheRoot.orNull,
         pluginsConfiguration = buildPluginsConfiguration(),
-        failOnWarning = failOnWarning.getSafe(),
-        offlineMode = offlineMode.getSafe(),
+        failOnWarning = failOnWarning.get(),
+        offlineMode = offlineMode.get(),
         pluginsClasspath = plugins.resolve().toList(),
         modules = childDokkaTasks.map { dokkaTask ->
             DokkaModuleDescriptionImpl(
-                name = dokkaTask.moduleName.getSafe(),
-                relativePathToOutputDirectory = targetChildOutputDirectory(dokkaTask).relativeTo(outputDirectory.getSafe()),
+                name = dokkaTask.moduleName.get(),
+                relativePathToOutputDirectory = targetChildOutputDirectory(dokkaTask).relativeTo(outputDirectory.get()),
                 includes = childDokkaTaskIncludes[dokkaTask.path].orEmpty(),
-                sourceOutputDirectory = dokkaTask.outputDirectory.getSafe()
+                sourceOutputDirectory = dokkaTask.outputDirectory.get()
             )
         },
         includes = includes.toSet(),

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/DokkaTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/DokkaTask.kt
@@ -10,16 +10,16 @@ import org.gradle.api.tasks.*
 abstract class DokkaTask : AbstractDokkaLeafTask() {
     override fun buildDokkaConfiguration(): DokkaConfigurationImpl =
         DokkaConfigurationImpl(
-            moduleName = moduleName.getSafe(),
+            moduleName = moduleName.get(),
             moduleVersion = moduleVersion.getValidVersionOrNull(),
-            outputDir = outputDirectory.getSafe(),
-            cacheRoot = cacheRoot.getSafe(),
-            offlineMode = offlineMode.getSafe(),
-            failOnWarning = failOnWarning.getSafe(),
+            outputDir = outputDirectory.get(),
+            cacheRoot = cacheRoot.orNull,
+            offlineMode = offlineMode.get(),
+            failOnWarning = failOnWarning.get(),
             sourceSets = unsuppressedSourceSets.build(),
             pluginsConfiguration = buildPluginsConfiguration(),
             pluginsClasspath = plugins.resolve().toList(),
-            suppressObviousFunctions = suppressObviousFunctions.getSafe(),
-            suppressInheritedMembers = suppressInheritedMembers.getSafe(),
+            suppressObviousFunctions = suppressObviousFunctions.get(),
+            suppressInheritedMembers = suppressInheritedMembers.get(),
         )
 }

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/DokkaTaskPartial.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/DokkaTaskPartial.kt
@@ -11,18 +11,18 @@ abstract class DokkaTaskPartial : AbstractDokkaLeafTask() {
 
     override fun buildDokkaConfiguration(): DokkaConfigurationImpl {
         return DokkaConfigurationImpl(
-            moduleName = moduleName.getSafe(),
+            moduleName = moduleName.get(),
             moduleVersion = moduleVersion.orNull,
-            outputDir = outputDirectory.getSafe(),
-            cacheRoot = cacheRoot.getSafe(),
-            offlineMode = offlineMode.getSafe(),
-            failOnWarning = failOnWarning.getSafe(),
+            outputDir = outputDirectory.get(),
+            cacheRoot = cacheRoot.orNull,
+            offlineMode = offlineMode.get(),
+            failOnWarning = failOnWarning.get(),
             sourceSets = unsuppressedSourceSets.build(),
             pluginsConfiguration = buildPluginsConfiguration(),
             pluginsClasspath = plugins.resolve().toList(),
             delayTemplateSubstitution = true,
-            suppressObviousFunctions = suppressObviousFunctions.getSafe(),
-            suppressInheritedMembers = suppressInheritedMembers.getSafe(),
+            suppressObviousFunctions = suppressObviousFunctions.get(),
+            suppressInheritedMembers = suppressInheritedMembers.get(),
         )
     }
 }

--- a/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/AndroidAutoConfigurationTest.kt
+++ b/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/AndroidAutoConfigurationTest.kt
@@ -49,12 +49,12 @@ class AndroidAutoConfigurationTest {
         dokkaTasks.flatMap { it.dokkaSourceSets }.forEach { sourceSet ->
             if ("test" in sourceSet.name.toLowerCase()) {
                 assertTrue(
-                    sourceSet.suppress.getSafe(),
+                    sourceSet.suppress.get(),
                     "Expected source set `${sourceSet.name}` to be suppressed by default"
                 )
             } else {
                 assertFalse(
-                    sourceSet.suppress.getSafe(),
+                    sourceSet.suppress.get(),
                     "Expected source set `${sourceSet.name}`to not be suppressed by default"
                 )
             }

--- a/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaMultiModuleFileLayoutTest.kt
+++ b/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaMultiModuleFileLayoutTest.kt
@@ -38,7 +38,7 @@ class DokkaMultiModuleFileLayoutTest {
 
         val targetOutputDirectory = CompactInParent.targetChildOutputDirectory(parentTask, childTask)
         assertEquals(
-            parentTask.outputDirectory.getSafe().resolve("intermediate/child"), targetOutputDirectory,
+            parentTask.outputDirectory.get().resolve("intermediate/child"), targetOutputDirectory,
             "Expected nested file structure representing project structure"
         )
     }
@@ -50,7 +50,7 @@ class DokkaMultiModuleFileLayoutTest {
         val childTask = project.tasks.create<DokkaTask>("child")
         val parentTask = project.tasks.create<DokkaMultiModuleTask>("parent")
 
-        val sourceOutputDirectory = childTask.outputDirectory.getSafe()
+        val sourceOutputDirectory = childTask.outputDirectory.get()
         sourceOutputDirectory.mkdirs()
         sourceOutputDirectory.resolve("some.file").writeText("some text")
         val subFolder = sourceOutputDirectory.resolve("subFolder")
@@ -102,7 +102,7 @@ class DokkaMultiModuleFileLayoutTest {
         val childTask = project.tasks.create<DokkaTask>("child")
         val parentTask = project.tasks.create<DokkaMultiModuleTask>("parent")
         parentTask.fileLayout.set(DokkaMultiModuleFileLayout { _, child ->
-            child.outputDirectory.getSafe().resolve("subfolder")
+            child.outputDirectory.get().resolve("subfolder")
         })
         assertFailsWith<DokkaException> { parentTask.copyChildOutputDirectory(childTask) }
     }

--- a/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/GradleDokkaSourceSetBuilderTest.kt
+++ b/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/GradleDokkaSourceSetBuilderTest.kt
@@ -52,7 +52,7 @@ class GradleDokkaSourceSetBuilderTest {
     fun displayName() {
         val sourceSet = GradleDokkaSourceSetBuilder("myName", project)
         assertNull(
-            sourceSet.displayName.getSafe(),
+            sourceSet.displayName.orNull,
             "Expected no ${GradleDokkaSourceSetBuilder::displayName.name} being set by default"
         )
 
@@ -361,7 +361,7 @@ class GradleDokkaSourceSetBuilderTest {
     @Test
     fun noStdlibLink() {
         val sourceSet = GradleDokkaSourceSetBuilder("", project)
-        assertFalse(sourceSet.noStdlibLink.getSafe(), "Expected 'noStdlibLink' to be set to false by default")
+        assertFalse(sourceSet.noStdlibLink.get(), "Expected 'noStdlibLink' to be set to false by default")
 
         assertEquals(1, sourceSet.build().externalDocumentationLinks.count {
             "https://kotlinlang.org/api" in it.url.toURI().toString()
@@ -379,7 +379,7 @@ class GradleDokkaSourceSetBuilderTest {
     @Test
     fun noJdkLink() {
         val sourceSet = GradleDokkaSourceSetBuilder("", project)
-        assertFalse(sourceSet.noJdkLink.getSafe(), "Expected 'noJdkLink' to be set to false by default")
+        assertFalse(sourceSet.noJdkLink.get(), "Expected 'noJdkLink' to be set to false by default")
 
         assertEquals(1, sourceSet.build().externalDocumentationLinks.count {
             "https://docs.oracle.com/" in it.url.toURI().toString()
@@ -398,7 +398,7 @@ class GradleDokkaSourceSetBuilderTest {
     @Test
     fun noAndroidSdkLink() {
         val sourceSet = GradleDokkaSourceSetBuilder("", project)
-        assertFalse(sourceSet.noAndroidSdkLink.getSafe(), "Expected 'noAndroidSdkLink' to be set to false by default")
+        assertFalse(sourceSet.noAndroidSdkLink.get(), "Expected 'noAndroidSdkLink' to be set to false by default")
 
         assertEquals(0, sourceSet.build().externalDocumentationLinks.count {
             "https://developer.android.com/reference" in it.url.toURI().toString()

--- a/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/KotlinDslDokkaTaskConfigurationTest.kt
+++ b/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/KotlinDslDokkaTaskConfigurationTest.kt
@@ -18,7 +18,7 @@ class KotlinDslDokkaTaskConfigurationTest {
         }
 
         project.tasks.withType(DokkaTask::class.java).forEach { dokkaTask ->
-            assertEquals(File("test"), dokkaTask.outputDirectory.getSafe())
+            assertEquals(File("test"), dokkaTask.outputDirectory.get())
         }
     }
 

--- a/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/KotlinSourceSetGistTest.kt
+++ b/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/KotlinSourceSetGistTest.kt
@@ -30,12 +30,12 @@ class KotlinSourceSetGistTest {
         )
 
         assertEquals(
-            KotlinPlatformType.jvm, mainSourceSetGist.platform.getSafe(),
+            KotlinPlatformType.jvm, mainSourceSetGist.platform.get(),
             "Expected correct platform"
         )
 
         assertTrue(
-            mainSourceSetGist.isMain.getSafe(),
+            mainSourceSetGist.isMain.get(),
             "Expected main sources to be marked as 'isMain'"
         )
 
@@ -55,7 +55,7 @@ class KotlinSourceSetGistTest {
         val testSourceSetGist = project.gistOf(testSourceSet)
 
         assertFalse(
-            testSourceSetGist.isMain.getSafe(),
+            testSourceSetGist.isMain.get(),
             "Expected test source set not being marked as 'isMain'"
         )
 
@@ -138,7 +138,7 @@ class KotlinSourceSetGistTest {
         }
 
         assertEquals(
-            emptySet(), mainSourceSetGist.classpath.getSafe().files,
+            emptySet(), mainSourceSetGist.classpath.get().files,
             "Expected no files on the classpath, since no file exists"
         )
 
@@ -149,7 +149,7 @@ class KotlinSourceSetGistTest {
         check(runtimeOnlyJar.createNewFile())
 
         assertEquals(
-            setOf(implementationJar, compileOnlyJar, apiJar), mainSourceSetGist.classpath.getSafe().files,
+            setOf(implementationJar, compileOnlyJar, apiJar), mainSourceSetGist.classpath.get().files,
             "Expected implementation, compileOnly and api dependencies on classpath"
         )
     }
@@ -187,47 +187,47 @@ class KotlinSourceSetGistTest {
         )
 
         assertEquals(
-            KotlinPlatformType.common, commonMainSourceSetGist.platform.getSafe(),
+            KotlinPlatformType.common, commonMainSourceSetGist.platform.get(),
             "Expected common platform for commonMain source set"
         )
 
         assertEquals(
-            KotlinPlatformType.jvm, jvmMainSourceSetGist.platform.getSafe(),
+            KotlinPlatformType.jvm, jvmMainSourceSetGist.platform.get(),
             "Expected jvm platform for jvmMain source set"
         )
 
         assertEquals(
-            KotlinPlatformType.native, macosMainSourceSetGist.platform.getSafe(),
+            KotlinPlatformType.native, macosMainSourceSetGist.platform.get(),
             "Expected native platform for macosMain source set"
         )
 
         assertTrue(
-            commonMainSourceSetGist.isMain.getSafe(),
+            commonMainSourceSetGist.isMain.get(),
             "Expected commonMain to be marked with 'isMain'"
         )
 
         assertTrue(
-            jvmMainSourceSetGist.isMain.getSafe(),
+            jvmMainSourceSetGist.isMain.get(),
             "Expected jvmMain to be marked with 'isMain'"
         )
 
         assertTrue(
-            macosMainSourceSetGist.isMain.getSafe(),
+            macosMainSourceSetGist.isMain.get(),
             "Expected macosMain to be marked with 'isMain'"
         )
 
         assertFalse(
-            project.gistOf(kotlin.sourceSets["commonTest"]).isMain.getSafe(),
+            project.gistOf(kotlin.sourceSets["commonTest"]).isMain.get(),
             "Expected commonTest not being marked with 'isMain'"
         )
 
         assertFalse(
-            project.gistOf(kotlin.sourceSets["jvmTest"]).isMain.getSafe(),
+            project.gistOf(kotlin.sourceSets["jvmTest"]).isMain.get(),
             "Expected jvmTest not being marked with 'isMain'"
         )
 
         assertFalse(
-            project.gistOf(kotlin.sourceSets["macosTest"]).isMain.getSafe(),
+            project.gistOf(kotlin.sourceSets["macosTest"]).isMain.get(),
             "Expected macosTest not being marked with 'isMain'"
         )
 

--- a/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/tasks/DokkaMultiModuleTaskTest.kt
+++ b/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/tasks/DokkaMultiModuleTaskTest.kt
@@ -101,7 +101,7 @@ class DokkaMultiModuleTaskTest {
                         name = "child",
                         relativePathToOutputDirectory = File("child"),
                         includes = setOf(include1, include2),
-                        sourceOutputDirectory = childDokkaTask.outputDirectory.getSafe()
+                        sourceOutputDirectory = childDokkaTask.outputDirectory.get()
                     )
                 )
             ),


### PR DESCRIPTION
Part of #2700 


This PR removes some of the custom Gradle utility functions that are now provided by the Gradle Kotlin DSL. 

* `getSafe()` ➡️ `get()`, or `orNull`
* `safeProperty()` ➡️ `org.gradle.kotlin.dsl.property()`
* `safeConvention()` ➡️ `convention()`

The benefit is closer alignment with the Gradle API, and more idiomatic code that helps with working with the Gradle plugin, as the code can be understood without needing to know about the custom utilities specific to Dokka.

This PR is similar to #2706.


Depends on 

* #2702
* #2705 
* #2706 