### PR TITLE
Fix unresolved link to declaration from another source set

### DIFF
--- a/core/src/main/kotlin/model/DisplaySourceSet.kt
+++ b/core/src/main/kotlin/model/DisplaySourceSet.kt
@@ -5,6 +5,14 @@ import org.jetbrains.dokka.DokkaSourceSetID
 import org.jetbrains.dokka.Platform
 import org.jetbrains.dokka.utilities.SelfRepresentingSingletonSet
 
+/**
+ * TODO: fix the example (asymmetric equivalence relation with [Set]):
+ * ```
+ * val ds = DokkaSourceSetImpl(sourceSetID = DokkaSourceSetID("", "")).toDisplaySourceSet()
+ * println(setOf(ds) == ds) // true
+ * println(ds == setOf(ds)) // false
+ * ```
+ */
 data class DisplaySourceSet(
     val sourceSetIDs: CompositeSourceSetID,
     val name: String,

--- a/plugins/base/src/main/kotlin/resolvers/local/DokkaLocationProvider.kt
+++ b/plugins/base/src/main/kotlin/resolvers/local/DokkaLocationProvider.kt
@@ -89,23 +89,33 @@ open class DokkaLocationProvider(
 
     private fun getLocalLocation(driWithSourceSets: DRIWithSourceSets, context: PageNode?): String? {
         val (dri, originalSourceSet) = driWithSourceSets
-        val allSourceSets =
+        val allSourceSets: List<Set<DisplaySourceSet>> =
             listOf(originalSourceSet) + originalSourceSet.let { oss ->
                 dokkaContext.configuration.sourceSets.filter { it.sourceSetID in oss.sourceSetIDs }
                     .flatMap { it.dependentSourceSets }
                     .mapNotNull { ssid ->
                         dokkaContext.configuration.sourceSets.find { it.sourceSetID == ssid }?.toDisplaySourceSet()
+                    }.map {
+                        setOf(it)
                     }
             }
 
-        return allSourceSets.asSequence().mapNotNull { displaySourceSet ->
-            pagesIndex[DRIWithSourceSets(dri, displaySourceSet)]?.let { page -> resolve(page, context) }
-                ?: anchorsIndex[driWithSourceSets]?.let { (page, kind) ->
-                    val dci = DCI(setOf(dri), kind)
-                    resolve(page, context) + "#" + anchorForDCI(dci, displaySourceSet)
-                }
-        }.firstOrNull()
+        return getLocalPageLink(dri, allSourceSets, context)
+            ?: getLocalAnchor(dri, allSourceSets, context)
     }
+
+    private fun getLocalPageLink(dri: DRI, allSourceSets: Iterable<Set<DisplaySourceSet>>, context: PageNode?)  =
+        allSourceSets.mapNotNull { displaySourceSet ->
+            pagesIndex[DRIWithSourceSets(dri, displaySourceSet)]
+        }.firstOrNull()?.let { page -> resolve(page, context) }
+
+    private fun getLocalAnchor(dri: DRI, allSourceSets: Iterable<Set<DisplaySourceSet>>, context: PageNode?)  =
+        allSourceSets.mapNotNull { displaySourceSet ->
+            anchorsIndex[DRIWithSourceSets(dri, displaySourceSet)]?.let { (page, kind) ->
+                val dci = DCI(setOf(dri), kind)
+                resolve(page, context) + "#" + anchorForDCI(dci, displaySourceSet)
+            }
+        }.firstOrNull()
 
     override fun pathToRoot(from: PageNode): String =
         pathTo(pageGraphRoot, from).removeSuffix(PAGE_WITH_CHILDREN_SUFFIX)

--- a/plugins/base/src/main/kotlin/resolvers/local/DokkaLocationProvider.kt
+++ b/plugins/base/src/main/kotlin/resolvers/local/DokkaLocationProvider.kt
@@ -96,6 +96,7 @@ open class DokkaLocationProvider(
                     .mapNotNull { ssid ->
                         dokkaContext.configuration.sourceSets.find { it.sourceSetID == ssid }?.toDisplaySourceSet()
                     }.map {
+                        // be careful `data DisplaySourceSet: Set<DisplaySourceSet>` but `setOf(someDisplaySourceSet) != someDisplaySourceSet`
                         setOf(it)
                     }
             }


### PR DESCRIPTION
Also, it fixed a weird link to `Enum.name` in stdlib since there are a lot of anchors to `Enum.name`.  