### PR TITLE
Update examples and tests to use Kotlin 1.9.0

### DIFF
--- a/examples/gradle/dokka-customFormat-example/build.gradle.kts
+++ b/examples/gradle/dokka-customFormat-example/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.base.DokkaBaseConfiguration
 
 plugins {
-    kotlin("jvm") version "1.8.20"
+    kotlin("jvm") version "1.9.0"
     id("org.jetbrains.dokka") version "1.8.20"
 }
 

--- a/examples/gradle/dokka-gradle-example/build.gradle.kts
+++ b/examples/gradle/dokka-gradle-example/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.dokka.gradle.DokkaTask
 import java.net.URL
 
 plugins {
-    kotlin("jvm") version "1.8.20"
+    kotlin("jvm") version "1.9.0"
     id("org.jetbrains.dokka") version "1.8.20"
 }
 

--- a/examples/gradle/dokka-kotlinAsJava-example/build.gradle.kts
+++ b/examples/gradle/dokka-kotlinAsJava-example/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.8.20"
+    kotlin("jvm") version "1.9.0"
     id("org.jetbrains.dokka") version "1.8.20"
 }
 

--- a/examples/gradle/dokka-library-publishing-example/build.gradle.kts
+++ b/examples/gradle/dokka-library-publishing-example/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.8.20"
+    kotlin("jvm") version "1.9.0"
     id("org.jetbrains.dokka") version "1.8.20"
     `java-library`
     `maven-publish`

--- a/examples/gradle/dokka-multimodule-example/gradle.properties
+++ b/examples/gradle/dokka-multimodule-example/gradle.properties
@@ -1,2 +1,2 @@
-kotlinVersion=1.8.20
+kotlinVersion=1.9.0
 dokkaVersion=1.8.20

--- a/examples/gradle/dokka-multiplatform-example/build.gradle.kts
+++ b/examples/gradle/dokka-multiplatform-example/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.dokka.Platform
 
 plugins {
-    kotlin("multiplatform") version "1.8.20"
+    kotlin("multiplatform") version "1.9.0"
     id("org.jetbrains.dokka") version "1.8.20"
 }
 

--- a/examples/gradle/dokka-multiplatform-example/build.gradle.kts
+++ b/examples/gradle/dokka-multiplatform-example/build.gradle.kts
@@ -19,7 +19,7 @@ kotlin {
     jvm() // Creates a JVM target with the default name "jvm"
     linuxX64("linux")
     macosX64("macos")
-    js(BOTH)
+    js()
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/examples/gradle/dokka-multiplatform-example/src/linuxMain/kotlin/org/kotlintestmpp/CInterop.kt
+++ b/examples/gradle/dokka-multiplatform-example/src/linuxMain/kotlin/org/kotlintestmpp/CInterop.kt
@@ -4,10 +4,12 @@ package org.kotlintestmpp
 
 import kotlinx.cinterop.CPointed
 import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.ExperimentalForeignApi
 
 /**
  * Low-level Linux function
  */
+@OptIn(ExperimentalForeignApi::class)
 fun <T : CPointed> printPointerRawValue(pointer: CPointer<T>) {
     println(pointer.rawValue)
 }

--- a/examples/gradle/dokka-versioning-multimodule-example/build.gradle.kts
+++ b/examples/gradle/dokka-versioning-multimodule-example/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.8.20"
+    kotlin("jvm") version "1.9.0"
     id("org.jetbrains.dokka") version "1.8.20" apply false
 }
 

--- a/examples/maven/pom.xml
+++ b/examples/maven/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>kotlin-maven-example</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <kotlin.version>1.8.20</kotlin.version>
+        <kotlin.version>1.9.0</kotlin.version>
         <dokka.version>1.8.20</dokka.version>
     </properties>
 

--- a/examples/plugin/hide-internal-api/build.gradle.kts
+++ b/examples/plugin/hide-internal-api/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.net.URI
 
 plugins {
-    kotlin("jvm") version "1.8.20"
+    kotlin("jvm") version "1.9.0"
     id("org.jetbrains.dokka") version "1.8.20"
     `maven-publish`
     signing

--- a/integration-tests/gradle/projects/it-basic-groovy/gradle.properties
+++ b/integration-tests/gradle/projects/it-basic-groovy/gradle.properties
@@ -1,1 +1,1 @@
-dokka_it_kotlin_version=1.8.20
+dokka_it_kotlin_version=1.9.0

--- a/integration-tests/gradle/projects/it-basic/gradle.properties
+++ b/integration-tests/gradle/projects/it-basic/gradle.properties
@@ -1,1 +1,1 @@
-dokka_it_kotlin_version=1.8.20
+dokka_it_kotlin_version=1.9.0

--- a/integration-tests/gradle/projects/it-collector-0/gradle.properties
+++ b/integration-tests/gradle/projects/it-collector-0/gradle.properties
@@ -1,1 +1,1 @@
-dokka_it_kotlin_version=1.8.20
+dokka_it_kotlin_version=1.9.0

--- a/integration-tests/gradle/projects/it-configuration/gradle.properties
+++ b/integration-tests/gradle/projects/it-configuration/gradle.properties
@@ -1,3 +1,3 @@
-dokka_it_kotlin_version=1.8.20
+dokka_it_kotlin_version=1.9.0
 fail_on_warning=false
 report_undocumented=false

--- a/integration-tests/gradle/projects/it-js-ir-0/gradle.properties
+++ b/integration-tests/gradle/projects/it-js-ir-0/gradle.properties
@@ -1,2 +1,2 @@
-dokka_it_kotlin_version=1.8.20
+dokka_it_kotlin_version=1.9.0
 react_version=18.2.0-pre.467

--- a/integration-tests/gradle/projects/it-multimodule-0/gradle.properties
+++ b/integration-tests/gradle/projects/it-multimodule-0/gradle.properties
@@ -1,1 +1,1 @@
-dokka_it_kotlin_version=1.8.20
+dokka_it_kotlin_version=1.9.0

--- a/integration-tests/gradle/projects/it-multimodule-1/gradle.properties
+++ b/integration-tests/gradle/projects/it-multimodule-1/gradle.properties
@@ -1,1 +1,1 @@
-dokka_it_kotlin_version=1.8.20
+dokka_it_kotlin_version=1.9.0

--- a/integration-tests/gradle/projects/it-multimodule-versioning-0/gradle.properties
+++ b/integration-tests/gradle/projects/it-multimodule-versioning-0/gradle.properties
@@ -1,2 +1,2 @@
-dokka_it_kotlin_version=1.8.20
+dokka_it_kotlin_version=1.9.0
 

--- a/integration-tests/gradle/projects/it-multiplatform-0/gradle.properties
+++ b/integration-tests/gradle/projects/it-multiplatform-0/gradle.properties
@@ -1,4 +1,4 @@
-dokka_it_kotlin_version=1.8.20
+dokka_it_kotlin_version=1.9.0
 #these flags are enabled by default since 1.6.20.
 #remove when this test is executed with Kotlin >= 1.6.20
 kotlin.mpp.enableGranularSourceSetsMetadata=true

--- a/integration-tests/gradle/projects/it-sequential-tasks-execution-stress/gradle.properties
+++ b/integration-tests/gradle/projects/it-sequential-tasks-execution-stress/gradle.properties
@@ -1,2 +1,2 @@
-dokka_it_kotlin_version=1.8.20
+dokka_it_kotlin_version=1.9.0
 task_number=100

--- a/integration-tests/gradle/projects/it-wasm-basic/gradle.properties
+++ b/integration-tests/gradle/projects/it-wasm-basic/gradle.properties
@@ -1,1 +1,1 @@
-dokka_it_kotlin_version=1.8.20
+dokka_it_kotlin_version=1.9.0

--- a/integration-tests/maven/projects/it-maven/pom.xml
+++ b/integration-tests/maven/projects/it-maven/pom.xml
@@ -7,7 +7,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <kotlin.version>1.8.20</kotlin.version>
+        <kotlin.version>1.9.0</kotlin.version>
     </properties>
     <build>
         <plugins>


### PR DESCRIPTION
A sanity check that we can build our own examples and tests with Kotlin 1.9.0, in case they uncover some unknown problems.