### PR TITLE
Do not render filter-section for empty source sets

### DIFF
--- a/plugins/base/src/main/kotlin/renderers/html/innerTemplating/DefaultTemplateModelFactory.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/innerTemplating/DefaultTemplateModelFactory.kt
@@ -72,7 +72,10 @@ class DefaultTemplateModelFactory(val context: DokkaContext) : TemplateModelFact
                 .sortedBy { it.comparableKey }
                 .map { SourceSetModel(it.name, it.platform.key, it.sourceSetIDs.merged.toString()) }
                 .toList()
-            mapper["sourceSets"] = sourceSets
+
+            if (sourceSets.isNotEmpty()) {
+                mapper["sourceSets"] = sourceSets
+            }
         }
         return mapper
     }

--- a/plugins/base/src/main/resources/dokka/templates/includes/source_set_selector.ftl
+++ b/plugins/base/src/main/resources/dokka/templates/includes/source_set_selector.ftl
@@ -1,5 +1,5 @@
 <#macro display>
-    <#if sourceSets??>
+    <#if sourceSets?has_content>
         <div class="filter-section" id="filter-section">
             <#list sourceSets as ss>
                 <button class="platform-tag platform-selector ${ss.platform}-like" data-active="" data-filter="${ss.filter}">${ss.name}</button>


### PR DESCRIPTION
Regression from #2848

Dokka was rendering an empty `filter-section` div on the all-modules page, which made the JS script think that everything was filtered out.

![image](https://user-images.githubusercontent.com/22685910/218531280-a730b91b-aa67-4aaa-bb52-23feceb09009.png)

