### PR TITLE
DGP: set cacheRoot using convention(), not set()

### DIFF
--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaPlugin.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/DokkaPlugin.kt
@@ -108,7 +108,7 @@ open class DokkaPlugin : Plugin<Project> {
         tasks.withType<AbstractDokkaTask>().configureEach {
             val formatClassifier = name.removePrefix("dokka").decapitalize()
             outputDirectory.convention(project.layout.buildDirectory.dir("dokka/$formatClassifier"))
-            cacheRoot.set(DokkaDefaults.cacheRoot)
+            cacheRoot.convention(project.layout.dir(providers.provider { DokkaDefaults.cacheRoot }))
         }
     }
 


### PR DESCRIPTION
This is a fix for https://github.com/Kotlin/dokka/labels/runner%3A%20Gradle%20plugin

By using `set()` this can override any configuration done in user scripts, but _before_ the `configureEach{}` block is evaluated. `convention()` means that even if `configureEach{}` runs later, it won't override any previous `set()`.

Unfortunately there's no clean way to set the convention of a DirectoryProperty https://github.com/gradle/gradle/issues/23708, hence the weird syntax.