### PR TITLE
Fix publishing to Gradle Plugin Portal

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("org.jetbrains.conventions.dokka")
 
     alias(libs.plugins.kotlinx.binaryCompatibilityValidator)
-    alias(libs.plugins.gradlePublish)
+    alias(libs.plugins.gradlePublish) apply false // see #xx for "apply false" reasoning
     alias(libs.plugins.nexusPublish)
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("org.jetbrains.conventions.dokka")
 
     alias(libs.plugins.kotlinx.binaryCompatibilityValidator)
-    alias(libs.plugins.gradlePublish) apply false // see #xx for "apply false" reasoning
+    alias(libs.plugins.gradlePublish) apply false // see #3031 for "apply false" reasoning
     alias(libs.plugins.nexusPublish)
 }
 


### PR DESCRIPTION
This seems to be a regression from #2912. It was blocking the release, but I [commited this fix](https://github.com/Kotlin/dokka/commit/46c10ac2b169a007aefdad3c9720031a8e05d784) directly into the release branch, so no rush now.

Without this change, running `./gradlew publishPlugins` results in:

```
> Task :publishPlugins FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':publishPlugins'.
> No plugins defined. Please declare at least one plugin in a pluginBundle plugins block

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.

* Get more help at https://help.gradle.org
```

With this change, the artifacts are built and published as expected (well, time will tell).

As far as I understand, we need to define the plugin use in the root project so that it can be used later on in the Gradle runner: 

https://github.com/Kotlin/dokka/blob/2b73ddd36d226e5547398daaf0e4370e48f4bb46/runners/gradle-plugin/build.gradle.kts#L7

If the plugin application is removed from the root project, then the line above in the Gradle runner will fail to resolve the plugin ("plugin was not found in any of the following sources").

So I'm not sure that what I'm suggesting is the best fix, looks like it could be improved, but it works for now. Perhaps, it should be revisited in https://github.com/Kotlin/dokka/pull/2919 or https://github.com/Kotlin/dokka/pull/3030. 

If a better alternative is suggested, I can try to implement it as part of this PR, but as long as it doesn't take a lot of time or a lot of re-writing - then it's best addressed separately.