### PR TITLE
Fix flaky nodejs dependency

### DIFF
--- a/plugins/base/frontend/build.gradle.kts
+++ b/plugins/base/frontend/build.gradle.kts
@@ -5,7 +5,10 @@ plugins {
 
 node {
     version.set(libs.versions.node)
+
+    // https://github.com/node-gradle/gradle-node-plugin/blob/3.5.1/docs/faq.md#is-this-plugin-compatible-with-centralized-repositories-declaration
     download.set(true)
+    distBaseUrl.set(null as String?) // Strange cast to avoid overload ambiguity
 }
 
 val npmRunBuild = tasks.getByName("npm_run_build") {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,7 +25,7 @@ dependencyResolutionManagement {
         // Required by Gradle Node plugin: https://github.com/node-gradle/gradle-node-plugin/blob/3.5.1/docs/faq.md#is-this-plugin-compatible-with-centralized-repositories-declaration
         exclusiveContent {
             forRepository {
-                ivy("https://nodejs.org/dist/") {
+                ivy("https://cache-redirector.jetbrains.com/nodejs.org/dist/") {
                     name = "Node Distributions at $url"
                     patternLayout { artifact("v[revision]/[artifact](-v[revision]-[classifier]).[ext]") }
                     metadataSources { artifact() }


### PR DESCRIPTION
Both unit and integration tests became extremely flaky because they are unable to find the node dependency, even though it can be downloaded manually.

```
org.gradle.internal.resolve.ModuleVersionNotFoundException: Could not find org.nodejs:node:16.13.0.
Searched in the following locations:
  - https://nodejs.org/dist/v16.13.0/node-v16.13.0-linux-x64.tar.gz
Required by:
    project :plugins:base:frontend
```