### PR TITLE
move POM config to maven-publish convention plugin

### DIFF
--- a/build-logic/src/main/kotlin/org/jetbrains/conventions/maven-publish.gradle.kts
+++ b/build-logic/src/main/kotlin/org/jetbrains/conventions/maven-publish.gradle.kts
@@ -26,5 +26,33 @@ publishing {
 
     publications.withType<MavenPublication>().configureEach {
         artifact(javadocJar)
+
+        pom {
+            name.convention(provider { "Dokka ${project.name}" })
+            description.convention("Dokka is an API documentation engine for Kotlin and Java, performing the same function as Javadoc for Java")
+            url.convention("https://github.com/Kotlin/dokka")
+
+            licenses {
+                license {
+                    name.convention("The Apache Software License, Version 2.0")
+                    url.convention("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                    distribution.convention("repo")
+                }
+            }
+
+            developers {
+                developer {
+                    id.convention("JetBrains")
+                    name.convention("JetBrains Team")
+                    organization.convention("JetBrains")
+                    organizationUrl.convention("https://www.jetbrains.com")
+                }
+            }
+
+            scm {
+                connection.convention("scm:git:git://github.com/Kotlin/dokka.git")
+                url.convention("https://github.com/Kotlin/dokka/tree/master")
+            }
+        }
     }
 }

--- a/build-logic/src/main/kotlin/org/jetbrains/publication.kt
+++ b/build-logic/src/main/kotlin/org/jetbrains/publication.kt
@@ -32,11 +32,10 @@ fun Project.registerDokkaArtifactPublication(
                 when (builder.component) {
                     DokkaPublicationBuilder.Component.Java -> from(components["java"])
                     DokkaPublicationBuilder.Component.Shadow -> run {
-                        extensions.getByType(ShadowExtension::class.java).component(this)
+                        extensions.getByType<ShadowExtension>().component(this)
                         artifact(tasks["sourcesJar"])
                     }
                 }
-                configurePom("Dokka ${project.name}")
             }
         }
     }
@@ -95,36 +94,6 @@ fun Project.createDokkaPublishTaskIfNecessary() {
 fun Project.configureSonatypePublicationIfNecessary(vararg publications: String) {
     if (publicationChannels.any { it.isMavenRepository() }) {
         signPublicationsIfKeyPresent(*publications)
-    }
-}
-
-fun MavenPublication.configurePom(projectName: String) {
-    pom {
-        name.set(projectName)
-        description.set("Dokka is an API documentation engine for Kotlin and Java, performing the same function as Javadoc for Java")
-        url.set("https://github.com/Kotlin/dokka")
-
-        licenses {
-            license {
-                name.set("The Apache Software License, Version 2.0")
-                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-                distribution.set("repo")
-            }
-        }
-
-        developers {
-            developer {
-                id.set("JetBrains")
-                name.set("JetBrains Team")
-                organization.set("JetBrains")
-                organizationUrl.set("https://www.jetbrains.com")
-            }
-        }
-
-        scm {
-            connection.set("scm:git:git://github.com/Kotlin/dokka.git")
-            url.set("https://github.com/Kotlin/dokka/tree/master")
-        }
     }
 }
 

--- a/runners/gradle-plugin/build.gradle.kts
+++ b/runners/gradle-plugin/build.gradle.kts
@@ -74,14 +74,7 @@ publishing {
         }
 
         register<MavenPublication>("pluginMaven") {
-            configurePom("Dokka ${project.name}")
             artifactId = "dokka-gradle-plugin"
-        }
-
-        afterEvaluate {
-            named<MavenPublication>("dokkaGradlePluginPluginMarkerMaven") {
-                configurePom("Dokka plugin")
-            }
         }
     }
 }


### PR DESCRIPTION
https://github.com/Kotlin/dokka/labels/infrastructure

Continue migrating the build logic to use convention plugins #2703 

It is a small part of simplifying the logic in `build-logic/src/main/kotlin/org/jetbrains/publication.kt`

### Impact

This change has only one change: I removed the `afterEvaluate {}` logic for configuring the Dokka Gradle Plugin POM. The result is that the POM is now different. 

<img width="2004" alt="image" src="https://user-images.githubusercontent.com/897017/228204836-1241ee52-311c-440c-b450-55ee4c9fa6b7.png">

(the PR is on the left, master is on the right)

I'd like to be able to avoid this, but I think that improving the build logic is better than trying to edit a POM that most people won't realise even exists!

### Testing

I have tested this by 

1. update `dokka_version` to be `1.8.20` (just so long as it's not a SNAPSHOT - otherwise the comparison below is impossible)
1. publishing to MavenProjectLocal
   `./gradlew publishAllPublicationsToMavenProjectLocalRepository`
2. rename `$rootDir/build/maven-project-local` to `$rootDir/build/maven-project-local-tmp`
3. checking out master branch
4. re-run 
   `./gradlew publishAllPublicationsToMavenProjectLocalRepository`
5. comparing ([with IntelliJ](https://www.jetbrains.com/help/idea/comparing-files-and-folders.html#comparing_folders)) `$rootDir/build/maven-project-local` with `$rootDir/build/maven-project-local-tmp`