### PR TITLE
Fix handling of Java contravariance

### DIFF
--- a/plugins/base/src/test/kotlin/model/JavaTest.kt
+++ b/plugins/base/src/test/kotlin/model/JavaTest.kt
@@ -10,6 +10,7 @@ import org.jetbrains.dokka.model.doc.Text
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import utils.AbstractModelTest
+import utils.assertContains
 import utils.assertNotNull
 import utils.name
 import kotlin.test.assertEquals
@@ -451,6 +452,11 @@ class JavaTest : AbstractModelTest("/src/main/kotlin/java/Test.java", "java") {
             """, configuration = configuration
         ) {
             with((this / "java" / "Foo").cast<DClass>()) {
+                val functionNames = functions.map { it.name }
+                assertContains(functionNames, "superBound")
+                assertContains(functionNames, "extendsBound")
+                assertContains(functionNames, "unbounded")
+
                 for (function in functions) {
                     val param = function.parameters.single()
                     val type = param.type as GenericTypeConstructor

--- a/subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/parsers/DokkaPsiParser.kt
+++ b/subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/parsers/DokkaPsiParser.kt
@@ -567,8 +567,10 @@ internal class DokkaPsiParser(
 
 
     private fun getVariance(type: PsiWildcardType): Projection = when {
+        type.isExtends -> Covariance(getBound(type.extendsBound))
+        type.isSuper -> Contravariance(getBound(type.superBound))
+        // If the type isn't explicitly bounded, it still has an implicit `extends Object` bound
         type.extendsBound != PsiType.NULL -> Covariance(getBound(type.extendsBound))
-        type.superBound != PsiType.NULL -> Contravariance(getBound(type.superBound))
         else -> throw IllegalStateException("${type.presentableText} has incorrect bounds")
     }
 


### PR DESCRIPTION
Previously, because `PsiWildcardType`s have an implicit bound of `extends Object`, a wildcard type with a `super` bound was being turned into a `Covariance` instead of a `Contravariance`.

Fixes #3091 