### PR TITLE
Remove unused Gradle tasks

### DIFF
--- a/runners/gradle-plugin/build.gradle.kts
+++ b/runners/gradle-plugin/build.gradle.kts
@@ -43,11 +43,6 @@ fun Configuration.excludeGradleCommonDependencies() {
         }
 }
 
-val sourceJar by tasks.registering(Jar::class) {
-    archiveClassifier.set("sources")
-    from(sourceSets["main"].allSource)
-}
-
 gradlePlugin {
     plugins {
         create("dokkaGradlePlugin") {

--- a/runners/maven-plugin/build.gradle.kts
+++ b/runners/maven-plugin/build.gradle.kts
@@ -81,11 +81,6 @@ val pluginDescriptor by tasks.registering(CrossPlatformExec::class) {
     outputs.dir(layout.buildDirectory.dir("maven/classes/java/main/META-INF/maven"))
 }
 
-val sourceJar by tasks.registering(Jar::class) {
-    archiveClassifier.set("sources")
-    from(java.sourceSets["main"].allSource)
-}
-
 tasks.jar {
     dependsOn(pluginDescriptor, helpMojo)
     metaInf {


### PR DESCRIPTION
This PR removes some defined, but unused, Gradle tasks

These custom `sourceJar` tasks are not used. A `sourcesJar` is auto-created using `withSourcesJar()`

https://github.com/Kotlin/dokka/blob/6b46d95bf31a15952c07e8072bc134bbbf02ca5f/buildSrc/src/main/kotlin/org/jetbrains/conventions/base-java.gradle.kts#L20-L22