### PR TITLE
nitpick: Gradle examples tidy up

### DIFF
--- a/examples/gradle/dokka-customFormat-example/build.gradle.kts
+++ b/examples/gradle/dokka-customFormat-example/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.dokka.base.DokkaBaseConfiguration
 
 plugins {
     kotlin("jvm") version "1.8.10"
-    id("org.jetbrains.dokka") version ("1.8.10")
+    id("org.jetbrains.dokka") version "1.8.10"
 }
 
 buildscript {

--- a/examples/gradle/dokka-gradle-example/build.gradle.kts
+++ b/examples/gradle/dokka-gradle-example/build.gradle.kts
@@ -3,7 +3,7 @@ import java.net.URL
 
 plugins {
     kotlin("jvm") version "1.8.10"
-    id("org.jetbrains.dokka") version ("1.8.10")
+    id("org.jetbrains.dokka") version "1.8.10"
 }
 
 repositories {

--- a/examples/gradle/dokka-kotlinAsJava-example/build.gradle.kts
+++ b/examples/gradle/dokka-kotlinAsJava-example/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     kotlin("jvm") version "1.8.10"
-    id("org.jetbrains.dokka") version ("1.8.10")
+    id("org.jetbrains.dokka") version "1.8.10"
 }
 
 repositories {

--- a/examples/gradle/dokka-library-publishing-example/build.gradle.kts
+++ b/examples/gradle/dokka-library-publishing-example/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     kotlin("jvm") version "1.8.10"
-    id("org.jetbrains.dokka") version ("1.8.10")
+    id("org.jetbrains.dokka") version "1.8.10"
     `java-library`
     `maven-publish`
 }
@@ -38,7 +38,3 @@ publishing {
         }
     }
 }
-
-
-
-

--- a/examples/gradle/dokka-versioning-multimodule-example/build.gradle.kts
+++ b/examples/gradle/dokka-versioning-multimodule-example/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     kotlin("jvm") version "1.8.10"
-    id("org.jetbrains.dokka") version ("1.8.10") apply false
+    id("org.jetbrains.dokka") version "1.8.10" apply false
 }
 
 // The versioning plugin must be applied in all submodules


### PR DESCRIPTION
remove unnecessary brackets from Dokka plugin version, so the Gradle examples are more idiomatic.