### PR TITLE
Replace invalid documentation links

### DIFF
--- a/plugins/base/src/main/kotlin/parsers/moduleAndPackage/parseModuleAndPackageDocumentationFragments.kt
+++ b/plugins/base/src/main/kotlin/parsers/moduleAndPackage/parseModuleAndPackageDocumentationFragments.kt
@@ -31,7 +31,7 @@ private fun parseModuleAndPackageDocFragment(
         "Package" -> Package
         else -> throw IllegalStateException(
             """Unexpected classifier: "${classifierAndName[0]}", expected either "Module" or "Package". 
-            |For more information consult the specification: https://kotlinlang.org/docs/reference/dokka-module-and-package-docs.html""".trimMargin()
+            |For more information consult the specification: https://kotlinlang.org/docs/dokka-module-and-package-docs.html""".trimMargin()
         )
     }
 

--- a/plugins/base/src/test/kotlin/transformers/InvalidContentModuleAndPackageDocumentationReaderTest.kt
+++ b/plugins/base/src/test/kotlin/transformers/InvalidContentModuleAndPackageDocumentationReaderTest.kt
@@ -75,7 +75,7 @@ class InvalidContentModuleAndPackageDocumentationReaderTest : AbstractContextMod
             runCatching { readerA[dModule(name = "moduleA", sourceSets = setOf(sourceSetA))] }.exceptionOrNull()
         assertEquals(
             "Unexpected classifier: \"Invalid\", expected either \"Module\" or \"Package\". \n" +
-                    "For more information consult the specification: https://kotlinlang.org/docs/reference/dokka-module-and-package-docs.html",
+                    "For more information consult the specification: https://kotlinlang.org/docs/dokka-module-and-package-docs.html",
             exception?.message
         )
     }

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/GradleDokkaSourceSetBuilder.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/GradleDokkaSourceSetBuilder.kt
@@ -69,7 +69,7 @@ open class GradleDokkaSourceSetBuilder(
 
     /**
      * List of Markdown files that contain
-     * [module and package documentation](https://kotlinlang.org/docs/reference/dokka-module-and-package-docs.html).
+     * [module and package documentation](https://kotlinlang.org/docs/dokka-module-and-package-docs.html).
      *
      * Contents of specified files will be parsed and embedded into documentation as module and package descriptions.
      *

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/DokkaMultiModuleTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/DokkaMultiModuleTask.kt
@@ -24,7 +24,7 @@ abstract class DokkaMultiModuleTask : AbstractDokkaParentTask() {
 
     /**
      * List of Markdown files that contain
-     * [module and package documentation](https://kotlinlang.org/docs/reference/dokka-module-and-package-docs.html).
+     * [module and package documentation](https://kotlinlang.org/docs/dokka-module-and-package-docs.html).
      *
      * Contents of specified files will be parsed and embedded into documentation as module and package descriptions.
      *

--- a/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
+++ b/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
@@ -66,7 +66,7 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
 
     /**
      * List of Markdown files that contain
-     * [module and package documentation](https://kotlinlang.org/docs/reference/dokka-module-and-package-docs.html).
+     * [module and package documentation](https://kotlinlang.org/docs/dokka-module-and-package-docs.html).
      *
      * Contents of specified files will be parsed and embedded into documentation as module and package descriptions.
      *


### PR DESCRIPTION
Multiple places throughout the repository link the [Module documentation](https://kotlinlang.org/docs/dokka-module-and-package-docs.html). The link contains an additional `/reference` in the path and therefore produce a `404`.

Old link:
```
https://kotlinlang.org/docs/reference/dokka-module-and-package-docs.html
```
New link:
```
https://kotlinlang.org/docs/dokka-module-and-package-docs.html
```

Should this be a temporary error on the kotlinlang website feel free to just close the PR.