### PR TITLE
DokkaConfiguration: Use LinkedHashSet instead of Set to preserve order for includes when deserialize (#2999)

### DIFF
--- a/core/src/main/kotlin/utilities/json.kt
+++ b/core/src/main/kotlin/utilities/json.kt
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.core.type.TypeReference as JacksonTypeReference
 private val objectMapper = run {
     val module = SimpleModule().apply {
         addSerializer(FileSerializer)
+        addAbstractTypeMapping(Set::class.java, LinkedHashSet::class.java)
     }
     jacksonObjectMapper()
         .registerModule(module)

--- a/core/src/test/kotlin/utilities/JsonKtTest.kt
+++ b/core/src/test/kotlin/utilities/JsonKtTest.kt
@@ -1,5 +1,6 @@
 package utilities
 
+import org.jetbrains.dokka.utilities.parseJson
 import org.jetbrains.dokka.utilities.serializeAsCompactJson
 import org.jetbrains.dokka.utilities.serializeAsPrettyJson
 import kotlin.test.assertEquals
@@ -42,6 +43,20 @@ class JsonTest {
         assertEquals(expected, actual)
     }
 
+    @Test
+    fun `should keep order of Set after serialize and deserialize`() {
+        val testObject = SimpleTestSetDataClass(
+            someStringSet = setOf("Foo", "Bar", "ABC")
+        )
+        val expected = testObject.someStringSet.toList() // ["Foo", "Bar", "ABC"]
+
+        val jsonString = serializeAsCompactJson(testObject)
+        val parsedClass: SimpleTestSetDataClass = parseJson(jsonString)
+        val actual = parsedClass.someStringSet.toList()
+
+        assertEquals(expected, actual)
+    }
+
     /**
      * If the expected output was generated on Linux, but the tests are run under Windows,
      * the test might fail when comparing the strings due to different separators.
@@ -54,4 +69,8 @@ data class SimpleTestDataClass(
     val someInt: Int,
     val someIntWithDefaultValue: Int = 42,
     val someDouble: Double
+)
+
+data class SimpleTestSetDataClass(
+    val someStringSet: Set<String>
 )


### PR DESCRIPTION
* for markdown files for multi module description