### PR TITLE
tidy up .gitignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,6 @@
-*.ipr
-*.iml
 
-### Maven template
-target/
-pom.xml.tag
-pom.xml.releaseBackup
-pom.xml.versionsBackup
-pom.xml.next
-release.properties
-dependency-reduced-pom.xml
-buildNumber.properties
-.mvn/timing.properties
-### Java template
+### Java
 *.class
-
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
 
 # Package Files #
 *.jar
@@ -24,82 +9,28 @@ buildNumber.properties
 
 # virtual machine crash logs, see https://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
-### JetBrains template
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
-# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
-# User-specific stuff:
-.idea/workspace.xml
-.idea/tasks.xml
-.idea/dictionaries
-.idea/vcs.xml
-.idea/shelf
-.idea/jsLibraryMappings.xml
-.idea/modules.xml
-.idea/misc.xml
-.idea/compiler.xml
+### IntelliJ
 
-# Sensitive or high-churn files:
-.idea/dataSources.ids
-.idea/dataSources.xml
-.idea/dataSources.local.xml
-.idea/sqlDataSources.xml
-.idea/dynamic.xml
-.idea/uiDesigner.xml
-
-# Gradle:
-.idea/gradle.xml
-.idea/libraries
-
-# Mongo Explorer plugin:
-.idea/mongoSettings.xml
+.idea/
+/out/
 
 ## File-based project format:
 *.iws
 *.iml
+*.ipr
 
-## Plugin-specific files:
-
-# IntelliJ
-/out/
-
-# mpeltonen/sbt-idea plugin
-.idea_modules/
-
-# JIRA plugin
-atlassian-ide-plugin.xml
-
-# Crashlytics plugin (for Android Studio and IntelliJ)
-com_crashlytics_export_strings.xml
-crashlytics.properties
-crashlytics-build.properties
-fabric.properties
-### Gradle template
+### Gradle
 .gradle
 build/
 
-# Ignore Gradle GUI config
-gradle-app.setting
-
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
-
-# Cache of project
-.gradletasknamecache
-
-# # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
-# gradle/wrapper/gradle-wrapper.properties
 
 !lib/*.jar
 
 local.properties
 android.local.properties
 
-!integration-tests/gradle-integration-tests/testData/basic/classDir/**/*.class
-
 core/out/
 runners/**/out/
-.idea
-plugins/base/src/main/resources/dokka/scripts/main.js
-plugins/base/src/main/resources/dokka/scripts/main.js.map
-/.idea/compiler.xml

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ build/
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
 
-!lib/*.jar
 
 local.properties
 android.local.properties

--- a/plugins/.gitignore
+++ b/plugins/.gitignore
@@ -1,2 +1,0 @@
-base/src/main/resources/dokka/scripts/main.js
-base/src/main/resources/dokka/scripts/main.js.map


### PR DESCRIPTION
* Removed unnecessary ignores for
  * Maven
  * Android
  * `.idea/` subdirectories (`.idea/` is already ignored)
  * old Gradle files (there's no Gradle UI any more, or task-cache file)
* Removed ignores for project files that don't exist any more
