### PR TITLE
Fix invisible packages for module names with space

### DIFF
--- a/plugins/base/src/main/resources/dokka/scripts/platform-content-handler.js
+++ b/plugins/base/src/main/resources/dokka/scripts/platform-content-handler.js
@@ -322,8 +322,8 @@ function refreshFiltering() {
     document.querySelectorAll("[data-filterable-set]")
         .forEach(
             elem => {
-                let platformList = elem.getAttribute("data-filterable-set").split(' ').filter(v => -1 !== sourcesetList.indexOf(v))
-                elem.setAttribute("data-filterable-current", platformList.join(' '))
+                let platformList = elem.getAttribute("data-filterable-set").split(',').filter(v => -1 !== sourcesetList.indexOf(v))
+                elem.setAttribute("data-filterable-current", platformList.join(','))
             }
         )
     refreshFilterButtons()

--- a/plugins/base/src/test/kotlin/renderers/html/SourceSetFilterTest.kt
+++ b/plugins/base/src/test/kotlin/renderers/html/SourceSetFilterTest.kt
@@ -1,0 +1,64 @@
+package renderers.html
+
+import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import signatures.renderedContent
+import utils.TestOutputWriterPlugin
+
+class SourceSetFilterTest : BaseAbstractTest() {
+
+    @Test // see #3011
+    fun `should separate multiple data-filterable attribute values with comma`() {
+        val configuration = dokkaConfiguration {
+            moduleName = "Dokka Module"
+
+            sourceSets {
+                val common = sourceSet {
+                    name = "common"
+                    displayName = "common"
+                    analysisPlatform = "common"
+                    sourceRoots = listOf("src/commonMain/kotlin/testing/Test.kt")
+                }
+                sourceSet {
+                    name = "jvm"
+                    displayName = "jvm"
+                    analysisPlatform = "jvm"
+                    dependentSourceSets = setOf(common.value.sourceSetID)
+                    sourceRoots = listOf("src/jvmMain/kotlin/testing/Test.kt")
+                }
+            }
+        }
+
+        val source = """
+            |/src/commonMain/kotlin/testing/Test.kt
+            |package testing
+            |
+            |expect open class Test
+            |
+            |/src/jvmMain/kotlin/testing/Test.kt
+            |package testing
+            |
+            |actual open class Test
+        """.trimIndent()
+
+        val writerPlugin = TestOutputWriterPlugin()
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin)
+        ) {
+            renderingStage = { _, _ ->
+                val packagePage = writerPlugin.writer.renderedContent("-dokka -module/testing/index.html")
+
+                val testClassRow = packagePage
+                    .select("div[data-togglable=TYPE]")
+                    .select("div[class=table-row]")
+                    .single()
+
+                assertEquals("Dokka Module/common,Dokka Module/jvm", testClassRow.attr("data-filterable-current"))
+                assertEquals("Dokka Module/common,Dokka Module/jvm", testClassRow.attr("data-filterable-set"))
+            }
+        }
+    }
+}

--- a/runners/cli/src/main/kotlin/org/jetbrains/dokka/SourceSetArgumentsParser.kt
+++ b/runners/cli/src/main/kotlin/org/jetbrains/dokka/SourceSetArgumentsParser.kt
@@ -7,6 +7,12 @@ import kotlinx.cli.delimiter
 
 internal fun parseSourceSet(moduleName: String, args: Array<String>): DokkaConfiguration.DokkaSourceSet {
 
+    if (moduleName.contains(',')) {
+        // To figure out why this is needed and if it is still relevant, see the comment here:
+        // https://github.com/Kotlin/dokka/issues/3011#issuecomment-1568620493
+        throw IllegalArgumentException("Module name cannot contain commas as it is used internally as a delimiter.")
+    }
+
     val parser = ArgParser("sourceSet", prefixStyle = ArgParser.OptionPrefixStyle.JVM)
 
     val sourceSetName by parser.option(

--- a/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
+++ b/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
@@ -353,6 +353,12 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
             }
         }
 
+        if (moduleName.contains(',')) {
+            // To figure out why this is needed and if it is still relevant, see the comment here:
+            // https://github.com/Kotlin/dokka/issues/3011#issuecomment-1568620493
+            throw IllegalArgumentException("Module name cannot contain commas as it is used internally as a delimiter.")
+        }
+
         fun defaultLinks(config: DokkaSourceSetImpl): Set<ExternalDocumentationLinkImpl> {
             val links = mutableSetOf<ExternalDocumentationLinkImpl>()
             if (!config.noJdkLink)


### PR DESCRIPTION
Fixes #3011 

Read my comment to understand what exactly the problem was: https://github.com/Kotlin/dokka/issues/3011#issuecomment-1568620493

There are better ways to resolve this problem, but this is the only solution that I could think of that wouldn't lead to a lot of other regressions and problems (including for Gradle users), because the value of `scopeId` is used in other parts of the code as well, such as sorting and anchor links, so changing it would lead to regression in behaviour.

One could argue that module names should not contain spaces - I would agree, but the `moduleName` property is used as the parent project name, so the desire to change it to something human-readable is quite understandable, and if we fix it know it's likely going to lead to bug reports. It really needs to be a separate property..

Ideally, a better solution should be implemented as part of #2779 - the current logic is quite error-prone and difficult to navigate..