### PR TITLE
TemplateProcessor: replace `mkdir()` with `mkdirs()`

### DIFF
--- a/plugins/templating/src/main/kotlin/templates/TemplateProcessor.kt
+++ b/plugins/templating/src/main/kotlin/templates/TemplateProcessor.kt
@@ -53,7 +53,7 @@ class DefaultSubmoduleTemplateProcessor(
         coroutineScope {
             val source = this@visit
             if (source.isDirectory) {
-                target.mkdir()
+                target.mkdirs()
                 val files = source.list().orEmpty()
                 val accWithSelf = configuredModulesPaths[source.absolutePath]
                     ?.takeIf { files.firstOrNull { !it.startsWith(".") } != null }


### PR DESCRIPTION
Replace `mkdir()` with `mkdirs()`, so that `relativePathToOutputDirectory` can be set as a nested. This improves the handling of aggregating modules, as they can be placed into distinct directories.

I am not sure how to test this...

Part of #2866