### PR TITLE
Fill `packageName` and `classNames` for constructors from parent

### DIFF
--- a/plugins/base/src/test/kotlin/translators/DefaultPsiToDocumentableTranslatorTest.kt
+++ b/plugins/base/src/test/kotlin/translators/DefaultPsiToDocumentableTranslatorTest.kt
@@ -827,6 +827,29 @@ class DefaultPsiToDocumentableTranslatorTest : BaseAbstractTest() {
             }
         }
     }
+
+    @Test
+    fun `default constructor should get the package name`() {
+        testInline(
+            """
+            |/src/main/java/org/test/A.java
+            |package org.test;
+            |public class A {
+            |}
+        """.trimIndent(),
+            configuration
+        ) {
+            documentablesMergingStage = { module ->
+                val testedClass = module.findClasslike(packageName = "org.test", "A") as DClass
+
+                assertEquals(1, testedClass.constructors.size, "Expect 1 default constructor")
+
+                val constructorDRI = testedClass.constructors.first().dri
+                assertEquals("org.test", constructorDRI.packageName)
+                assertEquals("A", constructorDRI.classNames)
+            }
+        }
+    }
 }
 
 private fun DFunction.visibility() = visibility.values.first()


### PR DESCRIPTION
In addition to #2795

The generated default constructor has an empty package name. Meanwhile, the explicit one has the proper package (as the parent).
In the change, we directly replace `parentName` and `classNames` properties in the DRI of the constructor with values from the parent.