### PR TITLE
Gradle Plugin: Remove 'by' property setter helper function

### DIFF
--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/GradleDokkaSourceSetBuilder.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/GradleDokkaSourceSetBuilder.kt
@@ -465,9 +465,9 @@ open class GradleDokkaSourceSetBuilder(
     fun externalDocumentationLink(url: URL, packageListUrl: URL? = null) {
         externalDocumentationLinks.add(
             GradleExternalDocumentationLinkBuilder(project).apply {
-                this.url by url
+                this.url.convention(url)
                 if (packageListUrl != null) {
-                    this.packageListUrl by packageListUrl
+                    this.packageListUrl.convention(packageListUrl)
                 }
             }
         )
@@ -475,4 +475,3 @@ open class GradleDokkaSourceSetBuilder(
 
     override fun build(): DokkaSourceSetImpl = toDokkaSourceSetImpl()
 }
-

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/sourceSetKotlinGistConfiguration.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/sourceSetKotlinGistConfiguration.kt
@@ -14,15 +14,15 @@ internal fun GradleDokkaSourceSetBuilder.configureWithKotlinSourceSetGist(source
         sourceSetNames.map { sourceSetName -> DokkaSourceSetID(sourceSetName) }
     }
 
-    this.suppress by sourceSet.isMain.map { !it }
+    this.suppress.convention(sourceSet.isMain.map { !it })
     this.sourceRoots.from(sourceSet.sourceRoots)
     this.classpath.from(sourceSet.classpath)
-    this.platform by sourceSet.platform.map { Platform.fromString(it.name) }
-    this.dependentSourceSets by dependentSourceSetIds
-    this.displayName by sourceSet.platform.map { platform ->
+    this.platform.convention(sourceSet.platform.map { Platform.fromString(it.name) })
+    this.dependentSourceSets.convention(dependentSourceSetIds)
+    this.displayName.convention(sourceSet.platform.map { platform ->
         sourceSet.name.substringBeforeLast(
             delimiter = "Main",
             missingDelimiterValue = platform.name
         )
-    }
+    })
 }

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/utils.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/utils.kt
@@ -3,30 +3,13 @@ package org.jetbrains.dokka.gradle
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.UnknownDomainObjectException
-import org.gradle.api.provider.HasMultipleValues
-import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
 import org.gradle.util.Path
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 
-internal infix fun <T> Property<T>.by(value: T?) {
-    this.set(value)
-}
 
-internal infix fun <T> Property<T>.by(value: Provider<T>) {
-    this.set(value)
-}
-
-internal infix fun <T> HasMultipleValues<in T>.by(values: Iterable<T>) {
-    this.set(values)
-}
-
-internal infix fun <T> HasMultipleValues<in T>.by(values: Provider<out Iterable<T>>) {
-    this.set(values)
-}
-
+/** Parse a Gradle path, e.g. `:project:subproject:taskName` */
 internal fun parsePath(path: String): Path = Path.path(path)
 
 internal val Project.kotlinOrNull: KotlinProjectExtension?

--- a/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/CheckSourceSetDependenciesTest.kt
+++ b/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/CheckSourceSetDependenciesTest.kt
@@ -50,7 +50,7 @@ class CheckSourceSetDependenciesTest {
             GradleDokkaSourceSetBuilder("common", project),
             GradleDokkaSourceSetBuilder("intermediate", project).apply {
                 dependsOn("common")
-                suppress by true
+                suppress.set(true)
             },
             GradleDokkaSourceSetBuilder("jvm", project).apply {
                 dependsOn("intermediate")

--- a/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaCollectorTaskTest.kt
+++ b/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaCollectorTaskTest.kt
@@ -33,11 +33,11 @@ class DokkaCollectorTaskTest {
 
         val collectorTasks = rootProject.tasks.withType<DokkaCollectorTask>()
         collectorTasks.configureEach { task ->
-            task.moduleName by "custom Module Name"
-            task.outputDirectory by File("customOutputDirectory")
-            task.cacheRoot by File("customCacheRoot")
-            task.failOnWarning by true
-            task.offlineMode by true
+            task.moduleName.set("custom Module Name")
+            task.outputDirectory.set(File("customOutputDirectory"))
+            task.cacheRoot.set(File("customCacheRoot"))
+            task.failOnWarning.set(true)
+            task.offlineMode.set(true)
         }
 
         assertTrue(collectorTasks.isNotEmpty(), "Expected at least one collector task")

--- a/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaConfigurationJsonTest.kt
+++ b/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaConfigurationJsonTest.kt
@@ -1,10 +1,11 @@
-@file:Suppress("UnstableApiUsage")
-
 package org.jetbrains.dokka.gradle
 
 import org.gradle.kotlin.dsl.withType
 import org.gradle.testfixtures.ProjectBuilder
-import org.jetbrains.dokka.*
+import org.jetbrains.dokka.DokkaConfiguration
+import org.jetbrains.dokka.DokkaConfigurationImpl
+import org.jetbrains.dokka.PluginConfigurationImpl
+import org.jetbrains.dokka.toJsonString
 import java.io.File
 import java.net.URL
 import kotlin.test.Test
@@ -21,25 +22,29 @@ class DokkaConfigurationJsonTest {
             dependencies.clear()
         }
         dokkaTask.apply {
-            this.failOnWarning by true
-            this.offlineMode by true
-            this.outputDirectory by File("customOutputDir")
-            this.cacheRoot by File("customCacheRoot")
-            this.pluginsConfiguration.add(PluginConfigurationImpl("A", DokkaConfiguration.SerializationFormat.JSON, """ { "key" : "value1" } """))
-            this.pluginsConfiguration.add(PluginConfigurationImpl("B", DokkaConfiguration.SerializationFormat.JSON, """ { "key" : "value2" } """))
+            this.failOnWarning.set(true)
+            this.offlineMode.set(true)
+            this.outputDirectory.set(File("customOutputDir"))
+            this.cacheRoot.set(File("customCacheRoot"))
+            this.pluginsConfiguration.add(
+                PluginConfigurationImpl("A", DokkaConfiguration.SerializationFormat.JSON, """ { "key" : "value1" } """)
+            )
+            this.pluginsConfiguration.add(
+                PluginConfigurationImpl("B", DokkaConfiguration.SerializationFormat.JSON, """ { "key" : "value2" } """)
+            )
             this.dokkaSourceSets.create("main") { sourceSet ->
-                sourceSet.displayName by "customSourceSetDisplayName"
-                sourceSet.reportUndocumented by true
+                sourceSet.displayName.set("customSourceSetDisplayName")
+                sourceSet.reportUndocumented.set(true)
 
                 sourceSet.externalDocumentationLink { link ->
-                    link.packageListUrl by URL("http://some.url")
-                    link.url by URL("http://some.other.url")
+                    link.packageListUrl.set(URL("http://some.url"))
+                    link.url.set(URL("http://some.other.url"))
                 }
                 sourceSet.perPackageOption { packageOption ->
-                    packageOption.includeNonPublic by true
-                    packageOption.reportUndocumented by true
-                    packageOption.skipDeprecated by true
-                    packageOption.documentedVisibilities by setOf(DokkaConfiguration.Visibility.PRIVATE)
+                    packageOption.includeNonPublic.set(true)
+                    packageOption.reportUndocumented.set(true)
+                    packageOption.skipDeprecated.set(true)
+                    packageOption.documentedVisibilities.set(setOf(DokkaConfiguration.Visibility.PRIVATE))
                 }
             }
         }

--- a/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaConfigurationSerializableTest.kt
+++ b/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaConfigurationSerializableTest.kt
@@ -29,26 +29,26 @@ class DokkaConfigurationSerializableTest {
             dependencies.clear()
         }
         dokkaTask.apply {
-            this.failOnWarning by true
-            this.offlineMode by true
-            this.outputDirectory by File("customOutputDir")
-            this.cacheRoot by File("customCacheRoot")
+            this.failOnWarning.set(true)
+            this.offlineMode.set(true)
+            this.outputDirectory.set(File("customOutputDir"))
+            this.cacheRoot.set(File("customCacheRoot"))
             this.pluginsConfiguration.add(PluginConfigurationImpl("A", DokkaConfiguration.SerializationFormat.JSON, """ { "key" : "value1" } """))
             this.pluginsConfiguration.add(PluginConfigurationImpl("B", DokkaConfiguration.SerializationFormat.JSON, """ { "key" : "value2" } """))
             this.dokkaSourceSets.create("main") { sourceSet ->
-                sourceSet.displayName by "customSourceSetDisplayName"
-                sourceSet.reportUndocumented by true
+                sourceSet.displayName.set("customSourceSetDisplayName")
+                sourceSet.reportUndocumented.set(true)
 
                 sourceSet.externalDocumentationLink { link ->
-                    link.packageListUrl by URL("http://some.url")
-                    link.url by URL("http://some.other.url")
+                    link.packageListUrl.set(URL("http://some.url"))
+                    link.url.set(URL("http://some.other.url"))
                 }
 
                 sourceSet.perPackageOption { packageOption ->
-                    packageOption.includeNonPublic by true
-                    packageOption.reportUndocumented by true
-                    packageOption.skipDeprecated by true
-                    packageOption.documentedVisibilities by setOf(DokkaConfiguration.Visibility.PRIVATE)
+                    packageOption.includeNonPublic.set(true)
+                    packageOption.reportUndocumented.set(true)
+                    packageOption.skipDeprecated.set(true)
+                    packageOption.documentedVisibilities.set(setOf(DokkaConfiguration.Visibility.PRIVATE))
                 }
             }
         }

--- a/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaMultiModuleFileLayoutTest.kt
+++ b/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaMultiModuleFileLayoutTest.kt
@@ -18,7 +18,7 @@ class DokkaMultiModuleFileLayoutTest {
         val project = ProjectBuilder.builder().build()
         val child = project.tasks.create<DokkaTask>("child")
         val parent = project.tasks.create<DokkaMultiModuleTask>("parent")
-        child.outputDirectory by File("some/path")
+        child.outputDirectory.set(File("some/path"))
 
         assertEquals(
             File("some/path"), NoCopy.targetChildOutputDirectory(parent, child),
@@ -57,11 +57,7 @@ class DokkaMultiModuleFileLayoutTest {
         subFolder.mkdirs()
         subFolder.resolve("other.file").writeText("other text")
 
-        parentTask.fileLayout by object : DokkaMultiModuleFileLayout {
-            override fun targetChildOutputDirectory(parent: DokkaMultiModuleTask, child: AbstractDokkaTask): File {
-                return parent.project.file("target/output")
-            }
-        }
+        parentTask.fileLayout.set(DokkaMultiModuleFileLayout { parent, _ -> parent.project.file("target/output") })
         parentTask.copyChildOutputDirectory(childTask)
 
         /* Assertions */
@@ -105,9 +101,9 @@ class DokkaMultiModuleFileLayoutTest {
         val project = ProjectBuilder.builder().build()
         val childTask = project.tasks.create<DokkaTask>("child")
         val parentTask = project.tasks.create<DokkaMultiModuleTask>("parent")
-        parentTask.fileLayout by DokkaMultiModuleFileLayout { _, child ->
+        parentTask.fileLayout.set(DokkaMultiModuleFileLayout { _, child ->
             child.outputDirectory.getSafe().resolve("subfolder")
-        }
+        })
         assertFailsWith<DokkaException> { parentTask.copyChildOutputDirectory(childTask) }
     }
 
@@ -116,7 +112,7 @@ class DokkaMultiModuleFileLayoutTest {
         val project = ProjectBuilder.builder().build()
         val childTask = project.tasks.create<DokkaTask>("child")
         val parentTask = project.tasks.create<DokkaMultiModuleTask>("parent")
-        parentTask.fileLayout by NoCopy
+        parentTask.fileLayout.set(NoCopy)
         parentTask.copyChildOutputDirectory(childTask)
     }
 }

--- a/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaMultiModuleTaskTest.kt
+++ b/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaMultiModuleTaskTest.kt
@@ -61,13 +61,19 @@ class DokkaMultiModuleTaskTest {
         }
 
         multiModuleTask.apply {
-            moduleVersion by "1.5.0"
-            moduleName by "custom Module Name"
-            outputDirectory by project.buildDir.resolve("customOutputDirectory")
-            cacheRoot by File("customCacheRoot")
-            pluginsConfiguration.add(PluginConfigurationImpl("pluginA", DokkaConfiguration.SerializationFormat.JSON, """ { "key" : "value2" } """))
-            failOnWarning by true
-            offlineMode by true
+            moduleVersion.set("1.5.0")
+            moduleName.set("custom Module Name")
+            outputDirectory.set(project.buildDir.resolve("customOutputDirectory"))
+            cacheRoot.set(File("customCacheRoot"))
+            pluginsConfiguration.add(
+                PluginConfigurationImpl(
+                    "pluginA",
+                    DokkaConfiguration.SerializationFormat.JSON,
+                    """ { "key" : "value2" } """
+                )
+            )
+            failOnWarning.set(true)
+            offlineMode.set(true)
             includes.from(listOf(topLevelInclude))
         }
 
@@ -78,7 +84,13 @@ class DokkaMultiModuleTaskTest {
                 moduleVersion = "1.5.0",
                 outputDir = multiModuleTask.project.buildDir.resolve("customOutputDirectory"),
                 cacheRoot = File("customCacheRoot"),
-                pluginsConfiguration = mutableListOf(PluginConfigurationImpl("pluginA", DokkaConfiguration.SerializationFormat.JSON, """ { "key" : "value2" } """)),
+                pluginsConfiguration = mutableListOf(
+                    PluginConfigurationImpl(
+                        "pluginA",
+                        DokkaConfiguration.SerializationFormat.JSON,
+                        """ { "key" : "value2" } """
+                    )
+                ),
                 pluginsClasspath = emptyList(),
                 failOnWarning = true,
                 offlineMode = true,
@@ -97,14 +109,14 @@ class DokkaMultiModuleTaskTest {
     }
 
     @Test
-    fun `multimodule task should not include unspecified version`(){
+    fun `multimodule task should not include unspecified version`() {
         childDokkaTask.apply {
             dokkaSourceSets.create("main")
             dokkaSourceSets.create("test")
         }
 
         multiModuleTask.apply {
-            moduleVersion by "unspecified"
+            moduleVersion.set("unspecified")
         }
 
         val dokkaConfiguration = multiModuleTask.buildDokkaConfiguration()
@@ -117,7 +129,10 @@ class DokkaMultiModuleTaskTest {
         assertEquals(1, dependenciesInitial.size, "Expected one dependency")
         val dependency = dependenciesInitial.single()
 
-        assertTrue(dependency is DokkaTaskPartial, "Expected dependency to be of Type ${DokkaTaskPartial::class.simpleName}")
+        assertTrue(
+            dependency is DokkaTaskPartial,
+            "Expected dependency to be of Type ${DokkaTaskPartial::class.simpleName}"
+        )
         assertEquals(childProject, dependency.project, "Expected dependency from child project")
 
 
@@ -184,7 +199,7 @@ class DokkaMultiModuleTaskTest {
         val childTask = child.tasks.create<DokkaTask>("child")
 
         parentTask.addChildTask(childTask)
-        childTask.outputDirectory by child.file("custom/output")
+        childTask.outputDirectory.set(child.file("custom/output"))
 
         assertEquals(
             listOf(parent.file("child/custom/output")), parentTask.sourceChildOutputDirectories,
@@ -202,10 +217,9 @@ class DokkaMultiModuleTaskTest {
 
         parentTask.addChildTask(childTask)
 
-        @Suppress("NAME_SHADOWING") // ¯\_(ツ)_/¯
-        parentTask.fileLayout by DokkaMultiModuleFileLayout { parent, child ->
-            parent.project.buildDir.resolve(child.name)
-        }
+        parentTask.fileLayout.set(DokkaMultiModuleFileLayout { taskParent, taskChild ->
+            taskParent.project.buildDir.resolve(taskChild.name)
+        })
 
         assertEquals(
             listOf(parent.project.buildDir.resolve("child")), parentTask.targetChildOutputDirectories,

--- a/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaTaskTest.kt
+++ b/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaTaskTest.kt
@@ -16,7 +16,7 @@ class DokkaTaskTest {
         task.dokkaSourceSets.register("main")
         task.dokkaSourceSets.register("jvm")
         task.dokkaSourceSets.register("test") {
-            it.suppress by true
+            it.suppress.set(true)
         }
 
         assertEquals(

--- a/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/GradleDokkaSourceSetBuilderTest.kt
+++ b/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/GradleDokkaSourceSetBuilderTest.kt
@@ -62,8 +62,7 @@ class GradleDokkaSourceSetBuilderTest {
                     "after building source set with no ${GradleDokkaSourceSetBuilder::displayName.name} being set"
         )
 
-        sourceSet.displayName by "displayName"
-
+        sourceSet.displayName.set("displayName")
         assertEquals(
             "displayName", sourceSet.build().displayName,
             "Expected previously set ${GradleDokkaSourceSetBuilder::displayName.name} to be present after build"
@@ -220,21 +219,21 @@ class GradleDokkaSourceSetBuilderTest {
 
         sourceSet.sourceLinks.add(
             GradleSourceLinkBuilder(project).apply {
-                this.remoteLineSuffix by "ls1"
-                this.localDirectory by project.file("p1")
-                this.remoteUrl by URL("https://u1")
+                this.remoteLineSuffix.set("ls1")
+                this.localDirectory.set(project.file("p1"))
+                this.remoteUrl.set(URL("https://u1"))
             })
 
         sourceSet.sourceLink {
-            it.remoteLineSuffix by "ls2"
-            it.localDirectory by project.file("p2")
-            it.remoteUrl by URL("https://u2")
+            it.remoteLineSuffix.set("ls2")
+            it.localDirectory.set(project.file("p2"))
+            it.remoteUrl.set(URL("https://u2"))
         }
 
         sourceSet.sourceLink(project.closureOf<GradleSourceLinkBuilder> {
-            this.remoteLineSuffix by "ls3"
-            this.localDirectory by project.file("p3")
-            this.remoteUrl by URL("https://u3")
+            this.remoteLineSuffix.set("ls3")
+            this.localDirectory.set(project.file("p3"))
+            this.remoteUrl.set(URL("https://u3"))
         })
 
         assertEquals(
@@ -266,15 +265,15 @@ class GradleDokkaSourceSetBuilderTest {
         assertEquals(emptyList(), sourceSet.build().perPackageOptions, "Expected no default per package options")
 
         sourceSet.perPackageOptions.add(GradlePackageOptionsBuilder(project).apply {
-            this.matchingRegex by "p1.*"
+            this.matchingRegex.set("p1.*")
         })
 
         sourceSet.perPackageOption {
-            it.matchingRegex by "p2.*"
+            it.matchingRegex.set("p2.*")
         }
 
         sourceSet.perPackageOption(project.closureOf<GradlePackageOptionsBuilder> {
-            this.matchingRegex by "p3.*"
+            this.matchingRegex.set("p3.*")
         })
 
         assertEquals(
@@ -296,9 +295,9 @@ class GradleDokkaSourceSetBuilderTest {
     @Test
     fun externalDocumentationLink() {
         val sourceSet = GradleDokkaSourceSetBuilder("", project)
-        sourceSet.noAndroidSdkLink by true
-        sourceSet.noJdkLink by true
-        sourceSet.noStdlibLink by true
+        sourceSet.noAndroidSdkLink.set(true)
+        sourceSet.noJdkLink.set(true)
+        sourceSet.noStdlibLink.set(true)
         assertEquals(
             emptySet(), sourceSet.build().externalDocumentationLinks,
             "Expected no default external documentation links"
@@ -306,17 +305,17 @@ class GradleDokkaSourceSetBuilderTest {
 
         sourceSet.externalDocumentationLinks.add(
             GradleExternalDocumentationLinkBuilder(project).apply {
-                this.url by URL("https://u1")
-                this.packageListUrl by URL("https://pl1")
+                this.url.set(URL("https://u1"))
+                this.packageListUrl.set(URL("https://pl1"))
             }
         )
 
         sourceSet.externalDocumentationLink {
-            it.url by URL("https://u2")
+            it.url.set(URL("https://u2"))
         }
 
         sourceSet.externalDocumentationLink(project.closureOf<GradleExternalDocumentationLinkBuilder> {
-            url by URL("https://u3")
+            url.set(URL("https://u3"))
         })
 
         sourceSet.externalDocumentationLink(url = "https://u4", packageListUrl = "https://pl4")
@@ -340,7 +339,7 @@ class GradleDokkaSourceSetBuilderTest {
         val sourceSet = GradleDokkaSourceSetBuilder("", project)
         assertNull(sourceSet.build().languageVersion, "Expected no language version being set by default")
 
-        sourceSet.languageVersion by "JAVA_20"
+        sourceSet.languageVersion.set("JAVA_20")
         assertEquals(
             "JAVA_20", sourceSet.build().languageVersion,
             "Expected previously set language version to be present after build"
@@ -352,7 +351,7 @@ class GradleDokkaSourceSetBuilderTest {
         val sourceSet = GradleDokkaSourceSetBuilder("", project)
         assertNull(sourceSet.build().apiVersion, "Expected no api version being set by default")
 
-        sourceSet.apiVersion by "20"
+        sourceSet.apiVersion.set("20")
         assertEquals(
             "20", sourceSet.build().apiVersion,
             "Expected previously set api version to be present after build"
@@ -368,7 +367,7 @@ class GradleDokkaSourceSetBuilderTest {
             "https://kotlinlang.org/api" in it.url.toURI().toString()
         }, "Expected kotlin stdlib in external documentation links")
 
-        sourceSet.noStdlibLink by true
+        sourceSet.noStdlibLink.set(true)
 
         assertEquals(
             0, sourceSet.build().externalDocumentationLinks.count {
@@ -386,7 +385,7 @@ class GradleDokkaSourceSetBuilderTest {
             "https://docs.oracle.com/" in it.url.toURI().toString()
         }, "Expected java jdk in external documentation links")
 
-        sourceSet.noJdkLink by true
+        sourceSet.noJdkLink.set(true)
 
         assertEquals(
             0, sourceSet.build().externalDocumentationLinks.count {
@@ -417,18 +416,20 @@ class GradleDokkaSourceSetBuilderTest {
         }, "Expected android sdk in external documentation links")
 
         assertEquals(1, sourceSet.build().externalDocumentationLinks.count {
-            "https://developer.android.com/reference/kotlin/androidx/package-list" in it.packageListUrl.toURI().toString()
+            "https://developer.android.com/reference/kotlin/androidx/package-list" in it.packageListUrl.toURI()
+                .toString()
         }, "Expected androidx in external documentation links")
 
 
-        sourceSet.noAndroidSdkLink by true
+        sourceSet.noAndroidSdkLink.set(true)
 
         assertEquals(0, sourceSet.build().externalDocumentationLinks.count {
             "https://developer.android.com/reference" in it.url.toURI().toString()
         }, "Expected no android sdk in external documentation links")
 
         assertEquals(0, sourceSet.build().externalDocumentationLinks.count {
-            "https://developer.android.com/reference/kotlin/androidx/package-list" in it.packageListUrl.toURI().toString()
+            "https://developer.android.com/reference/kotlin/androidx/package-list" in it.packageListUrl.toURI()
+                .toString()
         }, "Expected no androidx in external documentation links")
     }
 
@@ -479,7 +480,7 @@ class GradleDokkaSourceSetBuilderTest {
         val sourceSet = GradleDokkaSourceSetBuilder("", project)
         assertEquals(Platform.DEFAULT, sourceSet.build().analysisPlatform, "Expected default platform if not specified")
 
-        sourceSet.platform by Platform.common
+        sourceSet.platform.set(Platform.common)
         assertEquals(
             Platform.common, sourceSet.build().analysisPlatform,
             "Expected previously set analysis platform being present after build"

--- a/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/KotlinDslDokkaTaskConfigurationTest.kt
+++ b/runners/gradle-plugin/src/test/kotlin/org/jetbrains/dokka/gradle/KotlinDslDokkaTaskConfigurationTest.kt
@@ -14,7 +14,7 @@ class KotlinDslDokkaTaskConfigurationTest {
         val project = ProjectBuilder.builder().build()
         project.plugins.apply("org.jetbrains.dokka")
         project.tasks.withType<DokkaTask>().configureEach {
-            it.outputDirectory by File("test")
+            it.outputDirectory.set(File("test"))
         }
 
         project.tasks.withType(DokkaTask::class.java).forEach { dokkaTask ->


### PR DESCRIPTION
(a new version of https://github.com/Kotlin/dokka/pull/2706)

Part of #2700 

I found these extension functions very confusing. I'm not sure what their purpose is. Do they only rename an existing function? 

It's confusing because 'by' is already a Kotlin keyword for delegation, but these extension functions don't do anything with delegation. I think using the normal `.set()` function makes the code more readable and understandable because `.set()` is a common Gradle function.

