### PR TITLE
Fix `TypeNotPresentException` in projects without KGP

### DIFF
--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/utils.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/utils.kt
@@ -17,8 +17,13 @@ internal fun parsePath(path: String): Path = Path.path(path)
 internal val Project.kotlinOrNull: KotlinProjectExtension?
     get() = try {
         project.extensions.findByType()
-    } catch (e: NoClassDefFoundError) {
-        null
+    } catch (e: Throwable) {
+        when (e) {
+            // if the user project doesn't have KGP applied, we won't be able to load the class;
+            // TypeNotPresentException is possible if it's loaded through reified generics.
+            is NoClassDefFoundError, is TypeNotPresentException, is ClassNotFoundException -> null
+            else -> throw e
+        }
     }
 
 internal val Project.kotlin: KotlinProjectExtension


### PR DESCRIPTION
Regression from https://github.com/Kotlin/dokka/commit/0a09318eae5b21194507708af51a4469ec5d57aa#diff-127cb17801c64a32309502eaee33392ad749494ba8022bef47e8002359ea1b8eL17

Before, it was loading a specific java class, so it failed with `NoClassDefFoundError` that was caught, and we returned null.

With Kotlin DSL, `findByType()` is trying to load `reified T` through `Class#getGenericSuperclass`, which throws `TypeNotPresentException`.

We don't expect that `TypeNotPresentException` will be thrown, so it's not caught and the user project is failing with

```
Caused by: java.lang.TypeNotPresentException: Type org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension not present
        at org.gradle.api.reflect.TypeOf.captureTypeArgument(TypeOf.java:301)
        at org.gradle.api.reflect.TypeOf.<init>(TypeOf.java:97)
        at org.jetbrains.dokka.gradle.UtilsKt$kotlinOrNull$$inlined$findByType$1.<init>(TypeOfExtensions.kt:28)
        at org.jetbrains.dokka.gradle.UtilsKt.getKotlinOrNull(utils.kt:43)
```

This can be reproduced on projects that don't have KGP applied.