### PR TITLE
Set the correct testLauncher property in workflows

### DIFF
--- a/.github/workflows/tests-smoke.yml
+++ b/.github/workflows/tests-smoke.yml
@@ -6,6 +6,9 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+env:
+  JAVA_TEST_VERSION: 11
+
 jobs:
   test-matrix:
     strategy:
@@ -21,15 +24,18 @@ jobs:
           java-version: 17
           cache: 'maven'
       - uses: gradle/gradle-build-action@v2
-        env:
-          ORG_GRADLE_PROJECT_org.jetbrains.dokka.javaToolchain.test: 11
         with:
           gradle-home-cache-cleanup: true
       - name: Run tests under Windows
         if: matrix.os == 'windows-latest'
         # Running tests with the Gradle daemon on windows agents leads to some very strange
         # JVM crashes for some reason. Most likely a problem of Gradle/GitHub/Windows server
-        run: ./gradlew clean test --stacktrace --no-daemon --no-parallel "-Dorg.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=500m"
+        run: >
+          ./gradlew clean test --stacktrace --no-daemon --no-parallel 
+          "-Dorg.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=500m"
+          "-Porg.jetbrains.dokka.javaToolchain.testLauncher=$JAVA_TEST_VERSION"
       - name: Run tests under Ubuntu
         if: matrix.os != 'windows-latest'
-        run: ./gradlew clean test --stacktrace
+        run: >
+          ./gradlew clean test --stacktrace 
+          "-Porg.jetbrains.dokka.javaToolchain.testLauncher=$JAVA_TEST_VERSION"

--- a/.github/workflows/tests-smoke.yml
+++ b/.github/workflows/tests-smoke.yml
@@ -33,9 +33,9 @@ jobs:
         run: >
           ./gradlew clean test --stacktrace --no-daemon --no-parallel 
           "-Dorg.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=500m"
-          "-Porg.jetbrains.dokka.javaToolchain.testLauncher=$JAVA_TEST_VERSION"
+          "-Porg.jetbrains.dokka.javaToolchain.testLauncher=${{ env.JAVA_TEST_VERSION }}"
       - name: Run tests under Ubuntu
         if: matrix.os != 'windows-latest'
         run: >
           ./gradlew clean test --stacktrace 
-          "-Porg.jetbrains.dokka.javaToolchain.testLauncher=$JAVA_TEST_VERSION"
+          "-Porg.jetbrains.dokka.javaToolchain.testLauncher=${{ env.JAVA_TEST_VERSION }}"

--- a/.github/workflows/tests-thorough.yml
+++ b/.github/workflows/tests-thorough.yml
@@ -22,15 +22,18 @@ jobs:
           java-version: 17
           cache: 'maven'
       - uses: gradle/gradle-build-action@v2
-        env:
-          ORG_GRADLE_PROJECT_org.jetbrains.dokka.javaToolchain.test: ${{ matrix.javaVersion }}
         with:
           gradle-home-cache-cleanup: true
       - name: Run tests under Windows
         if: matrix.os == 'windows-latest'
         # Running tests with the Gradle daemon on windows agents leads to some very strange
         # JVM crashes for some reason. Most likely a problem of Gradle/GitHub/Windows server
-        run: ./gradlew clean test --stacktrace --no-daemon --no-parallel "-Dorg.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=500m"
+        run: >
+          ./gradlew clean test --stacktrace --no-daemon --no-parallel 
+          "-Dorg.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=500m"
+          "-Porg.jetbrains.dokka.javaToolchain.testLauncher=${{ matrix.javaVersion }}"
       - name: Run tests under Ubuntu/Macos
         if: matrix.os != 'windows-latest'
-        run: ./gradlew clean test --stacktrace
+        run: >
+          ./gradlew clean test --stacktrace 
+          "-Porg.jetbrains.dokka.javaToolchain.testLauncher=${{ matrix.javaVersion }}"

--- a/build-logic/src/main/kotlin/org/jetbrains/DokkaBuildProperties.kt
+++ b/build-logic/src/main/kotlin/org/jetbrains/DokkaBuildProperties.kt
@@ -12,7 +12,7 @@ import javax.inject.Inject
  * This is an extension created by the [org.jetbrains.conventions.Base_gradle] convention plugin.
  *
  * Default values are set in the root `gradle.properties`, and can be overridden via
- * [CLI args, system properties, and environment variables](https://docs.gradle.org/current/userguide/build_environment.html#sec:project_properties)
+ * [project properties](https://docs.gradle.org/current/userguide/build_environment.html#sec:project_properties)
  */
 abstract class DokkaBuildProperties @Inject constructor(
     private val providers: ProviderFactory,

--- a/build-logic/src/main/kotlin/org/jetbrains/conventions/base-java.gradle.kts
+++ b/build-logic/src/main/kotlin/org/jetbrains/conventions/base-java.gradle.kts
@@ -30,17 +30,6 @@ tasks.withType<Test>().configureEach {
     javaLauncher.set(javaToolchains.launcherFor {
         languageVersion.set(dokkaBuild.testJavaLauncherVersion)
     })
-
-    doLast {
-        logger.quiet(
-            """
-                Tests were run with:
-                * mainCompiler=${dokkaBuild.mainJavaVersion.get()}
-                * testLauncher=${dokkaBuild.testJavaLauncherVersion.get()}
-            """.trimIndent()
-        )
-
-    }
 }
 
 dependencies {

--- a/build-logic/src/main/kotlin/org/jetbrains/conventions/base-java.gradle.kts
+++ b/build-logic/src/main/kotlin/org/jetbrains/conventions/base-java.gradle.kts
@@ -27,10 +27,20 @@ tasks.withType<Test>().configureEach {
     } else {
         (Runtime.getRuntime().availableProcessors() / 2).takeIf { it > 0 } ?: 1
     }
-
     javaLauncher.set(javaToolchains.launcherFor {
         languageVersion.set(dokkaBuild.testJavaLauncherVersion)
     })
+
+    doLast {
+        logger.quiet(
+            """
+                Tests were run with:
+                * mainCompiler=${dokkaBuild.mainJavaVersion.get()}
+                * testLauncher=${dokkaBuild.testJavaLauncherVersion.get()}
+            """.trimIndent()
+        )
+
+    }
 }
 
 dependencies {


### PR DESCRIPTION
The `mainCompiler` version was updated to `11` in https://github.com/Kotlin/dokka/pull/3062/commits/80fc13b5906c9d500605bb414d0529f9141ff03f, which should've caused the [thorough tests](https://github.com/Kotlin/dokka/actions/runs/5483737953) to fail when run under Java 8, but all tests passed successfully.

Had a look at why and noticed that the property name was a bit off, so it should hopefully fix it.