### PR TITLE
potential fix for compatibility with KGP 1.9

### DIFF
--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/kotlin/kotlinClasspathUtils.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/kotlin/kotlinClasspathUtils.kt
@@ -57,8 +57,14 @@ private fun KotlinCompilation.getKotlinCompileTask(kgpVersion: KotlinGradlePlugi
 }
 
 private fun KotlinCompilation.platformDependencyFiles(): FileCollection {
+    val excludePlatformDependencyFiles = project.classpathProperty("excludePlatformDependencyFiles", default = false)
+
+    if (excludePlatformDependencyFiles) return project.files()
     return (this as? AbstractKotlinNativeCompilation)
         ?.target?.project?.configurations
         ?.findByName(@Suppress("DEPRECATION") this.defaultSourceSet.implementationMetadataConfigurationName) // KT-58640
         ?: project.files()
 }
+
+private fun Project.classpathProperty(name: String, default: Boolean): Boolean =
+    (findProperty("org.jetbrains.dokka.classpath.$name") as? String)?.toBoolean() ?: default

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/kotlin/kotlinClasspathUtils.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/kotlin/kotlinClasspathUtils.kt
@@ -40,7 +40,7 @@ private fun KotlinCompilation.compileClasspathOf(project: Project): FileCollecti
 
 private fun KotlinCompilation.newCompileClasspathOf(project: Project): FileCollection {
     val compilationClasspath = (compileTaskProvider.get() as? KotlinCompileTool)?.libraries ?: project.files()
-    return compilationClasspath + platformDependencyFiles()
+    return compilationClasspath + platformDependencyFiles(project)
 }
 
 private fun KotlinCompilation.oldCompileClasspathOf(project: Project): FileCollection {
@@ -48,7 +48,7 @@ private fun KotlinCompilation.oldCompileClasspathOf(project: Project): FileColle
         return this.classpathOf(project)
     }
 
-    return this.compileDependencyFiles + platformDependencyFiles() + this.classpathOf(project)
+    return this.compileDependencyFiles + platformDependencyFiles(project) + this.classpathOf(project)
 }
 
 private fun KotlinCompilation.classpathOf(project: Project): FileCollection {
@@ -76,7 +76,7 @@ private fun KotlinCompilation.getKotlinCompileTask(kgpVersion: KotlinGradlePlugi
     }
 }
 
-private fun KotlinCompilation.platformDependencyFiles(): FileCollection {
+private fun KotlinCompilation.platformDependencyFiles(project: Project): FileCollection {
     val excludePlatformDependencyFiles = project.classpathProperty("excludePlatformDependencyFiles", default = false)
 
     if (excludePlatformDependencyFiles) return project.files()

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/kotlin/kotlinClasspathUtils.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/kotlin/kotlinClasspathUtils.kt
@@ -28,12 +28,7 @@ private fun KotlinCompilation.compileClasspathOf(project: Project): FileCollecti
         return this.classpathOf(project)
     }
 
-    val platformDependencyFiles: FileCollection = (this as? AbstractKotlinNativeCompilation)
-        ?.target?.project?.configurations
-        ?.findByName(@Suppress("DEPRECATION") this.defaultSourceSet.implementationMetadataConfigurationName) // KT-58640
-        ?: project.files()
-
-    return this.compileDependencyFiles + platformDependencyFiles + this.classpathOf(project)
+    return this.compileDependencyFiles + platformDependencyFiles() + this.classpathOf(project)
 }
 
 private fun KotlinCompilation.classpathOf(project: Project): FileCollection {
@@ -43,7 +38,7 @@ private fun KotlinCompilation.classpathOf(project: Project): FileCollection {
     val shouldKeepBackwardsCompatibility = (kgpVersion != null && kgpVersion < KotlinGradlePluginVersion(1, 7, 0))
     return if (shouldKeepBackwardsCompatibility) {
         // removed since 1.9.0, left for compatibility with < Kotlin 1.7
-        val classpathGetter= kotlinCompile::class.members
+        val classpathGetter = kotlinCompile::class.members
             .first { it.name == "getClasspath" }
         classpathGetter.call(kotlinCompile) as FileCollection
     } else {
@@ -59,4 +54,11 @@ private fun KotlinCompilation.getKotlinCompileTask(kgpVersion: KotlinGradlePlugi
     } else {
         this.compileTaskProvider.get() as? KotlinCompile // introduced in 1.8.0
     }
+}
+
+private fun KotlinCompilation.platformDependencyFiles(): FileCollection {
+    return (this as? AbstractKotlinNativeCompilation)
+        ?.target?.project?.configurations
+        ?.findByName(@Suppress("DEPRECATION") this.defaultSourceSet.implementationMetadataConfigurationName) // KT-58640
+        ?: project.files()
 }

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/kotlin/kotlinClasspathUtils.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/kotlin/kotlinClasspathUtils.kt
@@ -12,14 +12,13 @@ internal fun Project.classpathOf(sourceSet: KotlinSourceSet): FileCollection {
     return if (compilations.isNotEmpty()) {
         compilations
             .map { compilation -> compilation.compileClasspathOf(project = this) }
-            .reduce { acc, fileCollection -> acc + fileCollection }
+            .reduce(FileCollection::plus)
     } else {
         // Dokka suppresses source sets that do no have compilations
         // since such configuration is invalid, it reports a warning or an error
         sourceSet.withAllDependentSourceSets()
-            .toList()
             .map { it.kotlin.sourceDirectories }
-            .reduce { acc, fileCollection -> acc + fileCollection }
+            .reduce(FileCollection::plus)
     }
 }
 


### PR DESCRIPTION
attempt to fix #3068 which is blocking building documentation for https://github.com/whyoleg/cryptography-kotlin/tree/dev (`dev` branch, KGP 1.9.0)
for recent changes consult: https://github.com/Kotlin/dokka/pull/3081#issuecomment-1666818036