### PR TITLE
Reorder dependency versions for update convenience

### DIFF
--- a/build-logic/src/main/kotlin/org/jetbrains/conventions/maven-cli-setup.gradle.kts
+++ b/build-logic/src/main/kotlin/org/jetbrains/conventions/maven-cli-setup.gradle.kts
@@ -36,8 +36,8 @@ abstract class MavenCliSetupExtension {
 
 val mavenCliSetupExtension =
     extensions.create("mavenCliSetup", MavenCliSetupExtension::class).apply {
-        mavenVersion.convention(libs.versions.apache.maven)
-        mavenPluginToolsVersion.convention(libs.versions.apache.mavenPluginTools)
+        mavenVersion.convention(libs.versions.apacheMaven.core)
+        mavenPluginToolsVersion.convention(libs.versions.apacheMaven.pluginTools)
 
         mavenBuildDir.convention(layout.buildDirectory.dir("maven"))
         mavenInstallDir.convention(layout.buildDirectory.dir("apache-maven"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     id("org.jetbrains.conventions.dokka")
 
     alias(libs.plugins.kotlinx.binaryCompatibilityValidator)
-    alias(libs.plugins.gradle.pluginPublish)
+    alias(libs.plugins.gradlePublish)
     alias(libs.plugins.nexusPublish)
 }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 dependencies {
-    api(libs.jetbrainsMarkdown)
+    api(libs.jetbrains.markdown)
     implementation(kotlin("reflect"))
 
     implementation(libs.jsoup)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,17 +19,17 @@ soywiz-korte = "2.7.0"
 kotlinx-html = "0.7.5"
 
 ## Markdown
-jetbrainsMarkdown = "0.3.1"
+jetbrains-markdown = "0.3.1"
 
 ## JSON
 jackson = "2.12.7" # jackson 2.13.X does not support kotlin language version 1.4, check before updating
 jacksonDatabind = "2.12.7.1" # fixes CVE-2022-42003
 
 ## Maven
-apache-maven = "3.5.0"
-apache-mavenArtifact = "3.8.5"
-apache-mavenArchiver = "2.5"
-apache-mavenPluginTools = "3.5.2"
+apacheMaven-core = "3.5.0"
+apacheMaven-artifact = "3.8.5"
+apacheMaven-archiver = "2.5"
+apacheMaven-pluginTools = "3.5.2"
 
 ## CLI
 kotlinx-cli = "0.3.4"
@@ -60,14 +60,14 @@ gradlePlugin-shadow = { module = "gradle.plugin.com.github.johnrengelman:shadow"
 
 #### Kotlin analysis ####
 kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref = "kotlin-compiler" }
-kotlinIdePlugin-common = { module = "org.jetbrains.kotlin:common", version.ref = "kotlin-ide-plugin" }
-kotlinIdePlugin-idea = { module = "org.jetbrains.kotlin:idea", version.ref = "kotlin-ide-plugin" }
-kotlinIdePlugin-core = { module = "org.jetbrains.kotlin:core", version.ref = "kotlin-ide-plugin" }
-kotlinIdePlugin-native = { module = "org.jetbrains.kotlin:native", version.ref = "kotlin-ide-plugin" }
+kotlin-idePlugin-common = { module = "org.jetbrains.kotlin:common", version.ref = "kotlin-ide-plugin" }
+kotlin-idePlugin-idea = { module = "org.jetbrains.kotlin:idea", version.ref = "kotlin-ide-plugin" }
+kotlin-idePlugin-core = { module = "org.jetbrains.kotlin:core", version.ref = "kotlin-ide-plugin" }
+kotlin-idePlugin-native = { module = "org.jetbrains.kotlin:native", version.ref = "kotlin-ide-plugin" }
 
 #### Java analysis ####
-jetbrainsIntelliJ-core = { module = "com.jetbrains.intellij.idea:intellij-core", version.ref = "intellij" }
-jetbrainsIntelliJ-jpsStandalone = { module = "com.jetbrains.intellij.idea:jps-standalone", version.ref = "intellij" }
+jetbrains-intellij-core = { module = "com.jetbrains.intellij.idea:intellij-core", version.ref = "intellij" }
+jetbrains-intellij-jpsStandalone = { module = "com.jetbrains.intellij.idea:jps-standalone", version.ref = "intellij" }
 
 #### HTML ####
 jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
@@ -76,7 +76,7 @@ kotlinx-html = { module = "org.jetbrains.kotlinx:kotlinx-html-jvm", version.ref 
 soywiz-korte = { module = "com.soywiz.korlibs.korte:korte-jvm", version.ref = "soywiz-korte" }
 
 #### Markdown ####
-jetbrainsMarkdown = { module = "org.jetbrains:markdown", version.ref = "jetbrainsMarkdown" }
+jetbrains-markdown = { module = "org.jetbrains:markdown", version.ref = "jetbrains-markdown" }
 
 #### Jackson ####
 jackson-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
@@ -84,11 +84,11 @@ jackson-xml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-xm
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jacksonDatabind" }
 
 #### Apache Maven ####
-apache-mavenArchiver = { module = "org.apache.maven:maven-archiver", version.ref = "apache-mavenArchiver" }
-apache-mavenCore = { module = "org.apache.maven:maven-core", version.ref = "apache-maven" }
-apache-mavenPluginAnnotations = { module = "org.apache.maven.plugin-tools:maven-plugin-annotations", version.ref = "apache-mavenPluginTools" }
-apache-mavenPluginApi = { module = "org.apache.maven:maven-plugin-api", version.ref = "apache-maven" }
-apache-mavenArtifact = { module = "org.apache.maven:maven-artifact", version.ref = "apache-mavenArtifact" }
+apacheMaven-archiver = { module = "org.apache.maven:maven-archiver", version.ref = "apacheMaven-archiver" }
+apacheMaven-core = { module = "org.apache.maven:maven-core", version.ref = "apacheMaven-core" }
+apacheMaven-pluginAnnotations = { module = "org.apache.maven.plugin-tools:maven-plugin-annotations", version.ref = "apacheMaven-pluginTools" }
+apacheMaven-pluginApi = { module = "org.apache.maven:maven-plugin-api", version.ref = "apacheMaven-core" }
+apacheMaven-artifact = { module = "org.apache.maven:maven-artifact", version.ref = "apacheMaven-artifact" }
 
 #### CLI #####
 kotlinx-cli = { module = "org.jetbrains.kotlinx:kotlinx-cli-jvm", version.ref = "kotlinx-cli" }
@@ -107,5 +107,5 @@ junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
 
 kotlinx-binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinx-bcv" }
 shadow = { id = "com.github.johnrengelman.shadow", version.ref = "gradlePlugin-shadow" }
-gradle-pluginPublish = { id = "com.gradle.plugin-publish", version.ref = "gradlePlugin-gradlePluginPublish" }
+gradlePublish = { id = "com.gradle.plugin-publish", version.ref = "gradlePlugin-gradlePluginPublish" }
 nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "gradlePlugin-nexusPublish" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,115 +1,111 @@
 [versions]
 
-kotlin = "1.8.10"
-kotlin-plugin = "213-1.8.10-release-430-IJ6777.52"
-kotlinx-coroutines = "1.6.3"
-kotlinx-html = "0.7.5"
-kotlinx-cli = "0.3.4"
+gradlePlugin-kotlin = "1.8.10"
+gradlePlugin-android = "4.0.1"
+gradlePlugin-dokka = "1.7.10"
 
-idea = "213.6777.52"
+kotlinx-coroutines = "1.6.3"
+kotlinx-bcv = "0.12.1"
+
+## Analysis
+kotlin-compiler = "1.8.10"
+kotlin-ide-plugin = "213-1.8.10-release-430-IJ6777.52"
+intellij = "213.6777.52"
+
+## HTML
+jsoup = "1.15.3"
+freemarker = "2.3.31"
+soywiz-korte = "2.7.0"
+kotlinx-html = "0.7.5"
+
+## Markdown
 jetbrainsMarkdown = "0.3.1"
 
-jsoup = "1.15.3"
-
+## JSON
 jackson = "2.12.7" # jackson 2.13.X does not support kotlin language version 1.4, check before updating
 jacksonDatabind = "2.12.7.1" # fixes CVE-2022-42003
 
-freemarker = "2.3.31"
-
-soywiz-korte = "2.7.0"
-
+## Maven
 apache-maven = "3.5.0"
 apache-mavenArtifact = "3.8.5"
 apache-mavenArchiver = "2.5"
 apache-mavenPluginTools = "3.5.2"
 
-eclipse-jgit = "5.12.0.202106070339-r"
+## CLI
+kotlinx-cli = "0.3.4"
 
-## test dependency versions ##
-junit = "5.9.2"
-assertk = "0.25"
-
-## Gradle plugins ##
-gradlePlugin-shadow = "7.1.2"
-gradlePlugin-binaryCompatibilityValidator = "0.12.1"
-gradlePlugin-nexusPublish = "1.1.0"
-gradlePlugin-dokka = "1.7.10"
-gradlePlugin-gradlePluginPublish = "0.20.0"
-gradlePlugin-gradle = "4.0.1"
-
-## NPM ##
+## NPM | Frontend
 node = "16.13.0"
 
+## Publishing
+gradlePlugin-shadow = "7.1.2"
+gradlePlugin-nexusPublish = "1.1.0"
+gradlePlugin-gradlePluginPublish = "0.20.0"
+
+## Test
+junit = "5.9.2"
+assertk = "0.25"
+eclipse-jgit = "5.12.0.202106070339-r"
 
 [libraries]
 
-eclipse-jgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "eclipse-jgit" }
-freemarker = { module = "org.freemarker:freemarker", version.ref = "freemarker" }
-jetbrainsIntelliJ-core = { module = "com.jetbrains.intellij.idea:intellij-core", version.ref = "idea" }
-jetbrainsIntelliJ-jpsStandalone = { module = "com.jetbrains.intellij.idea:jps-standalone", version.ref = "idea" }
-jetbrainsMarkdown = { module = "org.jetbrains:markdown", version.ref = "jetbrainsMarkdown" }
-jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
-soywiz-korte = { module = "com.soywiz.korlibs.korte:korte-jvm", version.ref = "soywiz-korte" }
-
-## Kotlin libs ##
-kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
-
-kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref = "kotlin" }
-kotlin-idea = { module = "org.jetbrains.kotlin:idea", version.ref = "kotlin" }
-kotlin-common = { module = "org.jetbrains.kotlin:common", version.ref = "kotlin" }
-kotlin-core = { module = "org.jetbrains.kotlin:core", version.ref = "kotlin" }
-kotlin-native = { module = "org.jetbrains.kotlin:native", version.ref = "kotlin" }
-
-kotlinx-cli = { module = "org.jetbrains.kotlinx:kotlinx-cli-jvm", version.ref = "kotlinx-cli" }
-kotlinx-html = { module = "org.jetbrains.kotlinx:kotlinx-html-jvm", version.ref = "kotlinx-html" }
-
-kotlinx-coroutines-bom = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-bom", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 
-## Kotlin Plugins ##
-kotlinPlugin-common = { module = "org.jetbrains.kotlin:common", version.ref = "kotlin.plugin" }
-kotlinPlugin-idea = { module = "org.jetbrains.kotlin:idea", version.ref = "kotlin.plugin" }
-kotlinPlugin-core = { module = "org.jetbrains.kotlin:core", version.ref = "kotlin.plugin" }
-kotlinPlugin-native = { module = "org.jetbrains.kotlin:native", version.ref = "kotlin.plugin" }
+#### Gradle plugins ####
+# The Maven coordinates of Gradle plugins that are either used in convention plugins, or in Dokka subprojects
+gradlePlugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "gradlePlugin-kotlin" }
+gradlePlugin-android = { module = "com.android.tools.build:gradle", version.ref = "gradlePlugin-android" }
+gradlePlugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "gradlePlugin-dokka" }
+gradlePlugin-shadow = { module = "gradle.plugin.com.github.johnrengelman:shadow", version.ref = "gradlePlugin-shadow" }
 
-## Jackson ##
-jackson-bom = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
+#### Kotlin analysis ####
+kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref = "kotlin-compiler" }
+kotlinIdePlugin-common = { module = "org.jetbrains.kotlin:common", version.ref = "kotlin-ide-plugin" }
+kotlinIdePlugin-idea = { module = "org.jetbrains.kotlin:idea", version.ref = "kotlin-ide-plugin" }
+kotlinIdePlugin-core = { module = "org.jetbrains.kotlin:core", version.ref = "kotlin-ide-plugin" }
+kotlinIdePlugin-native = { module = "org.jetbrains.kotlin:native", version.ref = "kotlin-ide-plugin" }
+
+#### Java analysis ####
+jetbrainsIntelliJ-core = { module = "com.jetbrains.intellij.idea:intellij-core", version.ref = "intellij" }
+jetbrainsIntelliJ-jpsStandalone = { module = "com.jetbrains.intellij.idea:jps-standalone", version.ref = "intellij" }
+
+#### HTML ####
+jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
+freemarker = { module = "org.freemarker:freemarker", version.ref = "freemarker" }
+kotlinx-html = { module = "org.jetbrains.kotlinx:kotlinx-html-jvm", version.ref = "kotlinx-html" }
+soywiz-korte = { module = "com.soywiz.korlibs.korte:korte-jvm", version.ref = "soywiz-korte" }
+
+#### Markdown ####
+jetbrainsMarkdown = { module = "org.jetbrains:markdown", version.ref = "jetbrainsMarkdown" }
+
+#### Jackson ####
 jackson-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 jackson-xml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml", version.ref = "jackson" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jacksonDatabind" }
 
-## Apache Maven ##
+#### Apache Maven ####
 apache-mavenArchiver = { module = "org.apache.maven:maven-archiver", version.ref = "apache-mavenArchiver" }
 apache-mavenCore = { module = "org.apache.maven:maven-core", version.ref = "apache-maven" }
 apache-mavenPluginAnnotations = { module = "org.apache.maven.plugin-tools:maven-plugin-annotations", version.ref = "apache-mavenPluginTools" }
 apache-mavenPluginApi = { module = "org.apache.maven:maven-plugin-api", version.ref = "apache-maven" }
 apache-mavenArtifact = { module = "org.apache.maven:maven-artifact", version.ref = "apache-mavenArtifact" }
 
+#### CLI #####
+kotlinx-cli = { module = "org.jetbrains.kotlinx:kotlinx-cli-jvm", version.ref = "kotlinx-cli" }
 
-#### test dependencies  ####
-
+#### Test dependencies  ####
 assertk = { module = "com.willowtreeapps.assertk:assertk", version.ref = "assertk" }
+eclipse-jgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "eclipse-jgit" }
 
-## junit ##
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
-
-
-#### Gradle plugins dependencies  ####
-# The Maven coordinates of Gradle plugins that are either used in convention plugins, or in Dokka subprojects
-
-gradlePlugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "gradlePlugin-dokka" }
-gradlePlugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-gradlePlugin-shadow = { module = "gradle.plugin.com.github.johnrengelman:shadow", version.ref = "gradlePlugin-shadow" }
-gradlePlugin-android = { module = "com.android.tools.build:gradle", version.ref = "gradlePlugin-gradle" }
-
 
 [plugins]
 # Gradle Plugins that are applied directly to subprojects
 # (Before defining plugins here, first consider creating convention plugins instead,
 # and define the Maven coordinates above to be used in build-logic/build.gradle.kts)
 
-kotlinx-binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "gradlePlugin-binaryCompatibilityValidator" }
+kotlinx-binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinx-bcv" }
 shadow = { id = "com.github.johnrengelman.shadow", version.ref = "gradlePlugin-shadow" }
 gradle-pluginPublish = { id = "com.gradle.plugin-publish", version.ref = "gradlePlugin-gradlePluginPublish" }
 nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "gradlePlugin-nexusPublish" }

--- a/kotlin-analysis/intellij-dependency/build.gradle.kts
+++ b/kotlin-analysis/intellij-dependency/build.gradle.kts
@@ -35,19 +35,19 @@ fun jpsModel() = zipTree(jpsStandalone.singleFile).matching {
 }
 
 dependencies {
-    api(libs.kotlinIdePlugin.common)
-    api(libs.kotlinIdePlugin.idea) {
+    api(libs.kotlin.idePlugin.common)
+    api(libs.kotlin.idePlugin.idea) {
         isTransitive = false
     }
-    api(libs.kotlinIdePlugin.core)
-    api(libs.kotlinIdePlugin.native)
+    api(libs.kotlin.idePlugin.core)
+    api(libs.kotlin.idePlugin.native)
 
     @Suppress("UnstableApiUsage")
-    intellijCore(libs.jetbrainsIntelliJ.core)
+    intellijCore(libs.jetbrains.intellij.core)
     implementation(intellijCoreAnalysis())
 
     @Suppress("UnstableApiUsage")
-    jpsStandalone(libs.jetbrainsIntelliJ.jpsStandalone)
+    jpsStandalone(libs.jetbrains.intellij.jpsStandalone)
     implementation(jpsModel())
 }
 

--- a/kotlin-analysis/intellij-dependency/build.gradle.kts
+++ b/kotlin-analysis/intellij-dependency/build.gradle.kts
@@ -35,12 +35,12 @@ fun jpsModel() = zipTree(jpsStandalone.singleFile).matching {
 }
 
 dependencies {
-    api(libs.kotlinPlugin.common)
-    api(libs.kotlinPlugin.idea) {
+    api(libs.kotlinIdePlugin.common)
+    api(libs.kotlinIdePlugin.idea) {
         isTransitive = false
     }
-    api(libs.kotlinPlugin.core)
-    api(libs.kotlinPlugin.native)
+    api(libs.kotlinIdePlugin.core)
+    api(libs.kotlinIdePlugin.native)
 
     @Suppress("UnstableApiUsage")
     intellijCore(libs.jetbrainsIntelliJ.core)

--- a/plugins/versioning/build.gradle.kts
+++ b/plugins/versioning/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
     implementation(libs.kotlinx.html)
 
     implementation(libs.jsoup)
-    implementation(libs.apache.mavenArtifact)
+    implementation(libs.apacheMaven.artifact)
 
     testImplementation(projects.core.testApi)
     testImplementation(platform(libs.junit.bom))

--- a/runners/maven-plugin/build.gradle.kts
+++ b/runners/maven-plugin/build.gradle.kts
@@ -10,10 +10,10 @@ plugins {
 dependencies {
     implementation(projects.core)
 
-    implementation(libs.apache.mavenCore)
-    implementation(libs.apache.mavenPluginApi)
-    implementation(libs.apache.mavenPluginAnnotations)
-    implementation(libs.apache.mavenArchiver)
+    implementation(libs.apacheMaven.core)
+    implementation(libs.apacheMaven.pluginApi)
+    implementation(libs.apacheMaven.pluginAnnotations)
+    implementation(libs.apacheMaven.archiver)
 }
 
 val mavenPluginTaskGroup = "maven plugin"


### PR DESCRIPTION
Needed to update the Kotlin version, and got kinda lost in the toml

It's best to just check out the branch locally and see if it's convenient from the maintenance perspective. If some things are confusing or you know in advance that you will struggle with it - do suggest an alternative

___

* Reordered dependency versions and redid the grouping so that it's (subjectively) more convenient to update:
    * The most important and frequently updated ones are at the top (KGP, AGP, analysis, etc)
    * Analysis is grouped together and decoupled, so we can update KGP and the compiler versions independently. This should be pretty useful when migrating to K2, and should be useful in general when migrating to new/dev versions of Kotlin, and especially useful for troubleshooting.
* Renamed a few properties to better represent what they are: `kotlin` -> `gradlePlugin-kotlin`, `kotlinPlugin` -> `kotlinIdePlugin`, idea` -> `intellij`, etc.
* Removed some unused library declarations, mostly boms - they are not applied anywhere, we can add them once we start using it. I hope they weren't applied automatically, at least I couldn't google anything like that.