### PR TITLE
disable publication of shadowRuntimeElements variant

### DIFF
--- a/build-logic/src/main/kotlin/org/jetbrains/conventions/maven-publish.gradle.kts
+++ b/build-logic/src/main/kotlin/org/jetbrains/conventions/maven-publish.gradle.kts
@@ -61,6 +61,8 @@ publishing {
 
 plugins.withType<ShadowPlugin>().configureEach {
     // manually disable publication of Shadow elements https://github.com/johnrengelman/shadow/issues/651#issue-839148311
+    // This is done to preserve compatibility and have the same behaviour as previous versions of Dokka.
+    // For more details, see https://github.com/Kotlin/dokka/pull/2704#issuecomment-1499517930
     val javaComponent = components["java"] as AdhocComponentWithVariants
     javaComponent.withVariantsFromConfiguration(configurations["shadowRuntimeElements"]) { skip() }
 }

--- a/build-logic/src/main/kotlin/org/jetbrains/conventions/maven-publish.gradle.kts
+++ b/build-logic/src/main/kotlin/org/jetbrains/conventions/maven-publish.gradle.kts
@@ -1,5 +1,7 @@
 package org.jetbrains.conventions
 
+import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
+
 plugins {
     id("org.jetbrains.conventions.base")
     `maven-publish`
@@ -55,4 +57,10 @@ publishing {
             }
         }
     }
+}
+
+plugins.withType<ShadowPlugin>().configureEach {
+    // manually disable publication of Shadow elements https://github.com/johnrengelman/shadow/issues/651#issue-839148311
+    val javaComponent = components["java"] as AdhocComponentWithVariants
+    javaComponent.withVariantsFromConfiguration(configurations["shadowRuntimeElements"]) { skip() }
 }


### PR DESCRIPTION
Fixes the issue described in https://github.com/Kotlin/dokka/pull/2704#issuecomment-1499517930

### Test

To test this I ran `./gradlew publishAllPublicationsToMavenProjectLocalRepository` and searched for `shadowRuntimeElements` in the directory `$rootDir/build/maven-project-local`

On master branch there was a match. On the PR branch, there was no match.