### PR TITLE
Fix sources not being linked when using Maven

### DIFF
--- a/docs/topics/runners/dokka-maven.md
+++ b/docs/topics/runners/dokka-maven.md
@@ -407,7 +407,7 @@ function in `kotlinx.coroutines`.
     <configuration>
         <sourceLinks>
             <link>
-                <path>${project.basedir}/src</path>
+                <path>src</path>
                 <url>https://github.com/kotlin/dokka/tree/master/src</url>
                 <lineSuffix>#L</lineSuffix>
             </link>
@@ -421,6 +421,9 @@ function in `kotlinx.coroutines`.
         <p>
             The path to the local source directory. The path must be relative to the root of the
             current module.
+        </p>
+        <p>
+            Note: Only Unix based paths are allowed, Windows-style paths will throw an error.
         </p>
     </def>
     <def title="url">

--- a/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
+++ b/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
@@ -383,7 +383,7 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
             skipEmptyPackages = skipEmptyPackages,
             skipDeprecated = skipDeprecated,
             jdkVersion = jdkVersion,
-            sourceLinks = sourceLinks.map { SourceLinkDefinitionImpl(it.path, URL(it.url), it.lineSuffix) }.toSet(),
+            sourceLinks = sourceLinks.map { SourceLinkDefinitionImpl(File(it.path).canonicalPath, URL(it.url), it.lineSuffix) }.toSet(),
             perPackageOptions = perPackageOptions.map {
                 @Suppress("DEPRECATION") // for includeNonPublic, preserve backwards compatibility
                 PackageOptionsImpl(


### PR DESCRIPTION
This PR transforms source links path into canonical paths, as the paths being checked when getting source links are absolute

This fixes sources not being linked when using relative paths in Maven projects, that was caused by `SourceLinksTransformer#resolveSources` comparing absolute paths to relative paths, when Maven was used.