### PR TITLE
Move the Properties block to be above Functions

### DIFF
--- a/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/HtmlRenderer.kt
@@ -90,8 +90,8 @@ open class HtmlRenderer(
                     listOf(
                         BasicTabbedContentType.CONSTRUCTOR,
                         BasicTabbedContentType.TYPE,
-                        BasicTabbedContentType.FUNCTION,
-                        BasicTabbedContentType.PROPERTY
+                        BasicTabbedContentType.PROPERTY,
+                        BasicTabbedContentType.FUNCTION
                     )
                 ),
             if (extensions.isEmpty()) null else ContentTab(
@@ -99,8 +99,8 @@ open class HtmlRenderer(
                 listOf(
                     BasicTabbedContentType.CONSTRUCTOR,
                     BasicTabbedContentType.TYPE,
-                    BasicTabbedContentType.FUNCTION,
                     BasicTabbedContentType.PROPERTY,
+                    BasicTabbedContentType.FUNCTION,
                     BasicTabbedContentType.EXTENSION_PROPERTY,
                     BasicTabbedContentType.EXTENSION_FUNCTION
                 )

--- a/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DefaultPageCreator.kt
@@ -318,10 +318,10 @@ open class DefaultPageCreator(
                 "Inherited functions", inheritedFunctions + inheritedExtensionFunctions
             )
         } else {
-            functionsBlock("Functions", functions + extensionFuns)
             propertiesBlock(
                 "Properties", properties + extensionProps
             )
+            functionsBlock("Functions", functions + extensionFuns)
         }
     }
 

--- a/plugins/base/src/test/kotlin/renderers/html/TabbedContentTest.kt
+++ b/plugins/base/src/test/kotlin/renderers/html/TabbedContentTest.kt
@@ -142,4 +142,40 @@ class TabbedContentTest : BaseAbstractTest() {
             }
         }
     }
+
+    @Test
+    fun `should have expected order of content types within a members tab`() {
+        val source = """
+            |/src/main/kotlin/test/Result.kt
+            |package example
+            |
+            |class Result(val d: Int = 0) {
+            |  class Success(): Result()
+            |  
+            |  val isFailed = false
+            |  fun reset() = 0
+            |  fun String.extension() = 0
+            |}
+            """
+        val writerPlugin = TestOutputWriterPlugin()
+
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin)
+        ) {
+            renderingStage = { _, _ ->
+                val classContent = writerPlugin.writer.renderedContent("root/example/-result/index.html")
+                val tabSectionNames = classContent.select("div .tabs-section-body > div[data-togglable]")
+                    .map { it.attr("data-togglable") }
+
+                val expectedOrder = listOf("CONSTRUCTOR", "TYPE", "PROPERTY", "FUNCTION")
+
+                assertEquals(expectedOrder.size, tabSectionNames.size)
+                expectedOrder.forEachIndexed { index, element ->
+                    assertEquals(element, tabSectionNames[index])
+                }
+            }
+        }
+    }
 }

--- a/plugins/base/src/test/kotlin/signatures/InheritedAccessorsSignatureTest.kt
+++ b/plugins/base/src/test/kotlin/signatures/InheritedAccessorsSignatureTest.kt
@@ -205,13 +205,13 @@ class InheritedAccessorsSignatureTest : BaseAbstractTest() {
                     "Expected 5 signatures: class signature, constructor, property and two accessor lookalikes"
                 )
 
-                val getterLookalikeFunction = signatures[2]
+                val getterLookalikeFunction = signatures[3]
                 getterLookalikeFunction.match(
                     "open fun ", A("getA"), "():", A("Int"),
                     ignoreSpanWithTokenStyle = true
                 )
 
-                val setterLookalikeFunction = signatures[3]
+                val setterLookalikeFunction = signatures[4]
                 setterLookalikeFunction.match(
                     "open fun ", A("setA"), "(", Parameters(
                         Parameter("a: ", A("Int"))
@@ -219,7 +219,7 @@ class InheritedAccessorsSignatureTest : BaseAbstractTest() {
                     ignoreSpanWithTokenStyle = true
                 )
 
-                val property = signatures[4]
+                val property = signatures[2]
                 property.match(
                     "var ", A("a"), ":", A("Int"),
                     ignoreSpanWithTokenStyle = true


### PR DESCRIPTION
* It is more consistent with the declaration order described in our [coding conventions](https://kotlinlang.org/docs/coding-conventions.html#class-layout)
* There are usually less properties than functions, so it should help with not having to scroll as much to get to them

Current (that is, before this change) behaviour could be seen here: [kotlinx-datetime#Instant](https://kotlinlang.org/api/kotlinx-datetime/kotlinx-datetime/kotlinx.datetime/-instant/)