### PR TITLE
Incorrectly handles a click on a method and other elements in the mobile version

### DIFF
--- a/plugins/base/src/main/resources/dokka/styles/style.css
+++ b/plugins/base/src/main/resources/dokka/styles/style.css
@@ -1153,6 +1153,12 @@ td.content {
     fill: var(--hover-link-color);
 }
 
+@media (hover: none) {
+    .main-subrow .anchor-icon {
+        display: none;
+    }
+}
+
 .main-subrow .anchor-wrapper {
     position: relative;
     width: 24px;


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTL-1028

The first click on a method in the mobile version, the copy icon appears.