### PR TITLE
Add source links to the dokka-multimodule-example project

### DIFF
--- a/examples/gradle/dokka-multimodule-example/parentProject/build.gradle.kts
+++ b/examples/gradle/dokka-multimodule-example/parentProject/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.dokka.DokkaConfiguration.Visibility
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
+import java.net.URL
 
 plugins {
     kotlin("jvm")
@@ -17,6 +18,19 @@ subprojects {
                 Visibility.PUBLIC,
                 Visibility.PROTECTED
             ))
+
+            // In multi-project builds, `remoteUrl` must point to that project's dir specifically, so if you
+            // want to configure sourceLinks at once in `subprojects {}`, you have to find the relative path.
+            // Alternatively, you can move this configuration up into subproject build scripts,
+            // and just hardcode the exact paths as demonstrated in the basic dokka-gradle-example.
+            sourceLink {
+                val exampleDir = "https://github.com/Kotlin/dokka/tree/master/examples/gradle/dokka-multimodule-example"
+                val projectRelativePath = rootProject.projectDir.toPath().relativize(projectDir.toPath())
+
+                localDirectory.set(file("src"))
+                remoteUrl.set(URL("$exampleDir/$projectRelativePath/src"))
+                remoteLineSuffix.set("#L")
+            }
         }
     }
 }

--- a/examples/gradle/dokka-multimodule-example/parentProject/build.gradle.kts
+++ b/examples/gradle/dokka-multimodule-example/parentProject/build.gradle.kts
@@ -27,7 +27,7 @@ subprojects {
                 val exampleDir = "https://github.com/Kotlin/dokka/tree/master/examples/gradle/dokka-multimodule-example"
                 val projectRelativePath = rootProject.projectDir.toPath().relativize(projectDir.toPath())
 
-                localDirectory.set(file("src"))
+                localDirectory.set(projectDir.resolve("src"))
                 remoteUrl.set(URL("$exampleDir/$projectRelativePath/src"))
                 remoteLineSuffix.set("#L")
             }

--- a/examples/gradle/dokka-multimodule-example/parentProject/build.gradle.kts
+++ b/examples/gradle/dokka-multimodule-example/parentProject/build.gradle.kts
@@ -23,6 +23,8 @@ subprojects {
             // want to configure sourceLinks at once in `subprojects {}`, you have to find the relative path.
             // Alternatively, you can move this configuration up into subproject build scripts,
             // and just hardcode the exact paths as demonstrated in the basic dokka-gradle-example.
+            //
+            // Read docs for more details: https://kotlinlang.org/docs/dokka-gradle.html#source-link-configuration
             sourceLink {
                 val exampleDir = "https://github.com/Kotlin/dokka/tree/master/examples/gradle/dokka-multimodule-example"
                 val projectRelativePath = rootProject.projectDir.toPath().relativize(projectDir.toPath())


### PR DESCRIPTION
The configuration of source links in multimodule projects has been asked about multiple times, and we don't seem to have an example for it.

A community member asked about it yesterday in the Kotlin Community Slack, so I decided to add an example both to check that it works and to point people to it for configuration tips