### PR TITLE
Make the compatibility metadata variant check more specific

### DIFF
--- a/integration-tests/gradle/projects/it-wasm-basic/build.gradle.kts
+++ b/integration-tests/gradle/projects/it-wasm-basic/build.gradle.kts
@@ -14,7 +14,6 @@ repositories {
 }
 
 kotlin {
-    jvm() // artificial empty target to avoid single target project
     wasm()
     sourceSets {
         val wasmMain by getting {

--- a/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/WasmGradleIntegrationTest.kt
+++ b/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/WasmGradleIntegrationTest.kt
@@ -10,7 +10,8 @@ class WasmGradleIntegrationTest(override val versions: BuildVersions) : Abstract
     companion object {
         @get:JvmStatic
         @get:Parameters(name = "{0}")
-        val versions = listOf(TestedVersions.LATEST)
+        val versions = TestedVersions.ALL_SUPPORTED
+            .filter { it.kotlinVersion >= "1.8.20" } // 1.8.20 is the first public version that can be tested with wasm
     }
 
     @BeforeTest

--- a/runners/gradle-plugin/api/gradle-plugin.api
+++ b/runners/gradle-plugin/api/gradle-plugin.api
@@ -179,7 +179,3 @@ public final class org/jetbrains/dokka/gradle/internal/AbstractDokkaTaskExtensio
 	public static synthetic fun buildJsonConfiguration$default (Lorg/jetbrains/dokka/gradle/AbstractDokkaTask;ZILjava/lang/Object;)Ljava/lang/String;
 }
 
-public final class org/jetbrains/dokka/gradle/kotlin/KotlinClasspathUtilsKt {
-	public static final fun isHMPPEnabled (Lorg/gradle/api/Project;)Z
-}
-

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/kotlin/kotlinClasspathUtils.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/kotlin/kotlinClasspathUtils.kt
@@ -5,25 +5,12 @@ import org.gradle.api.file.FileCollection
 import org.jetbrains.dokka.gradle.isAndroidTarget
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import org.jetbrains.kotlin.gradle.plugin.mpp.AbstractKotlinNativeCompilation
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinCommonCompilation
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
-val Project.isHMPPEnabled
-    // [KotlinCommonCompilation.isKlibCompilation] is internal, so we use this
-    get() = (this.findProperty("kotlin.mpp.enableGranularSourceSetsMetadata") as? String)?.toBoolean() ?: false
 
 internal fun Project.classpathOf(sourceSet: KotlinSourceSet): FileCollection {
     val compilations = compilationsOf(sourceSet)
     return if (compilations.isNotEmpty()) {
         compilations
-            /**
-             * If the project has enabled Compatibility Metadata Variant (produces legacy variant),
-             * we don't touch it due to some dependant library
-             * might be published without Compatibility Metadata Variant.
-             * Dokka needs only HMPP variant
-             * Ignore [org.jetbrains.kotlin.gradle.plugin.mpp.KotlinCommonCompilation]  for `commonMain`  sourceSet with name `main`
-             */
-            .filterNot { compilation -> isHMPPEnabled && compilation is KotlinCommonCompilation && compilation.name == "main" }
             .map { compilation -> compilation.compileClasspathOf(project = this) }
             .reduce { acc, fileCollection -> acc + fileCollection }
     } else {

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/kotlin/kotlinCompilationUtils.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/kotlin/kotlinCompilationUtils.kt
@@ -17,14 +17,14 @@ internal fun Project.compilationsOf(sourceSet: KotlinSourceSet): List<KotlinComp
         sourceSet in compilation.kotlinSourceSets || sourceSet == compilation.defaultSourceSet
     }
 
-    val hasCompatibilityMetadataVariant = compilations.size >= 2
+    val hasAdditionalCommonCompatibilityMetadataVariant = compilations.size >= 2
             && this.isHmppEnabled()
             && compilations.any { it is KotlinCommonCompilation && it.compilationName == "main" }
             && compilations.any { it is KotlinCommonCompilation && it.compilationName == "commonMain" }
 
-    return if (hasCompatibilityMetadataVariant) {
+    return if (hasAdditionalCommonCompatibilityMetadataVariant) {
         // If the project has `kotlin.mpp.enableCompatibilityMetadataVariant` set to `true`
-        // and it produces a legacy variant, we filter it out because one of the dependencies
+        // and it produces a legacy variant for common, we filter it out because one of the dependencies
         // might be published without it, and it would lead to the following error:
         //
         // > Execution failed for task ':project:dokkaHtmlPartial'.

--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/kotlin/kotlinCompilationUtils.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/kotlin/kotlinCompilationUtils.kt
@@ -6,15 +6,47 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinCommonOptions
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinSingleTargetExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinCommonCompilation
 
 internal typealias KotlinCompilation =
         org.jetbrains.kotlin.gradle.plugin.KotlinCompilation<KotlinCommonOptions>
 
 internal fun Project.compilationsOf(sourceSet: KotlinSourceSet): List<KotlinCompilation> {
     //KT-45412 Make sure .kotlinSourceSets and .allKotlinSourceSets include the default source set
-    return allCompilationsOf(sourceSet).filter { compilation ->
+    val compilations = allCompilationsOf(sourceSet).filter { compilation ->
         sourceSet in compilation.kotlinSourceSets || sourceSet == compilation.defaultSourceSet
     }
+
+    val hasCompatibilityMetadataVariant = compilations.size >= 2
+            && this.isHmppEnabled()
+            && compilations.any { it is KotlinCommonCompilation && it.compilationName == "main" }
+            && compilations.any { it is KotlinCommonCompilation && it.compilationName == "commonMain" }
+
+    return if (hasCompatibilityMetadataVariant) {
+        // If the project has `kotlin.mpp.enableCompatibilityMetadataVariant` set to `true`
+        // and it produces a legacy variant, we filter it out because one of the dependencies
+        // might be published without it, and it would lead to the following error:
+        //
+        // > Execution failed for task ':project:dokkaHtmlPartial'.
+        // > Could not resolve all files for configuration ':project:metadataCompileClasspath'.
+        //    > Could not resolve com.example.dependency:0.1.0.
+        //       > The consumer was configured to find a usage of 'kotlin-api' of a library, preferably optimized for
+        //         non-jvm, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'common'. However we
+        //         cannot choose between the following variants of com.example.dependency:0.1.0:
+        //
+        // This can be reproduced consistently on Ktor of version 2.3.2
+        compilations.filterNot { it is KotlinCommonCompilation && it.compilationName == "main" }
+    } else {
+        compilations
+    }
+}
+
+private fun Project.isHmppEnabled(): Boolean {
+    // [KotlinCommonCompilation.isKlibCompilation] is internal, so we use this property instead.
+    // The property name might seem misleading, but it's set by KGP if HMPP is enabled:
+    // https://github.com/JetBrains/kotlin/blob/1.9.0/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/internal/hierarchicalStructureMigrationHandling.kt#L33
+    return (this.findProperty("kotlin.mpp.enableGranularSourceSetsMetadata") as? String)?.toBoolean()
+        ?: false
 }
 
 internal fun Project.allCompilationsOf(


### PR DESCRIPTION
This **transitively** fixes the support for single-target multiplatform projects.

## Background 

During some refactoring in KGP, a bug was noticed that led to the creation of a redundant commonMain compilation in single-target multiplatform projects. This bug was fixed in KGP 1.9, so single-target multi-platform projects do not have this accidental compilation anymore.

Dokka had [an additional check](https://github.com/Kotlin/dokka/blob/master/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/kotlin/kotlinClasspathUtils.kt#L26) that filtered out the compatibility / legacy `main` compilation.

This led to the situation where single-target multiplatform projects using Kotlin 1.9.0 had no viable compilations **from Dokka's perspective** (because one was removed by KGP, and another one filtered out by Dokka), so it failed with an error (#3063).

However, if you looked at which compilations were returned by KGP for single-target multiplatform projects, you would see that it actually had the `main` compilation, which could be used to generate documentation successfully, but Dokka was filtering it out.

If you removed the check that filtered out the `main` compilation, it would fix the issue for single-target multiplatform projects, but it would lead to problems in other projects that have set `kotlin.mpp.enableCompatibilityMetadataVariant=true` (like ktor).

## The solution

An additional condition was added to the check: the compatibility compilation should only be filtered out if this source set has an additional proper compilation which would be used instead. Otherwise, we have a chance of filtering out all available compilations.

Now, single-target multiplatform projects should work as they (for some reason) have the `main` compilation, and Dokka doesn't filter it out, so it is used to generate documentation.

I've stressed "**transitively**" specifically because there are no guarantees that single-target projects will have that `main` compilation in the future - it might be removed (because such projects are still [not supported officially](https://youtrack.jetbrains.com/issue/KT-52664/Multiplatform-projects-with-a-single-target)), and the support for single-target projects would be broken again.

Maybe by that time we'll have migrated to a different API provided by KGP, so it wouldn't be a problem anymore - we'll see.