### PR TITLE
Change default logging level of console apps

### DIFF
--- a/core/src/main/kotlin/utilities/DokkaLogging.kt
+++ b/core/src/main/kotlin/utilities/DokkaLogging.kt
@@ -39,7 +39,7 @@ fun interface MessageEmitter : (String) -> Unit {
 }
 
 class DokkaConsoleLogger(
-    val minLevel: LoggingLevel = LoggingLevel.DEBUG,
+    val minLevel: LoggingLevel = LoggingLevel.PROGRESS,
     private val emitter: MessageEmitter = MessageEmitter.consoleEmitter
 ) : DokkaLogger {
     private val warningsCounter = AtomicInteger()

--- a/plugins/all-modules-page/src/test/kotlin/MultiModuleDokkaTestGenerator.kt
+++ b/plugins/all-modules-page/src/test/kotlin/MultiModuleDokkaTestGenerator.kt
@@ -13,6 +13,7 @@ import org.jetbrains.dokka.testApi.testRunner.TestBuilder
 import org.jetbrains.dokka.testApi.testRunner.TestMethods
 import org.jetbrains.dokka.utilities.DokkaConsoleLogger
 import org.jetbrains.dokka.utilities.DokkaLogger
+import org.jetbrains.dokka.utilities.LoggingLevel
 
 class MultiModuleDokkaTestGenerator(
     configuration: DokkaConfiguration,
@@ -85,7 +86,7 @@ class MultiModuleTestBuilder : TestBuilder<MultiModuleTestMethods>() {
     )
 }
 
-abstract class MultiModuleAbstractTest(logger: TestLogger = TestLogger(DokkaConsoleLogger())) :
+abstract class MultiModuleAbstractTest(logger: TestLogger = TestLogger(DokkaConsoleLogger(LoggingLevel.DEBUG))) :
     AbstractTest<MultiModuleTestMethods, MultiModuleTestBuilder, MultiModuleDokkaTestGenerator>(
         ::MultiModuleTestBuilder,
         ::MultiModuleDokkaTestGenerator,

--- a/plugins/base/base-test-utils/src/main/kotlin/renderers/TestPage.kt
+++ b/plugins/base/base-test-utils/src/main/kotlin/renderers/TestPage.kt
@@ -9,12 +9,13 @@ import org.jetbrains.dokka.model.doc.DocTag
 import org.jetbrains.dokka.model.properties.PropertyContainer
 import org.jetbrains.dokka.pages.*
 import org.jetbrains.dokka.utilities.DokkaConsoleLogger
+import org.jetbrains.dokka.utilities.LoggingLevel
 
 fun testPage(callback: PageContentBuilder.DocumentableContentBuilder.() -> Unit): RawTestPage {
     val content = PageContentBuilder(
         EmptyCommentConverter,
-        KotlinSignatureProvider(EmptyCommentConverter, DokkaConsoleLogger()),
-        DokkaConsoleLogger()
+        KotlinSignatureProvider(EmptyCommentConverter, DokkaConsoleLogger(LoggingLevel.DEBUG)),
+        DokkaConsoleLogger(LoggingLevel.DEBUG)
     ).contentFor(
         DRI.topLevel,
         emptySet(),

--- a/plugins/base/src/test/kotlin/basic/FailOnWarningTest.kt
+++ b/plugins/base/src/test/kotlin/basic/FailOnWarningTest.kt
@@ -5,6 +5,7 @@ import org.jetbrains.dokka.testApi.logger.TestLogger
 import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
 import org.jetbrains.dokka.utilities.DokkaConsoleLogger
 import org.jetbrains.dokka.utilities.DokkaLogger
+import org.jetbrains.dokka.utilities.LoggingLevel
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -116,7 +117,7 @@ class FailOnWarningTest : BaseAbstractTest() {
 }
 
 private class ZeroErrorOrWarningCountDokkaLogger(
-    logger: DokkaLogger = DokkaConsoleLogger()
+    logger: DokkaLogger = DokkaConsoleLogger(LoggingLevel.DEBUG)
 ) : DokkaLogger by logger {
     override var warningsCount: Int = 0
     override var errorsCount: Int = 0

--- a/plugins/base/src/test/kotlin/transformers/ContextModuleAndPackageDocumentationReaderTest1.kt
+++ b/plugins/base/src/test/kotlin/transformers/ContextModuleAndPackageDocumentationReaderTest1.kt
@@ -7,6 +7,7 @@ import org.jetbrains.dokka.model.doc.DocumentationNode
 import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.testApi.logger.TestLogger
 import org.jetbrains.dokka.utilities.DokkaConsoleLogger
+import org.jetbrains.dokka.utilities.LoggingLevel
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -75,7 +76,7 @@ class ContextModuleAndPackageDocumentationReaderTest1 : AbstractContextModuleAnd
     private val context by lazy {
         DokkaContext.create(
             configuration = configurationBuilder.build(),
-            logger = TestLogger(DokkaConsoleLogger()),
+            logger = TestLogger(DokkaConsoleLogger(LoggingLevel.DEBUG)),
             pluginOverrides = emptyList()
         )
     }

--- a/plugins/base/src/test/kotlin/transformers/ContextModuleAndPackageDocumentationReaderTest3.kt
+++ b/plugins/base/src/test/kotlin/transformers/ContextModuleAndPackageDocumentationReaderTest3.kt
@@ -4,6 +4,7 @@ import org.jetbrains.dokka.base.transformers.documentables.ModuleAndPackageDocum
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.utilities.DokkaConsoleLogger
+import org.jetbrains.dokka.utilities.LoggingLevel
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testApi.testRunner.TestDokkaConfigurationBuilder
@@ -36,7 +37,7 @@ class ContextModuleAndPackageDocumentationReaderTest3 : AbstractContextModuleAnd
     private val context by lazy {
         DokkaContext.create(
             configuration = configurationBuilder.build(),
-            logger = DokkaConsoleLogger(),
+            logger = DokkaConsoleLogger(LoggingLevel.DEBUG),
             pluginOverrides = emptyList()
         )
     }

--- a/plugins/base/src/test/kotlin/transformers/InvalidContentModuleAndPackageDocumentationReaderTest.kt
+++ b/plugins/base/src/test/kotlin/transformers/InvalidContentModuleAndPackageDocumentationReaderTest.kt
@@ -3,6 +3,7 @@ package transformers
 import org.jetbrains.dokka.base.transformers.documentables.ModuleAndPackageDocumentationReader
 import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.utilities.DokkaConsoleLogger
+import org.jetbrains.dokka.utilities.LoggingLevel
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testApi.testRunner.TestDokkaConfigurationBuilder
@@ -52,14 +53,14 @@ class InvalidContentModuleAndPackageDocumentationReaderTest : AbstractContextMod
     private val contextA by lazy {
         DokkaContext.create(
             configuration = configurationBuilderA.build(),
-            logger = DokkaConsoleLogger(),
+            logger = DokkaConsoleLogger(LoggingLevel.DEBUG),
             pluginOverrides = emptyList()
         )
     }
     private val contextB by lazy {
         DokkaContext.create(
             configuration = configurationBuilderB.build(),
-            logger = DokkaConsoleLogger(),
+            logger = DokkaConsoleLogger(LoggingLevel.DEBUG),
             pluginOverrides = emptyList()
         )
     }

--- a/plugins/templating/src/test/kotlin/org/jetbrains/dokka/templates/TemplatingDokkaTestGenerator.kt
+++ b/plugins/templating/src/test/kotlin/org/jetbrains/dokka/templates/TemplatingDokkaTestGenerator.kt
@@ -12,6 +12,7 @@ import org.jetbrains.dokka.testApi.testRunner.TestBuilder
 import org.jetbrains.dokka.testApi.testRunner.TestMethods
 import org.jetbrains.dokka.utilities.DokkaConsoleLogger
 import org.jetbrains.dokka.utilities.DokkaLogger
+import org.jetbrains.dokka.utilities.LoggingLevel
 
 class TemplatingDokkaTestGenerator(
     configuration: DokkaConfiguration,
@@ -61,7 +62,7 @@ class TemplatingTestBuilder : TestBuilder<TemplatingTestMethods>() {
     )
 }
 
-abstract class TemplatingAbstractTest(logger: TestLogger = TestLogger(DokkaConsoleLogger())) :
+abstract class TemplatingAbstractTest(logger: TestLogger = TestLogger(DokkaConsoleLogger(LoggingLevel.DEBUG))) :
     AbstractTest<TemplatingTestMethods, TemplatingTestBuilder, TemplatingDokkaTestGenerator>(
         ::TemplatingTestBuilder,
         ::TemplatingDokkaTestGenerator,

--- a/runners/cli/src/main/kotlin/org/jetbrains/dokka/GlobalArguments.kt
+++ b/runners/cli/src/main/kotlin/org/jetbrains/dokka/GlobalArguments.kt
@@ -120,13 +120,13 @@ class GlobalArguments(args: Array<String>) : DokkaConfiguration {
                 "WARN" -> LoggingLevel.WARN
                 "ERROR" -> LoggingLevel.ERROR
                 else -> {
-                    println("""Failed to deserialize logging level, got $it expected one of 
-                        |"DEBUG", "PROGRESS", "INFO", "WARN", "ERROR", falling back to DEBUG""".trimMargin())
-                    LoggingLevel.DEBUG
+                    println("""Failed to deserialize logging level, got $it expected one of
+                        |"DEBUG", "PROGRESS", "INFO", "WARN", "ERROR", falling back to PROGRESS""".trimMargin())
+                    LoggingLevel.PROGRESS
                 }
             }
         }, toString = { it.toString() }
-        )).default(LoggingLevel.DEBUG)
+        )).default(LoggingLevel.PROGRESS)
 
     override val modules: List<DokkaConfiguration.DokkaModuleDescription> = emptyList()
 


### PR DESCRIPTION
This is a prerequisite / enabler for https://github.com/Kotlin/dokka/issues/2873

* Changed the default logging level of the CLI runner configuration (DEBUG -> PROGRESS)
* Changed the default logging level of `DokkaConsoleLogger` (DEBUG -> PROGRESS)
* Preserved the `DEBUG` level in public test API declarations
* Changed our tests that created `DokkaConsoleLogger` to create it with the `DEBUG` level as before, in case it was important

I don't think `DEBUG` is a reasonable default value for any logger. It can leak sensitive and excessive information. Luckily, this is easily configurable, so it should not cause migration problems if it affects any users/plugins. 

Dokka itself emits only one log message with the debug level:

https://github.com/Kotlin/dokka/blob/73f78dc34bbcb683f345192629bdbc631035887e/plugins/base/src/main/kotlin/translators/psi/parsers/PsiCommentsUtils.kt#L106-L109