### PR TITLE
build config: Gradle Version Catalog + type-safe project dependencies

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,5 +1,3 @@
-import java.util.*
-
 plugins {
     `kotlin-dsl`
 }
@@ -10,22 +8,8 @@ kotlin {
     }
 }
 
-// TODO define versions in Gradle Version Catalog https://github.com/Kotlin/dokka/pull/2884
-val properties = file("../gradle.properties").inputStream().use {
-    Properties().apply { load(it) }
-}
-
-val kotlinVersion = properties["kotlin_version"]
-
 dependencies {
-    // Import Gradle Plugins that will be used in the buildSrc pre-compiled script plugins, and any `build.gradle.kts`
-    // files in the project.
-    // Use their Maven coordinates (plus versions), not Gradle plugin IDs!
-    // This should be the only place that Gradle plugin versions are defined, so they are aligned across all build scripts
-
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
-    implementation("gradle.plugin.com.github.johnrengelman:shadow:7.1.2")
-    implementation("org.jetbrains.kotlinx:binary-compatibility-validator:0.12.1")
-    implementation("io.github.gradle-nexus:publish-plugin:1.1.0")
-    implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.8.10")
+    implementation(libs.gradlePlugin.dokka)
+    implementation(libs.gradlePlugin.kotlin)
+    implementation(libs.gradlePlugin.shadow)
 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -12,4 +12,8 @@ dependencies {
     implementation(libs.gradlePlugin.dokka)
     implementation(libs.gradlePlugin.kotlin)
     implementation(libs.gradlePlugin.shadow)
+
+    // workaround for accessing version-catalog in convention plugins
+    // https://github.com/gradle/gradle/issues/15383#issuecomment-779893192
+    implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 }

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -14,4 +14,10 @@ dependencyResolutionManagement {
         google()
         gradlePluginPortal()
     }
+
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
 }

--- a/build-logic/src/main/kotlin/org/jetbrains/conventions/maven-cli-setup.gradle.kts
+++ b/build-logic/src/main/kotlin/org/jetbrains/conventions/maven-cli-setup.gradle.kts
@@ -15,7 +15,7 @@ plugins {
     base
 }
 
-abstract class SetupMavenProperties {
+abstract class MavenCliSetupExtension {
     abstract val mavenVersion: Property<String>
     abstract val mavenPluginToolsVersion: Property<String>
     abstract val mavenBuildDir: DirectoryProperty
@@ -34,10 +34,10 @@ abstract class SetupMavenProperties {
     abstract val mvn: RegularFileProperty
 }
 
-val setupMavenProperties =
-    extensions.create("setupMavenProperties", SetupMavenProperties::class).apply {
-        mavenVersion.convention(providers.gradleProperty("mavenVersion"))
-        mavenPluginToolsVersion.convention(providers.gradleProperty("mavenPluginToolsVersion"))
+val mavenCliSetupExtension =
+    extensions.create("mavenCliSetup", MavenCliSetupExtension::class).apply {
+        mavenVersion.convention(libs.versions.apache.maven)
+        mavenPluginToolsVersion.convention(libs.versions.apache.mavenPluginTools)
 
         mavenBuildDir.convention(layout.buildDirectory.dir("maven"))
         mavenInstallDir.convention(layout.buildDirectory.dir("apache-maven"))
@@ -64,7 +64,7 @@ val mavenBinary by configurations.registering {
     isVisible = false
 
     defaultDependencies {
-        addLater(setupMavenProperties.mavenVersion.map { mavenVersion ->
+        addLater(mavenCliSetupExtension.mavenVersion.map { mavenVersion ->
             project.dependencies.create(
                 group = "org.apache.maven",
                 name = "apache-maven",
@@ -77,8 +77,8 @@ val mavenBinary by configurations.registering {
 }
 
 tasks.clean {
-    delete(setupMavenProperties.mavenBuildDir)
-    delete(setupMavenProperties.mavenInstallDir)
+    delete(mavenCliSetupExtension.mavenBuildDir)
+    delete(mavenCliSetupExtension.mavenInstallDir)
 }
 
 val installMavenBinary by tasks.registering(Sync::class) {
@@ -99,5 +99,5 @@ val installMavenBinary by tasks.registering(Sync::class) {
         }
         includeEmptyDirs = false
     }
-    into(setupMavenProperties.mavenInstallDir)
+    into(mavenCliSetupExtension.mavenInstallDir)
 }

--- a/build-logic/src/main/kotlin/org/jetbrains/internal/gradleKotlinDslAccessors.kt
+++ b/build-logic/src/main/kotlin/org/jetbrains/internal/gradleKotlinDslAccessors.kt
@@ -1,0 +1,24 @@
+@file:Suppress("PackageDirectoryMismatch")
+
+package org.gradle.kotlin.dsl // for convenience use a default package for gradle.kts scripts
+
+import org.gradle.api.Project
+import org.gradle.accessors.dm.LibrariesForLibs
+
+/*
+ * Utility functions for accessing Gradle extensions that are created by convention plugins.
+ *
+ * (Gradle can't generate the nice DSL accessors for the project that defines them)
+ *
+ * These functions are not needed outside the convention plugins project and should be marked as
+ * `internal`
+ */
+
+
+/**
+ * workaround for accessing version-catalog in convention plugins
+ *
+ * See https://github.com/gradle/gradle/issues/15383#issuecomment-779893192
+ */
+internal val Project.libs : LibrariesForLibs
+    get() = extensions.getByType()

--- a/build-logic/src/main/kotlin/org/jetbrains/publication.kt
+++ b/build-logic/src/main/kotlin/org/jetbrains/publication.kt
@@ -2,13 +2,9 @@ package org.jetbrains
 
 import com.github.jengelman.gradle.plugins.shadow.ShadowExtension
 import org.gradle.api.Project
-import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
-import org.gradle.api.tasks.TaskContainer
-import org.gradle.api.tasks.TaskProvider
-import org.gradle.api.tasks.bundling.Jar
 import org.gradle.kotlin.dsl.*
 import org.gradle.plugins.signing.SigningExtension
 import org.jetbrains.DokkaPublicationChannel.*
@@ -24,7 +20,10 @@ class DokkaPublicationBuilder {
 }
 
 
-fun Project.registerDokkaArtifactPublication(publicationName: String, configure: DokkaPublicationBuilder.() -> Unit) {
+fun Project.registerDokkaArtifactPublication(
+    publicationName: String,
+    configure: DokkaPublicationBuilder.() -> Unit
+) {
     configure<PublishingExtension> {
         publications {
             register<MavenPublication>(publicationName) {
@@ -143,9 +142,10 @@ private fun Project.signPublicationsIfKeyPresent(vararg publications: String) {
                 useInMemoryPgpKeys(signingKey, signingKeyPassphrase)
             }
             publications.forEach { publicationName ->
-                extensions.findByType(PublishingExtension::class)!!.publications.findByName(publicationName)?.let {
-                    sign(it)
-                }
+                extensions.getByType<PublishingExtension>()
+                    .publications
+                    .findByName(publicationName)
+                    ?.let { sign(it) }
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,14 @@
 import org.jetbrains.ValidatePublications
 import org.jetbrains.publicationChannels
 
+@Suppress("DSL_SCOPE_VIOLATION") // fixed in Gradle 8.1 https://github.com/gradle/gradle/pull/23639
 plugins {
-    id("org.jetbrains.conventions.base") apply false
-    id("org.jetbrains.dokka") version "1.8.10"
-    id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
-    id("com.gradle.plugin-publish") version "0.20.0"
-    id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.12.1"
+    id("org.jetbrains.conventions.base")
+    id("org.jetbrains.conventions.dokka")
+
+    alias(libs.plugins.kotlinx.binaryCompatibilityValidator)
+    alias(libs.plugins.gradle.pluginPublish)
+    alias(libs.plugins.nexusPublish)
 }
 
 val dokka_version: String by project

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -7,26 +7,22 @@ plugins {
 }
 
 dependencies {
-    api("org.jetbrains:markdown:0.3.1")
+    api(libs.jetbrainsMarkdown)
     implementation(kotlin("reflect"))
 
-    val jsoup_version: String by project
-    implementation("org.jsoup:jsoup:$jsoup_version")
+    implementation(libs.jsoup)
 
-    val jackson_version: String by project
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jackson_version")
-    val jackson_databind_version: String by project
+    implementation(libs.jackson.kotlin)
+    implementation(libs.jackson.xml)
     constraints {
-        implementation("com.fasterxml.jackson.core:jackson-databind:$jackson_databind_version") {
+        implementation(libs.jackson.databind) {
             because("CVE-2022-42003")
         }
     }
 
-    val coroutines_version: String by project
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version")
+    implementation(libs.kotlinx.coroutines.core)
 
-    testImplementation(project(":core:test-api"))
+    testImplementation(projects.core.testApi)
     testImplementation(kotlin("test-junit"))
 }
 

--- a/core/content-matcher-test-utils/build.gradle.kts
+++ b/core/content-matcher-test-utils/build.gradle.kts
@@ -3,8 +3,8 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":core:test-api"))
-    implementation(kotlin("stdlib-jdk8"))
+    implementation(projects.core.testApi)
+
     implementation(kotlin("reflect"))
-    implementation("com.willowtreeapps.assertk:assertk-jvm:0.25")
+    implementation(libs.assertk)
 }

--- a/core/test-api/build.gradle.kts
+++ b/core/test-api/build.gradle.kts
@@ -6,10 +6,9 @@ plugins {
 }
 
 dependencies {
-    api(project(":core"))
-    implementation(project(":kotlin-analysis"))
+    api(projects.core)
+    implementation(projects.kotlinAnalysis)
     implementation("junit:junit:4.13.2") // TODO: remove dependency to junit
-    implementation(kotlin("stdlib"))
     implementation(kotlin("reflect"))
 }
 

--- a/examples/gradle/dokka-customFormat-example/build.gradle.kts
+++ b/examples/gradle/dokka-customFormat-example/build.gradle.kts
@@ -31,6 +31,5 @@ tasks.dokkaHtml {
 }
 
 dependencies {
-    implementation(kotlin("stdlib"))
     testImplementation(kotlin("test-junit"))
 }

--- a/examples/gradle/dokka-gradle-example/build.gradle.kts
+++ b/examples/gradle/dokka-gradle-example/build.gradle.kts
@@ -11,7 +11,6 @@ repositories {
 }
 
 dependencies {
-    implementation(kotlin("stdlib"))
     testImplementation(kotlin("test-junit"))
 }
 

--- a/examples/gradle/dokka-kotlinAsJava-example/build.gradle.kts
+++ b/examples/gradle/dokka-kotlinAsJava-example/build.gradle.kts
@@ -8,7 +8,6 @@ repositories {
 }
 
 dependencies {
-    implementation(kotlin("stdlib"))
     testImplementation(kotlin("test-junit"))
 
     // Will apply the plugin to all Dokka tasks

--- a/examples/gradle/dokka-library-publishing-example/build.gradle.kts
+++ b/examples/gradle/dokka-library-publishing-example/build.gradle.kts
@@ -10,7 +10,6 @@ repositories {
 }
 
 dependencies {
-    implementation(kotlin("stdlib"))
     testImplementation(kotlin("test-junit"))
 }
 

--- a/examples/gradle/dokka-multimodule-example/parentProject/build.gradle.kts
+++ b/examples/gradle/dokka-multimodule-example/parentProject/build.gradle.kts
@@ -26,8 +26,3 @@ subprojects {
 tasks.dokkaHtmlMultiModule {
     moduleName.set("Dokka MultiModule Example")
 }
-
-dependencies {
-    implementation(kotlin("stdlib"))
-}
-

--- a/examples/gradle/dokka-multimodule-example/parentProject/childProjectA/build.gradle.kts
+++ b/examples/gradle/dokka-multimodule-example/parentProject/childProjectA/build.gradle.kts
@@ -5,10 +5,6 @@ plugins {
     id("org.jetbrains.dokka")
 }
 
-dependencies {
-    implementation(kotlin("stdlib"))
-}
-
 // configuration specific to this subproject.
 // notice the use of Partial task
 tasks.withType<DokkaTaskPartial>().configureEach {

--- a/examples/gradle/dokka-multimodule-example/parentProject/childProjectB/build.gradle.kts
+++ b/examples/gradle/dokka-multimodule-example/parentProject/childProjectB/build.gradle.kts
@@ -5,10 +5,6 @@ plugins {
     id("org.jetbrains.dokka")
 }
 
-dependencies {
-    implementation(kotlin("stdlib"))
-}
-
 // configuration specific to this subproject.
 // notice the use of Partial task
 tasks.withType<DokkaTaskPartial>().configureEach {

--- a/examples/gradle/dokka-versioning-multimodule-example/parentProject/build.gradle.kts
+++ b/examples/gradle/dokka-versioning-multimodule-example/parentProject/build.gradle.kts
@@ -12,10 +12,6 @@ buildscript {
     }
 }
 
-dependencies {
-    implementation(kotlin("stdlib"))
-}
-
 val currentVersion = "1.0"
 val previousVersionsDirectory = project.rootProject.projectDir.resolve("previousDocVersions").invariantSeparatorsPath
 

--- a/examples/gradle/dokka-versioning-multimodule-example/parentProject/childProjectA/build.gradle.kts
+++ b/examples/gradle/dokka-versioning-multimodule-example/parentProject/childProjectA/build.gradle.kts
@@ -1,3 +1,1 @@
-dependencies {
-
-}
+// intentionally empty - build config is set in the root build.gradle.kts

--- a/examples/gradle/dokka-versioning-multimodule-example/parentProject/childProjectA/build.gradle.kts
+++ b/examples/gradle/dokka-versioning-multimodule-example/parentProject/childProjectA/build.gradle.kts
@@ -1,3 +1,3 @@
 dependencies {
-    implementation(kotlin("stdlib"))
+
 }

--- a/examples/gradle/dokka-versioning-multimodule-example/parentProject/childProjectB/build.gradle.kts
+++ b/examples/gradle/dokka-versioning-multimodule-example/parentProject/childProjectB/build.gradle.kts
@@ -1,3 +1,1 @@
-dependencies {
-
-}
+// intentionally empty - build config is set in the root build.gradle.kts

--- a/examples/gradle/dokka-versioning-multimodule-example/parentProject/childProjectB/build.gradle.kts
+++ b/examples/gradle/dokka-versioning-multimodule-example/parentProject/childProjectB/build.gradle.kts
@@ -1,3 +1,3 @@
 dependencies {
-    implementation(kotlin("stdlib"))
+
 }

--- a/examples/plugin/hide-internal-api/build.gradle.kts
+++ b/examples/plugin/hide-internal-api/build.gradle.kts
@@ -19,7 +19,7 @@ repositories {
 
 val dokkaVersion: String by project
 dependencies {
-    implementation(kotlin("stdlib"))
+
     compileOnly("org.jetbrains.dokka:dokka-core:$dokkaVersion")
     implementation("org.jetbrains.dokka:dokka-base:$dokkaVersion")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,19 +1,7 @@
 # Project Settings
 dokka_version=1.8.20-SNAPSHOT
 dokka_integration_test_parallelism=2
-# Versions
-kotlin_version=1.8.10
-coroutines_version=1.6.3
-kotlinx_html_version=0.7.5
-kotlin_plugin_version=213-1.8.10-release-430-IJ6777.52
-jsoup_version=1.15.3
-idea_version=213.6777.52
 language_version=1.4
-# jackson 2.13.X does not support kotlin language version 1.4, check before updating
-jackson_version=2.12.7
-# fixes CVE-2022-42003
-jackson_databind_version=2.12.7.1
-freemarker_version=2.3.31
 # Code style
 kotlin.code.style=official
 # Gradle settings

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,7 +47,7 @@ jetbrainsIntelliJ-core = { module = "com.jetbrains.intellij.idea:intellij-core",
 jetbrainsIntelliJ-jpsStandalone = { module = "com.jetbrains.intellij.idea:jps-standalone", version.ref = "idea" }
 jetbrainsMarkdown = { module = "org.jetbrains:markdown", version.ref = "jetbrainsMarkdown" }
 jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
-soywiz-korte = { module = "com.soywiz.korlibs.korte:korte", version.ref = "soywiz-korte" }
+soywiz-korte = { module = "com.soywiz.korlibs.korte:korte-jvm", version.ref = "soywiz-korte" }
 
 ## Kotlin libs ##
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
@@ -58,8 +58,8 @@ kotlin-common = { module = "org.jetbrains.kotlin:common", version.ref = "kotlin"
 kotlin-core = { module = "org.jetbrains.kotlin:core", version.ref = "kotlin" }
 kotlin-native = { module = "org.jetbrains.kotlin:native", version.ref = "kotlin" }
 
-kotlinx-cli = { module = "org.jetbrains.kotlinx:kotlinx-cli", version = "0.3.4" }
-kotlinx-html = { module = "org.jetbrains.kotlinx:kotlinx-html", version.ref = "kotlinx-html" }
+kotlinx-cli = { module = "org.jetbrains.kotlinx:kotlinx-cli-jvm", version = "0.3.4" }
+kotlinx-html = { module = "org.jetbrains.kotlinx:kotlinx-html-jvm", version.ref = "kotlinx-html" }
 
 kotlinx-coroutines-bom = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-bom", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,15 +4,17 @@ kotlin = "1.8.10"
 kotlin-plugin = "213-1.8.10-release-430-IJ6777.52"
 kotlinx-coroutines = "1.6.3"
 kotlinx-html = "0.7.5"
-jsoup = "1.15.3"
+kotlinx-cli = "0.3.4"
+
 idea = "213.6777.52"
+jetbrainsMarkdown = "0.3.1"
+
+jsoup = "1.15.3"
 
 jackson = "2.12.7" # jackson 2.13.X does not support kotlin language version 1.4, check before updating
 jacksonDatabind = "2.12.7.1" # fixes CVE-2022-42003
 
 freemarker = "2.3.31"
-
-jetbrainsMarkdown = "0.3.1"
 
 soywiz-korte = "2.7.0"
 
@@ -58,7 +60,7 @@ kotlin-common = { module = "org.jetbrains.kotlin:common", version.ref = "kotlin"
 kotlin-core = { module = "org.jetbrains.kotlin:core", version.ref = "kotlin" }
 kotlin-native = { module = "org.jetbrains.kotlin:native", version.ref = "kotlin" }
 
-kotlinx-cli = { module = "org.jetbrains.kotlinx:kotlinx-cli-jvm", version = "0.3.4" }
+kotlinx-cli = { module = "org.jetbrains.kotlinx:kotlinx-cli-jvm", version.ref = "kotlinx-cli" }
 kotlinx-html = { module = "org.jetbrains.kotlinx:kotlinx-html-jvm", version.ref = "kotlinx-html" }
 
 kotlinx-coroutines-bom = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-bom", version.ref = "kotlinx-coroutines" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,6 @@
 [versions]
 
-## compilation ##
-jvm = "11"
 kotlin = "1.8.10"
-kotlin-languageLevel = "1.4"
-
-
-## libs ##
 kotlin-plugin = "213-1.8.10-release-430-IJ6777.52"
 kotlinx-coroutines = "1.6.3"
 kotlinx-html = "0.7.5"
@@ -20,6 +14,7 @@ freemarker = "2.3.31"
 
 jetbrainsMarkdown = "0.3.1"
 
+soywiz-korte = "2.7.0"
 
 apache-maven = "3.5.0"
 apache-mavenArtifact = "3.8.5"
@@ -28,10 +23,11 @@ apache-mavenPluginTools = "3.5.2"
 
 eclipse-jgit = "5.12.0.202106070339-r"
 
-## test ##
+## test dependency versions ##
 junit = "5.9.2"
+assertk = "0.25"
 
-## gradle plugins ##
+## Gradle plugins ##
 gradlePlugin-shadow = "7.1.2"
 gradlePlugin-binaryCompatibilityValidator = "0.12.1"
 gradlePlugin-nexusPublish = "1.1.0"
@@ -42,9 +38,18 @@ gradlePlugin-gradle = "4.0.1"
 ## NPM ##
 node = "16.13.0"
 
+
 [libraries]
 
-## Kotlin ##
+eclipse-jgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "eclipse-jgit" }
+freemarker = { module = "org.freemarker:freemarker", version.ref = "freemarker" }
+jetbrainsIntelliJ-core = { module = "com.jetbrains.intellij.idea:intellij-core", version.ref = "idea" }
+jetbrainsIntelliJ-jpsStandalone = { module = "com.jetbrains.intellij.idea:jps-standalone", version.ref = "idea" }
+jetbrainsMarkdown = { module = "org.jetbrains:markdown", version.ref = "jetbrainsMarkdown" }
+jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
+soywiz-korte = { module = "com.soywiz.korlibs.korte:korte", version.ref = "soywiz-korte" }
+
+## Kotlin libs ##
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
 
 kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref = "kotlin" }
@@ -59,27 +64,17 @@ kotlinx-html = { module = "org.jetbrains.kotlinx:kotlinx-html", version.ref = "k
 kotlinx-coroutines-bom = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-bom", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 
+## Kotlin Plugins ##
 kotlinPlugin-common = { module = "org.jetbrains.kotlin:common", version.ref = "kotlin.plugin" }
 kotlinPlugin-idea = { module = "org.jetbrains.kotlin:idea", version.ref = "kotlin.plugin" }
 kotlinPlugin-core = { module = "org.jetbrains.kotlin:core", version.ref = "kotlin.plugin" }
 kotlinPlugin-native = { module = "org.jetbrains.kotlin:native", version.ref = "kotlin.plugin" }
 
-jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
-jetbrainsMarkdown = { module = "org.jetbrains:markdown", version.ref = "jetbrainsMarkdown" }
-freemarker = { module = "org.freemarker:freemarker", version.ref = "freemarker" }
-soywiz-korte = { module = "com.soywiz.korlibs.korte:korte", version = "2.7.0" }
-
-jetbrainsIntelliJ-core = { module = "com.jetbrains.intellij.idea:intellij-core", version.ref = "idea" }
-jetbrainsIntelliJ-jpsStandalone = { module = "com.jetbrains.intellij.idea:jps-standalone", version.ref = "idea" }
-
 ## Jackson ##
 jackson-bom = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 jackson-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 jackson-xml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml", version.ref = "jackson" }
-
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jacksonDatabind" }
-
-
 
 ## Apache Maven ##
 apache-mavenArchiver = { module = "org.apache.maven:maven-archiver", version.ref = "apache-mavenArchiver" }
@@ -89,25 +84,17 @@ apache-mavenPluginApi = { module = "org.apache.maven:maven-plugin-api", version.
 apache-mavenArtifact = { module = "org.apache.maven:maven-artifact", version.ref = "apache-mavenArtifact" }
 
 
-eclipse-jgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "eclipse-jgit" }
+#### test dependencies  ####
 
-## logging ##
-
-
-#############
-### test  ###
-#############
-
-## junit ##
+assertk = { module = "com.willowtreeapps.assertk:assertk", version.ref = "assertk" }
 
 ## junit ##
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
 
-assertk = { module = "com.willowtreeapps.assertk:assertk", version = "0.25" }
 
-### Gradle plugins  ###
-# The Maven coordinates of Gradle plugins that are used as
+#### Gradle plugins dependencies  ####
+# The Maven coordinates of Gradle plugins that are either used in convention plugins, or in Dokka subprojects
 
 gradlePlugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "gradlePlugin-dokka" }
 gradlePlugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -116,6 +103,9 @@ gradlePlugin-android = { module = "com.android.tools.build:gradle", version.ref 
 
 
 [plugins]
+# Gradle Plugins that are applied directly to subprojects
+# (Before defining plugins here, first consider creating convention plugins instead,
+# and define the Maven coordinates above to be used in build-logic/build.gradle.kts)
 
 kotlinx-binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "gradlePlugin-binaryCompatibilityValidator" }
 shadow = { id = "com.github.johnrengelman.shadow", version.ref = "gradlePlugin-shadow" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,123 @@
+[versions]
+
+## compilation ##
+jvm = "11"
+kotlin = "1.8.10"
+kotlin-languageLevel = "1.4"
+
+
+## libs ##
+kotlin-plugin = "213-1.8.10-release-430-IJ6777.52"
+kotlinx-coroutines = "1.6.3"
+kotlinx-html = "0.7.5"
+jsoup = "1.15.3"
+idea = "213.6777.52"
+
+jackson = "2.12.7" # jackson 2.13.X does not support kotlin language version 1.4, check before updating
+jacksonDatabind = "2.12.7.1" # fixes CVE-2022-42003
+
+freemarker = "2.3.31"
+
+jetbrainsMarkdown = "0.3.1"
+
+
+apache-maven = "3.5.0"
+apache-mavenArtifact = "3.8.5"
+apache-mavenArchiver = "2.5"
+apache-mavenPluginTools = "3.5.2"
+
+eclipse-jgit = "5.12.0.202106070339-r"
+
+## test ##
+junit = "5.9.2"
+
+## gradle plugins ##
+gradlePlugin-shadow = "7.1.2"
+gradlePlugin-binaryCompatibilityValidator = "0.12.1"
+gradlePlugin-nexusPublish = "1.1.0"
+gradlePlugin-dokka = "1.7.10"
+gradlePlugin-gradlePluginPublish = "0.20.0"
+gradlePlugin-gradle = "4.0.1"
+
+## NPM ##
+node = "16.13.0"
+
+[libraries]
+
+## Kotlin ##
+kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
+
+kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref = "kotlin" }
+kotlin-idea = { module = "org.jetbrains.kotlin:idea", version.ref = "kotlin" }
+kotlin-common = { module = "org.jetbrains.kotlin:common", version.ref = "kotlin" }
+kotlin-core = { module = "org.jetbrains.kotlin:core", version.ref = "kotlin" }
+kotlin-native = { module = "org.jetbrains.kotlin:native", version.ref = "kotlin" }
+
+kotlinx-cli = { module = "org.jetbrains.kotlinx:kotlinx-cli", version = "0.3.4" }
+kotlinx-html = { module = "org.jetbrains.kotlinx:kotlinx-html", version.ref = "kotlinx-html" }
+
+kotlinx-coroutines-bom = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-bom", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+
+kotlinPlugin-common = { module = "org.jetbrains.kotlin:common", version.ref = "kotlin.plugin" }
+kotlinPlugin-idea = { module = "org.jetbrains.kotlin:idea", version.ref = "kotlin.plugin" }
+kotlinPlugin-core = { module = "org.jetbrains.kotlin:core", version.ref = "kotlin.plugin" }
+kotlinPlugin-native = { module = "org.jetbrains.kotlin:native", version.ref = "kotlin.plugin" }
+
+jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
+jetbrainsMarkdown = { module = "org.jetbrains:markdown", version.ref = "jetbrainsMarkdown" }
+freemarker = { module = "org.freemarker:freemarker", version.ref = "freemarker" }
+soywiz-korte = { module = "com.soywiz.korlibs.korte:korte", version = "2.7.0" }
+
+jetbrainsIntelliJ-core = { module = "com.jetbrains.intellij.idea:intellij-core", version.ref = "idea" }
+jetbrainsIntelliJ-jpsStandalone = { module = "com.jetbrains.intellij.idea:jps-standalone", version.ref = "idea" }
+
+## Jackson ##
+jackson-bom = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
+jackson-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
+jackson-xml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml", version.ref = "jackson" }
+
+jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jacksonDatabind" }
+
+
+
+## Apache Maven ##
+apache-mavenArchiver = { module = "org.apache.maven:maven-archiver", version.ref = "apache-mavenArchiver" }
+apache-mavenCore = { module = "org.apache.maven:maven-core", version.ref = "apache-maven" }
+apache-mavenPluginAnnotations = { module = "org.apache.maven.plugin-tools:maven-plugin-annotations", version.ref = "apache-mavenPluginTools" }
+apache-mavenPluginApi = { module = "org.apache.maven:maven-plugin-api", version.ref = "apache-maven" }
+apache-mavenArtifact = { module = "org.apache.maven:maven-artifact", version.ref = "apache-mavenArtifact" }
+
+
+eclipse-jgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "eclipse-jgit" }
+
+## logging ##
+
+
+#############
+### test  ###
+#############
+
+## junit ##
+
+## junit ##
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
+
+assertk = { module = "com.willowtreeapps.assertk:assertk", version = "0.25" }
+
+### Gradle plugins  ###
+# The Maven coordinates of Gradle plugins that are used as
+
+gradlePlugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "gradlePlugin-dokka" }
+gradlePlugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+gradlePlugin-shadow = { module = "gradle.plugin.com.github.johnrengelman:shadow", version.ref = "gradlePlugin-shadow" }
+gradlePlugin-android = { module = "com.android.tools.build:gradle", version.ref = "gradlePlugin-gradle" }
+
+
+[plugins]
+
+kotlinx-binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "gradlePlugin-binaryCompatibilityValidator" }
+shadow = { id = "com.github.johnrengelman.shadow", version.ref = "gradlePlugin-shadow" }
+gradle-pluginPublish = { id = "com.gradle.plugin-publish", version.ref = "gradlePlugin-gradlePluginPublish" }
+nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "gradlePlugin-nexusPublish" }

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -3,11 +3,8 @@ plugins {
 }
 
 dependencies {
-    implementation(kotlin("stdlib"))
-    api(project(":test-utils"))
-    val coroutines_version: String by project
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version")
-    val jsoup_version: String by project
-    implementation("org.jsoup:jsoup:$jsoup_version")
-    implementation("org.eclipse.jgit:org.eclipse.jgit:5.12.0.202106070339-r")
+    api(projects.testUtils)
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.jsoup)
+    implementation(libs.eclipse.jgit)
 }

--- a/integration-tests/cli/build.gradle.kts
+++ b/integration-tests/cli/build.gradle.kts
@@ -10,9 +10,8 @@ evaluationDependsOn(":runners:cli")
 evaluationDependsOn(":plugins:base")
 
 dependencies {
-    implementation(kotlin("stdlib"))
     implementation(kotlin("test-junit"))
-    implementation(project(":integration-tests"))
+    implementation(projects.integrationTests)
 }
 
 /* Create a fat base plugin jar for cli tests */
@@ -23,8 +22,8 @@ val basePluginShadow: Configuration by configurations.creating {
 }
 
 dependencies {
-    basePluginShadow(project(":plugins:base"))
-    basePluginShadow(project(":kotlin-analysis")) // compileOnly in base plugin
+    basePluginShadow(projects.plugins.base)
+    basePluginShadow(projects.kotlinAnalysis) // compileOnly in base plugin
 }
 
 val basePluginShadowJar by tasks.register("basePluginShadowJar", ShadowJar::class) {
@@ -41,4 +40,3 @@ tasks.integrationTest {
     dependsOn(cliJar)
     dependsOn(basePluginShadowJar)
 }
-

--- a/integration-tests/gradle/build.gradle.kts
+++ b/integration-tests/gradle/build.gradle.kts
@@ -5,13 +5,12 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":integration-tests"))
-    implementation(kotlin("stdlib"))
+    implementation(projects.integrationTests)
+
     implementation(kotlin("test-junit"))
     implementation(gradleTestKit())
 
-    val jsoup_version: String by project
-    implementation("org.jsoup:jsoup:$jsoup_version")
+    implementation(libs.jsoup)
 }
 
 tasks.integrationTest {

--- a/integration-tests/gradle/projects/it-android-0/build.gradle.kts
+++ b/integration-tests/gradle/projects/it-android-0/build.gradle.kts
@@ -14,7 +14,5 @@ android {
 }
 
 dependencies {
-    implementation(kotlin("stdlib"))
     implementation("androidx.appcompat:appcompat:1.1.0")
 }
-

--- a/integration-tests/gradle/projects/it-basic/build.gradle.kts
+++ b/integration-tests/gradle/projects/it-basic/build.gradle.kts
@@ -21,7 +21,6 @@ version = "1.8.10-SNAPSHOT"
 apply(from = "../template.root.gradle.kts")
 
 dependencies {
-    implementation(kotlin("stdlib"))
     testImplementation(kotlin("test-junit"))
 }
 

--- a/integration-tests/gradle/projects/it-collector-0/moduleA/moduleB/build.gradle.kts
+++ b/integration-tests/gradle/projects/it-collector-0/moduleA/moduleB/build.gradle.kts
@@ -2,7 +2,3 @@ plugins {
     kotlin("jvm")
     id("org.jetbrains.dokka")
 }
-
-dependencies {
-    implementation(kotlin("stdlib"))
-}

--- a/integration-tests/gradle/projects/it-collector-0/moduleA/moduleC/build.gradle.kts
+++ b/integration-tests/gradle/projects/it-collector-0/moduleA/moduleC/build.gradle.kts
@@ -2,7 +2,3 @@ plugins {
     kotlin("jvm")
     id("org.jetbrains.dokka")
 }
-
-dependencies {
-    implementation(kotlin("stdlib"))
-}

--- a/integration-tests/gradle/projects/it-js-ir-0/build.gradle.kts
+++ b/integration-tests/gradle/projects/it-js-ir-0/build.gradle.kts
@@ -13,7 +13,6 @@ kotlin {
 }
 
 dependencies {
-    implementation(kotlin("stdlib"))
     implementation(npm("is-sorted", "1.0.5"))
 
     val reactVersion = properties["react_version"]

--- a/integration-tests/gradle/projects/it-multimodule-0/moduleA/moduleB/build.gradle.kts
+++ b/integration-tests/gradle/projects/it-multimodule-0/moduleA/moduleB/build.gradle.kts
@@ -5,10 +5,6 @@ plugins {
     id("org.jetbrains.dokka")
 }
 
-dependencies {
-    implementation(kotlin("stdlib"))
-}
-
 tasks.withType<DokkaTask>().configureEach {
     moduleName.set("!Module B!")
     dokkaSourceSets.configureEach {

--- a/integration-tests/gradle/projects/it-multimodule-0/moduleA/moduleC/build.gradle.kts
+++ b/integration-tests/gradle/projects/it-multimodule-0/moduleA/moduleC/build.gradle.kts
@@ -5,10 +5,6 @@ plugins {
     id("org.jetbrains.dokka")
 }
 
-dependencies {
-    implementation(kotlin("stdlib"))
-}
-
 tasks.withType<DokkaTask>().configureEach {
     dokkaSourceSets.configureEach {
         includes.from("Module.md")

--- a/integration-tests/gradle/projects/it-multimodule-0/moduleA/moduleD/build.gradle.kts
+++ b/integration-tests/gradle/projects/it-multimodule-0/moduleA/moduleD/build.gradle.kts
@@ -4,7 +4,3 @@ plugins {
     kotlin("jvm")
     id("org.jetbrains.dokka")
 }
-
-dependencies {
-    implementation(kotlin("stdlib"))
-}

--- a/integration-tests/gradle/projects/it-sequential-tasks-execution-stress/build.gradle.kts
+++ b/integration-tests/gradle/projects/it-sequential-tasks-execution-stress/build.gradle.kts
@@ -18,10 +18,6 @@ buildscript {
 
 apply(from = "../template.root.gradle.kts")
 
-dependencies {
-    implementation(kotlin("stdlib"))
-}
-
 fun createTask(name: String) {
     tasks.register(name, org.jetbrains.dokka.gradle.DokkaTask::class) {
         dokkaSourceSets {
@@ -42,4 +38,3 @@ task("runTasks") {
         dependsOn ("task_"+i)
     }
 }
-

--- a/integration-tests/maven/build.gradle.kts
+++ b/integration-tests/maven/build.gradle.kts
@@ -8,8 +8,8 @@ plugins {
 evaluationDependsOn(":runners:maven-plugin")
 
 dependencies {
-    implementation(project(":integration-tests"))
-    implementation(kotlin("stdlib"))
+    implementation(projects.integrationTests)
+
     implementation(kotlin("test-junit"))
 }
 

--- a/integration-tests/maven/build.gradle.kts
+++ b/integration-tests/maven/build.gradle.kts
@@ -15,7 +15,7 @@ tasks.integrationTest {
     dependsOnMavenLocalPublication()
 
     dependsOn(tasks.installMavenBinary)
-    val mvn = setupMavenProperties.mvn
+    val mvn = mavenCliSetup.mvn
     inputs.file(mvn)
 
     val dokka_version: String by project

--- a/kotlin-analysis/build.gradle.kts
+++ b/kotlin-analysis/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 dependencies {
-    compileOnly(project(":core"))
+    compileOnly(projects.core)
     api(project("intellij-dependency", configuration = "shadow"))
     api(project("compiler-dependency", configuration = "shadow"))
 }

--- a/kotlin-analysis/compiler-dependency/build.gradle.kts
+++ b/kotlin-analysis/compiler-dependency/build.gradle.kts
@@ -8,8 +8,7 @@ plugins {
 }
 
 dependencies {
-    val kotlin_version: String by project
-    api("org.jetbrains.kotlin:kotlin-compiler:$kotlin_version")
+    api(libs.kotlin.compiler)
 }
 
 tasks {

--- a/kotlin-analysis/intellij-dependency/build.gradle.kts
+++ b/kotlin-analysis/intellij-dependency/build.gradle.kts
@@ -35,19 +35,19 @@ fun jpsModel() = zipTree(jpsStandalone.singleFile).matching {
 }
 
 dependencies {
-    val kotlin_plugin_version: String by project
-    api("org.jetbrains.kotlin:common:$kotlin_plugin_version")
-    api("org.jetbrains.kotlin:idea:$kotlin_plugin_version") {
+//    val kotlin_plugin_version: String = libs.versions.kotlin.plugin.get()
+
+    api(libs.kotlinPlugin.common)
+    api(libs.kotlinPlugin.idea) {
         isTransitive = false
     }
-    api("org.jetbrains.kotlin:core:$kotlin_plugin_version")
-    api("org.jetbrains.kotlin:native:$kotlin_plugin_version")
+    api(libs.kotlinPlugin.core)
+    api(libs.kotlinPlugin.native)
 
-    val idea_version: String by project
-    intellijCore("com.jetbrains.intellij.idea:intellij-core:$idea_version")
+    intellijCore(libs.jetbrainsIntelliJ.core)
     implementation(intellijCoreAnalysis())
 
-    jpsStandalone("com.jetbrains.intellij.idea:jps-standalone:$idea_version")
+    jpsStandalone(libs.jetbrainsIntelliJ.jpsStandalone)
     implementation(jpsModel())
 }
 

--- a/kotlin-analysis/intellij-dependency/build.gradle.kts
+++ b/kotlin-analysis/intellij-dependency/build.gradle.kts
@@ -42,9 +42,11 @@ dependencies {
     api(libs.kotlinPlugin.core)
     api(libs.kotlinPlugin.native)
 
+    @Suppress("UnstableApiUsage")
     intellijCore(libs.jetbrainsIntelliJ.core)
     implementation(intellijCoreAnalysis())
 
+    @Suppress("UnstableApiUsage")
     jpsStandalone(libs.jetbrainsIntelliJ.jpsStandalone)
     implementation(jpsModel())
 }

--- a/kotlin-analysis/intellij-dependency/build.gradle.kts
+++ b/kotlin-analysis/intellij-dependency/build.gradle.kts
@@ -35,8 +35,6 @@ fun jpsModel() = zipTree(jpsStandalone.singleFile).matching {
 }
 
 dependencies {
-//    val kotlin_plugin_version: String = libs.versions.kotlin.plugin.get()
-
     api(libs.kotlinPlugin.common)
     api(libs.kotlinPlugin.idea) {
         isTransitive = false

--- a/plugins/all-modules-page/build.gradle.kts
+++ b/plugins/all-modules-page/build.gradle.kts
@@ -10,37 +10,30 @@ registerDokkaArtifactPublication("dokkaAllModulesPage") {
 }
 
 dependencies {
-    compileOnly(project(":core"))
-    implementation(kotlin("stdlib-jdk8"))
-    implementation(kotlin("stdlib"))
+    compileOnly(projects.core)
     implementation(kotlin("reflect"))
 
-    compileOnly(project(":kotlin-analysis"))
-    implementation(project(":plugins:base"))
-    implementation(project(":plugins:templating"))
-    testImplementation(project(":plugins:base"))
-    testImplementation(project(":plugins:base:base-test-utils"))
-    testImplementation(project(":plugins:gfm"))
-    testImplementation(project(":plugins:gfm:gfm-template-processing"))
-    testImplementation(project(":core:content-matcher-test-utils"))
+    compileOnly(projects.kotlinAnalysis)
+    implementation(projects.plugins.base)
+    implementation(projects.plugins.templating)
+    testImplementation(projects.plugins.base)
+    testImplementation(projects.plugins.base.baseTestUtils)
+    testImplementation(projects.plugins.gfm)
+    testImplementation(projects.plugins.gfm.gfmTemplateProcessing)
+    testImplementation(projects.core.contentMatcherTestUtils)
 
-    val coroutines_version: String by project
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version")
-    val jackson_version: String by project
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
-    val jackson_databind_version: String by project
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.jackson.kotlin)
     constraints {
-        implementation("com.fasterxml.jackson.core:jackson-databind:$jackson_databind_version") {
+        implementation(libs.jackson.databind) {
             because("CVE-2022-42003")
         }
     }
-    val kotlinx_html_version: String by project
-    implementation("org.jetbrains.kotlinx:kotlinx-html-jvm:$kotlinx_html_version")
+    implementation(libs.kotlinx.html)
+    implementation(libs.jsoup)
 
-    val jsoup_version: String by project
-    implementation("org.jsoup:jsoup:$jsoup_version")
-
-    testImplementation(project(":test-utils"))
-    testImplementation(project(":core:test-api"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.6.0")
+    testImplementation(projects.testUtils)
+    testImplementation(projects.core.testApi)
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
 }

--- a/plugins/android-documentation/build.gradle.kts
+++ b/plugins/android-documentation/build.gradle.kts
@@ -6,17 +6,17 @@ plugins {
 }
 
 dependencies {
-    compileOnly(project(":core"))
-    implementation(kotlin("stdlib-jdk8"))
-    implementation(kotlin("stdlib"))
-    implementation(kotlin("reflect"))
+    compileOnly(projects.core)
 
-    implementation(project(":plugins:base"))
-    testImplementation(project(":plugins:base"))
-    testImplementation(project(":plugins:base:base-test-utils"))
-    testImplementation(project(":test-utils"))
-    testImplementation(project(":core:test-api"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.6.0")
+    implementation(kotlin("reflect"))
+    implementation(projects.plugins.base)
+
+    testImplementation(projects.plugins.base)
+    testImplementation(projects.plugins.base.baseTestUtils)
+    testImplementation(projects.testUtils)
+    testImplementation(projects.core.testApi)
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
 }
 
 registerDokkaArtifactPublication("androidDocumentationPlugin") {

--- a/plugins/base/base-test-utils/build.gradle.kts
+++ b/plugins/base/base-test-utils/build.gradle.kts
@@ -6,20 +6,21 @@ plugins {
 }
 
 dependencies {
-    compileOnly(project(":core"))
-    implementation(kotlin("stdlib-jdk8"))
-    implementation(kotlin("stdlib"))
+    compileOnly(projects.core)
+
+
     implementation(kotlin("reflect"))
 
-    compileOnly(project(":plugins:base"))
-    implementation(project(":core:test-api"))
-    val jsoup_version: String by project
-    implementation("org.jsoup:jsoup:$jsoup_version")
+    compileOnly(projects.plugins.base)
+    implementation(projects.core.testApi)
+
+    implementation(libs.jsoup)
     implementation(kotlin("test-junit"))
 
-    testImplementation(project(":test-utils"))
-    testImplementation(project(":core:test-api"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.6.0")
+    testImplementation(projects.testUtils)
+    testImplementation(projects.core.testApi)
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
 }
 
 registerDokkaArtifactPublication("dokkaBaseTestUtils") {

--- a/plugins/base/build.gradle.kts
+++ b/plugins/base/build.gradle.kts
@@ -6,59 +6,55 @@ plugins {
 }
 
 dependencies {
-    compileOnly(project(":core"))
-    implementation(kotlin("stdlib-jdk8"))
-    implementation(kotlin("stdlib"))
+    compileOnly(projects.core)
+
     implementation(kotlin("reflect"))
 
-    val coroutines_version: String by project
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version")
+    implementation(libs.kotlinx.coroutines.core)
 
-    compileOnly(project(":kotlin-analysis"))
-    val jsoup_version: String by project
-    implementation("org.jsoup:jsoup:$jsoup_version")
+    compileOnly(projects.kotlinAnalysis)
+    implementation(libs.jsoup)
 
-    val jackson_version: String by project
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
-    val jackson_databind_version: String by project
+    implementation(libs.jackson.kotlin)
     constraints {
-        implementation("com.fasterxml.jackson.core:jackson-databind:$jackson_databind_version") {
+        implementation(libs.jackson.databind) {
             because("CVE-2022-42003")
         }
     }
 
-    val freemarker_version: String by project
-    implementation("org.freemarker:freemarker:$freemarker_version")
+    implementation(libs.freemarker)
 
-    testImplementation(project(":plugins:base:base-test-utils"))
-    testImplementation(project(":core:content-matcher-test-utils"))
+    testImplementation(projects.plugins.base.baseTestUtils)
+    testImplementation(projects.core.contentMatcherTestUtils)
 
-    val kotlinx_html_version: String by project
-    implementation("org.jetbrains.kotlinx:kotlinx-html-jvm:$kotlinx_html_version")
+    implementation(libs.kotlinx.html)
 
-    testImplementation(project(":kotlin-analysis"))
-    testImplementation(project(":test-utils"))
-    testImplementation(project(":core:test-api"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.6.0")
+    testImplementation(projects.kotlinAnalysis)
+    testImplementation(projects.testUtils)
+    testImplementation(projects.core.testApi)
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
 }
 
 val projectDistDir = project(":plugins:base:frontend").file("dist")
 val generateFrontendFiles = tasks.getByPath(":plugins:base:frontend:generateFrontendFiles")
 
-val copyJsFiles by tasks.registering(Copy::class){
-    from(projectDistDir){
+val copyJsFiles by tasks.registering(Copy::class) {
+    from(projectDistDir) {
         include("*.js")
     }
     dependsOn(generateFrontendFiles)
-    destinationDir = File(sourceSets.main.get().resources.sourceDirectories.singleFile, "dokka/scripts")
+    destinationDir =
+        File(sourceSets.main.get().resources.sourceDirectories.singleFile, "dokka/scripts")
 }
 
-val copyCssFiles by tasks.registering(Copy::class){
-    from(projectDistDir){
+val copyCssFiles by tasks.registering(Copy::class) {
+    from(projectDistDir) {
         include("*.css")
     }
     dependsOn(generateFrontendFiles)
-    destinationDir = File(sourceSets.main.get().resources.sourceDirectories.singleFile, "dokka/styles")
+    destinationDir =
+        File(sourceSets.main.get().resources.sourceDirectories.singleFile, "dokka/styles")
 }
 
 val copyFrontend by tasks.registering {

--- a/plugins/base/frontend/build.gradle.kts
+++ b/plugins/base/frontend/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 node {
-    version.set("16.13.0")
+    version.set(libs.versions.node)
     download.set(true)
 }
 

--- a/plugins/gfm/build.gradle.kts
+++ b/plugins/gfm/build.gradle.kts
@@ -6,22 +6,19 @@ plugins {
 }
 
 dependencies {
-    compileOnly(project(":core"))
-    implementation(kotlin("stdlib-jdk8"))
-    implementation(kotlin("stdlib"))
+    compileOnly(projects.core)
     implementation(kotlin("reflect"))
-    implementation(project(":plugins:base"))
-    testImplementation(project(":plugins:base"))
-    testImplementation(project(":plugins:base:base-test-utils"))
-    val jackson_version: String by project
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
-    testImplementation(project(":test-utils"))
-    testImplementation(project(":core:test-api"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.6.0")
-    
-    val jackson_databind_version: String by project
+    implementation(projects.plugins.base)
+    testImplementation(projects.plugins.base)
+    testImplementation(projects.plugins.base.baseTestUtils)
+    implementation(libs.jackson.kotlin)
+    testImplementation(projects.testUtils)
+    testImplementation(projects.core.testApi)
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+
     constraints {
-        implementation("com.fasterxml.jackson.core:jackson-databind:$jackson_databind_version") {
+        implementation(libs.jackson.databind) {
             because("CVE-2022-42003")
         }
     }

--- a/plugins/gfm/gfm-template-processing/build.gradle.kts
+++ b/plugins/gfm/gfm-template-processing/build.gradle.kts
@@ -6,21 +6,20 @@ plugins {
 }
 
 dependencies {
-    compileOnly(project(":core"))
-    implementation(kotlin("stdlib-jdk8"))
-    implementation(kotlin("stdlib"))
+    compileOnly(projects.core)
+
     implementation(kotlin("reflect"))
-    implementation(project(":plugins:base"))
-    implementation(project(":plugins:gfm"))
-    implementation(project(":plugins:all-modules-page"))
-    implementation(project(":plugins:templating"))
+    implementation(projects.plugins.base)
+    implementation(projects.plugins.gfm)
+    implementation(projects.plugins.allModulesPage)
+    implementation(projects.plugins.templating)
 
-    val coroutines_version: String by project
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version")
+    implementation(libs.kotlinx.coroutines.core)
 
-    testImplementation(project(":test-utils"))
-    testImplementation(project(":core:test-api"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.6.0")
+    testImplementation(projects.testUtils)
+    testImplementation(projects.core.testApi)
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
 }
 
 registerDokkaArtifactPublication("dokkaGfmTemplateProcessing") {

--- a/plugins/javadoc/build.gradle.kts
+++ b/plugins/javadoc/build.gradle.kts
@@ -6,28 +6,25 @@ plugins {
 }
 
 dependencies {
-    compileOnly(project(":core"))
-    implementation(kotlin("stdlib-jdk8"))
-    implementation(kotlin("stdlib"))
+    compileOnly(projects.core)
+    compileOnly(projects.kotlinAnalysis)
+
     implementation(kotlin("reflect"))
-    compileOnly(project(":kotlin-analysis"))
-    implementation("com.soywiz.korlibs.korte:korte-jvm:2.7.0")
-    implementation(project(":plugins:base"))
-    implementation(project(":plugins:kotlin-as-java"))
-    testImplementation(project(":plugins:base:base-test-utils"))
+    implementation(libs.soywiz.korte)
+    implementation(projects.plugins.base)
+    implementation(projects.plugins.kotlinAsJava)
 
-    val kotlinx_html_version: String by project
-    implementation("org.jetbrains.kotlinx:kotlinx-html-jvm:$kotlinx_html_version")
+    implementation(libs.kotlinx.html)
+    implementation(libs.kotlinx.coroutines.core)
 
-    val coroutines_version: String by project
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version")
+    testImplementation(projects.plugins.base.baseTestUtils)
+    testImplementation(projects.testUtils)
+    testImplementation(projects.core.testApi)
 
-    val jsoup_version: String by project
-    testImplementation("org.jsoup:jsoup:$jsoup_version")
+    testImplementation(libs.jsoup)
 
-    testImplementation(project(":test-utils"))
-    testImplementation(project(":core:test-api"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.6.0")
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
 }
 
 registerDokkaArtifactPublication("javadocPlugin") {

--- a/plugins/jekyll/build.gradle.kts
+++ b/plugins/jekyll/build.gradle.kts
@@ -6,16 +6,15 @@ plugins {
 }
 
 dependencies {
-    compileOnly(project(":core"))
-    implementation(kotlin("stdlib-jdk8"))
-    implementation(kotlin("stdlib"))
+    compileOnly(projects.core)
     implementation(kotlin("reflect"))
-    implementation(project(":plugins:base"))
-    implementation(project(":plugins:gfm"))
+    implementation(projects.plugins.base)
+    implementation(projects.plugins.gfm)
 
-    testImplementation(project(":test-utils"))
-    testImplementation(project(":core:test-api"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.6.0")
+    testImplementation(projects.testUtils)
+    testImplementation(projects.core.testApi)
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
 }
 
 registerDokkaArtifactPublication("jekyllPlugin") {

--- a/plugins/jekyll/jekyll-template-processing/build.gradle.kts
+++ b/plugins/jekyll/jekyll-template-processing/build.gradle.kts
@@ -6,24 +6,22 @@ plugins {
 }
 
 dependencies {
-    compileOnly(project(":core"))
-    implementation(kotlin("stdlib-jdk8"))
-    implementation(kotlin("stdlib"))
+    compileOnly(projects.core)
     implementation(kotlin("reflect"))
 
-    implementation(project(":plugins:base"))
-    implementation(project(":plugins:jekyll"))
-    implementation(project(":plugins:all-modules-page"))
-    implementation(project(":plugins:templating"))
-    implementation(project(":plugins:gfm"))
-    implementation(project(":plugins:gfm:gfm-template-processing"))
+    implementation(projects.plugins.base)
+    implementation(projects.plugins.jekyll)
+    implementation(projects.plugins.allModulesPage)
+    implementation(projects.plugins.templating)
+    implementation(projects.plugins.gfm)
+    implementation(projects.plugins.gfm.gfmTemplateProcessing)
 
-    val coroutines_version: String by project
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version")
+    implementation(libs.kotlinx.coroutines.core)
 
-    testImplementation(project(":test-utils"))
-    testImplementation(project(":core:test-api"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.6.0")
+    testImplementation(projects.testUtils)
+    testImplementation(projects.core.testApi)
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
 }
 
 registerDokkaArtifactPublication("dokkaJekyllTemplateProcessing") {

--- a/plugins/kotlin-as-java/build.gradle.kts
+++ b/plugins/kotlin-as-java/build.gradle.kts
@@ -6,22 +6,20 @@ plugins {
 }
 
 dependencies {
-    compileOnly(project(":core"))
-    implementation(kotlin("stdlib-jdk8"))
-    implementation(kotlin("stdlib"))
+    compileOnly(projects.core)
     implementation(kotlin("reflect"))
-    compileOnly(project(":kotlin-analysis"))
-    implementation(project(":plugins:base"))
-    testImplementation(project(":plugins:base"))
-    testImplementation(project(":plugins:base:base-test-utils"))
-    testImplementation(project(":core:content-matcher-test-utils"))
-    val jsoup_version: String by project
-    testImplementation("org.jsoup:jsoup:$jsoup_version")
-    testImplementation(project(":kotlin-analysis"))
+    compileOnly(projects.kotlinAnalysis)
+    implementation(projects.plugins.base)
+    testImplementation(projects.plugins.base)
+    testImplementation(projects.plugins.base.baseTestUtils)
+    testImplementation(projects.core.contentMatcherTestUtils)
+    testImplementation(libs.jsoup)
+    testImplementation(projects.kotlinAnalysis)
 
-    testImplementation(project(":test-utils"))
-    testImplementation(project(":core:test-api"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.6.0")
+    testImplementation(projects.testUtils)
+    testImplementation(projects.core.testApi)
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
 }
 
 registerDokkaArtifactPublication("kotlinAsJavaPlugin") {

--- a/plugins/mathjax/build.gradle.kts
+++ b/plugins/mathjax/build.gradle.kts
@@ -6,22 +6,20 @@ plugins {
 }
 
 dependencies {
-    compileOnly(project(":core"))
-    implementation(kotlin("stdlib-jdk8"))
-    implementation(kotlin("stdlib"))
+    compileOnly(projects.core)
     implementation(kotlin("reflect"))
-    implementation(project(":plugins:base"))
+    implementation(projects.plugins.base)
 
-    val jsoup_version: String by project
-    testImplementation("org.jsoup:jsoup:$jsoup_version")
-    testImplementation(project(":plugins:base:base-test-utils"))
-    testImplementation(project(":core:content-matcher-test-utils"))
+    testImplementation(libs.jsoup)
+    testImplementation(projects.plugins.base.baseTestUtils)
+    testImplementation(projects.core.contentMatcherTestUtils)
     testImplementation(kotlin("test-junit"))
-    testImplementation(project(":kotlin-analysis"))
+    testImplementation(projects.kotlinAnalysis)
 
-    testImplementation(project(":test-utils"))
-    testImplementation(project(":core:test-api"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.6.0")
+    testImplementation(projects.testUtils)
+    testImplementation(projects.core.testApi)
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
 }
 
 registerDokkaArtifactPublication("mathjaxPlugin") {

--- a/plugins/templating/build.gradle.kts
+++ b/plugins/templating/build.gradle.kts
@@ -10,30 +10,26 @@ registerDokkaArtifactPublication("templating-plugin") {
 }
 
 dependencies {
-    compileOnly(project(":core"))
-    implementation(kotlin("stdlib-jdk8"))
-    implementation(kotlin("stdlib"))
-    implementation(kotlin("reflect"))
-    implementation(project(":plugins:base"))
+    compileOnly(projects.core)
 
-    val coroutines_version: String by project
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version")
-    val jackson_version: String by project
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
-    val jackson_databind_version: String by project
+
+    implementation(kotlin("reflect"))
+    implementation(projects.plugins.base)
+
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.jackson.kotlin)
     constraints {
-        implementation("com.fasterxml.jackson.core:jackson-databind:$jackson_databind_version") {
+        implementation(libs.jackson.databind) {
             because("CVE-2022-42003")
         }
     }
-    val kotlinx_html_version: String by project
-    implementation("org.jetbrains.kotlinx:kotlinx-html-jvm:$kotlinx_html_version")
+    implementation(libs.kotlinx.html)
 
-    val jsoup_version: String by project
-    implementation("org.jsoup:jsoup:$jsoup_version")
-    testImplementation(project(":plugins:base:base-test-utils"))
+    implementation(libs.jsoup)
+    testImplementation(projects.plugins.base.baseTestUtils)
 
-    testImplementation(project(":test-utils"))
-    testImplementation(project(":core:test-api"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.6.0")
+    testImplementation(projects.testUtils)
+    testImplementation(projects.core.testApi)
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
 }

--- a/plugins/versioning/build.gradle.kts
+++ b/plugins/versioning/build.gradle.kts
@@ -10,31 +10,26 @@ registerDokkaArtifactPublication("versioning-plugin") {
 }
 
 dependencies {
-    compileOnly(project(":core"))
-    implementation(kotlin("stdlib-jdk8"))
-    implementation(kotlin("stdlib"))
+    compileOnly(projects.core)
     implementation(kotlin("reflect"))
-    implementation(project(":plugins:base"))
-    implementation(project(":plugins:templating"))
+    implementation(projects.plugins.base)
+    implementation(projects.plugins.templating)
+    implementation(projects.plugins.templating)
 
-    val coroutines_version: String by project
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version")
-    val jackson_version: String by project
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
-    val jackson_databind_version: String by project
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.jackson.kotlin)
     constraints {
-        implementation("com.fasterxml.jackson.core:jackson-databind:$jackson_databind_version") {
+        implementation(libs.jackson.databind) {
             because("CVE-2022-42003")
         }
     }
-    val kotlinx_html_version: String by project
-    implementation("org.jetbrains.kotlinx:kotlinx-html-jvm:$kotlinx_html_version")
+    implementation(libs.kotlinx.html)
 
-    val jsoup_version: String by project
-    implementation("org.jsoup:jsoup:$jsoup_version")
-    implementation("org.apache.maven:maven-artifact:3.8.5")
+    implementation(libs.jsoup)
+    implementation(libs.apache.mavenArtifact)
 
-    testImplementation(project(":test-utils"))
-    testImplementation(project(":core:test-api"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.6.0")
+    testImplementation(projects.testUtils)
+    testImplementation(projects.core.testApi)
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
 }

--- a/runners/cli/build.gradle.kts
+++ b/runners/cli/build.gradle.kts
@@ -8,9 +8,9 @@ plugins {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlinx:kotlinx-cli-jvm:0.3.4")
-    implementation(project(":core"))
-    implementation(kotlin("stdlib"))
+    implementation(projects.core)
+    implementation(libs.kotlinx.cli)
+
     testImplementation(kotlin("test-junit"))
 }
 

--- a/runners/gradle-plugin/build.gradle.kts
+++ b/runners/gradle-plugin/build.gradle.kts
@@ -8,15 +8,14 @@ plugins {
 }
 
 dependencies {
-    api(project(":core"))
+    implementation(projects.core)
 
-    compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin")
-    compileOnly("com.android.tools.build:gradle:4.0.1")
-    compileOnly(gradleKotlinDsl())
-    testImplementation(project(":test-utils"))
-    testImplementation(gradleKotlinDsl())
-    testImplementation("org.jetbrains.kotlin:kotlin-gradle-plugin")
-    testImplementation("com.android.tools.build:gradle:4.0.1")
+    compileOnly(libs.gradlePlugin.kotlin)
+    compileOnly(libs.gradlePlugin.android)
+
+    testImplementation(projects.testUtils)
+    testImplementation(libs.gradlePlugin.kotlin)
+    testImplementation(libs.gradlePlugin.android)
 }
 
 // Gradle will put its own version of the stdlib in the classpath, so not pull our own we will end up with

--- a/runners/gradle-plugin/build.gradle.kts
+++ b/runners/gradle-plugin/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 dependencies {
-    implementation(projects.core)
+    api(projects.core)
 
     compileOnly(libs.gradlePlugin.kotlin)
     compileOnly(libs.gradlePlugin.android)

--- a/runners/maven-plugin/build.gradle.kts
+++ b/runners/maven-plugin/build.gradle.kts
@@ -10,12 +10,14 @@ plugins {
 val setupMaven by tasks.register<SetupMaven>("setupMaven")
 
 dependencies {
-    implementation(project(":core"))
-    implementation("org.apache.maven:maven-core:${setupMaven.mavenVersion}")
-    implementation("org.apache.maven:maven-plugin-api:${setupMaven.mavenVersion}")
-    implementation("org.apache.maven.plugin-tools:maven-plugin-annotations:${setupMaven.mavenPluginToolsVersion}")
-    implementation("org.apache.maven:maven-archiver:2.5")
-    implementation(kotlin("stdlib-jdk8"))
+    implementation(projects.core)
+
+    implementation(libs.apache.mavenCore)
+    implementation(libs.apache.mavenPluginApi)
+    implementation(libs.apache.mavenPluginAnnotations)
+    implementation(libs.apache.mavenArchiver)
+
+
 }
 
 val mavenBuildDir = setupMaven.mavenBuildDir
@@ -39,7 +41,10 @@ val generatePom by tasks.registering(Copy::class) {
 
     eachFile {
         filter { line ->
-            line.replace("<maven.version></maven.version>", "<maven.version>${setupMaven.mavenVersion}</maven.version>")
+            line.replace(
+                "<maven.version></maven.version>",
+                "<maven.version>${setupMaven.mavenVersion}</maven.version>"
+            )
         }
         filter { line ->
             line.replace("<version>dokka_version</version>", "<version>$dokka_version</version>")
@@ -76,7 +81,12 @@ val helpMojo by tasks.registering(CrossPlatformExec::class) {
 val pluginDescriptor by tasks.registering(CrossPlatformExec::class) {
     dependsOn(setupMaven, generatePom, syncClasses)
     workingDir(setupMaven.mavenBuildDir)
-    commandLine(setupMaven.mvn, "-e", "-B", "org.apache.maven.plugins:maven-plugin-plugin:descriptor")
+    commandLine(
+        setupMaven.mvn,
+        "-e",
+        "-B",
+        "org.apache.maven.plugins:maven-plugin-plugin:descriptor"
+    )
 
     outputs.dir(layout.buildDirectory.dir("maven/classes/java/main/META-INF/maven"))
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,57 @@
+@file:Suppress("UnstableApiUsage")
+
 rootProject.name = "dokka"
+
+pluginManagement {
+    includeBuild("build-logic")
+
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+
+    // subproject :kotlin-analysis:intellij-dependency requires specific repositories that should not be used in
+    // the other subprojects, so use PREFER_PROJECT to allow subprojects to override the repositories defined here.
+    repositoriesMode.set(RepositoriesMode.PREFER_PROJECT)
+
+    repositories {
+        mavenCentral()
+        google()
+
+        // Declare the Node.js & Yarn download repositories
+        // Required by Gradle Node plugin: https://github.com/node-gradle/gradle-node-plugin/blob/3.5.1/docs/faq.md#is-this-plugin-compatible-with-centralized-repositories-declaration
+        exclusiveContent {
+            forRepository {
+                ivy("https://nodejs.org/dist/") {
+                    name = "Node Distributions at $url"
+                    patternLayout { artifact("v[revision]/[artifact](-v[revision]-[classifier]).[ext]") }
+                    metadataSources { artifact() }
+                    content { includeModule("org.nodejs", "node") }
+                }
+            }
+            filter { includeGroup("org.nodejs") }
+        }
+
+        exclusiveContent {
+            forRepository {
+                ivy("https://github.com/yarnpkg/yarn/releases/download") {
+                    name = "Yarn Distributions at $url"
+                    patternLayout { artifact("v[revision]/[artifact](-v[revision]).[ext]") }
+                    metadataSources { artifact() }
+                    content { includeModule("com.yarnpkg", "yarn") }
+                }
+            }
+            filter { includeGroup("com.yarnpkg") }
+        }
+    }
+}
+
+plugins {
+    `gradle-enterprise`
+}
 
 include(
     ":core",
@@ -39,20 +92,10 @@ include(
 
     ":mkdocs",
 )
-includeBuild("build-logic")
 
 val isCiBuild = System.getenv("GITHUB_ACTIONS") != null || System.getenv("TEAMCITY_VERSION") != null
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenCentral()
-    }
-}
 
-plugins {
-    `gradle-enterprise`
-}
 
 gradleEnterprise {
     buildScan {
@@ -62,41 +105,5 @@ gradleEnterprise {
     }
 }
 
-@Suppress("UnstableApiUsage")
-dependencyResolutionManagement {
 
-    // subproject :kotlin-analysis:intellij-dependency requires specific repositories that should not be used in
-    // the other subprojects, so use PREFER_PROJECT to allow subprojects to override the repositories defined here.
-    repositoriesMode.set(RepositoriesMode.PREFER_PROJECT)
-
-    repositories {
-        mavenCentral()
-        google()
-
-        // Declare the Node.js & Yarn download repositories
-        // Required by Gradle Node plugin: https://github.com/node-gradle/gradle-node-plugin/blob/3.5.1/docs/faq.md#is-this-plugin-compatible-with-centralized-repositories-declaration
-        exclusiveContent {
-            forRepository {
-                ivy("https://nodejs.org/dist/") {
-                    name = "Node Distributions at $url"
-                    patternLayout { artifact("v[revision]/[artifact](-v[revision]-[classifier]).[ext]") }
-                    metadataSources { artifact() }
-                    content { includeModule("org.nodejs", "node") }
-                }
-            }
-            filter { includeGroup("org.nodejs") }
-        }
-
-        exclusiveContent {
-            forRepository {
-                ivy("https://github.com/yarnpkg/yarn/releases/download") {
-                    name = "Yarn Distributions at $url"
-                    patternLayout { artifact("v[revision]/[artifact](-v[revision]).[ext]") }
-                    metadataSources { artifact() }
-                    content { includeModule("com.yarnpkg", "yarn") }
-                }
-            }
-            filter { includeGroup("com.yarnpkg") }
-        }
-    }
-}
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
* Moves versions out of `gradle.properties` and into `libs.versions.toml` [version catalog](https://docs.gradle.org/current/userguide/platforms.html)
* Uses [type-safe project dependencies](https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:type-safe-project-accessors) for internal projects
* refactor the maven-cli downloader convention plugin (added in #2911) to use the version catalog, and for clarity
* Additionally updates JUnit to 5.9.2

Depends on #2652 



