### PR TITLE
disable showing this "copy anchor" popup if JS is disabled

### DIFF
--- a/plugins/base/src/main/resources/dokka/styles/style.css
+++ b/plugins/base/src/main/resources/dokka/styles/style.css
@@ -1131,7 +1131,7 @@ td.content {
     position: relative;
 }
 
-.main-subrow:hover .anchor-icon {
+.js .main-subrow:hover .anchor-icon {
     opacity: 1;
     transition: 0.2s;
 }


### PR DESCRIPTION
> Also, if it's not too much to ask, can you disable showing this "copy anchor" popup if JS is disabled? It's not going to work if it's pressed. Hover over any function/property name from the left column

Request from original PR: https://github.com/Kotlin/dokka/pull/2836