### PR TITLE
Add `dokkaPlugin` configuration to example code

### DIFF
--- a/docs/topics/dokka-plugins.md
+++ b/docs/topics/dokka-plugins.md
@@ -34,6 +34,7 @@ The Gradle plugin for Dokka creates convenient dependency configurations that al
 for a specific output format only.
 
 ```kotlin
+val dokkaPlugin by configurations
 dependencies {
     // Is applied universally
     dokkaPlugin("org.jetbrains.dokka:mathjax-plugin:%dokkaVersion%")


### PR DESCRIPTION
In the process of trying to apply a `dokkaPlugin`, it was in example code to include this line but not mentioned in the documentation. This is a one line change to add that line to the Kotlin script example. I'm not certain if this also applies to the Maven and Groovy implementations, but I wanted to at least start the conversation