### PR TITLE
Introduce configuration for K1 analysis plugin

### DIFF
--- a/subprojects/analysis-kotlin-descriptors/compiler/api/compiler.api
+++ b/subprojects/analysis-kotlin-descriptors/compiler/api/compiler.api
@@ -60,6 +60,24 @@ public final class org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/conf
 	public fun dispose ()V
 }
 
+public final class org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/DokkaAnalysisConfiguration : org/jetbrains/dokka/plugability/ConfigurableBlock {
+	public static final field Companion Lorg/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/DokkaAnalysisConfiguration$Companion;
+	public static final field DEFAULT_IGNORE_COMMON_BUILT_INS Z
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lorg/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/DokkaAnalysisConfiguration;
+	public static synthetic fun copy$default (Lorg/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/DokkaAnalysisConfiguration;ZILjava/lang/Object;)Lorg/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/DokkaAnalysisConfiguration;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIgnoreCommonBuiltIns ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/DokkaAnalysisConfiguration$Companion {
+}
+
 public abstract class org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/KotlinAnalysis : java/io/Closeable {
 	public fun <init> ()V
 	public fun <init> (Lorg/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/KotlinAnalysis;)V

--- a/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/CompilerDescriptorAnalysisPlugin.kt
+++ b/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/CompilerDescriptorAnalysisPlugin.kt
@@ -6,6 +6,7 @@ import org.jetbrains.dokka.CoreExtensions
 import org.jetbrains.dokka.InternalDokkaApi
 import org.jetbrains.dokka.analysis.java.BreakingAbstractionKotlinLightMethodChecker
 import org.jetbrains.dokka.analysis.java.JavaAnalysisPlugin
+import org.jetbrains.dokka.analysis.kotlin.descriptors.compiler.configuration.DokkaAnalysisConfiguration
 import org.jetbrains.dokka.analysis.kotlin.descriptors.compiler.configuration.KotlinAnalysis
 import org.jetbrains.dokka.analysis.kotlin.descriptors.compiler.configuration.ProjectKotlinAnalysis
 import org.jetbrains.dokka.analysis.kotlin.descriptors.compiler.impl.*
@@ -13,12 +14,9 @@ import org.jetbrains.dokka.analysis.kotlin.descriptors.compiler.impl.moduledocs.
 import org.jetbrains.dokka.analysis.kotlin.descriptors.compiler.java.*
 import org.jetbrains.dokka.analysis.kotlin.descriptors.compiler.translator.DefaultDescriptorToDocumentableTranslator
 import org.jetbrains.dokka.analysis.kotlin.descriptors.compiler.translator.DefaultExternalDocumentablesProvider
-import org.jetbrains.dokka.plugability.DokkaPlugin
-import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
-import org.jetbrains.dokka.plugability.PluginApiPreviewAcknowledgement
-import org.jetbrains.dokka.plugability.querySingle
 import org.jetbrains.dokka.renderers.PostAction
 import org.jetbrains.dokka.analysis.kotlin.internal.InternalKotlinAnalysisPlugin
+import org.jetbrains.dokka.plugability.*
 import org.jetbrains.kotlin.asJava.elements.KtLightAbstractAnnotation
 
 @Suppress("unused")
@@ -44,10 +42,14 @@ class CompilerDescriptorAnalysisPlugin : DokkaPlugin() {
     }
 
     internal val defaultKotlinAnalysis by extending {
+        @OptIn(DokkaPluginApiPreview::class)
         kotlinAnalysis providing { ctx ->
+            val configuration = configuration<CompilerDescriptorAnalysisPlugin, DokkaAnalysisConfiguration>(ctx)
+                ?: DokkaAnalysisConfiguration()
             ProjectKotlinAnalysis(
                 sourceSets = ctx.configuration.sourceSets,
-                context = ctx
+                context = ctx,
+                analysisConfiguration = configuration
             )
         }
     }

--- a/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/AnalysisContext.kt
+++ b/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/AnalysisContext.kt
@@ -6,6 +6,7 @@ import org.jetbrains.dokka.Platform
 import org.jetbrains.dokka.analysis.kotlin.descriptors.compiler.AnalysisContextCreator
 import org.jetbrains.dokka.analysis.kotlin.descriptors.compiler.CompilerDescriptorAnalysisPlugin
 import org.jetbrains.dokka.plugability.DokkaContext
+import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
 import org.jetbrains.dokka.plugability.plugin
 import org.jetbrains.dokka.plugability.querySingle
 import org.jetbrains.dokka.utilities.DokkaLogger
@@ -19,6 +20,7 @@ import org.jetbrains.kotlin.resolve.lazy.ResolveSession
 import java.io.Closeable
 import java.io.File
 
+@OptIn(DokkaPluginApiPreview::class)
 internal fun createAnalysisContext(
     context: DokkaContext,
     sourceSets: List<DokkaConfiguration.DokkaSourceSet>,
@@ -38,6 +40,7 @@ internal fun createAnalysisContext(
     )
 }
 
+@OptIn(DokkaPluginApiPreview::class)
 internal fun createAnalysisContext(
     context: DokkaContext,
     classpath: List<File>,

--- a/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/KotlinAnalysis.kt
+++ b/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/KotlinAnalysis.kt
@@ -4,9 +4,12 @@ import org.jetbrains.dokka.DokkaConfiguration.DokkaSourceSet
 import org.jetbrains.dokka.DokkaSourceSetID
 import org.jetbrains.dokka.InternalDokkaApi
 import org.jetbrains.dokka.model.SourceSetDependent
+import org.jetbrains.dokka.plugability.ConfigurableBlock
 import org.jetbrains.dokka.plugability.DokkaContext
+import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
 import java.io.Closeable
 
+@OptIn(DokkaPluginApiPreview::class)
 @Suppress("FunctionName")
 internal fun ProjectKotlinAnalysis(
     sourceSets: List<DokkaSourceSet>,
@@ -29,6 +32,7 @@ internal fun ProjectKotlinAnalysis(
  *  Usually the analysis created for samples is short-lived and can be closed right after
  *  it's been used, there's no need to wait for [projectKotlinAnalysis] to be closed as it must be handled separately.
  */
+@OptIn(DokkaPluginApiPreview::class)
 @Suppress("FunctionName")
 internal fun SamplesKotlinAnalysis(
     sourceSets: List<DokkaSourceSet>,
@@ -50,18 +54,16 @@ internal fun SamplesKotlinAnalysis(
 
     return EnvironmentKotlinAnalysis(environments, projectKotlinAnalysis)
 }
-
-internal class DokkaAnalysisConfiguration(
+@DokkaPluginApiPreview
+data class DokkaAnalysisConfiguration(
     /**
      * Only for common platform ignore BuiltIns for StdLib since it can cause a conflict
      * between BuiltIns from a compiler and ones from source code.
      */
-    val ignoreCommonBuiltIns: Boolean = shouldIgnoreCommonBuiltIns()
-) {
+    val ignoreCommonBuiltIns: Boolean = DEFAULT_IGNORE_COMMON_BUILT_INS
+): ConfigurableBlock {
     companion object {
-        private const val SHOULD_IGNORE_COMMON_BUILT_INS_SYS_PROP = "dokka.shouldIgnoreCommonBuiltIns"
-        internal fun shouldIgnoreCommonBuiltIns() =
-            System.getProperty(SHOULD_IGNORE_COMMON_BUILT_INS_SYS_PROP) in listOf("true", "1")
+        const val DEFAULT_IGNORE_COMMON_BUILT_INS = false
     }
 }
 

--- a/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/impl/KotlinSampleProvider.kt
+++ b/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/impl/KotlinSampleProvider.kt
@@ -13,6 +13,7 @@ import org.jetbrains.dokka.plugability.plugin
 import org.jetbrains.dokka.plugability.querySingle
 import org.jetbrains.dokka.analysis.kotlin.internal.SampleProvider
 import org.jetbrains.dokka.analysis.kotlin.internal.SampleProviderFactory
+import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtDeclarationWithBody
@@ -39,6 +40,7 @@ open class KotlinSampleProvider(val context: DokkaContext): SampleProvider {
          * Currently, all `ThreadLocal`s are in a compiler/IDE codebase.
          */
         runBlocking(Dispatchers.Default) {
+            @OptIn(DokkaPluginApiPreview::class)
             SamplesKotlinAnalysis(
                 sourceSets = context.configuration.sourceSets,
                 context = context,


### PR DESCRIPTION
Instead of the [system property](https://github.com/Kotlin/dokka/commit/900fbccf3da483946227d99ce52b71afe0e62007) the configuration has been introduced since a system property does not have the possibility to run tasks with different options.