### PR TITLE
Allow to specify order of modules in the multi-module documentation page in DokkaMultiModuleTask

### DIFF
--- a/plugins/all-modules-page/src/main/kotlin/MultimodulePageCreator.kt
+++ b/plugins/all-modules-page/src/main/kotlin/MultimodulePageCreator.kt
@@ -54,7 +54,7 @@ class MultimodulePageCreator(
             header(2, "All modules:")
             table(styles = setOf(MultimoduleTable)) {
                 header { group { text("Name") } }
-                modules.filter { it.name in creationContext.nonEmptyModules }.sortedBy { it.name }
+                modules.filter { it.name in creationContext.nonEmptyModules }
                     .forEach { module ->
                         val displayedModuleDocumentation = getDisplayedModuleDocumentation(module)
                         val dri = DRI(packageName = MULTIMODULE_PACKAGE_PLACEHOLDER, classNames = module.name)

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaMultiModuleOrder.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaMultiModuleOrder.kt
@@ -1,0 +1,19 @@
+package org.jetbrains.dokka.gradle
+
+import org.jetbrains.dokka.DokkaConfiguration
+
+sealed class DokkaMultiModuleOrder {
+    abstract val comparator: Comparator<DokkaConfiguration.DokkaModuleDescription>
+
+    object Default : DokkaMultiModuleOrder() {
+        override val comparator: Comparator<DokkaConfiguration.DokkaModuleDescription> =
+            compareBy { it.relativePathToOutputDirectory }
+    }
+
+    object AsSpecified : DokkaMultiModuleOrder() {
+        override val comparator: Comparator<DokkaConfiguration.DokkaModuleDescription> =
+            compareBy { 0 }
+    }
+
+    class Custom(override val comparator: Comparator<DokkaConfiguration.DokkaModuleDescription>) : DokkaMultiModuleOrder()
+}

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaMultiModuleTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaMultiModuleTask.kt
@@ -52,6 +52,10 @@ abstract class DokkaMultiModuleTask : AbstractDokkaParentTask() {
     val fileLayout: Property<DokkaMultiModuleFileLayout> = project.objects.safeProperty<DokkaMultiModuleFileLayout>()
         .safeConvention(DokkaMultiModuleFileLayout.CompactInParent)
 
+    @Internal
+    val moduleOrder: Property<DokkaMultiModuleOrder> = project.objects.safeProperty<DokkaMultiModuleOrder>()
+        .safeConvention(DokkaMultiModuleOrder.Default)
+
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
     internal val sourceChildOutputDirectories: Iterable<File>
@@ -93,7 +97,7 @@ abstract class DokkaMultiModuleTask : AbstractDokkaParentTask() {
                 includes = childDokkaTaskIncludes[dokkaTask.path].orEmpty(),
                 sourceOutputDirectory = dokkaTask.outputDirectory.getSafe()
             )
-        },
+        }.sortedWith(moduleOrder.get().comparator),
         includes = includes.toSet(),
     )
 }


### PR DESCRIPTION
Allow to specify order of modules in the multi-module documentation page in DokkaMultiModuleTask and then preserve that order of modules in other places.