### PR TITLE
Add the ability to get serialized configuration of a task

### DIFF
--- a/runners/gradle-plugin/api/gradle-plugin.api
+++ b/runners/gradle-plugin/api/gradle-plugin.api
@@ -174,7 +174,8 @@ public final class org/jetbrains/dokka/gradle/SourceSetKotlinGistConfigurationKt
 }
 
 public final class org/jetbrains/dokka/gradle/internal/AbstractDokkaTaskExtensionsKt {
-	public static final fun buildJsonConfiguration (Lorg/jetbrains/dokka/gradle/AbstractDokkaTask;)Ljava/lang/String;
+	public static final fun buildJsonConfiguration (Lorg/jetbrains/dokka/gradle/AbstractDokkaTask;Z)Ljava/lang/String;
+	public static synthetic fun buildJsonConfiguration$default (Lorg/jetbrains/dokka/gradle/AbstractDokkaTask;ZILjava/lang/Object;)Ljava/lang/String;
 }
 
 public final class org/jetbrains/dokka/gradle/kotlin/KotlinClasspathUtilsKt {

--- a/runners/gradle-plugin/api/gradle-plugin.api
+++ b/runners/gradle-plugin/api/gradle-plugin.api
@@ -174,7 +174,7 @@ public final class org/jetbrains/dokka/gradle/SourceSetKotlinGistConfigurationKt
 }
 
 public final class org/jetbrains/dokka/gradle/internal/AbstractDokkaTaskExtensionsKt {
-	public static final fun getJsonConfiguration (Lorg/jetbrains/dokka/gradle/AbstractDokkaTask;)Ljava/lang/String;
+	public static final fun buildJsonConfiguration (Lorg/jetbrains/dokka/gradle/AbstractDokkaTask;)Ljava/lang/String;
 }
 
 public final class org/jetbrains/dokka/gradle/kotlin/KotlinClasspathUtilsKt {

--- a/runners/gradle-plugin/api/gradle-plugin.api
+++ b/runners/gradle-plugin/api/gradle-plugin.api
@@ -173,6 +173,10 @@ public final class org/jetbrains/dokka/gradle/SourceSetKotlinGistConfigurationKt
 	public static final fun configureWithKotlinSourceSet (Lorg/jetbrains/dokka/gradle/GradleDokkaSourceSetBuilder;Lorg/jetbrains/kotlin/gradle/plugin/KotlinSourceSet;)V
 }
 
+public final class org/jetbrains/dokka/gradle/internal/AbstractDokkaTaskExtensionsKt {
+	public static final fun getJsonConfiguration (Lorg/jetbrains/dokka/gradle/AbstractDokkaTask;)Ljava/lang/String;
+}
+
 public final class org/jetbrains/dokka/gradle/kotlin/KotlinClasspathUtilsKt {
 	public static final fun isHMPPEnabled (Lorg/gradle/api/Project;)Z
 }

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/internal/AbstractDokkaTaskExtensions.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/internal/AbstractDokkaTaskExtensions.kt
@@ -4,15 +4,21 @@ import org.jetbrains.dokka.InternalDokkaApi
 import org.jetbrains.dokka.gradle.AbstractDokkaTask
 import org.jetbrains.dokka.toPrettyJsonString
 import org.jetbrains.dokka.DokkaConfiguration
+import org.jetbrains.dokka.toCompactJsonString
 
 /**
- * Serializes [DokkaConfiguration] of this [AbstractDokkaTask] as pretty json
+ * Serializes [DokkaConfiguration] of this [AbstractDokkaTask] as json
  *
- * Should be used for debugging only, no guarantees are given for the support of this API.
+ * Should be used for short-term debugging only, no guarantees are given for the support of this API.
  *
  * Better alternative should be introduced as part of [#2873](https://github.com/Kotlin/dokka/issues/2873).
  */
 @InternalDokkaApi
-fun AbstractDokkaTask.buildJsonConfiguration(): String {
-    return this.buildDokkaConfiguration().toPrettyJsonString()
+fun AbstractDokkaTask.buildJsonConfiguration(prettyPrint: Boolean = true): String {
+    val configuration = this.buildDokkaConfiguration()
+    return if (prettyPrint) {
+        configuration.toPrettyJsonString()
+    } else {
+        configuration.toCompactJsonString()
+    }
 }

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/internal/AbstractDokkaTaskExtensions.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/internal/AbstractDokkaTaskExtensions.kt
@@ -13,6 +13,6 @@ import org.jetbrains.dokka.DokkaConfiguration
  * Better alternative should be introduced as part of [#2873](https://github.com/Kotlin/dokka/issues/2873).
  */
 @InternalDokkaApi
-fun AbstractDokkaTask.getJsonConfiguration(): String {
+fun AbstractDokkaTask.buildJsonConfiguration(): String {
     return this.buildDokkaConfiguration().toPrettyJsonString()
 }

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/internal/AbstractDokkaTaskExtensions.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/internal/AbstractDokkaTaskExtensions.kt
@@ -1,0 +1,18 @@
+package org.jetbrains.dokka.gradle.internal
+
+import org.jetbrains.dokka.InternalDokkaApi
+import org.jetbrains.dokka.gradle.AbstractDokkaTask
+import org.jetbrains.dokka.toPrettyJsonString
+import org.jetbrains.dokka.DokkaConfiguration
+
+/**
+ * Serializes [DokkaConfiguration] of this [AbstractDokkaTask] as pretty json
+ *
+ * Should be used for debugging only, no guarantees are given for the support of this API.
+ *
+ * Better alternative should be introduced as part of [#2873](https://github.com/Kotlin/dokka/issues/2873).
+ */
+@InternalDokkaApi
+fun AbstractDokkaTask.getJsonConfiguration(): String {
+    return this.buildDokkaConfiguration().toPrettyJsonString()
+}


### PR DESCRIPTION
A proposal for an intermediate solution for #2873, which should help with debugging configuration and compatibility issues.

cc @aSemy