### PR TITLE
Mark tasks as not compatible with the Gradle configuration cache

### DIFF
--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/AbstractDokkaTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/AbstractDokkaTask.kt
@@ -232,6 +232,7 @@ abstract class AbstractDokkaTask : DefaultTask() {
 
     init {
         group = JavaBasePlugin.DOCUMENTATION_GROUP
+        super.notCompatibleWithConfigurationCache("Dokka tasks are not yet compatible with the Gradle configuration cache. See https://github.com/Kotlin/dokka/issues/1217")
     }
 
     internal fun buildPluginsConfiguration(): List<PluginConfigurationImpl> {

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/AbstractDokkaTask.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/AbstractDokkaTask.kt
@@ -23,6 +23,7 @@ import org.jetbrains.dokka.plugability.DokkaPlugin
 import java.util.concurrent.atomic.AtomicReference
 import java.util.function.BiConsumer
 import kotlin.reflect.full.createInstance
+import kotlin.reflect.full.memberFunctions
 
 @DisableCachingByDefault(because = "Abstract super-class, not to be instantiated directly")
 abstract class AbstractDokkaTask : DefaultTask() {
@@ -232,7 +233,11 @@ abstract class AbstractDokkaTask : DefaultTask() {
 
     init {
         group = JavaBasePlugin.DOCUMENTATION_GROUP
-        super.notCompatibleWithConfigurationCache("Dokka tasks are not yet compatible with the Gradle configuration cache. See https://github.com/Kotlin/dokka/issues/1217")
+        // notCompatibleWithConfigurationCache was introduced in Gradle 7.4
+        val containsNotCompatibleWithConfigurationCache = this::class.memberFunctions.any { it.name == "notCompatibleWithConfigurationCache" && it.parameters.firstOrNull()?.name == "reason" }
+        if (containsNotCompatibleWithConfigurationCache) {
+            super.notCompatibleWithConfigurationCache("Dokka tasks are not yet compatible with the Gradle configuration cache. See https://github.com/Kotlin/dokka/issues/1217")
+        }
     }
 
     internal fun buildPluginsConfiguration(): List<PluginConfigurationImpl> {


### PR DESCRIPTION
Since, as for now, Dokka is not compatible with the Gradle configuration cache (see [#1217](https://github.com/Kotlin/dokka/issues/1217)), using it in a project that has it enabled will fail the build. 
Marking the tasks as incompatible avoids these fails.
