### PR TITLE
KTL-982; redundant spacing for tabs

### DIFF
--- a/plugins/base/src/main/resources/dokka/styles/style.css
+++ b/plugins/base/src/main/resources/dokka/styles/style.css
@@ -500,9 +500,10 @@ td:first-child {
 }
 /* /--- Breadcrumbs styles --- */
 
-.tabs-section > .section-tab:first-child,
-.platform-hinted > .platform-bookmarks-row > .platform-bookmark:first-child {
-    margin-left: 0;
+.tabs-section,
+.platform-hinted > .platform-bookmarks-row {
+    margin-left: -8px;
+    margin-right: -8px;
 }
 
 .section-tab,


### PR DESCRIPTION
<details>
  <summary>Bug screenshot</summary>
  <img width="177" alt="Screenshot 2023-02-01 at 16 14 51" src="https://github.com/Kotlin/dokka/assets/242514/80c253bf-2f77-48c3-b6d5-78c2b41c48ef">
</details>
<details>
  <summary>Fixed screenshot</summary>
  <img width="182" alt="Screenshot 2023-05-30 at 19 03 28" src="https://github.com/Kotlin/dokka/assets/242514/2f2e641b-ffce-4f1f-acdc-3e48d00fbcf2">
</details>
