### PR TITLE
all-modules-page: Validate cross-module links during resolution

### DIFF
--- a/plugins/all-modules-page/src/test/kotlin/templates/ResolveLinkCommandResolutionTest.kt
+++ b/plugins/all-modules-page/src/test/kotlin/templates/ResolveLinkCommandResolutionTest.kt
@@ -56,7 +56,7 @@ class ResolveLinkCommandResolutionTest : MultiModuleAbstractTest() {
             }
         }
 
-        val contentFile = setup(link)
+        val contentFile = setup(link, testedDri)
         val configuration = configuration()
 
         testFromData(configuration, useOutputLocationFromConfig = true) {
@@ -95,10 +95,16 @@ class ResolveLinkCommandResolutionTest : MultiModuleAbstractTest() {
         }
     }
 
-    fun setup(content: String): File {
+    private fun setup(content: String, resolutionTarget: DRI? = null): File {
         folder.create()
         val innerModule1 = folder.newFolder("module1")
         val innerModule2 = folder.newFolder("module2")
+        if (resolutionTarget != null) {
+            val resolvedFile = innerModule2
+                .resolve("${resolutionTarget.packageName}/-${resolutionTarget.classNames?.toLowerCase()}/index.html")
+            resolvedFile.parentFile.mkdirs()
+            resolvedFile.createNewFile()
+        }
         val packageList = innerModule2.resolve("package-list")
         packageList.writeText(mockedPackageListForPackages(RecognizedLinkFormat.DokkaHtml, "package2"))
         val contentFile = innerModule1.resolve("index.html")

--- a/plugins/all-modules-page/src/test/kotlin/templates/ResolveLinkGfmCommandResolutionTest.kt
+++ b/plugins/all-modules-page/src/test/kotlin/templates/ResolveLinkGfmCommandResolutionTest.kt
@@ -51,7 +51,7 @@ class ResolveLinkGfmCommandResolutionTest : MultiModuleAbstractTest() {
 
         val expected = "[Sample text inside](../module2/package2/-sample/index.md)"
 
-        val content = setup(link)
+        val content = setup(link, testedDri)
         val configuration = configuration()
 
         testFromData(configuration, pluginOverrides = listOf(GfmTemplateProcessingPlugin(), GfmPlugin()), useOutputLocationFromConfig = true) {
@@ -61,10 +61,16 @@ class ResolveLinkGfmCommandResolutionTest : MultiModuleAbstractTest() {
         }
     }
 
-    private fun setup(content: String): File {
+    private fun setup(content: String, resolutionTarget: DRI? = null): File {
         folder.create()
-        val innerModule1 = folder.newFolder( "module1")
-        val innerModule2 = folder.newFolder( "module2")
+        val innerModule1 = folder.newFolder("module1")
+        val innerModule2 = folder.newFolder("module2")
+        if (resolutionTarget != null) {
+            val resolvedFile = innerModule2
+                .resolve("${resolutionTarget.packageName}/-${resolutionTarget.classNames?.toLowerCase()}/index.md")
+            resolvedFile.parentFile.mkdirs()
+            resolvedFile.createNewFile()
+        }
         val packageList = innerModule2.resolve("package-list")
         packageList.writeText(mockedPackageListForPackages(RecognizedLinkFormat.DokkaGFM, "package2"))
         val contentFile = innerModule1.resolve("index.md")


### PR DESCRIPTION
I scanned the list of open issues but didn't spot one that matched my experience directly, but the closest might be #2037 or #2272. I'm not sure if this is necessarily the correct or ideal fix, and the underlying wider issue of supporting split packages probably requires further changes, but I did want to at least share this as it makes Dokka usable for our use-cases.

From commit message:

>The existing behavior was just taking the first module that includes the package name of a given reference, so this resulted in broken links when a package is split across multiple modules.
>
>This change checks to ensure the resolved file exists before choosing it as the target for the resolved link.
