### PR TITLE
Get rid of bintray and jcenter mentions in our buildscript

### DIFF
--- a/examples/plugin/hide-internal-api/build.gradle.kts
+++ b/examples/plugin/hide-internal-api/build.gradle.kts
@@ -14,7 +14,6 @@ version = "1.4-SNAPSHOT"
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 val dokkaVersion: String by project

--- a/integration-tests/gradle/projects/template.root.gradle.kts
+++ b/integration-tests/gradle/projects/template.root.gradle.kts
@@ -1,11 +1,8 @@
 allprojects {
     repositories {
-        maven("https://cache-redirector.jetbrains.com/jcenter.bintray.com")
         mavenLocal()
         mavenCentral()
         google()
-        maven("https://cache-redirector.jetbrains.com/dl.bintray.com/kotlin/kotlin-eap")
-        maven("https://cache-redirector.jetbrains.com/dl.bintray.com/kotlin/kotlin-dev")
         maven("https://maven.pkg.jetbrains.space/public/p/kotlinx-html/maven") {
             content {
                 includeGroup("org.jetbrains.kotlinx")

--- a/integration-tests/gradle/projects/template.settings.gradle.kts
+++ b/integration-tests/gradle/projects/template.settings.gradle.kts
@@ -28,11 +28,8 @@ pluginManagement {
     }
     repositories {
         mavenLocal()
-        maven("https://cache-redirector.jetbrains.com/jcenter.bintray.com")
         mavenCentral()
         gradlePluginPortal()
         google()
-        maven("https://cache-redirector.jetbrains.com/dl.bintray.com/kotlin/kotlin-eap")
-        maven("https://cache-redirector.jetbrains.com/dl.bintray.com/kotlin/kotlin-dev")
     }
 }

--- a/integration-tests/maven/projects/biojava/biojava.diff
+++ b/integration-tests/maven/projects/biojava/biojava.diff
@@ -2,23 +2,11 @@ diff --git a/pom.xml b/pom.xml
 index 7e3e806d1..765b6dea3 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -31,6 +31,24 @@
+@@ -31,6 +31,12 @@
  			<distribution>repo</distribution>
  		</license>
  	</licenses>
 +	<pluginRepositories>
-+		<pluginRepository>
-+			<id>kotlin-dev</id>
-+			<url>https://dl.bintray.com/kotlin/kotlin-dev</url>
-+		</pluginRepository>
-+		<pluginRepository>
-+			<id>kotlin-eap</id>
-+			<url>https://dl.bintray.com/kotlin/kotlin-eap</url>
-+		</pluginRepository>
-+		<pluginRepository>
-+			<id>jcenter</id>
-+			<url>https://jcenter.bintray.com/</url>
-+		</pluginRepository>
 +		<pluginRepository>
 +			<id>space</id>
 +			<url>https://maven.pkg.jetbrains.space/public/p/kotlinx-html/maven/</url>

--- a/integration-tests/maven/projects/it-maven/pom.xml
+++ b/integration-tests/maven/projects/it-maven/pom.xml
@@ -170,19 +170,6 @@
 
     <pluginRepositories>
         <pluginRepository>
-            <id>kotlin-eap</id>
-            <url>https://cache-redirector.jetbrains.com/dl.bintray.com/kotlin/kotlin-eap/</url>
-        </pluginRepository>
-        <pluginRepository>
-            <id>kotlin-dev</id>
-            <url>https://cache-redirector.jetbrains.com/dl.bintray.com/kotlin/kotlin-dev/</url>
-        </pluginRepository>
-        <pluginRepository>
-            <id>jcenter</id>
-            <name>JCenter</name>
-            <url>https://cache-redirector.jetbrains.com/jcenter.bintray.com/</url>
-        </pluginRepository>
-        <pluginRepository>
             <id>Space</id>
             <name>Space</name>
             <url>https://maven.pkg.jetbrains.space/public/p/kotlinx-html/maven/</url>


### PR DESCRIPTION
Otherwise, our integration tests try to resolve these repositories on failures