### PR TITLE
add reproducible archive build config

### DIFF
--- a/build-logic/src/main/kotlin/org/jetbrains/conventions/base.gradle.kts
+++ b/build-logic/src/main/kotlin/org/jetbrains/conventions/base.gradle.kts
@@ -14,8 +14,13 @@ plugins {
 
 val dokkaBuildProperties: DokkaBuildProperties = extensions.create(DokkaBuildProperties.EXTENSION_NAME)
 
-
 if (project != rootProject) {
     project.group = rootProject.group
     project.version = rootProject.version
+}
+
+tasks.withType<AbstractArchiveTask>().configureEach {
+    // https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives
+    isPreserveFileTimestamps = false
+    isReproducibleFileOrder = true
 }


### PR DESCRIPTION
https://github.com/Kotlin/dokka/labels/infrastructure

This PR adds [reproducible archive build config](https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives)

This helps Gradle caching and improves build speed.

I tested this by 

1. update `dokka_version` to be `1.8.20` (just so long as it's not a SNAPSHOT - otherwise the comparison below is impossible)
1. publishing to MavenProjectLocal
   `./gradlew publishAllPublicationsToMavenProjectLocalRepository`
2. rename `$rootDir/build/maven-project-local` to `$rootDir/build/maven-project-local-tmp`
4. re-run 
   `./gradlew publishAllPublicationsToMavenProjectLocalRepository`
5. comparing ([with IntelliJ](https://www.jetbrains.com/help/idea/comparing-files-and-folders.html#comparing_folders)) `$rootDir/build/maven-project-local` with `$rootDir/build/maven-project-local-tmp`, and see that the only changes are the `maven-metadata.xml` timestamp
   <img width="1580" alt="image" src="https://user-images.githubusercontent.com/897017/228207750-c8156f94-6b9f-417e-9ba4-27148f27543d.png">


Repeating the same test on master test reveals that some JARs change, even if the source code does not.