### PR TITLE
fix(KTL-1177): Resize Observer has indefinite loop

### DIFF
--- a/plugins/base/src/main/resources/dokka/scripts/symbol-parameters-wrapper_deferred.js
+++ b/plugins/base/src/main/resources/dokka/scripts/symbol-parameters-wrapper_deferred.js
@@ -16,16 +16,18 @@
 
     function wrapSymbolParameters(entry) {
         const symbol = entry.target;
-        const futureWidth = entry.borderBoxSize && entry.borderBoxSize[0] && entry.borderBoxSize[0].inlineSize;
+        const symbolBlockWidth = entry.borderBoxSize && entry.borderBoxSize[0] && entry.borderBoxSize[0].inlineSize;
 
         // Even though the script is marked as `defer` and we wait for `DOMContentLoaded` event,
-        // or if this block is a part of hidden tab, it can happen that `futureWidth` is 0,
+        // or if this block is a part of hidden tab, it can happen that `symbolBlockWidth` is 0,
         // indicating that something hasn't been loaded.
         // In this case, observer will be triggered onсe again when it will be ready.
-        if (futureWidth > 0) {
+        if (symbolBlockWidth > 0) {
             const node = symbol.querySelector(".parameters");
 
-            if (node) { // need to re-calculate if params need to be wrapped after resize
+            if (node) {
+                // if window resize happened and observer was triggered, reset previously wrapped
+                // parameters as they might not need wrapping anymore, and check again
                 node.classList.remove("wrapped");
                 node.querySelectorAll(".parameter .nbsp-indent")
                     .forEach(indent => indent.remove());
@@ -36,7 +38,7 @@
                     .reduce((a, b) => a + b, 0);
 
                 // if signature text takes up more than a single line, wrap params for readability
-                if (innerTextWidth > (futureWidth - leftPaddingPx)) {
+                if (innerTextWidth > (symbolBlockWidth - leftPaddingPx)) {
                     node.classList.add("wrapped");
                     node.querySelectorAll(".parameter").forEach(param => {
                         // has to be a physical indent so that it can be copied. styles like

--- a/plugins/base/src/main/resources/dokka/scripts/symbol-parameters-wrapper_deferred.js
+++ b/plugins/base/src/main/resources/dokka/scripts/symbol-parameters-wrapper_deferred.js
@@ -4,84 +4,59 @@
 
 // helps with some corner cases where <wbr> starts working already,
 // but the signature is not yet long enough to be wrapped
-const leftPaddingPx = 60
+(function() {
+    const leftPaddingPx = 60;
 
-const symbolResizeObserver = new ResizeObserver(entries => {
-    entries.forEach(entry => {
-        const symbolElement = entry.target
-        symbolResizeObserver.unobserve(symbolElement) // only need it once, otherwise will be executed multiple times
-        wrapSymbolParameters(symbolElement);
-    })
-});
-
-const wrapAllSymbolParameters = () => {
-    document.querySelectorAll("div.symbol").forEach(symbol => wrapSymbolParameters(symbol))
-}
-
-const wrapSymbolParameters = (symbol) => {
-    let parametersBlock = symbol.querySelector("span.parameters")
-    if (parametersBlock == null) {
-        return // nothing to wrap
+    function createNbspIndent() {
+        let indent = document.createElement("span");
+        indent.append(document.createTextNode("\u00A0\u00A0\u00A0\u00A0"));
+        indent.classList.add("nbsp-indent");
+        return indent;
     }
 
-    let symbolBlockWidth = symbol.clientWidth
+    function wrapSymbolParameters(entry) {
+        const symbol = entry.target;
+        const futureWidth = entry.borderBoxSize && entry.borderBoxSize[0] && entry.borderBoxSize[0].inlineSize;
 
-    // Even though the script is marked as `defer` and we wait for `DOMContentLoaded` event,
-    // it can happen that `symbolBlockWidth` is 0, indicating that something hasn't been loaded.
-    // In this case, just retry once all styles have been applied and it has been resized correctly.
-    if (symbolBlockWidth === 0) {
-        symbolResizeObserver.observe(symbol)
-        return
+        // Even though the script is marked as `defer` and we wait for `DOMContentLoaded` event,
+        // or if this block is a part of hidden tab, it can happen that `futureWidth` is 0,
+        // indicating that something hasn't been loaded.
+        // In this case, observer will be triggered onсe again when it will be ready.
+        if (futureWidth > 0) {
+            const node = symbol.querySelector(".parameters");
+
+            if (node) { // need to re-calculate if params need to be wrapped after resize
+                node.classList.remove("wrapped");
+                node.querySelectorAll(".parameter .nbsp-indent")
+                    .forEach(indent => indent.remove());
+
+                const innerTextWidth = Array.from(symbol.children)
+                    .filter(it => !it.classList.contains("block")) // blocks are usually on their own (like annotations), so ignore it
+                    .map(it => it.getBoundingClientRect().width)
+                    .reduce((a, b) => a + b, 0);
+
+                // if signature text takes up more than a single line, wrap params for readability
+                if (innerTextWidth > (futureWidth - leftPaddingPx)) {
+                    node.classList.add("wrapped");
+                    node.querySelectorAll(".parameter").forEach(param => {
+                        // has to be a physical indent so that it can be copied. styles like
+                        // paddings and `::before { content: "    " }` do not work for that
+                        param.prepend(createNbspIndent());
+                    });
+                }
+            }
+        }
     }
 
-    let innerTextWidth = Array.from(symbol.children)
-        .filter(it => !it.classList.contains("block")) // blocks are usually on their own (like annotations), so ignore it
-        .map(it => it.getBoundingClientRect().width).reduce((a, b) => a + b, 0)
+    const symbolsObserver = new ResizeObserver(entries => entries.forEach(wrapSymbolParameters));
 
-    // if signature text takes up more than a single line, wrap params for readability
-    let shouldWrapParams = innerTextWidth > (symbolBlockWidth - leftPaddingPx)
-    if (shouldWrapParams) {
-        parametersBlock.classList.add("wrapped")
-        parametersBlock.querySelectorAll("span.parameter").forEach(param => {
-            // has to be a physical indent so that it can be copied. styles like
-            // paddings and `::before { content: "    " }` do not work for that
-            param.prepend(createNbspIndent())
-        })
+    function initHandlers() {
+        document.querySelectorAll("div.symbol").forEach(symbol => symbolsObserver.observe(symbol));
     }
-}
 
-const createNbspIndent = () => {
-    let indent = document.createElement("span")
-    indent.append(document.createTextNode("\u00A0\u00A0\u00A0\u00A0"))
-    indent.classList.add("nbsp-indent")
-    return indent
-}
+    if (document.readyState === 'loading') window.addEventListener('DOMContentLoaded', initHandlers);
+    else initHandlers();
 
-const resetAllSymbolParametersWrapping = () => {
-    document.querySelectorAll("div.symbol").forEach(symbol => resetSymbolParametersWrapping(symbol))
-}
-
-const resetSymbolParametersWrapping = (symbol) => {
-    let parameters = symbol.querySelector("span.parameters")
-    if (parameters != null) {
-        parameters.classList.remove("wrapped")
-        parameters.querySelectorAll("span.parameter").forEach(param => {
-            let indent = param.querySelector("span.nbsp-indent")
-            if (indent != null) indent.remove()
-        })
-    }
-}
-
-if (document.readyState === 'loading') {
-    window.addEventListener('DOMContentLoaded', () => {
-        wrapAllSymbolParameters()
-    })
-} else {
-    wrapAllSymbolParameters()
-}
-
-window.onresize = event => {
-    // need to re-calculate if params need to be wrapped after resize
-    resetAllSymbolParametersWrapping()
-    wrapAllSymbolParameters()
-}
+    // ToDo: Add `unobserve` if dokka will be SPA-like:
+    //       https://github.com/w3c/csswg-drafts/issues/5155
+})();


### PR DESCRIPTION
symbol wrapper script in dokka has Infinity cycling code based on [observe](https://github.com/Kotlin/dokka/blob/879d4f2652d528f20c95d5bb17899d6cb10c5e85/plugins/base/src/main/resources/dokka/scripts/symbol-parameters-wrapper_deferred.js#L29)/[unobserve](https://github.com/Kotlin/dokka/blob/879d4f2652d528f20c95d5bb17899d6cb10c5e85/plugins/base/src/main/resources/dokka/scripts/symbol-parameters-wrapper_deferred.js#L8) inside resize handler.

MRE:
```javascript
const observer = new ResizeObserver(entries => entries.forEach({ target } => {
  observer.unobserve(target);
  observer.observe(target); // fire re-call this ResizeObserver handler
}));

document.querySelectorAll('...').forEach(item => observer.observe(item));
```