### PR TITLE
Use info level for progress in Dokka Gradle plugin

### DIFF
--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/AbstractDokkaTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/AbstractDokkaTask.kt
@@ -220,7 +220,7 @@ abstract class AbstractDokkaTask : DefaultTask() {
         when (level) {
             "debug" -> logger.debug(message)
             "info" -> logger.info(message)
-            "progress" -> logger.lifecycle(message)
+            "progress" -> logger.info(message)
             "warn" -> logger.warn(message)
             "error" -> logger.error(message)
         }


### PR DESCRIPTION
fixes #1894

Level for progress set to `info`. See the issue for more details