### PR TITLE
Stop testing on Java 15

### DIFF
--- a/.github/workflows/gradle-test.pr.yml
+++ b/.github/workflows/gradle-test.pr.yml
@@ -26,7 +26,7 @@ jobs:
   test-windows:
     strategy:
       matrix:
-        version: [ 11, 15, 17 ]
+        version: [ 11, 17 ]
       fail-fast: false
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
This version is unsupported so there's little value in testing with it.