### PR TITLE
Enable explicit API mode

### DIFF
--- a/build-logic/src/main/kotlin/org/jetbrains/conventions/kotlin-jvm.gradle.kts
+++ b/build-logic/src/main/kotlin/org/jetbrains/conventions/kotlin-jvm.gradle.kts
@@ -5,6 +5,7 @@
 package org.jetbrains.conventions
 
 import org.jetbrains.configureDokkaVersion
+import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -14,25 +15,44 @@ plugins {
 
 configureDokkaVersion()
 
-val projectsWithoutOptInDependency = setOf(
-    ":integration-tests", ":integration-tests:gradle", ":integration-tests:maven", ":integration-tests:cli")
+kotlin {
+    explicitApi = ExplicitApiMode.Strict
+
+    compilerOptions {
+        allWarningsAsErrors.set(true)
+        languageVersion.set(dokkaBuild.kotlinLanguageLevel)
+        apiVersion.set(dokkaBuild.kotlinLanguageLevel)
+
+        freeCompilerArgs.addAll(
+            listOf(
+                // need 1.4 support, otherwise there might be problems
+                // with Gradle 6.x (it's bundling Kotlin 1.4)
+                "-Xsuppress-version-warnings",
+                "-Xjsr305=strict",
+                "-Xskip-metadata-version-check",
+            )
+        )
+    }
+}
+
+val projectsWithoutInternalDokkaApiUsage = setOf(
+    ":integration-tests",
+    ":integration-tests:gradle",
+    ":integration-tests:maven",
+    ":integration-tests:cli"
+)
 
 tasks.withType<KotlinCompile>().configureEach {
     // By path because Dokka has multiple projects with the same name (i.e. 'cli')
-    if (project.path in projectsWithoutOptInDependency) return@configureEach
+    if (project.path in projectsWithoutInternalDokkaApiUsage) {
+        return@configureEach
+    }
     compilerOptions {
         freeCompilerArgs.addAll(
             listOf(
                 "-opt-in=kotlin.RequiresOptIn",
                 "-opt-in=org.jetbrains.dokka.InternalDokkaApi",
-                "-Xjsr305=strict",
-                "-Xskip-metadata-version-check",
-                // need 1.4 support, otherwise there might be problems with Gradle 6.x (it's bundling Kotlin 1.4)
-                "-Xsuppress-version-warnings",
             )
         )
-        allWarningsAsErrors.set(true)
-        languageVersion.set(dokkaBuild.kotlinLanguageLevel)
-        apiVersion.set(dokkaBuild.kotlinLanguageLevel)
     }
 }

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -658,7 +658,7 @@ public final class org/jetbrains/dokka/model/ActualTypealias : org/jetbrains/dok
 
 public final class org/jetbrains/dokka/model/ActualTypealias$Companion : org/jetbrains/dokka/model/properties/ExtraProperty$Key {
 	public synthetic fun mergeStrategyFor (Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
-	public fun mergeStrategyFor (Lorg/jetbrains/dokka/model/ActualTypealias;Lorg/jetbrains/dokka/model/ActualTypealias;)Lorg/jetbrains/dokka/model/properties/MergeStrategy$Fail;
+	public fun mergeStrategyFor (Lorg/jetbrains/dokka/model/ActualTypealias;Lorg/jetbrains/dokka/model/ActualTypealias;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
 }
 
 public final class org/jetbrains/dokka/model/AdditionalExtrasKt {
@@ -817,7 +817,7 @@ public final class org/jetbrains/dokka/model/CheckedExceptions : org/jetbrains/d
 
 public final class org/jetbrains/dokka/model/CheckedExceptions$Companion : org/jetbrains/dokka/model/properties/ExtraProperty$Key {
 	public synthetic fun mergeStrategyFor (Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
-	public fun mergeStrategyFor (Lorg/jetbrains/dokka/model/CheckedExceptions;Lorg/jetbrains/dokka/model/CheckedExceptions;)Lorg/jetbrains/dokka/model/properties/MergeStrategy$Replace;
+	public fun mergeStrategyFor (Lorg/jetbrains/dokka/model/CheckedExceptions;Lorg/jetbrains/dokka/model/CheckedExceptions;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
 }
 
 public abstract interface class org/jetbrains/dokka/model/ClassKind {
@@ -1505,7 +1505,7 @@ public final class org/jetbrains/dokka/model/ExceptionInSupertypes : org/jetbrai
 
 public final class org/jetbrains/dokka/model/ExceptionInSupertypes$Companion : org/jetbrains/dokka/model/properties/ExtraProperty$Key {
 	public synthetic fun mergeStrategyFor (Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
-	public fun mergeStrategyFor (Lorg/jetbrains/dokka/model/ExceptionInSupertypes;Lorg/jetbrains/dokka/model/ExceptionInSupertypes;)Lorg/jetbrains/dokka/model/properties/MergeStrategy$Replace;
+	public fun mergeStrategyFor (Lorg/jetbrains/dokka/model/ExceptionInSupertypes;Lorg/jetbrains/dokka/model/ExceptionInSupertypes;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
 }
 
 public abstract interface class org/jetbrains/dokka/model/Expression {
@@ -1707,7 +1707,7 @@ public final class org/jetbrains/dokka/model/ImplementedInterfaces : org/jetbrai
 
 public final class org/jetbrains/dokka/model/ImplementedInterfaces$Companion : org/jetbrains/dokka/model/properties/ExtraProperty$Key {
 	public synthetic fun mergeStrategyFor (Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
-	public fun mergeStrategyFor (Lorg/jetbrains/dokka/model/ImplementedInterfaces;Lorg/jetbrains/dokka/model/ImplementedInterfaces;)Lorg/jetbrains/dokka/model/properties/MergeStrategy$Replace;
+	public fun mergeStrategyFor (Lorg/jetbrains/dokka/model/ImplementedInterfaces;Lorg/jetbrains/dokka/model/ImplementedInterfaces;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
 }
 
 public final class org/jetbrains/dokka/model/InheritedMember : org/jetbrains/dokka/model/properties/ExtraProperty {
@@ -1726,7 +1726,7 @@ public final class org/jetbrains/dokka/model/InheritedMember : org/jetbrains/dok
 
 public final class org/jetbrains/dokka/model/InheritedMember$Companion : org/jetbrains/dokka/model/properties/ExtraProperty$Key {
 	public synthetic fun mergeStrategyFor (Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
-	public fun mergeStrategyFor (Lorg/jetbrains/dokka/model/InheritedMember;Lorg/jetbrains/dokka/model/InheritedMember;)Lorg/jetbrains/dokka/model/properties/MergeStrategy$Replace;
+	public fun mergeStrategyFor (Lorg/jetbrains/dokka/model/InheritedMember;Lorg/jetbrains/dokka/model/InheritedMember;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
 }
 
 public final class org/jetbrains/dokka/model/IntValue : org/jetbrains/dokka/model/LiteralValue {
@@ -4103,8 +4103,7 @@ public final class org/jetbrains/dokka/pages/MultimoduleRootPageNode : org/jetbr
 	public fun getName ()Ljava/lang/String;
 	public synthetic fun modified (Ljava/lang/String;Ljava/util/List;)Lorg/jetbrains/dokka/pages/PageNode;
 	public fun modified (Ljava/lang/String;Ljava/util/List;)Lorg/jetbrains/dokka/pages/RootPageNode;
-	public synthetic fun modified (Ljava/lang/String;Lorg/jetbrains/dokka/pages/ContentNode;Ljava/util/Set;Ljava/util/List;Ljava/util/List;)Lorg/jetbrains/dokka/pages/ContentPage;
-	public fun modified (Ljava/lang/String;Lorg/jetbrains/dokka/pages/ContentNode;Ljava/util/Set;Ljava/util/List;Ljava/util/List;)Lorg/jetbrains/dokka/pages/MultimoduleRootPageNode;
+	public fun modified (Ljava/lang/String;Lorg/jetbrains/dokka/pages/ContentNode;Ljava/util/Set;Ljava/util/List;Ljava/util/List;)Lorg/jetbrains/dokka/pages/ContentPage;
 }
 
 public final class org/jetbrains/dokka/pages/MultimoduleTable : org/jetbrains/dokka/pages/Style {
@@ -4166,7 +4165,7 @@ public final class org/jetbrains/dokka/pages/PlatformHintedContent : org/jetbrai
 	public synthetic fun transformChildren (Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/dokka/pages/ContentComposite;
 	public fun transformChildren (Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/dokka/pages/PlatformHintedContent;
 	public synthetic fun withNewExtras (Lorg/jetbrains/dokka/model/properties/PropertyContainer;)Ljava/lang/Object;
-	public fun withNewExtras (Lorg/jetbrains/dokka/model/properties/PropertyContainer;)Ljava/lang/Void;
+	public fun withNewExtras (Lorg/jetbrains/dokka/model/properties/PropertyContainer;)Lorg/jetbrains/dokka/pages/ContentNode;
 	public synthetic fun withSourceSets (Ljava/util/Set;)Lorg/jetbrains/dokka/pages/ContentNode;
 	public fun withSourceSets (Ljava/util/Set;)Lorg/jetbrains/dokka/pages/PlatformHintedContent;
 }

--- a/core/content-matcher-test-utils/src/main/kotlin/matchers/content/contentMatchers.kt
+++ b/core/content-matcher-test-utils/src/main/kotlin/matchers/content/contentMatchers.kt
@@ -14,15 +14,18 @@ import kotlin.reflect.KClass
 import kotlin.reflect.full.cast
 import kotlin.reflect.full.safeCast
 
-sealed class MatcherElement
+public sealed class MatcherElement
 
-class TextMatcher(val text: String) : MatcherElement()
+public class TextMatcher(
+    public val text: String
+) : MatcherElement()
 
-open class NodeMatcher<T : ContentNode>(
-    val kclass: KClass<T>,
-    val assertions: T.() -> Unit = {}
+public open class NodeMatcher<T : ContentNode>(
+    public val kclass: KClass<T>,
+    public val assertions: T.() -> Unit = {}
 ) : MatcherElement() {
-    open fun tryMatch(node: ContentNode) {
+
+    public open fun tryMatch(node: ContentNode) {
         kclass.safeCast(node)?.apply {
             try {
                 assertions()
@@ -37,11 +40,12 @@ open class NodeMatcher<T : ContentNode>(
     }
 }
 
-class CompositeMatcher<T : ContentComposite>(
+public class CompositeMatcher<T : ContentComposite>(
     kclass: KClass<T>,
     private val children: List<MatcherElement>,
     assertions: T.() -> Unit = {}
 ) : NodeMatcher<T>(kclass, assertions) {
+
     internal val normalizedChildren: List<MatcherElement> by lazy {
         children.fold(listOf()) { acc, e ->
             when {
@@ -61,7 +65,7 @@ class CompositeMatcher<T : ContentComposite>(
     }
 }
 
-object Anything : MatcherElement()
+public object Anything : MatcherElement()
 
 private sealed class MatchWalkerState {
     abstract fun next(node: ContentNode): MatchWalkerState
@@ -176,7 +180,7 @@ private fun ContentNode.debugRepresentation() = asPrintableTree { element ->
     )
 }
 
-data class MatcherError(
+public data class MatcherError(
     override val message: String,
     val anchor: MatcherElement,
     val anchorAfter: Boolean = false,

--- a/core/src/main/kotlin/ConfigurationJsonUtils.kt
+++ b/core/src/main/kotlin/ConfigurationJsonUtils.kt
@@ -9,15 +9,15 @@ import org.jetbrains.dokka.utilities.parseJson
 import org.jetbrains.dokka.utilities.serializeAsCompactJson
 import org.jetbrains.dokka.utilities.serializeAsPrettyJson
 
-fun DokkaConfigurationImpl(json: String): DokkaConfigurationImpl = parseJson(json)
+public fun DokkaConfigurationImpl(json: String): DokkaConfigurationImpl = parseJson(json)
 
-fun GlobalDokkaConfiguration(json: String): GlobalDokkaConfiguration = parseJson(json)
-
-@Deprecated("Renamed to better distinguish between compact/pretty prints", ReplaceWith("this.toCompactJsonString()"))
-fun DokkaConfiguration.toJsonString(): String = this.toCompactJsonString()
+public fun GlobalDokkaConfiguration(json: String): GlobalDokkaConfiguration = parseJson(json)
 
 @Deprecated("Renamed to better distinguish between compact/pretty prints", ReplaceWith("this.toCompactJsonString()"))
-fun <T : ConfigurableBlock> T.toJsonString(): String = this.toCompactJsonString()
+public fun DokkaConfiguration.toJsonString(): String = this.toCompactJsonString()
+
+@Deprecated("Renamed to better distinguish between compact/pretty prints", ReplaceWith("this.toCompactJsonString()"))
+public fun <T : ConfigurableBlock> T.toJsonString(): String = this.toCompactJsonString()
 
 /**
  * Serializes [DokkaConfiguration] as a machine-readable and compact JSON string.
@@ -25,7 +25,7 @@ fun <T : ConfigurableBlock> T.toJsonString(): String = this.toCompactJsonString(
  * The returned string is not very human friendly as it will be difficult to parse by eyes due to it
  * being compact and in one line. If you want to show the output to a human being, see [toPrettyJsonString].
  */
-fun DokkaConfiguration.toCompactJsonString(): String = serializeAsCompactJson(this)
+public fun DokkaConfiguration.toCompactJsonString(): String = serializeAsCompactJson(this)
 
 /**
  * Serializes [DokkaConfiguration] as a human-readable (pretty printed) JSON string.
@@ -34,7 +34,7 @@ fun DokkaConfiguration.toCompactJsonString(): String = serializeAsCompactJson(th
  * desirable when passing this value between API consumers/producers. If you want
  * a machine-readable and compact json string, see [toCompactJsonString].
  */
-fun DokkaConfiguration.toPrettyJsonString(): String = serializeAsPrettyJson(this)
+public fun DokkaConfiguration.toPrettyJsonString(): String = serializeAsPrettyJson(this)
 
 /**
  * Serializes a [ConfigurableBlock] as a machine-readable and compact JSON string.
@@ -42,7 +42,7 @@ fun DokkaConfiguration.toPrettyJsonString(): String = serializeAsPrettyJson(this
  * The returned string is not very human friendly as it will be difficult to parse by eyes due to it
  * being compact and in one line. If you want to show the output to a human being, see [toPrettyJsonString].
  */
-fun <T : ConfigurableBlock> T.toCompactJsonString(): String = serializeAsCompactJson(this)
+public fun <T : ConfigurableBlock> T.toCompactJsonString(): String = serializeAsCompactJson(this)
 
 /**
  * Serializes a [ConfigurableBlock] as a human-readable (pretty printed) JSON string.
@@ -51,4 +51,4 @@ fun <T : ConfigurableBlock> T.toCompactJsonString(): String = serializeAsCompact
  * desirable when passing this value between API consumers/producers. If you want
  * a machine-readable and compact json string, see [toCompactJsonString].
  */
-fun <T : ConfigurableBlock> T.toPrettyJsonString(): String = serializeAsCompactJson(this)
+public fun <T : ConfigurableBlock> T.toPrettyJsonString(): String = serializeAsCompactJson(this)

--- a/core/src/main/kotlin/CoreExtensions.kt
+++ b/core/src/main/kotlin/CoreExtensions.kt
@@ -16,17 +16,25 @@ import org.jetbrains.dokka.transformers.sources.SourceToDocumentableTranslator
 import org.jetbrains.dokka.validity.PreGenerationChecker
 import kotlin.reflect.KProperty
 
-object CoreExtensions {
+public object CoreExtensions {
 
-    val preGenerationCheck by coreExtensionPoint<PreGenerationChecker>()
-    val generation by coreExtensionPoint<Generation>()
-    val sourceToDocumentableTranslator by coreExtensionPoint<SourceToDocumentableTranslator>()
-    val documentableMerger by coreExtensionPoint<DocumentableMerger>()
-    val documentableTransformer by coreExtensionPoint<DocumentableTransformer>()
-    val documentableToPageTranslator by coreExtensionPoint<DocumentableToPageTranslator>()
-    val pageTransformer by coreExtensionPoint<PageTransformer>()
-    val renderer by coreExtensionPoint<Renderer>()
-    val postActions by coreExtensionPoint<PostAction>()
+    public val preGenerationCheck: ExtensionPoint<PreGenerationChecker> by coreExtensionPoint<PreGenerationChecker>()
+
+    public val generation: ExtensionPoint<Generation> by coreExtensionPoint<Generation>()
+
+    public val sourceToDocumentableTranslator: ExtensionPoint<SourceToDocumentableTranslator> by coreExtensionPoint<SourceToDocumentableTranslator>()
+
+    public val documentableMerger: ExtensionPoint<DocumentableMerger> by coreExtensionPoint<DocumentableMerger>()
+
+    public val documentableTransformer: ExtensionPoint<DocumentableTransformer> by coreExtensionPoint<DocumentableTransformer>()
+
+    public val documentableToPageTranslator: ExtensionPoint<DocumentableToPageTranslator> by coreExtensionPoint<DocumentableToPageTranslator>()
+
+    public val pageTransformer: ExtensionPoint<PageTransformer> by coreExtensionPoint<PageTransformer>()
+
+    public val renderer: ExtensionPoint<Renderer> by coreExtensionPoint<Renderer>()
+
+    public val postActions: ExtensionPoint<PostAction> by coreExtensionPoint<PostAction>()
 
     private fun <T : Any> coreExtensionPoint() = object {
         operator fun provideDelegate(thisRef: CoreExtensions, property: KProperty<*>): Lazy<ExtensionPoint<T>> =

--- a/core/src/main/kotlin/DokkaBootstrap.kt
+++ b/core/src/main/kotlin/DokkaBootstrap.kt
@@ -6,10 +6,10 @@ package org.jetbrains.dokka
 
 import java.util.function.BiConsumer
 
-interface DokkaBootstrap {
+public interface DokkaBootstrap {
     @Throws(Throwable::class)
-    fun configure(serializedConfigurationJSON: String, logger: BiConsumer<String, String>)
+    public fun configure(serializedConfigurationJSON: String, logger: BiConsumer<String, String>)
 
     @Throws(Throwable::class)
-    fun generate()
+    public fun generate()
 }

--- a/core/src/main/kotlin/DokkaBootstrapImpl.kt
+++ b/core/src/main/kotlin/DokkaBootstrapImpl.kt
@@ -13,9 +13,11 @@ import java.util.function.BiConsumer
  * Accessed with reflection
  */
 @Suppress("unused")
-class DokkaBootstrapImpl : DokkaBootstrap {
+public class DokkaBootstrapImpl : DokkaBootstrap {
 
-    class DokkaProxyLogger(val consumer: BiConsumer<String, String>) : DokkaLogger {
+    public class DokkaProxyLogger(
+        public val consumer: BiConsumer<String, String>
+    ) : DokkaLogger {
         private val warningsCounter = AtomicInteger()
         private val errorsCounter = AtomicInteger()
 
@@ -50,14 +52,18 @@ class DokkaBootstrapImpl : DokkaBootstrap {
 
     private lateinit var generator: DokkaGenerator
 
-    fun configure(logger: DokkaLogger, configuration: DokkaConfigurationImpl) {
+    public fun configure(logger: DokkaLogger, configuration: DokkaConfigurationImpl) {
         generator = DokkaGenerator(configuration, logger)
     }
 
-    override fun configure(serializedConfigurationJSON: String, logger: BiConsumer<String, String>) = configure(
-        DokkaProxyLogger(logger),
-        DokkaConfigurationImpl(serializedConfigurationJSON)
-    )
+    override fun configure(serializedConfigurationJSON: String, logger: BiConsumer<String, String>) {
+        configure(
+            DokkaProxyLogger(logger),
+            DokkaConfigurationImpl(serializedConfigurationJSON)
+        )
+    }
 
-    override fun generate() = generator.generate()
+    override fun generate() {
+        generator.generate()
+    }
 }

--- a/core/src/main/kotlin/DokkaException.kt
+++ b/core/src/main/kotlin/DokkaException.kt
@@ -4,4 +4,4 @@
 
 package org.jetbrains.dokka
 
-open class DokkaException(message: String) : RuntimeException(message)
+public open class DokkaException(message: String) : RuntimeException(message)

--- a/core/src/main/kotlin/DokkaGenerator.kt
+++ b/core/src/main/kotlin/DokkaGenerator.kt
@@ -18,33 +18,35 @@ import org.jetbrains.dokka.utilities.DokkaLogger
  *
  * [generate] method has been split into submethods for test reasons
  */
-class DokkaGenerator(
+public class DokkaGenerator(
     private val configuration: DokkaConfiguration,
     private val logger: DokkaLogger
 ) {
 
-    fun generate() = timed(logger) {
-        report("Initializing plugins")
-        val context = initializePlugins(configuration, logger)
+    public fun generate() {
+        timed(logger) {
+            report("Initializing plugins")
+            val context = initializePlugins(configuration, logger)
 
-        runCatching {
-            context.single(CoreExtensions.generation).run {
-                logger.progress("Dokka is performing: $generationName")
-                generate()
+            runCatching {
+                context.single(CoreExtensions.generation).run {
+                    logger.progress("Dokka is performing: $generationName")
+                    generate()
+                }
+            }.exceptionOrNull()?.let { e ->
+                finalizeCoroutines()
+                throw e
             }
-        }.exceptionOrNull()?.let { e ->
+
             finalizeCoroutines()
-            throw e
-        }
+        }.dump("\n\n === TIME MEASUREMENT ===\n")
+    }
 
-        finalizeCoroutines()
-    }.dump("\n\n === TIME MEASUREMENT ===\n")
-
-    fun initializePlugins(
+    public fun initializePlugins(
         configuration: DokkaConfiguration,
         logger: DokkaLogger,
         additionalPlugins: List<DokkaPlugin> = emptyList()
-    ) = DokkaContext.create(configuration, logger, additionalPlugins)
+    ): DokkaContext = DokkaContext.create(configuration, logger, additionalPlugins)
 
     @OptIn(DelicateCoroutinesApi::class)
     private fun finalizeCoroutines() {
@@ -54,15 +56,15 @@ class DokkaGenerator(
     }
 }
 
-class Timer internal constructor(startTime: Long, private val logger: DokkaLogger?) {
+public class Timer internal constructor(startTime: Long, private val logger: DokkaLogger?) {
     private val steps = mutableListOf("" to startTime)
 
-    fun report(name: String) {
+    public fun report(name: String) {
         logger?.progress(name)
         steps += (name to System.currentTimeMillis())
     }
 
-    fun dump(prefix: String = "") {
+    public fun dump(prefix: String = "") {
         logger?.info(prefix)
         val namePad = steps.map { it.first.length }.maxOrNull() ?: 0
         val timePad = steps.windowed(2).map { (p1, p2) -> p2.second - p1.second }.maxOrNull()?.toString()?.length ?: 0

--- a/core/src/main/kotlin/DokkaVersion.kt
+++ b/core/src/main/kotlin/DokkaVersion.kt
@@ -6,8 +6,8 @@ package org.jetbrains.dokka
 
 import java.util.*
 
-object DokkaVersion {
-    val version: String by lazy {
+public object DokkaVersion {
+    public val version: String by lazy {
         javaClass.getResourceAsStream("/META-INF/dokka/dokka-version.properties").use { stream ->
             Properties().apply { load(stream) }.getProperty("dokka-version")
         }

--- a/core/src/main/kotlin/configuration.kt
+++ b/core/src/main/kotlin/configuration.kt
@@ -9,53 +9,55 @@ import java.io.File
 import java.io.Serializable
 import java.net.URL
 
-object DokkaDefaults {
-    val moduleName: String = "root"
-    val moduleVersion: String? = null
-    val outputDir = File("./dokka")
-    const val failOnWarning: Boolean = false
-    const val suppressObviousFunctions = true
-    const val suppressInheritedMembers = false
-    const val offlineMode: Boolean = false
+public object DokkaDefaults {
+    public val moduleName: String = "root"
+    public val moduleVersion: String? = null
+    public val outputDir: File = File("./dokka")
+    public const val failOnWarning: Boolean = false
+    public const val suppressObviousFunctions: Boolean = true
+    public const val suppressInheritedMembers: Boolean = false
+    public const val offlineMode: Boolean = false
 
-    const val sourceSetDisplayName = "JVM"
-    const val sourceSetName = "main"
-    val analysisPlatform: Platform = Platform.DEFAULT
+    public const val sourceSetDisplayName: String = "JVM"
+    public const val sourceSetName: String = "main"
+    public val analysisPlatform: Platform = Platform.DEFAULT
 
-    const val suppress: Boolean = false
-    const val suppressGeneratedFiles: Boolean = true
+    public const val suppress: Boolean = false
+    public const val suppressGeneratedFiles: Boolean = true
 
-    const val skipEmptyPackages: Boolean = true
-    const val skipDeprecated: Boolean = false
+    public const val skipEmptyPackages: Boolean = true
+    public const val skipDeprecated: Boolean = false
 
-    const val reportUndocumented: Boolean = false
+    public const val reportUndocumented: Boolean = false
 
-    const val noStdlibLink: Boolean = false
-    const val noAndroidSdkLink: Boolean = false
-    const val noJdkLink: Boolean = false
-    const val jdkVersion: Int = 8
+    public const val noStdlibLink: Boolean = false
+    public const val noAndroidSdkLink: Boolean = false
+    public const val noJdkLink: Boolean = false
+    public const val jdkVersion: Int = 8
 
-    const val includeNonPublic: Boolean = false
-    val documentedVisibilities: Set<DokkaConfiguration.Visibility> = setOf(DokkaConfiguration.Visibility.PUBLIC)
+    public const val includeNonPublic: Boolean = false
+    public val documentedVisibilities: Set<DokkaConfiguration.Visibility> = setOf(DokkaConfiguration.Visibility.PUBLIC)
 
-    val pluginsConfiguration = mutableListOf<PluginConfigurationImpl>()
+    public val pluginsConfiguration: List<PluginConfigurationImpl> = mutableListOf()
 
-    const val delayTemplateSubstitution: Boolean = false
+    public const val delayTemplateSubstitution: Boolean = false
 
-    val cacheRoot: File? = null
+    public val cacheRoot: File? = null
 }
 
-enum class Platform(val key: String) {
+public enum class Platform(
+    public val key: String
+) {
     jvm("jvm"),
     js("js"),
     wasm("wasm"),
     native("native"),
     common("common");
 
-    companion object {
-        val DEFAULT = jvm
+    public companion object {
+        public val DEFAULT: Platform = jvm
 
-        fun fromString(key: String): Platform {
+        public fun fromString(key: String): Platform {
             return when (key.toLowerCase()) {
                 jvm.key -> jvm
                 js.key -> js
@@ -70,14 +72,13 @@ enum class Platform(val key: String) {
     }
 }
 
-fun interface DokkaConfigurationBuilder<T : Any> {
-    fun build(): T
+public fun interface DokkaConfigurationBuilder<T : Any> {
+    public fun build(): T
 }
 
-fun <T : Any> Iterable<DokkaConfigurationBuilder<T>>.build(): List<T> = this.map { it.build() }
+public fun <T : Any> Iterable<DokkaConfigurationBuilder<T>>.build(): List<T> = this.map { it.build() }
 
-
-data class DokkaSourceSetID(
+public data class DokkaSourceSetID(
     /**
      * Unique identifier of the scope that this source set is placed in.
      * Each scope provide only unique source set names.
@@ -102,13 +103,13 @@ data class DokkaSourceSetID(
  *
  * @see [apply] to learn how to apply global configuration
  */
-data class GlobalDokkaConfiguration(
+public data class GlobalDokkaConfiguration(
     val perPackageOptions: List<PackageOptionsImpl>?,
     val externalDocumentationLinks: List<ExternalDocumentationLinkImpl>?,
     val sourceLinks: List<SourceLinkDefinitionImpl>?
 )
 
-fun DokkaConfiguration.apply(globals: GlobalDokkaConfiguration): DokkaConfiguration = this.apply {
+public fun DokkaConfiguration.apply(globals: GlobalDokkaConfiguration): DokkaConfiguration = this.apply {
     sourceSets.forEach {
         it.perPackageOptions.cast<MutableList<DokkaConfiguration.PackageOptions>>()
             .addAll(globals.perPackageOptions ?: emptyList())
@@ -124,21 +125,21 @@ fun DokkaConfiguration.apply(globals: GlobalDokkaConfiguration): DokkaConfigurat
     }
 }
 
-interface DokkaConfiguration : Serializable {
-    val moduleName: String
-    val moduleVersion: String?
-    val outputDir: File
-    val cacheRoot: File?
-    val offlineMode: Boolean
-    val failOnWarning: Boolean
-    val sourceSets: List<DokkaSourceSet>
-    val modules: List<DokkaModuleDescription>
-    val pluginsClasspath: List<File>
-    val pluginsConfiguration: List<PluginConfiguration>
-    val delayTemplateSubstitution: Boolean
-    val suppressObviousFunctions: Boolean
-    val includes: Set<File>
-    val suppressInheritedMembers: Boolean
+public interface DokkaConfiguration : Serializable {
+    public val moduleName: String
+    public val moduleVersion: String?
+    public val outputDir: File
+    public val cacheRoot: File?
+    public val offlineMode: Boolean
+    public val failOnWarning: Boolean
+    public val sourceSets: List<DokkaSourceSet>
+    public val modules: List<DokkaModuleDescription>
+    public val pluginsClasspath: List<File>
+    public val pluginsConfiguration: List<PluginConfiguration>
+    public val delayTemplateSubstitution: Boolean
+    public val suppressObviousFunctions: Boolean
+    public val includes: Set<File>
+    public val suppressInheritedMembers: Boolean
 
     /**
      * Whether coroutines dispatchers should be shutdown after
@@ -157,46 +158,46 @@ interface DokkaConfiguration : Serializable {
      * and closing it down will leave the build in an inoperable state.
      * One such example is unit tests, for which finalization should be disabled.
      */
-    val finalizeCoroutines: Boolean
+    public val finalizeCoroutines: Boolean
 
-    enum class SerializationFormat : Serializable {
+    public enum class SerializationFormat : Serializable {
         JSON, XML
     }
 
-    interface PluginConfiguration : Serializable {
-        val fqPluginName: String
-        val serializationFormat: SerializationFormat
-        val values: String
+    public interface PluginConfiguration : Serializable {
+        public val fqPluginName: String
+        public val serializationFormat: SerializationFormat
+        public val values: String
     }
 
-    interface DokkaSourceSet : Serializable {
-        val sourceSetID: DokkaSourceSetID
-        val displayName: String
-        val classpath: List<File>
-        val sourceRoots: Set<File>
-        val dependentSourceSets: Set<DokkaSourceSetID>
-        val samples: Set<File>
-        val includes: Set<File>
+    public interface DokkaSourceSet : Serializable {
+        public val sourceSetID: DokkaSourceSetID
+        public val displayName: String
+        public val classpath: List<File>
+        public val sourceRoots: Set<File>
+        public val dependentSourceSets: Set<DokkaSourceSetID>
+        public val samples: Set<File>
+        public val includes: Set<File>
 
         @Deprecated(message = "Use [documentedVisibilities] property for a more flexible control over documented visibilities")
-        val includeNonPublic: Boolean
-        val reportUndocumented: Boolean
-        val skipEmptyPackages: Boolean
-        val skipDeprecated: Boolean
-        val jdkVersion: Int
-        val sourceLinks: Set<SourceLinkDefinition>
-        val perPackageOptions: List<PackageOptions>
-        val externalDocumentationLinks: Set<ExternalDocumentationLink>
-        val languageVersion: String?
-        val apiVersion: String?
-        val noStdlibLink: Boolean
-        val noJdkLink: Boolean
-        val suppressedFiles: Set<File>
-        val analysisPlatform: Platform
-        val documentedVisibilities: Set<Visibility>
+        public val includeNonPublic: Boolean
+        public val reportUndocumented: Boolean
+        public val skipEmptyPackages: Boolean
+        public val skipDeprecated: Boolean
+        public val jdkVersion: Int
+        public val sourceLinks: Set<SourceLinkDefinition>
+        public val perPackageOptions: List<PackageOptions>
+        public val externalDocumentationLinks: Set<ExternalDocumentationLink>
+        public val languageVersion: String?
+        public val apiVersion: String?
+        public val noStdlibLink: Boolean
+        public val noJdkLink: Boolean
+        public val suppressedFiles: Set<File>
+        public val analysisPlatform: Platform
+        public val documentedVisibilities: Set<Visibility>
     }
 
-    enum class Visibility {
+    public enum class Visibility {
         /**
          * `public` modifier for Java, default visibility for Kotlin
          */
@@ -222,45 +223,45 @@ interface DokkaConfiguration : Serializable {
          */
         PACKAGE;
 
-        companion object {
-            fun fromString(value: String) = valueOf(value.toUpperCase())
+        public companion object {
+            public fun fromString(value: String): Visibility = valueOf(value.toUpperCase())
         }
     }
 
-    interface SourceLinkDefinition : Serializable {
-        val localDirectory: String
-        val remoteUrl: URL
-        val remoteLineSuffix: String?
+    public interface SourceLinkDefinition : Serializable {
+        public val localDirectory: String
+        public val remoteUrl: URL
+        public val remoteLineSuffix: String?
     }
 
-    interface DokkaModuleDescription : Serializable {
-        val name: String
-        val relativePathToOutputDirectory: File
-        val sourceOutputDirectory: File
-        val includes: Set<File>
+    public interface DokkaModuleDescription : Serializable {
+        public val name: String
+        public val relativePathToOutputDirectory: File
+        public val sourceOutputDirectory: File
+        public val includes: Set<File>
     }
 
-    interface PackageOptions : Serializable {
-        val matchingRegex: String
+    public interface PackageOptions : Serializable {
+        public val matchingRegex: String
 
         @Deprecated("Use [documentedVisibilities] property for a more flexible control over documented visibilities")
-        val includeNonPublic: Boolean
-        val reportUndocumented: Boolean?
-        val skipDeprecated: Boolean
-        val suppress: Boolean
-        val documentedVisibilities: Set<Visibility>
+        public val includeNonPublic: Boolean
+        public val reportUndocumented: Boolean?
+        public val skipDeprecated: Boolean
+        public val suppress: Boolean
+        public val documentedVisibilities: Set<Visibility>
     }
 
-    interface ExternalDocumentationLink : Serializable {
-        val url: URL
-        val packageListUrl: URL
+    public interface ExternalDocumentationLink : Serializable {
+        public val url: URL
+        public val packageListUrl: URL
 
-        companion object
+        public companion object
     }
 }
 
 @Suppress("FunctionName")
-fun ExternalDocumentationLink(
+public fun ExternalDocumentationLink(
     url: URL? = null,
     packageListUrl: URL? = null
 ): ExternalDocumentationLinkImpl {
@@ -273,7 +274,7 @@ fun ExternalDocumentationLink(
 }
 
 @Suppress("FunctionName")
-fun ExternalDocumentationLink(
+public fun ExternalDocumentationLink(
     url: String, packageListUrl: String? = null
 ): ExternalDocumentationLinkImpl =
     ExternalDocumentationLink(url.let(::URL), packageListUrl?.let(::URL))

--- a/core/src/main/kotlin/defaultConfiguration.kt
+++ b/core/src/main/kotlin/defaultConfiguration.kt
@@ -8,7 +8,7 @@ import org.jetbrains.dokka.DokkaConfiguration.DokkaSourceSet
 import java.io.File
 import java.net.URL
 
-data class DokkaConfigurationImpl(
+public data class DokkaConfigurationImpl(
     override val moduleName: String = DokkaDefaults.moduleName,
     override val moduleVersion: String? = DokkaDefaults.moduleVersion,
     override val outputDir: File = DokkaDefaults.outputDir,
@@ -26,14 +26,14 @@ data class DokkaConfigurationImpl(
     override val finalizeCoroutines: Boolean = true,
 ) : DokkaConfiguration
 
-data class PluginConfigurationImpl(
+public data class PluginConfigurationImpl(
     override val fqPluginName: String,
     override val serializationFormat: DokkaConfiguration.SerializationFormat,
     override val values: String
 ) : DokkaConfiguration.PluginConfiguration
 
 
-data class DokkaSourceSetImpl(
+public data class DokkaSourceSetImpl(
     override val displayName: String = DokkaDefaults.sourceSetDisplayName,
     override val sourceSetID: DokkaSourceSetID,
     override val classpath: List<File> = emptyList(),
@@ -59,20 +59,21 @@ data class DokkaSourceSetImpl(
     override val documentedVisibilities: Set<DokkaConfiguration.Visibility> = DokkaDefaults.documentedVisibilities,
 ) : DokkaSourceSet
 
-data class DokkaModuleDescriptionImpl(
+public data class DokkaModuleDescriptionImpl(
     override val name: String,
     override val relativePathToOutputDirectory: File,
     override val includes: Set<File>,
     override val sourceOutputDirectory: File
 ) : DokkaConfiguration.DokkaModuleDescription
 
-data class SourceLinkDefinitionImpl(
+public data class SourceLinkDefinitionImpl(
     override val localDirectory: String,
     override val remoteUrl: URL,
     override val remoteLineSuffix: String?,
 ) : DokkaConfiguration.SourceLinkDefinition {
-    companion object {
-        fun parseSourceLinkDefinition(srcLink: String): SourceLinkDefinitionImpl {
+
+    public companion object {
+        public fun parseSourceLinkDefinition(srcLink: String): SourceLinkDefinitionImpl {
             val (path, urlAndLine) = srcLink.split('=')
             return SourceLinkDefinitionImpl(
                 localDirectory = File(path).canonicalPath,
@@ -82,7 +83,7 @@ data class SourceLinkDefinitionImpl(
     }
 }
 
-data class PackageOptionsImpl(
+public data class PackageOptionsImpl(
     override val matchingRegex: String,
     @Deprecated("Use [documentedVisibilities] property for a more flexible control over documented visibilities")
     override val includeNonPublic: Boolean,
@@ -93,7 +94,7 @@ data class PackageOptionsImpl(
 ) : DokkaConfiguration.PackageOptions
 
 
-data class ExternalDocumentationLinkImpl(
+public data class ExternalDocumentationLinkImpl(
     override val url: URL,
     override val packageListUrl: URL,
 ) : DokkaConfiguration.ExternalDocumentationLink

--- a/core/src/main/kotlin/defaultExternalLinks.kt
+++ b/core/src/main/kotlin/defaultExternalLinks.kt
@@ -8,7 +8,7 @@ import org.jetbrains.dokka.DokkaConfiguration.ExternalDocumentationLink
 import java.net.URL
 
 
-fun ExternalDocumentationLink.Companion.jdk(jdkVersion: Int): ExternalDocumentationLinkImpl =
+public fun ExternalDocumentationLink.Companion.jdk(jdkVersion: Int): ExternalDocumentationLinkImpl =
     ExternalDocumentationLink(
         url =
         if (jdkVersion < 11) "https://docs.oracle.com/javase/${jdkVersion}/docs/api/"
@@ -19,15 +19,15 @@ fun ExternalDocumentationLink.Companion.jdk(jdkVersion: Int): ExternalDocumentat
     )
 
 
-fun ExternalDocumentationLink.Companion.kotlinStdlib(): ExternalDocumentationLinkImpl =
+public fun ExternalDocumentationLink.Companion.kotlinStdlib(): ExternalDocumentationLinkImpl =
     ExternalDocumentationLink("https://kotlinlang.org/api/latest/jvm/stdlib/")
 
 
-fun ExternalDocumentationLink.Companion.androidSdk(): ExternalDocumentationLinkImpl =
+public fun ExternalDocumentationLink.Companion.androidSdk(): ExternalDocumentationLinkImpl =
     ExternalDocumentationLink("https://developer.android.com/reference/kotlin/")
 
 
-fun ExternalDocumentationLink.Companion.androidX(): ExternalDocumentationLinkImpl = ExternalDocumentationLink(
+public fun ExternalDocumentationLink.Companion.androidX(): ExternalDocumentationLinkImpl = ExternalDocumentationLink(
     url = URL("https://developer.android.com/reference/kotlin/"),
     packageListUrl = URL("https://developer.android.com/reference/kotlin/androidx/package-list")
 )

--- a/core/src/main/kotlin/generation/Generation.kt
+++ b/core/src/main/kotlin/generation/Generation.kt
@@ -6,14 +6,14 @@ package org.jetbrains.dokka.generation
 
 import org.jetbrains.dokka.Timer
 
-interface Generation {
-    fun Timer.generate()
-    val generationName: String
+public interface Generation {
+    public fun Timer.generate()
+    public val generationName: String
 }
 
 // This needs to be public for now but in the future it should be replaced with system of checks provided by EP
-fun exitGenerationGracefully(reason: String): Nothing {
+public fun exitGenerationGracefully(reason: String): Nothing {
     throw GracefulGenerationExit(reason)
 }
 
-class GracefulGenerationExit(val reason: String) : Throwable()
+public class GracefulGenerationExit(public val reason: String) : Throwable()

--- a/core/src/main/kotlin/links/DRI.kt
+++ b/core/src/main/kotlin/links/DRI.kt
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 /**
  * [DRI] stands for DokkaResourceIdentifier
  */
-data class DRI(
+public data class DRI(
     val packageName: String? = null,
     val classNames: String? = null,
     val callable: Callable? = null,
@@ -23,47 +23,47 @@ data class DRI(
         "${packageName.orEmpty()}/${classNames.orEmpty()}/${callable?.name.orEmpty()}/${callable?.signature()
             .orEmpty()}/$target/${extra.orEmpty()}"
 
-    companion object {
-        val topLevel = DRI()
-
+    public companion object {
+        public val topLevel: DRI = DRI()
     }
 }
 
-object EnumEntryDRIExtra: DRIExtraProperty<EnumEntryDRIExtra>()
+public object EnumEntryDRIExtra: DRIExtraProperty<EnumEntryDRIExtra>()
 
-abstract class DRIExtraProperty<T> {
-    val key: String = this::class.qualifiedName
+public abstract class DRIExtraProperty<T> {
+    public val key: String = this::class.qualifiedName
         ?: (this.javaClass.let { it.`package`.name + "." + it.simpleName.ifEmpty { "anonymous" } })
 }
 
 
-class DRIExtraContainer(val data: String? = null) {
-    val map: MutableMap<String, Any> = if (data != null) OBJECT_MAPPER.readValue(data) else mutableMapOf()
-    inline operator fun <reified T> get(prop: DRIExtraProperty<T>): T? =
+public class DRIExtraContainer(public val data: String? = null) {
+    public val map: MutableMap<String, Any> = if (data != null) OBJECT_MAPPER.readValue(data) else mutableMapOf()
+    public inline operator fun <reified T> get(prop: DRIExtraProperty<T>): T? =
         map[prop.key]?.let { prop as? T }
 
-    inline operator fun <reified T> set(prop: DRIExtraProperty<T>, value: T) =
-        value.also { map[prop.key] = it as Any }
+    public inline operator fun <reified T> set(prop: DRIExtraProperty<T>, value: T) {
+        map[prop.key] = value as Any
+    }
 
-    fun encode(): String = OBJECT_MAPPER.writeValueAsString(map)
+    public fun encode(): String = OBJECT_MAPPER.writeValueAsString(map)
 
     private companion object {
         private val OBJECT_MAPPER = ObjectMapper()
     }
 }
 
-val DriOfUnit = DRI("kotlin", "Unit")
-val DriOfAny = DRI("kotlin", "Any")
+public val DriOfUnit: DRI = DRI("kotlin", "Unit")
+public val DriOfAny: DRI = DRI("kotlin", "Any")
 
-fun DRI.withClass(name: String) = copy(classNames = if (classNames.isNullOrBlank()) name else "$classNames.$name")
+public fun DRI.withClass(name: String): DRI = copy(classNames = if (classNames.isNullOrBlank()) name else "$classNames.$name")
 
-fun DRI.withTargetToDeclaration() = copy(target = PointingToDeclaration)
+public fun DRI.withTargetToDeclaration(): DRI = copy(target = PointingToDeclaration)
 
-fun DRI.withEnumEntryExtra() = copy(
+public fun DRI.withEnumEntryExtra(): DRI = copy(
     extra = DRIExtraContainer(this.extra).also { it[EnumEntryDRIExtra] = EnumEntryDRIExtra }.encode()
 )
 
-val DRI.parent: DRI
+public val DRI.parent: DRI
     get() = when {
         extra != null -> when {
             DRIExtraContainer(extra)[EnumEntryDRIExtra] != null -> copy(
@@ -78,68 +78,68 @@ val DRI.parent: DRI
         else -> DRI.topLevel
     }
 
-val DRI.sureClassNames
+public val DRI.sureClassNames: String
     get() = classNames ?: throw IllegalStateException("Malformed DRI. It requires classNames in this context.")
 
-data class Callable(
+public data class Callable(
     val name: String,
     val receiver: TypeReference? = null,
     val params: List<TypeReference>
 ) {
-    fun signature() = "${receiver?.toString().orEmpty()}#${params.joinToString("#")}"
+    public fun signature(): String = "${receiver?.toString().orEmpty()}#${params.joinToString("#")}"
 
-    companion object
+    public companion object
 }
 
 @JsonTypeInfo(use = CLASS)
-sealed class TypeReference {
-    companion object
+public sealed class TypeReference {
+    public companion object
 }
 
-data class JavaClassReference(val name: String) : TypeReference() {
+public data class JavaClassReference(val name: String) : TypeReference() {
     override fun toString(): String = name
 }
 
-data class TypeParam(val bounds: List<TypeReference>) : TypeReference()
+public data class TypeParam(val bounds: List<TypeReference>) : TypeReference()
 
-data class TypeConstructor(
+public data class TypeConstructor(
     val fullyQualifiedName: String,
     val params: List<TypeReference>
 ) : TypeReference() {
-    override fun toString() = fullyQualifiedName +
+    override fun toString(): String = fullyQualifiedName +
             (if (params.isNotEmpty()) "[${params.joinToString(",")}]" else "")
 }
 
-data class RecursiveType(val rank: Int): TypeReference() {
-    override fun toString() = "^".repeat(rank + 1)
+public data class RecursiveType(val rank: Int): TypeReference() {
+    override fun toString(): String = "^".repeat(rank + 1)
 }
 
-data class Nullable(val wrapped: TypeReference) : TypeReference() {
-    override fun toString() = "$wrapped?"
+public data class Nullable(val wrapped: TypeReference) : TypeReference() {
+    override fun toString(): String = "$wrapped?"
 }
 
-object StarProjection : TypeReference() {
-    override fun toString() = "*"
+public object StarProjection : TypeReference() {
+    override fun toString(): String = "*"
 }
 
 @JsonTypeInfo(use = CLASS)
-sealed class DriTarget {
+public sealed class DriTarget {
     override fun toString(): String = this.javaClass.simpleName
 
-    companion object
+    public companion object
 }
 
-data class PointingToGenericParameters(val parameterIndex: Int) : DriTarget() {
+public data class PointingToGenericParameters(val parameterIndex: Int) : DriTarget() {
     override fun toString(): String = "PointingToGenericParameters($parameterIndex)"
 }
 
-object PointingToDeclaration : DriTarget()
+public object PointingToDeclaration : DriTarget()
 
-data class PointingToCallableParameters(val parameterIndex: Int) : DriTarget() {
+public data class PointingToCallableParameters(val parameterIndex: Int) : DriTarget() {
     override fun toString(): String = "PointingToCallableParameters($parameterIndex)"
 }
 
-fun DriTarget.nextTarget(): DriTarget = when (this) {
+public fun DriTarget.nextTarget(): DriTarget = when (this) {
     is PointingToGenericParameters -> PointingToGenericParameters(this.parameterIndex + 1)
     is PointingToCallableParameters -> PointingToCallableParameters(this.parameterIndex + 1)
     else -> this

--- a/core/src/main/kotlin/model/CompositeSourceSetID.kt
+++ b/core/src/main/kotlin/model/CompositeSourceSetID.kt
@@ -32,15 +32,15 @@ public data class CompositeSourceSetID(
 
     public val all: Set<DokkaSourceSetID> = setOf(merged, *children.toTypedArray())
 
-    operator fun contains(sourceSetId: DokkaSourceSetID): Boolean {
+    public operator fun contains(sourceSetId: DokkaSourceSetID): Boolean {
         return sourceSetId in all
     }
 
-    operator fun contains(sourceSet: DokkaConfiguration.DokkaSourceSet): Boolean {
+    public operator fun contains(sourceSet: DokkaConfiguration.DokkaSourceSet): Boolean {
         return sourceSet.sourceSetID in this
     }
 
-    operator fun plus(other: DokkaSourceSetID): CompositeSourceSetID {
+    public operator fun plus(other: DokkaSourceSetID): CompositeSourceSetID {
         return copy(children = children + other)
     }
 }

--- a/core/src/main/kotlin/model/Documentable.kt
+++ b/core/src/main/kotlin/model/Documentable.kt
@@ -10,92 +10,95 @@ import org.jetbrains.dokka.model.doc.DocumentationNode
 import org.jetbrains.dokka.model.properties.PropertyContainer
 import org.jetbrains.dokka.model.properties.WithExtraProperties
 
-interface AnnotationTarget
+public interface AnnotationTarget
 
-abstract class Documentable : WithChildren<Documentable>,
+public abstract class Documentable : WithChildren<Documentable>,
     AnnotationTarget {
-    abstract val name: String?
-    abstract val dri: DRI
-    abstract val documentation: SourceSetDependent<DocumentationNode>
-    abstract val sourceSets: Set<DokkaSourceSet>
-    abstract val expectPresentInSet: DokkaSourceSet?
+    public abstract val name: String?
+    public abstract val dri: DRI
+    public abstract val documentation: SourceSetDependent<DocumentationNode>
+    public abstract val sourceSets: Set<DokkaSourceSet>
+    public abstract val expectPresentInSet: DokkaSourceSet?
     abstract override val children: List<Documentable>
 
     override fun toString(): String =
         "${javaClass.simpleName}($dri)"
 
-    override fun equals(other: Any?) =
+    override fun equals(other: Any?): Boolean =
         other is Documentable && this.dri == other.dri // TODO: https://github.com/Kotlin/dokka/pull/667#discussion_r382555806
 
-    override fun hashCode() = dri.hashCode()
+    override fun hashCode(): Int = dri.hashCode()
 }
 
-typealias SourceSetDependent<T> = Map<DokkaSourceSet, T>
+public typealias SourceSetDependent<T> = Map<DokkaSourceSet, T>
 
-interface WithSources {
-    val sources: SourceSetDependent<DocumentableSource>
+public interface WithSources {
+    public val sources: SourceSetDependent<DocumentableSource>
 }
 
-interface WithScope {
-    val functions: List<DFunction>
-    val properties: List<DProperty>
-    val classlikes: List<DClasslike>
+public interface WithScope {
+    public val functions: List<DFunction>
+    public val properties: List<DProperty>
+    public val classlikes: List<DClasslike>
 }
 
-interface WithVisibility {
-    val visibility: SourceSetDependent<Visibility>
+public interface WithVisibility {
+    public val visibility: SourceSetDependent<Visibility>
 }
 
-interface WithType {
-    val type: Bound
+public interface WithType {
+    public val type: Bound
 }
 
-interface WithAbstraction {
-    val modifier: SourceSetDependent<Modifier>
+public interface WithAbstraction {
+    public val modifier: SourceSetDependent<Modifier>
 }
 
-sealed class Modifier(val name: String)
-sealed class KotlinModifier(name: String) : Modifier(name) {
-    object Abstract : KotlinModifier("abstract")
-    object Open : KotlinModifier("open")
-    object Final : KotlinModifier("final")
-    object Sealed : KotlinModifier("sealed")
-    object Empty : KotlinModifier("")
+public sealed class Modifier(
+    public val name: String
+)
+
+public sealed class KotlinModifier(name: String) : Modifier(name) {
+    public object Abstract : KotlinModifier("abstract")
+    public object Open : KotlinModifier("open")
+    public object Final : KotlinModifier("final")
+    public object Sealed : KotlinModifier("sealed")
+    public object Empty : KotlinModifier("")
 }
 
-sealed class JavaModifier(name: String) : Modifier(name) {
-    object Abstract : JavaModifier("abstract")
-    object Final : JavaModifier("final")
-    object Empty : JavaModifier("")
+public sealed class JavaModifier(name: String) : Modifier(name) {
+    public object Abstract : JavaModifier("abstract")
+    public object Final : JavaModifier("final")
+    public object Empty : JavaModifier("")
 }
 
-interface WithCompanion {
-    val companion: DObject?
+public interface WithCompanion {
+    public val companion: DObject?
 }
 
-interface WithConstructors {
-    val constructors: List<DFunction>
+public interface WithConstructors {
+    public val constructors: List<DFunction>
 }
 
-interface WithGenerics {
-    val generics: List<DTypeParameter>
+public interface WithGenerics {
+    public val generics: List<DTypeParameter>
 }
 
-interface WithSupertypes {
-    val supertypes: SourceSetDependent<List<TypeConstructorWithKind>>
+public interface WithSupertypes {
+    public val supertypes: SourceSetDependent<List<TypeConstructorWithKind>>
 }
 
-interface WithIsExpectActual {
-    val isExpectActual: Boolean
+public interface WithIsExpectActual {
+    public val isExpectActual: Boolean
 }
 
-interface Callable : WithVisibility, WithType, WithAbstraction, WithSources, WithIsExpectActual {
-    val receiver: DParameter?
+public interface Callable : WithVisibility, WithType, WithAbstraction, WithSources, WithIsExpectActual {
+    public val receiver: DParameter?
 }
 
-sealed class DClasslike : Documentable(), WithScope, WithVisibility, WithSources, WithIsExpectActual
+public sealed class DClasslike : Documentable(), WithScope, WithVisibility, WithSources, WithIsExpectActual
 
-data class DModule(
+public data class DModule(
     override val name: String,
     val packages: List<DPackage>,
     override val documentation: SourceSetDependent<DocumentationNode>,
@@ -107,10 +110,10 @@ data class DModule(
     override val children: List<Documentable>
         get() = packages
 
-    override fun withNewExtras(newExtras: PropertyContainer<DModule>) = copy(extra = newExtras)
+    override fun withNewExtras(newExtras: PropertyContainer<DModule>): DModule = copy(extra = newExtras)
 }
 
-data class DPackage(
+public data class DPackage(
     override val dri: DRI,
     override val functions: List<DFunction>,
     override val properties: List<DProperty>,
@@ -134,10 +137,10 @@ data class DPackage(
 
     override val children: List<Documentable> = properties + functions + classlikes + typealiases
 
-    override fun withNewExtras(newExtras: PropertyContainer<DPackage>) = copy(extra = newExtras)
+    override fun withNewExtras(newExtras: PropertyContainer<DPackage>): DPackage = copy(extra = newExtras)
 }
 
-data class DClass(
+public data class DClass(
     override val dri: DRI,
     override val name: String,
     override val constructors: List<DFunction>,
@@ -161,10 +164,10 @@ data class DClass(
     override val children: List<Documentable>
         get() = (functions + properties + classlikes + constructors)
 
-    override fun withNewExtras(newExtras: PropertyContainer<DClass>) = copy(extra = newExtras)
+    override fun withNewExtras(newExtras: PropertyContainer<DClass>): DClass = copy(extra = newExtras)
 }
 
-data class DEnum(
+public data class DEnum(
     override val dri: DRI,
     override val name: String,
     val entries: List<DEnumEntry>,
@@ -185,10 +188,10 @@ data class DEnum(
     override val children: List<Documentable>
         get() = (entries + functions + properties + classlikes + constructors)
 
-    override fun withNewExtras(newExtras: PropertyContainer<DEnum>) = copy(extra = newExtras)
+    override fun withNewExtras(newExtras: PropertyContainer<DEnum>): DEnum = copy(extra = newExtras)
 }
 
-data class DEnumEntry(
+public data class DEnumEntry(
     override val dri: DRI,
     override val name: String,
     override val documentation: SourceSetDependent<DocumentationNode>,
@@ -202,10 +205,10 @@ data class DEnumEntry(
     override val children: List<Documentable>
         get() = (functions + properties + classlikes)
 
-    override fun withNewExtras(newExtras: PropertyContainer<DEnumEntry>) = copy(extra = newExtras)
+    override fun withNewExtras(newExtras: PropertyContainer<DEnumEntry>): DEnumEntry = copy(extra = newExtras)
 }
 
-data class DFunction(
+public data class DFunction(
     override val dri: DRI,
     override val name: String,
     val isConstructor: Boolean,
@@ -225,10 +228,10 @@ data class DFunction(
     override val children: List<Documentable>
         get() = parameters
 
-    override fun withNewExtras(newExtras: PropertyContainer<DFunction>) = copy(extra = newExtras)
+    override fun withNewExtras(newExtras: PropertyContainer<DFunction>): DFunction = copy(extra = newExtras)
 }
 
-data class DInterface(
+public data class DInterface(
     override val dri: DRI,
     override val name: String,
     override val documentation: SourceSetDependent<DocumentationNode>,
@@ -248,10 +251,10 @@ data class DInterface(
     override val children: List<Documentable>
         get() = (functions + properties + classlikes)
 
-    override fun withNewExtras(newExtras: PropertyContainer<DInterface>) = copy(extra = newExtras)
+    override fun withNewExtras(newExtras: PropertyContainer<DInterface>): DInterface = copy(extra = newExtras)
 }
 
-data class DObject(
+public data class DObject(
     override val name: String?,
     override val dri: DRI,
     override val documentation: SourceSetDependent<DocumentationNode>,
@@ -269,10 +272,10 @@ data class DObject(
     override val children: List<Documentable>
         get() = (functions + properties + classlikes)
 
-    override fun withNewExtras(newExtras: PropertyContainer<DObject>) = copy(extra = newExtras)
+    override fun withNewExtras(newExtras: PropertyContainer<DObject>): DObject = copy(extra = newExtras)
 }
 
-data class DAnnotation(
+public data class DAnnotation(
     override val name: String,
     override val dri: DRI,
     override val documentation: SourceSetDependent<DocumentationNode>,
@@ -292,10 +295,10 @@ data class DAnnotation(
     override val children: List<Documentable>
         get() = (functions + properties + classlikes + constructors)
 
-    override fun withNewExtras(newExtras: PropertyContainer<DAnnotation>) = copy(extra = newExtras)
+    override fun withNewExtras(newExtras: PropertyContainer<DAnnotation>): DAnnotation = copy(extra = newExtras)
 }
 
-data class DProperty(
+public data class DProperty(
     override val dri: DRI,
     override val name: String,
     override val documentation: SourceSetDependent<DocumentationNode>,
@@ -315,11 +318,11 @@ data class DProperty(
     override val children: List<Nothing>
         get() = emptyList()
 
-    override fun withNewExtras(newExtras: PropertyContainer<DProperty>) = copy(extra = newExtras)
+    override fun withNewExtras(newExtras: PropertyContainer<DProperty>): DProperty = copy(extra = newExtras)
 }
 
 // TODO: treat named Parameters and receivers differently
-data class DParameter(
+public data class DParameter(
     override val dri: DRI,
     override val name: String?,
     override val documentation: SourceSetDependent<DocumentationNode>,
@@ -331,10 +334,10 @@ data class DParameter(
     override val children: List<Nothing>
         get() = emptyList()
 
-    override fun withNewExtras(newExtras: PropertyContainer<DParameter>) = copy(extra = newExtras)
+    override fun withNewExtras(newExtras: PropertyContainer<DParameter>): DParameter = copy(extra = newExtras)
 }
 
-data class DTypeParameter(
+public data class DTypeParameter(
     val variantTypeParameter: Variance<TypeParameter>,
     override val documentation: SourceSetDependent<DocumentationNode>,
     override val expectPresentInSet: DokkaSourceSet?,
@@ -343,7 +346,7 @@ data class DTypeParameter(
     override val extra: PropertyContainer<DTypeParameter> = PropertyContainer.empty()
 ) : Documentable(), WithExtraProperties<DTypeParameter> {
 
-    constructor(
+    public constructor(
         dri: DRI,
         name: String,
         presentableName: String?,
@@ -367,10 +370,10 @@ data class DTypeParameter(
     override val children: List<Nothing>
         get() = emptyList()
 
-    override fun withNewExtras(newExtras: PropertyContainer<DTypeParameter>) = copy(extra = newExtras)
+    override fun withNewExtras(newExtras: PropertyContainer<DTypeParameter>): DTypeParameter = copy(extra = newExtras)
 }
 
-data class DTypeAlias(
+public data class DTypeAlias(
     override val dri: DRI,
     override val name: String,
     override val type: Bound,
@@ -386,12 +389,12 @@ data class DTypeAlias(
     override val children: List<Nothing>
         get() = emptyList()
 
-    override fun withNewExtras(newExtras: PropertyContainer<DTypeAlias>) = copy(extra = newExtras)
+    override fun withNewExtras(newExtras: PropertyContainer<DTypeAlias>): DTypeAlias = copy(extra = newExtras)
 }
 
-sealed class Projection
-sealed class Bound : Projection()
-data class TypeParameter(
+public sealed class Projection
+public sealed class Bound : Projection()
+public data class TypeParameter(
     val dri: DRI,
     val name: String,
     val presentableName: String? = null,
@@ -401,13 +404,13 @@ data class TypeParameter(
         copy(extra = extra)
 }
 
-sealed class TypeConstructor : Bound(), AnnotationTarget {
-    abstract val dri: DRI
-    abstract val projections: List<Projection>
-    abstract val presentableName: String?
+public sealed class TypeConstructor : Bound(), AnnotationTarget {
+    public abstract val dri: DRI
+    public abstract val projections: List<Projection>
+    public abstract val presentableName: String?
 }
 
-data class GenericTypeConstructor(
+public data class GenericTypeConstructor(
     override val dri: DRI,
     override val projections: List<Projection>,
     override val presentableName: String? = null,
@@ -417,7 +420,7 @@ data class GenericTypeConstructor(
         copy(extra = newExtras)
 }
 
-data class FunctionalTypeConstructor(
+public data class FunctionalTypeConstructor(
     override val dri: DRI,
     override val projections: List<Projection>,
     val isExtensionFunction: Boolean = false,
@@ -430,7 +433,7 @@ data class FunctionalTypeConstructor(
 }
 
 // kotlin.annotation.AnnotationTarget.TYPEALIAS
-data class TypeAliased(
+public data class TypeAliased(
     val typeAlias: Bound,
     val inner: Bound,
     override val extra: PropertyContainer<TypeAliased> = PropertyContainer.empty()
@@ -439,7 +442,7 @@ data class TypeAliased(
         copy(extra = newExtras)
 }
 
-data class PrimitiveJavaType(
+public data class PrimitiveJavaType(
     val name: String,
     override val extra: PropertyContainer<PrimitiveJavaType> = PropertyContainer.empty()
 ) : Bound(), AnnotationTarget, WithExtraProperties<PrimitiveJavaType> {
@@ -447,13 +450,13 @@ data class PrimitiveJavaType(
         copy(extra = newExtras)
 }
 
-data class JavaObject(override val extra: PropertyContainer<JavaObject> = PropertyContainer.empty()) :
+public data class JavaObject(override val extra: PropertyContainer<JavaObject> = PropertyContainer.empty()) :
     Bound(), AnnotationTarget, WithExtraProperties<JavaObject> {
     override fun withNewExtras(newExtras: PropertyContainer<JavaObject>): JavaObject =
         copy(extra = newExtras)
 }
 
-data class UnresolvedBound(
+public data class UnresolvedBound(
     val name: String,
     override val extra: PropertyContainer<UnresolvedBound> = PropertyContainer.empty()
 ) : Bound(), AnnotationTarget, WithExtraProperties<UnresolvedBound> {
@@ -462,66 +465,67 @@ data class UnresolvedBound(
 }
 
 // The following Projections are not AnnotationTargets; they cannot be annotated.
-data class Nullable(val inner: Bound) : Bound()
+public data class Nullable(val inner: Bound) : Bound()
 
 /**
  * It introduces [definitely non-nullable types](https://github.com/Kotlin/KEEP/blob/c72601cf35c1e95a541bb4b230edb474a6d1d1a8/proposals/definitely-non-nullable-types.md)
  */
-data class DefinitelyNonNullable(val inner: Bound) : Bound()
+public data class DefinitelyNonNullable(val inner: Bound) : Bound()
 
-sealed class Variance<out T : Bound> : Projection() {
-    abstract val inner: T
+public sealed class Variance<out T : Bound> : Projection() {
+    public abstract val inner: T
 }
 
-data class Covariance<out T : Bound>(override val inner: T) : Variance<T>() {
-    override fun toString() = "out"
+public data class Covariance<out T : Bound>(override val inner: T) : Variance<T>() {
+    override fun toString(): String = "out"
 }
 
-data class Contravariance<out T : Bound>(override val inner: T) : Variance<T>() {
-    override fun toString() = "in"
+public data class Contravariance<out T : Bound>(override val inner: T) : Variance<T>() {
+    override fun toString(): String = "in"
 }
 
-data class Invariance<out T : Bound>(override val inner: T) : Variance<T>() {
-    override fun toString() = ""
+public data class Invariance<out T : Bound>(override val inner: T) : Variance<T>() {
+    override fun toString(): String = ""
 }
 
-object Star : Projection()
+public object Star : Projection()
 
-object Void : Bound()
-object Dynamic : Bound()
+public object Void : Bound()
+public object Dynamic : Bound()
 
-fun Variance<TypeParameter>.withDri(dri: DRI) = when (this) {
+public fun Variance<TypeParameter>.withDri(dri: DRI): Variance<TypeParameter> = when (this) {
     is Contravariance -> Contravariance(TypeParameter(dri, inner.name, inner.presentableName))
     is Covariance -> Covariance(TypeParameter(dri, inner.name, inner.presentableName))
     is Invariance -> Invariance(TypeParameter(dri, inner.name, inner.presentableName))
 }
 
-fun Documentable.dfs(predicate: (Documentable) -> Boolean): Documentable? =
+public fun Documentable.dfs(predicate: (Documentable) -> Boolean): Documentable? =
     if (predicate(this)) {
         this
     } else {
         this.children.asSequence().mapNotNull { it.dfs(predicate) }.firstOrNull()
     }
 
-sealed class Visibility(val name: String)
-sealed class KotlinVisibility(name: String) : Visibility(name) {
-    object Public : KotlinVisibility("public")
-    object Private : KotlinVisibility("private")
-    object Protected : KotlinVisibility("protected")
-    object Internal : KotlinVisibility("internal")
+public sealed class Visibility(public val name: String)
+
+public sealed class KotlinVisibility(name: String) : Visibility(name) {
+    public object Public : KotlinVisibility("public")
+    public object Private : KotlinVisibility("private")
+    public object Protected : KotlinVisibility("protected")
+    public object Internal : KotlinVisibility("internal")
 }
 
-sealed class JavaVisibility(name: String) : Visibility(name) {
-    object Public : JavaVisibility("public")
-    object Private : JavaVisibility("private")
-    object Protected : JavaVisibility("protected")
-    object Default : JavaVisibility("")
+public sealed class JavaVisibility(name: String) : Visibility(name) {
+    public object Public : JavaVisibility("public")
+    public object Private : JavaVisibility("private")
+    public object Protected : JavaVisibility("protected")
+    public object Default : JavaVisibility("")
 }
 
-fun <T> SourceSetDependent<T>?.orEmpty(): SourceSetDependent<T> = this ?: emptyMap()
+public fun <T> SourceSetDependent<T>?.orEmpty(): SourceSetDependent<T> = this ?: emptyMap()
 
-interface DocumentableSource {
-    val path: String
+public interface DocumentableSource {
+    public val path: String
 
     /**
      * Computes the first line number of the documentable's declaration/signature/identifier.
@@ -530,7 +534,7 @@ interface DocumentableSource {
      *
      * May return null if the sources could not be found - for example, for synthetic/generated declarations.
      */
-    fun computeLineNumber(): Int?
+    public fun computeLineNumber(): Int?
 }
 
-data class TypeConstructorWithKind(val typeConstructor: TypeConstructor, val kind: ClassKind)
+public data class TypeConstructorWithKind(val typeConstructor: TypeConstructor, val kind: ClassKind)

--- a/core/src/main/kotlin/model/JvmField.kt
+++ b/core/src/main/kotlin/model/JvmField.kt
@@ -6,9 +6,9 @@ package org.jetbrains.dokka.model
 
 import org.jetbrains.dokka.links.DRI
 
-const val JVM_FIELD_PACKAGE_NAME = "kotlin.jvm"
-const val JVM_FIELD_CLASS_NAMES = "JvmField"
+public const val JVM_FIELD_PACKAGE_NAME: String = "kotlin.jvm"
+public const val JVM_FIELD_CLASS_NAMES: String = "JvmField"
 
-fun DRI.isJvmField(): Boolean = packageName == JVM_FIELD_PACKAGE_NAME && classNames == JVM_FIELD_CLASS_NAMES
+public fun DRI.isJvmField(): Boolean = packageName == JVM_FIELD_PACKAGE_NAME && classNames == JVM_FIELD_CLASS_NAMES
 
-fun Annotations.Annotation.isJvmField(): Boolean = dri.isJvmField()
+public fun Annotations.Annotation.isJvmField(): Boolean = dri.isJvmField()

--- a/core/src/main/kotlin/model/WithChildren.kt
+++ b/core/src/main/kotlin/model/WithChildren.kt
@@ -4,39 +4,39 @@
 
 package org.jetbrains.dokka.model
 
-interface WithChildren<out T> {
-    val children: List<T>
+public interface WithChildren<out T> {
+    public val children: List<T>
 }
 
-inline fun <reified T> WithChildren<*>.firstChildOfTypeOrNull(): T? =
+public inline fun <reified T> WithChildren<*>.firstChildOfTypeOrNull(): T? =
     children.filterIsInstance<T>().firstOrNull()
 
-inline fun <reified T> WithChildren<*>.firstChildOfTypeOrNull(predicate: (T) -> Boolean): T? =
+public inline fun <reified T> WithChildren<*>.firstChildOfTypeOrNull(predicate: (T) -> Boolean): T? =
     children.filterIsInstance<T>().firstOrNull(predicate)
 
-inline fun <reified T> WithChildren<*>.firstChildOfType(): T =
+public inline fun <reified T> WithChildren<*>.firstChildOfType(): T =
     children.filterIsInstance<T>().first()
 
-inline fun <reified T> WithChildren<*>.childrenOfType(): List<T> =
+public inline fun <reified T> WithChildren<*>.childrenOfType(): List<T> =
     children.filterIsInstance<T>()
 
-inline fun <reified T> WithChildren<*>.firstChildOfType(predicate: (T) -> Boolean): T =
+public inline fun <reified T> WithChildren<*>.firstChildOfType(predicate: (T) -> Boolean): T =
     children.filterIsInstance<T>().first(predicate)
 
-inline fun <reified T> WithChildren<WithChildren<*>>.firstMemberOfType(): T where T : WithChildren<*> {
+public inline fun <reified T> WithChildren<WithChildren<*>>.firstMemberOfType(): T where T : WithChildren<*> {
     return withDescendants().filterIsInstance<T>().first()
 }
 
-inline fun <reified T> WithChildren<WithChildren<*>>.firstMemberOfType(
+public inline fun <reified T> WithChildren<WithChildren<*>>.firstMemberOfType(
     predicate: (T) -> Boolean
 ): T where T : WithChildren<*> = withDescendants().filterIsInstance<T>().first(predicate)
 
 
-inline fun <reified T> WithChildren<WithChildren<*>>.firstMemberOfTypeOrNull(): T? where T : WithChildren<*> {
+public inline fun <reified T> WithChildren<WithChildren<*>>.firstMemberOfTypeOrNull(): T? where T : WithChildren<*> {
     return withDescendants().filterIsInstance<T>().firstOrNull()
 }
 
-fun <T> T.withDescendants(): Sequence<T> where T : WithChildren<T> {
+public fun <T> T.withDescendants(): Sequence<T> where T : WithChildren<T> {
     return sequence {
         yield(this@withDescendants)
         children.forEach { child ->
@@ -46,7 +46,7 @@ fun <T> T.withDescendants(): Sequence<T> where T : WithChildren<T> {
 }
 
 @JvmName("withDescendantsProjection")
-fun WithChildren<*>.withDescendants(): Sequence<Any?> {
+public fun WithChildren<*>.withDescendants(): Sequence<Any?> {
     return sequence {
         yield(this@withDescendants)
         children.forEach { child ->
@@ -58,7 +58,7 @@ fun WithChildren<*>.withDescendants(): Sequence<Any?> {
 }
 
 @JvmName("withDescendantsAny")
-fun WithChildren<Any>.withDescendants(): Sequence<Any> {
+public fun WithChildren<Any>.withDescendants(): Sequence<Any> {
     return sequence {
         yield(this@withDescendants)
         children.forEach { child ->
@@ -69,13 +69,13 @@ fun WithChildren<Any>.withDescendants(): Sequence<Any> {
     }
 }
 
-fun <T> T.dfs(predicate: (T) -> Boolean): T? where T : WithChildren<T> = if (predicate(this)) {
+public fun <T> T.dfs(predicate: (T) -> Boolean): T? where T : WithChildren<T> = if (predicate(this)) {
     this
 } else {
     children.asSequence().mapNotNull { it.dfs(predicate) }.firstOrNull()
 }
 
-fun <T : WithChildren<T>> T.asPrintableTree(
+public fun <T : WithChildren<T>> T.asPrintableTree(
     nodeNameBuilder: Appendable.(T) -> Unit = { append(it.toString()) }
 ): String {
     fun Appendable.append(element: T, ownPrefix: String, childPrefix: String) {

--- a/core/src/main/kotlin/model/additionalExtras.kt
+++ b/core/src/main/kotlin/model/additionalExtras.kt
@@ -8,8 +8,11 @@ import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.model.properties.ExtraProperty
 import org.jetbrains.dokka.model.properties.MergeStrategy
 
-class AdditionalModifiers(val content: SourceSetDependent<Set<ExtraModifiers>>) : ExtraProperty<Documentable> {
-    companion object : ExtraProperty.Key<Documentable, AdditionalModifiers> {
+public class AdditionalModifiers(
+    public val content: SourceSetDependent<Set<ExtraModifiers>>
+) : ExtraProperty<Documentable> {
+
+    public companion object : ExtraProperty.Key<Documentable, AdditionalModifiers> {
         override fun mergeStrategyFor(
             left: AdditionalModifiers,
             right: AdditionalModifiers
@@ -19,23 +22,23 @@ class AdditionalModifiers(val content: SourceSetDependent<Set<ExtraModifiers>>) 
     override fun equals(other: Any?): Boolean =
         if (other is AdditionalModifiers) other.content == content else false
 
-    override fun hashCode() = content.hashCode()
+    override fun hashCode(): Int = content.hashCode()
     override val key: ExtraProperty.Key<Documentable, *> = AdditionalModifiers
 }
 
-fun SourceSetDependent<Set<ExtraModifiers>>.toAdditionalModifiers() = AdditionalModifiers(this)
+public fun SourceSetDependent<Set<ExtraModifiers>>.toAdditionalModifiers(): AdditionalModifiers = AdditionalModifiers(this)
 
-data class Annotations(
+public data class Annotations(
     private val myContent: SourceSetDependent<List<Annotation>>
 ) : ExtraProperty<AnnotationTarget> {
-    companion object : ExtraProperty.Key<AnnotationTarget, Annotations> {
+    public companion object : ExtraProperty.Key<AnnotationTarget, Annotations> {
         override fun mergeStrategyFor(left: Annotations, right: Annotations): MergeStrategy<AnnotationTarget> =
             MergeStrategy.Replace(Annotations(left.myContent + right.myContent))
     }
 
     override val key: ExtraProperty.Key<AnnotationTarget, *> = Annotations
 
-    data class Annotation(
+    public data class Annotation(
         val dri: DRI,
         val params: Map<String, AnnotationParameterValue>,
         val mustBeDocumented: Boolean = false,
@@ -64,51 +67,60 @@ data class Annotations(
             else Pair(key, withoutFileLevel)
         }.toMap()
 
-    enum class AnnotationScope {
+    public enum class AnnotationScope {
         DIRECT, FILE, GETTER, SETTER
     }
 }
 
-fun SourceSetDependent<List<Annotations.Annotation>>.toAnnotations() = Annotations(this)
+public fun SourceSetDependent<List<Annotations.Annotation>>.toAnnotations(): Annotations = Annotations(this)
 
-sealed class AnnotationParameterValue
-data class AnnotationValue(val annotation: Annotations.Annotation) : AnnotationParameterValue()
-data class ArrayValue(val value: List<AnnotationParameterValue>) : AnnotationParameterValue()
-data class EnumValue(val enumName: String, val enumDri: DRI) : AnnotationParameterValue()
-data class ClassValue(val className: String, val classDRI: DRI) : AnnotationParameterValue()
-abstract class LiteralValue : AnnotationParameterValue() {
-    abstract fun text() : String
+public sealed class AnnotationParameterValue
+
+public data class AnnotationValue(val annotation: Annotations.Annotation) : AnnotationParameterValue()
+
+public data class ArrayValue(val value: List<AnnotationParameterValue>) : AnnotationParameterValue()
+
+public data class EnumValue(val enumName: String, val enumDri: DRI) : AnnotationParameterValue()
+
+public data class ClassValue(val className: String, val classDRI: DRI) : AnnotationParameterValue()
+
+public abstract class LiteralValue : AnnotationParameterValue() {
+    public abstract fun text() : String
 }
-data class IntValue(val value: Int) : LiteralValue() {
+public data class IntValue(val value: Int) : LiteralValue() {
     override fun text(): String = value.toString()
 }
 
-data class LongValue(val value: Long) : LiteralValue() {
+public data class LongValue(val value: Long) : LiteralValue() {
     override fun text(): String = value.toString()
 }
-data class FloatValue(val value: Float) : LiteralValue() {
+
+public data class FloatValue(val value: Float) : LiteralValue() {
     override fun text(): String = value.toString()
 }
-data class DoubleValue(val value: Double) : LiteralValue() {
+
+public data class DoubleValue(val value: Double) : LiteralValue() {
     override fun text(): String = value.toString()
 }
-object NullValue : LiteralValue() {
+
+public object NullValue : LiteralValue() {
     override fun text(): String = "null"
 }
-data class BooleanValue(val value: Boolean) : LiteralValue() {
+
+public data class BooleanValue(val value: Boolean) : LiteralValue() {
     override fun text(): String = value.toString()
 }
-data class StringValue(val value: String) : LiteralValue() {
+
+public data class StringValue(val value: String) : LiteralValue() {
     override fun text(): String = value
     override fun toString(): String = value
 }
 
-
-object PrimaryConstructorExtra : ExtraProperty<DFunction>, ExtraProperty.Key<DFunction, PrimaryConstructorExtra> {
+public object PrimaryConstructorExtra : ExtraProperty<DFunction>, ExtraProperty.Key<DFunction, PrimaryConstructorExtra> {
     override val key: ExtraProperty.Key<DFunction, *> = this
 }
 
-data class ActualTypealias(
+public data class ActualTypealias(
     val typeAlias: DTypeAlias
 ) : ExtraProperty<DClasslike> {
 
@@ -117,11 +129,11 @@ data class ActualTypealias(
     val underlyingType: SourceSetDependent<Bound>
         get() = typeAlias.underlyingType
 
-    companion object : ExtraProperty.Key<DClasslike, ActualTypealias> {
+    public companion object : ExtraProperty.Key<DClasslike, ActualTypealias> {
         override fun mergeStrategyFor(
             left: ActualTypealias,
             right: ActualTypealias
-        ) = MergeStrategy.Fail {
+        ): MergeStrategy<DClasslike> = MergeStrategy.Fail {
             throw IllegalStateException("Adding [ActualTypealias] should be after merging all documentables")
         }
     }

--- a/core/src/main/kotlin/model/ancestryNode.kt
+++ b/core/src/main/kotlin/model/ancestryNode.kt
@@ -4,12 +4,12 @@
 
 package org.jetbrains.dokka.model
 
-data class AncestryNode(
+public data class AncestryNode(
     val typeConstructor: TypeConstructor,
     val superclass: AncestryNode?,
     val interfaces: List<AncestryNode>,
 ) {
-    fun allImplementedInterfaces(): List<TypeConstructor> {
+    public fun allImplementedInterfaces(): List<TypeConstructor> {
         fun traverseInterfaces(ancestry: AncestryNode): List<TypeConstructor> =
             ancestry.interfaces.flatMap { listOf(it.typeConstructor) + traverseInterfaces(it) } +
                     (ancestry.superclass?.let(::traverseInterfaces) ?: emptyList())

--- a/core/src/main/kotlin/model/classKinds.kt
+++ b/core/src/main/kotlin/model/classKinds.kt
@@ -4,9 +4,9 @@
 
 package org.jetbrains.dokka.model
 
-interface ClassKind
+public interface ClassKind
 
-enum class KotlinClassKindTypes : ClassKind {
+public enum class KotlinClassKindTypes : ClassKind {
     CLASS,
     INTERFACE,
     ENUM_CLASS,
@@ -15,7 +15,7 @@ enum class KotlinClassKindTypes : ClassKind {
     OBJECT;
 }
 
-enum class JavaClassKindTypes : ClassKind {
+public enum class JavaClassKindTypes : ClassKind {
     CLASS,
     INTERFACE,
     ENUM_CLASS,

--- a/core/src/main/kotlin/model/defaultValues.kt
+++ b/core/src/main/kotlin/model/defaultValues.kt
@@ -7,12 +7,15 @@ package org.jetbrains.dokka.model
 import org.jetbrains.dokka.model.properties.ExtraProperty
 import org.jetbrains.dokka.model.properties.MergeStrategy
 
-class DefaultValue(val expression: SourceSetDependent<Expression>): ExtraProperty<Documentable> {
+public class DefaultValue(
+    public val expression: SourceSetDependent<Expression>
+): ExtraProperty<Documentable> {
 
     @Deprecated("Use `expression` property that depends on source set", ReplaceWith("this.expression.values.first()"))
-    val value: Expression
+    public val value: Expression
         get() = expression.values.first()
-    companion object : ExtraProperty.Key<Documentable, DefaultValue> {
+
+    public companion object : ExtraProperty.Key<Documentable, DefaultValue> {
         override fun mergeStrategyFor(left: DefaultValue, right: DefaultValue): MergeStrategy<Documentable> =
             MergeStrategy.Replace(DefaultValue(left.expression + right.expression))
 
@@ -22,10 +25,10 @@ class DefaultValue(val expression: SourceSetDependent<Expression>): ExtraPropert
         get() = Companion
 }
 
-interface Expression
-data class ComplexExpression(val value: String) : Expression
-data class IntegerConstant(val value: Long) : Expression
-data class StringConstant(val value: String) : Expression
-data class DoubleConstant(val value: Double) : Expression
-data class FloatConstant(val value: Float) : Expression
-data class BooleanConstant(val value: Boolean) : Expression
+public interface Expression
+public data class ComplexExpression(val value: String) : Expression
+public data class IntegerConstant(val value: Long) : Expression
+public data class StringConstant(val value: String) : Expression
+public data class DoubleConstant(val value: Double) : Expression
+public data class FloatConstant(val value: Float) : Expression
+public data class BooleanConstant(val value: Boolean) : Expression

--- a/core/src/main/kotlin/model/doc/DocTag.kt
+++ b/core/src/main/kotlin/model/doc/DocTag.kt
@@ -7,363 +7,366 @@ package org.jetbrains.dokka.model.doc
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.model.WithChildren
 
-sealed class DocTag : WithChildren<DocTag> {
-    abstract val params: Map<String, String>
+public sealed class DocTag : WithChildren<DocTag> {
+    public abstract val params: Map<String, String>
 
-    companion object {
-        fun contentTypeParam(type: String): Map<String, String> = mapOf("content-type" to type)
+    public companion object {
+        public fun contentTypeParam(type: String): Map<String, String> = mapOf("content-type" to type)
     }
 }
 
-data class A(
+public data class A(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Big(
+public data class Big(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class B(
+public data class B(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class BlockQuote(
+public data class BlockQuote(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-object Br : DocTag() {
-    override val params = emptyMap<String, String>()
-    override val children = emptyList<DocTag>()
+public object Br : DocTag() {
+    override val children: List<DocTag> = emptyList()
+    override val params: Map<String, String> = emptyMap()
 }
 
-data class Cite(
+public data class Cite(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-sealed class Code : DocTag()
+public sealed class Code : DocTag()
 
-data class CodeInline(
+public data class CodeInline(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : Code()
 
-data class CodeBlock(
+public data class CodeBlock(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : Code()
 
-data class CustomDocTag(
+public data class CustomDocTag(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap(),
     val name: String
 ) : DocTag()
 
-data class Dd(
+public data class Dd(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Dfn(
+public data class Dfn(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Dir(
+public data class Dir(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Div(
+public data class Div(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Dl(
+public data class Dl(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class DocumentationLink(
+public data class DocumentationLink(
     val dri: DRI,
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Dt(
+public data class Dt(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Em(
+public data class Em(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Font(
+public data class Font(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Footer(
+public data class Footer(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Frame(
+public data class Frame(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class FrameSet(
+public data class FrameSet(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class H1(
+public data class H1(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class H2(
+public data class H2(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class H3(
+public data class H3(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class H4(
+public data class H4(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class H5(
+public data class H5(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class H6(
+public data class H6(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Head(
+public data class Head(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Header(
+public data class Header(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-object HorizontalRule : DocTag() {
-    override val params = emptyMap<String, String>()
-    override val children = emptyList<DocTag>()
+public object HorizontalRule : DocTag() {
+    override val children: List<DocTag> = emptyList()
+    override val params: Map<String, String> = emptyMap()
 }
 
-data class Html(
+public data class Html(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class I(
+public data class I(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class IFrame(
+public data class IFrame(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Img(
+public data class Img(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Index(
+public data class Index(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Input(
+public data class Input(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Li(
+public data class Li(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Link(
+public data class Link(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Listing(
+public data class Listing(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Main(
+public data class Main(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Menu(
+public data class Menu(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Meta(
+public data class Meta(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Nav(
+public data class Nav(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class NoFrames(
+public data class NoFrames(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class NoScript(
+public data class NoScript(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Ol(
+public data class Ol(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class P(
+public data class P(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Pre(
+public data class Pre(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Script(
+public data class Script(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Section(
+public data class Section(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Small(
+public data class Small(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Span(
+public data class Span(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Strikethrough(
+public data class Strikethrough(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Strong(
+public data class Strong(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Sub(
+public data class Sub(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Sup(
+public data class Sup(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Table(
+public data class Table(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Text(
+public data class Text(
     val body: String = "",
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class TBody(
+public data class TBody(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Td(
+public data class Td(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class TFoot(
+public data class TFoot(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Th(
+public data class Th(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class THead(
+public data class THead(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Title(
+public data class Title(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Tr(
+public data class Tr(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Tt(
+public data class Tt(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class U(override val children: List<DocTag> = emptyList(), override val params: Map<String, String> = emptyMap()) :
-    DocTag()
-
-data class Ul(
+public data class U(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Var(
+public data class Ul(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
 
-data class Caption(
+public data class Var(
     override val children: List<DocTag> = emptyList(),
     override val params: Map<String, String> = emptyMap()
 ) : DocTag()
+
+public data class Caption(
+    override val children: List<DocTag> = emptyList(),
+    override val params: Map<String, String> = emptyMap()
+) : DocTag()
+

--- a/core/src/main/kotlin/model/doc/DocumentationNode.kt
+++ b/core/src/main/kotlin/model/doc/DocumentationNode.kt
@@ -6,4 +6,4 @@ package org.jetbrains.dokka.model.doc
 
 import org.jetbrains.dokka.model.WithChildren
 
-data class DocumentationNode(override val children: List<TagWrapper>): WithChildren<TagWrapper>
+public data class DocumentationNode(override val children: List<TagWrapper>): WithChildren<TagWrapper>

--- a/core/src/main/kotlin/model/doc/TagWrapper.kt
+++ b/core/src/main/kotlin/model/doc/TagWrapper.kt
@@ -7,29 +7,30 @@ package org.jetbrains.dokka.model.doc
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.model.WithChildren
 
-sealed class TagWrapper : WithChildren<DocTag> {
-    abstract val root: DocTag
+public sealed class TagWrapper : WithChildren<DocTag> {
+    public abstract val root: DocTag
+
     override val children: List<DocTag>
         get() = root.children
 }
 
-sealed class NamedTagWrapper : TagWrapper() {
-    abstract val name: String
+public sealed class NamedTagWrapper : TagWrapper() {
+    public abstract val name: String
 }
 
-data class Description(override val root: DocTag) : TagWrapper()
-data class Author(override val root: DocTag) : TagWrapper()
-data class Version(override val root: DocTag) : TagWrapper()
-data class Since(override val root: DocTag) : TagWrapper()
-data class See(override val root: DocTag, override val name: String, val address: DRI?) : NamedTagWrapper()
-data class Param(override val root: DocTag, override val name: String) : NamedTagWrapper()
-data class Return(override val root: DocTag) : TagWrapper()
-data class Receiver(override val root: DocTag) : TagWrapper()
-data class Constructor(override val root: DocTag) : TagWrapper()
+public data class Description(override val root: DocTag) : TagWrapper()
+public data class Author(override val root: DocTag) : TagWrapper()
+public data class Version(override val root: DocTag) : TagWrapper()
+public data class Since(override val root: DocTag) : TagWrapper()
+public data class See(override val root: DocTag, override val name: String, val address: DRI?) : NamedTagWrapper()
+public data class Param(override val root: DocTag, override val name: String) : NamedTagWrapper()
+public data class Return(override val root: DocTag) : TagWrapper()
+public data class Receiver(override val root: DocTag) : TagWrapper()
+public data class Constructor(override val root: DocTag) : TagWrapper()
 //TODO this naming is confusing since kotlin has Throws annotation
-data class Throws(override val root: DocTag, override val name: String, val exceptionAddress: DRI?) : NamedTagWrapper()
-data class Sample(override val root: DocTag, override val name: String) : NamedTagWrapper()
-data class Deprecated(override val root: DocTag) : TagWrapper()
-data class Property(override val root: DocTag, override val name: String) : NamedTagWrapper()
-data class Suppress(override val root: DocTag) : TagWrapper()
-data class CustomTagWrapper(override val root: DocTag, override val name: String) : NamedTagWrapper()
+public data class Throws(override val root: DocTag, override val name: String, val exceptionAddress: DRI?) : NamedTagWrapper()
+public data class Sample(override val root: DocTag, override val name: String) : NamedTagWrapper()
+public data class Deprecated(override val root: DocTag) : TagWrapper()
+public data class Property(override val root: DocTag, override val name: String) : NamedTagWrapper()
+public data class Suppress(override val root: DocTag) : TagWrapper()
+public data class CustomTagWrapper(override val root: DocTag, override val name: String) : NamedTagWrapper()

--- a/core/src/main/kotlin/model/documentableProperties.kt
+++ b/core/src/main/kotlin/model/documentableProperties.kt
@@ -9,37 +9,37 @@ import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.model.properties.ExtraProperty
 import org.jetbrains.dokka.model.properties.MergeStrategy
 
-data class InheritedMember(val inheritedFrom: SourceSetDependent<DRI?>) : ExtraProperty<Documentable> {
-    companion object : ExtraProperty.Key<Documentable, InheritedMember> {
-        override fun mergeStrategyFor(left: InheritedMember, right: InheritedMember) = MergeStrategy.Replace(
+public data class InheritedMember(val inheritedFrom: SourceSetDependent<DRI?>) : ExtraProperty<Documentable> {
+    public companion object : ExtraProperty.Key<Documentable, InheritedMember> {
+        override fun mergeStrategyFor(left: InheritedMember, right: InheritedMember): MergeStrategy<Documentable> = MergeStrategy.Replace(
             InheritedMember(left.inheritedFrom + right.inheritedFrom)
         )
     }
 
-    fun isInherited(sourceSetDependent: DokkaSourceSet): Boolean = inheritedFrom[sourceSetDependent] != null
+    public fun isInherited(sourceSetDependent: DokkaSourceSet): Boolean = inheritedFrom[sourceSetDependent] != null
 
     override val key: ExtraProperty.Key<Documentable, *> = InheritedMember
 }
 
-data class ImplementedInterfaces(val interfaces: SourceSetDependent<List<TypeConstructor>>) : ExtraProperty<Documentable> {
-    companion object : ExtraProperty.Key<Documentable, ImplementedInterfaces> {
-        override fun mergeStrategyFor(left: ImplementedInterfaces, right: ImplementedInterfaces) =
+public data class ImplementedInterfaces(val interfaces: SourceSetDependent<List<TypeConstructor>>) : ExtraProperty<Documentable> {
+    public companion object : ExtraProperty.Key<Documentable, ImplementedInterfaces> {
+        override fun mergeStrategyFor(left: ImplementedInterfaces, right: ImplementedInterfaces): MergeStrategy<Documentable> =
             MergeStrategy.Replace(ImplementedInterfaces(left.interfaces + right.interfaces))
     }
 
     override val key: ExtraProperty.Key<Documentable, *> = ImplementedInterfaces
 }
 
-data class ExceptionInSupertypes(val exceptions: SourceSetDependent<List<TypeConstructor>>): ExtraProperty<Documentable> {
-    companion object : ExtraProperty.Key<Documentable, ExceptionInSupertypes> {
-        override fun mergeStrategyFor(left: ExceptionInSupertypes, right: ExceptionInSupertypes) =
+public data class ExceptionInSupertypes(val exceptions: SourceSetDependent<List<TypeConstructor>>): ExtraProperty<Documentable> {
+    public companion object : ExtraProperty.Key<Documentable, ExceptionInSupertypes> {
+        override fun mergeStrategyFor(left: ExceptionInSupertypes, right: ExceptionInSupertypes): MergeStrategy<Documentable> =
             MergeStrategy.Replace(ExceptionInSupertypes(left.exceptions + right.exceptions))
     }
 
     override val key: ExtraProperty.Key<Documentable, *> = ExceptionInSupertypes
 }
 
-object ObviousMember : ExtraProperty<Documentable>, ExtraProperty.Key<Documentable, ObviousMember> {
+public object ObviousMember : ExtraProperty<Documentable>, ExtraProperty.Key<Documentable, ObviousMember> {
     override val key: ExtraProperty.Key<Documentable, *> = this
 }
 
@@ -49,12 +49,12 @@ object ObviousMember : ExtraProperty<Documentable>, ExtraProperty.Key<Documentab
  * In case of properties that came from `Java`, [IsVar] is added if
  * the java field has no accessors at all (plain field) or has a setter
  */
-object IsVar : ExtraProperty<DProperty>, ExtraProperty.Key<DProperty, IsVar> {
+public object IsVar : ExtraProperty<DProperty>, ExtraProperty.Key<DProperty, IsVar> {
     override val key: ExtraProperty.Key<DProperty, *> = this
 }
 
-data class IsAlsoParameter(val inSourceSets: List<DokkaSourceSet>) : ExtraProperty<DProperty> {
-    companion object : ExtraProperty.Key<DProperty, IsAlsoParameter> {
+public data class IsAlsoParameter(val inSourceSets: List<DokkaSourceSet>) : ExtraProperty<DProperty> {
+    public companion object : ExtraProperty.Key<DProperty, IsAlsoParameter> {
         override fun mergeStrategyFor(left: IsAlsoParameter, right: IsAlsoParameter): MergeStrategy<DProperty> =
             MergeStrategy.Replace(IsAlsoParameter(left.inSourceSets + right.inSourceSets))
     }
@@ -62,9 +62,9 @@ data class IsAlsoParameter(val inSourceSets: List<DokkaSourceSet>) : ExtraProper
     override val key: ExtraProperty.Key<DProperty, *> = IsAlsoParameter
 }
 
-data class CheckedExceptions(val exceptions: SourceSetDependent<List<DRI>>) : ExtraProperty<Documentable>, ExtraProperty.Key<Documentable, ObviousMember> {
-    companion object : ExtraProperty.Key<Documentable, CheckedExceptions> {
-        override fun mergeStrategyFor(left: CheckedExceptions, right: CheckedExceptions) =
+public data class CheckedExceptions(val exceptions: SourceSetDependent<List<DRI>>) : ExtraProperty<Documentable>, ExtraProperty.Key<Documentable, ObviousMember> {
+    public companion object : ExtraProperty.Key<Documentable, CheckedExceptions> {
+        override fun mergeStrategyFor(left: CheckedExceptions, right: CheckedExceptions): MergeStrategy<Documentable> =
             MergeStrategy.Replace(CheckedExceptions(left.exceptions + right.exceptions))
     }
     override val key: ExtraProperty.Key<Documentable, *> = CheckedExceptions

--- a/core/src/main/kotlin/model/documentableUtils.kt
+++ b/core/src/main/kotlin/model/documentableUtils.kt
@@ -6,10 +6,10 @@ package org.jetbrains.dokka.model
 
 import org.jetbrains.dokka.DokkaConfiguration.DokkaSourceSet
 
-fun <T> SourceSetDependent<T>.filtered(sourceSets: Set<DokkaSourceSet>) = filter { it.key in sourceSets }
-fun DokkaSourceSet?.filtered(sourceSets: Set<DokkaSourceSet>) = takeIf { this in sourceSets }
+public fun <T> SourceSetDependent<T>.filtered(sourceSets: Set<DokkaSourceSet>): SourceSetDependent<T> = filter { it.key in sourceSets }
+public fun DokkaSourceSet?.filtered(sourceSets: Set<DokkaSourceSet>): DokkaSourceSet? = takeIf { this in sourceSets }
 
-fun DTypeParameter.filter(filteredSet: Set<DokkaSourceSet>) =
+public fun DTypeParameter.filter(filteredSet: Set<DokkaSourceSet>): DTypeParameter? =
     if (filteredSet.containsAll(sourceSets)) this
     else {
         val intersection = filteredSet.intersect(sourceSets)
@@ -24,4 +24,4 @@ fun DTypeParameter.filter(filteredSet: Set<DokkaSourceSet>) =
         )
     }
 
-fun Documentable.isExtension() = this is Callable && receiver != null
+public fun Documentable.isExtension(): Boolean = this is Callable && receiver != null

--- a/core/src/main/kotlin/model/extraModifiers.kt
+++ b/core/src/main/kotlin/model/extraModifiers.kt
@@ -4,40 +4,40 @@
 
 package org.jetbrains.dokka.model
 
-sealed class ExtraModifiers(val name: String) {
+public sealed class ExtraModifiers(public val name: String) {
 
-    sealed class KotlinOnlyModifiers(name: String) : ExtraModifiers(name) {
-        object Inline : KotlinOnlyModifiers("inline")
-        object Value : KotlinOnlyModifiers("value")
-        object Infix : KotlinOnlyModifiers("infix")
-        object External : KotlinOnlyModifiers("external")
-        object Suspend : KotlinOnlyModifiers("suspend")
-        object Reified : KotlinOnlyModifiers("reified")
-        object CrossInline : KotlinOnlyModifiers("crossinline")
-        object NoInline : KotlinOnlyModifiers("noinline")
-        object Override : KotlinOnlyModifiers("override")
-        object Data : KotlinOnlyModifiers("data")
-        object Const : KotlinOnlyModifiers("const")
-        object Inner : KotlinOnlyModifiers("inner")
-        object LateInit : KotlinOnlyModifiers("lateinit")
-        object Operator : KotlinOnlyModifiers("operator")
-        object TailRec : KotlinOnlyModifiers("tailrec")
-        object VarArg : KotlinOnlyModifiers("vararg")
-        object Fun : KotlinOnlyModifiers("fun")
+    public sealed class KotlinOnlyModifiers(name: String) : ExtraModifiers(name) {
+        public object Inline : KotlinOnlyModifiers("inline")
+        public object Value : KotlinOnlyModifiers("value")
+        public object Infix : KotlinOnlyModifiers("infix")
+        public object External : KotlinOnlyModifiers("external")
+        public object Suspend : KotlinOnlyModifiers("suspend")
+        public object Reified : KotlinOnlyModifiers("reified")
+        public object CrossInline : KotlinOnlyModifiers("crossinline")
+        public object NoInline : KotlinOnlyModifiers("noinline")
+        public object Override : KotlinOnlyModifiers("override")
+        public object Data : KotlinOnlyModifiers("data")
+        public object Const : KotlinOnlyModifiers("const")
+        public object Inner : KotlinOnlyModifiers("inner")
+        public object LateInit : KotlinOnlyModifiers("lateinit")
+        public object Operator : KotlinOnlyModifiers("operator")
+        public object TailRec : KotlinOnlyModifiers("tailrec")
+        public object VarArg : KotlinOnlyModifiers("vararg")
+        public object Fun : KotlinOnlyModifiers("fun")
     }
 
-    sealed class JavaOnlyModifiers(name: String) : ExtraModifiers(name) {
-        object Static : JavaOnlyModifiers("static")
-        object Native : JavaOnlyModifiers("native")
-        object Synchronized : JavaOnlyModifiers("synchronized")
-        object StrictFP : JavaOnlyModifiers("strictfp")
-        object Transient : JavaOnlyModifiers("transient")
-        object Volatile : JavaOnlyModifiers("volatile")
-        object Transitive : JavaOnlyModifiers("transitive")
+    public sealed class JavaOnlyModifiers(name: String) : ExtraModifiers(name) {
+        public object Static : JavaOnlyModifiers("static")
+        public object Native : JavaOnlyModifiers("native")
+        public object Synchronized : JavaOnlyModifiers("synchronized")
+        public object StrictFP : JavaOnlyModifiers("strictfp")
+        public object Transient : JavaOnlyModifiers("transient")
+        public object Volatile : JavaOnlyModifiers("volatile")
+        public object Transitive : JavaOnlyModifiers("transitive")
     }
 
-    companion object {
-        fun valueOf(str: String) = when (str) {
+    public companion object {
+        public fun valueOf(str: String): ExtraModifiers = when (str) {
             "inline" -> KotlinOnlyModifiers.Inline
             "value" -> KotlinOnlyModifiers.Value
             "infix" -> KotlinOnlyModifiers.Infix

--- a/core/src/main/kotlin/model/jvmName.kt
+++ b/core/src/main/kotlin/model/jvmName.kt
@@ -6,6 +6,6 @@ package org.jetbrains.dokka.model
 
 import org.jetbrains.dokka.links.DRI
 
-fun DRI.isJvmName(): Boolean = packageName == "kotlin.jvm" && classNames == "JvmName"
+public fun DRI.isJvmName(): Boolean = packageName == "kotlin.jvm" && classNames == "JvmName"
 
-fun Annotations.Annotation.isJvmName(): Boolean = dri.isJvmName()
+public fun Annotations.Annotation.isJvmName(): Boolean = dri.isJvmName()

--- a/core/src/main/kotlin/model/properties/PropertyContainer.kt
+++ b/core/src/main/kotlin/model/properties/PropertyContainer.kt
@@ -4,43 +4,44 @@
 
 package org.jetbrains.dokka.model.properties
 
-data class PropertyContainer<C : Any> internal constructor(
+public data class PropertyContainer<C : Any> internal constructor(
     @PublishedApi internal val map: Map<ExtraProperty.Key<C, *>, ExtraProperty<C>>
 ) {
-    operator fun <D : C> plus(prop: ExtraProperty<D>): PropertyContainer<D> =
+    public operator fun <D : C> plus(prop: ExtraProperty<D>): PropertyContainer<D> =
         PropertyContainer(map + (prop.key to prop))
 
     // TODO: Add logic for caching calculated properties
-    inline operator fun <reified T : Any> get(key: ExtraProperty.Key<C, T>): T? = when (val prop = map[key]) {
+    public inline operator fun <reified T : Any> get(key: ExtraProperty.Key<C, T>): T? = when (val prop = map[key]) {
         is T? -> prop
         else -> throw ClassCastException("Property for $key stored under not matching key type.")
     }
 
-    inline fun <reified T : Any> allOfType(): List<T> = map.values.filterIsInstance<T>()
-    fun <D : C> addAll(extras: Collection<ExtraProperty<D>>): PropertyContainer<D> =
+    public inline fun <reified T : Any> allOfType(): List<T> = map.values.filterIsInstance<T>()
+
+    public fun <D : C> addAll(extras: Collection<ExtraProperty<D>>): PropertyContainer<D> =
         PropertyContainer(map + extras.map { p -> p.key to p })
 
-    operator fun <D : C> minus(prop: ExtraProperty.Key<C, *>): PropertyContainer<D> =
+    public operator fun <D : C> minus(prop: ExtraProperty.Key<C, *>): PropertyContainer<D> =
         PropertyContainer(map.filterNot { it.key == prop })
 
-    companion object {
-        fun <T : Any> empty(): PropertyContainer<T> = PropertyContainer(emptyMap())
-        fun <T : Any> withAll(vararg extras: ExtraProperty<T>?) = empty<T>().addAll(extras.filterNotNull())
-        fun <T : Any> withAll(extras: Collection<ExtraProperty<T>>) = empty<T>().addAll(extras)
+    public companion object {
+        public fun <T : Any> empty(): PropertyContainer<T> = PropertyContainer(emptyMap())
+        public fun <T : Any> withAll(vararg extras: ExtraProperty<T>?): PropertyContainer<T> = empty<T>().addAll(extras.filterNotNull())
+        public fun <T : Any> withAll(extras: Collection<ExtraProperty<T>>): PropertyContainer<T> = empty<T>().addAll(extras)
     }
 }
 
-operator fun <D: Any> PropertyContainer<D>.plus(prop: ExtraProperty<D>?): PropertyContainer<D> =
+public operator fun <D: Any> PropertyContainer<D>.plus(prop: ExtraProperty<D>?): PropertyContainer<D> =
     if (prop == null) this else PropertyContainer(map + (prop.key to prop))
 
 
-interface WithExtraProperties<C : Any> {
-    val extra: PropertyContainer<C>
+public interface WithExtraProperties<C : Any> {
+    public val extra: PropertyContainer<C>
 
-    fun withNewExtras(newExtras: PropertyContainer<C>): C
+    public fun withNewExtras(newExtras: PropertyContainer<C>): C
 }
 
-fun <C> C.mergeExtras(left: C, right: C): C where C : Any, C : WithExtraProperties<C> {
+public fun <C> C.mergeExtras(left: C, right: C): C where C : Any, C : WithExtraProperties<C> {
     val aggregatedExtras: List<List<ExtraProperty<C>>> =
         (left.extra.map.values + right.extra.map.values)
             .groupBy { it.key }

--- a/core/src/main/kotlin/model/properties/properties.kt
+++ b/core/src/main/kotlin/model/properties/properties.kt
@@ -4,23 +4,33 @@
 
 package org.jetbrains.dokka.model.properties
 
-interface ExtraProperty<in C : Any> {
-    interface Key<in C : Any, T : Any> {
-        fun mergeStrategyFor(left: T, right: T): MergeStrategy<C> = MergeStrategy.Fail {
+public interface ExtraProperty<in C : Any> {
+    public interface Key<in C : Any, T : Any> {
+        public fun mergeStrategyFor(left: T, right: T): MergeStrategy<C> = MergeStrategy.Fail {
             throw NotImplementedError("Property merging for $this is not implemented")
         }
     }
 
-    val key: Key<C, *>
+    public val key: Key<C, *>
 }
 
-interface CalculatedProperty<in C : Any, T : Any> : ExtraProperty.Key<C, T> {
-    fun calculate(subject: C): T
+public interface CalculatedProperty<in C : Any, T : Any> : ExtraProperty.Key<C, T> {
+    public fun calculate(subject: C): T
 }
 
-sealed class MergeStrategy<in C> {
-    class Replace<in C : Any>(val newProperty: ExtraProperty<C>) : MergeStrategy<C>()
-    object Remove : MergeStrategy<Any>()
-    class Full<C : Any>(val merger: (preMerged: C, left: C, right: C) -> C) : MergeStrategy<C>()
-    class Fail(val error: () -> Nothing) : MergeStrategy<Any>()
+public sealed class MergeStrategy<in C> {
+
+    public class Replace<in C : Any>(
+        public val newProperty: ExtraProperty<C>
+    ) : MergeStrategy<C>()
+
+    public object Remove : MergeStrategy<Any>()
+
+    public class Full<C : Any>(
+        public val merger: (preMerged: C, left: C, right: C) -> C
+    ) : MergeStrategy<C>()
+
+    public class Fail(
+        public val error: () -> Nothing
+    ) : MergeStrategy<Any>()
 }

--- a/core/src/main/kotlin/pages/ContentNodes.kt
+++ b/core/src/main/kotlin/pages/ContentNodes.kt
@@ -10,25 +10,25 @@ import org.jetbrains.dokka.model.WithChildren
 import org.jetbrains.dokka.model.properties.PropertyContainer
 import org.jetbrains.dokka.model.properties.WithExtraProperties
 
-data class DCI(val dri: Set<DRI>, val kind: Kind) {
-    override fun toString() = "$dri[$kind]"
+public data class DCI(val dri: Set<DRI>, val kind: Kind) {
+    override fun toString(): String = "$dri[$kind]"
 }
 
-interface ContentNode : WithExtraProperties<ContentNode>, WithChildren<ContentNode> {
-    val dci: DCI
-    val sourceSets: Set<DisplaySourceSet>
-    val style: Set<Style>
+public interface ContentNode : WithExtraProperties<ContentNode>, WithChildren<ContentNode> {
+    public val dci: DCI
+    public val sourceSets: Set<DisplaySourceSet>
+    public val style: Set<Style>
 
-    fun hasAnyContent(): Boolean
+    public fun hasAnyContent(): Boolean
 
-    fun withSourceSets(sourceSets: Set<DisplaySourceSet>): ContentNode
+    public fun withSourceSets(sourceSets: Set<DisplaySourceSet>): ContentNode
 
     override val children: List<ContentNode>
         get() = emptyList()
 }
 
 /** Simple text */
-data class ContentText(
+public data class ContentText(
     val text: String,
     override val dci: DCI,
     override val sourceSets: Set<DisplaySourceSet>,
@@ -40,7 +40,7 @@ data class ContentText(
     override fun hasAnyContent(): Boolean = text.isNotBlank()
 }
 
-data class ContentBreakLine(
+public data class ContentBreakLine(
     override val sourceSets: Set<DisplaySourceSet>,
     override val dci: DCI = DCI(emptySet(), ContentKind.Empty),
     override val style: Set<Style> = emptySet(),
@@ -52,7 +52,7 @@ data class ContentBreakLine(
 }
 
 /** Headers */
-data class ContentHeader(
+public data class ContentHeader(
     override val children: List<ContentNode>,
     val level: Int,
     override val dci: DCI,
@@ -60,7 +60,7 @@ data class ContentHeader(
     override val style: Set<Style>,
     override val extra: PropertyContainer<ContentNode> = PropertyContainer.empty()
 ) : ContentComposite {
-    constructor(level: Int, c: ContentComposite) : this(c.children, level, c.dci, c.sourceSets, c.style, c.extra)
+    public constructor(level: Int, c: ContentComposite) : this(c.children, level, c.dci, c.sourceSets, c.style, c.extra)
 
     override fun withNewExtras(newExtras: PropertyContainer<ContentNode>): ContentHeader = copy(extra = newExtras)
 
@@ -71,10 +71,10 @@ data class ContentHeader(
         copy(sourceSets = sourceSets)
 }
 
-interface ContentCode : ContentComposite
+public interface ContentCode : ContentComposite
 
 /** Code blocks */
-data class ContentCodeBlock(
+public data class ContentCodeBlock(
     override val children: List<ContentNode>,
     val language: String,
     override val dci: DCI,
@@ -92,7 +92,7 @@ data class ContentCodeBlock(
 
 }
 
-data class ContentCodeInline(
+public data class ContentCodeInline(
     override val children: List<ContentNode>,
     val language: String,
     override val dci: DCI,
@@ -111,10 +111,10 @@ data class ContentCodeInline(
 }
 
 /** Union type replacement */
-interface ContentLink : ContentComposite
+public interface ContentLink : ContentComposite
 
 /** All links to classes, packages, etc. that have te be resolved */
-data class ContentDRILink(
+public data class ContentDRILink(
     override val children: List<ContentNode>,
     val address: DRI,
     override val dci: DCI,
@@ -133,7 +133,7 @@ data class ContentDRILink(
 }
 
 /** All links that do not need to be resolved */
-data class ContentResolvedLink(
+public data class ContentResolvedLink(
     override val children: List<ContentNode>,
     val address: String,
     override val dci: DCI,
@@ -152,7 +152,7 @@ data class ContentResolvedLink(
 }
 
 /** Embedded resources like images */
-data class ContentEmbeddedResource(
+public data class ContentEmbeddedResource(
     override val children: List<ContentNode> = emptyList(),
     val address: String,
     val altText: String?,
@@ -172,18 +172,18 @@ data class ContentEmbeddedResource(
 }
 
 /** Logical grouping of [ContentNode]s  */
-interface ContentComposite : ContentNode {
+public interface ContentComposite : ContentNode {
     override val children: List<ContentNode> // overwrite to make it abstract once again
 
     override val sourceSets: Set<DisplaySourceSet> get() = children.flatMap { it.sourceSets }.toSet()
 
-    fun transformChildren(transformer: (ContentNode) -> ContentNode): ContentComposite
+    public fun transformChildren(transformer: (ContentNode) -> ContentNode): ContentComposite
 
     override fun hasAnyContent(): Boolean = children.any { it.hasAnyContent() }
 }
 
 /** Tables */
-data class ContentTable(
+public data class ContentTable(
     val header: List<ContentGroup>,
     val caption: ContentGroup? = null,
     override val children: List<ContentGroup>,
@@ -203,7 +203,7 @@ data class ContentTable(
 }
 
 /** Lists */
-data class ContentList(
+public data class ContentList(
     override val children: List<ContentNode>,
     val ordered: Boolean,
     override val dci: DCI,
@@ -221,7 +221,7 @@ data class ContentList(
 }
 
 /** Default group, eg. for blocks of Functions, Properties, etc. **/
-data class ContentGroup(
+public data class ContentGroup(
     override val children: List<ContentNode>,
     override val dci: DCI,
     override val sourceSets: Set<DisplaySourceSet>,
@@ -240,7 +240,7 @@ data class ContentGroup(
 /**
  * @property groupID is used for finding and copying [ContentDivergentInstance]s when merging [ContentPage]s
  */
-data class ContentDivergentGroup(
+public data class ContentDivergentGroup(
     override val children: List<ContentDivergentInstance>,
     override val dci: DCI,
     override val style: Set<Style>,
@@ -248,7 +248,7 @@ data class ContentDivergentGroup(
     val groupID: GroupID,
     val implicitlySourceSetHinted: Boolean = true
 ) : ContentComposite {
-    data class GroupID(val name: String)
+    public data class GroupID(val name: String)
 
     override val sourceSets: Set<DisplaySourceSet>
         get() = children.flatMap { it.sourceSets }.distinct().toSet()
@@ -263,7 +263,7 @@ data class ContentDivergentGroup(
 }
 
 /** Instance of a divergent content */
-data class ContentDivergentInstance(
+public data class ContentDivergentInstance(
     val before: ContentNode?,
     val divergent: ContentNode,
     val after: ContentNode?,
@@ -290,11 +290,11 @@ data class ContentDivergentInstance(
 
 }
 
-data class PlatformHintedContent(
+public data class PlatformHintedContent(
     val inner: ContentNode,
     override val sourceSets: Set<DisplaySourceSet>
 ) : ContentComposite {
-    override val children = listOf(inner)
+    override val children: List<ContentNode> = listOf(inner)
 
     override val dci: DCI
         get() = inner.dci
@@ -305,7 +305,7 @@ data class PlatformHintedContent(
     override val style: Set<Style>
         get() = inner.style
 
-    override fun withNewExtras(newExtras: PropertyContainer<ContentNode>) =
+    override fun withNewExtras(newExtras: PropertyContainer<ContentNode>): ContentNode =
         throw UnsupportedOperationException("This method should not be called on this PlatformHintedContent")
 
     override fun transformChildren(transformer: (ContentNode) -> ContentNode): PlatformHintedContent =
@@ -316,14 +316,14 @@ data class PlatformHintedContent(
 
 }
 
-interface Style
-interface Kind
+public interface Style
+public interface Kind
 
 /**
  * [ContentKind] represents a grouping of content of one kind that can can be rendered
  * as part of a composite page (one tab/block within a class's page, for instance).
  */
-enum class ContentKind : Kind {
+public enum class ContentKind : Kind {
 
     /**
      * Marks all sorts of signatures. Can contain sub-kinds marked as [SymbolContentKind]
@@ -344,7 +344,7 @@ enum class ContentKind : Kind {
      */
     Deprecation;
 
-    companion object {
+    public companion object {
         private val platformTagged =
             setOf(
                 Constructors,
@@ -358,14 +358,14 @@ enum class ContentKind : Kind {
                 Extensions
             )
 
-        fun shouldBePlatformTagged(kind: Kind): Boolean = kind in platformTagged
+        public fun shouldBePlatformTagged(kind: Kind): Boolean = kind in platformTagged
     }
 }
 
 /**
  * Content kind for [ContentKind.Symbol] content, which is essentially about signatures
  */
-enum class SymbolContentKind : Kind {
+public enum class SymbolContentKind : Kind {
     /**
      * Marks constructor/function parameters, everything in-between parentheses.
      *
@@ -385,17 +385,17 @@ enum class SymbolContentKind : Kind {
     Parameter,
 }
 
-enum class TokenStyle : Style {
+public enum class TokenStyle : Style {
     Keyword, Punctuation, Function, Operator, Annotation, Number, String, Boolean, Constant
 }
 
-enum class TextStyle : Style {
+public enum class TextStyle : Style {
     Bold, Italic, Strong, Strikethrough, Paragraph,
     Block, Span, Monospace, Indented, Cover, UnderCoverText, BreakableAfter, Breakable, InlineComment, Quotation,
     FloatingRight, Var, Underlined
 }
 
-enum class ContentStyle : Style {
+public enum class ContentStyle : Style {
     RowTitle,
     /**
      * The style is used only for HTML. It is applied only for [ContentGroup].
@@ -407,7 +407,7 @@ enum class ContentStyle : Style {
     Wrapped, Indented, KDocTag, Footnote
 }
 
-enum class ListStyle : Style {
+public enum class ListStyle : Style {
     /**
      * Represents a list of groups of [DescriptionTerm] and [DescriptionDetails].
      * Common uses for this element are to implement a glossary or to display
@@ -429,8 +429,8 @@ enum class ListStyle : Style {
     DescriptionDetails
 }
 
-object CommentTable : Style
+public object CommentTable : Style
 
-object MultimoduleTable : Style
+public object MultimoduleTable : Style
 
-fun ContentNode.hasStyle(style: Style) = this.style.contains(style)
+public fun ContentNode.hasStyle(style: Style): Boolean = this.style.contains(style)

--- a/core/src/main/kotlin/pages/PageNodes.kt
+++ b/core/src/main/kotlin/pages/PageNodes.kt
@@ -9,28 +9,28 @@ import org.jetbrains.dokka.model.Documentable
 import org.jetbrains.dokka.model.WithChildren
 import java.util.*
 
-interface PageNode : WithChildren<PageNode> {
-    val name: String
+public interface PageNode : WithChildren<PageNode> {
+    public val name: String
     override val children: List<PageNode>
 
-    fun modified(
+    public fun modified(
         name: String = this.name,
         children: List<PageNode> = this.children
     ): PageNode
 }
 
-interface ContentPage : PageNode {
-    val content: ContentNode
-    val dri: Set<DRI>
-    val embeddedResources: List<String>
+public interface ContentPage : PageNode {
+    public val content: ContentNode
+    public val dri: Set<DRI>
+    public val embeddedResources: List<String>
 
     @Deprecated("Deprecated. Remove its usages from your code.",
         ReplaceWith("this.documentables.firstOrNull()")
     )
-    val documentable: Documentable?
+    public val documentable: Documentable?
         get() = if (this is WithDocumentables) this.documentables.firstOrNull() else null
 
-    fun modified(
+    public fun modified(
         name: String = this.name,
         content: ContentNode = this.content,
         dri: Set<DRI> = this.dri,
@@ -39,12 +39,14 @@ interface ContentPage : PageNode {
     ): ContentPage
 }
 
-interface WithDocumentables {
-    val documentables: List<Documentable>
+public interface WithDocumentables {
+    public val documentables: List<Documentable>
 }
 
-abstract class RootPageNode(val forceTopLevelName: Boolean = false) : PageNode {
-    val parentMap: Map<PageNode, PageNode> by lazy {
+public abstract class RootPageNode(
+    public val forceTopLevelName: Boolean = false
+) : PageNode {
+    public val parentMap: Map<PageNode, PageNode> by lazy {
         IdentityHashMap<PageNode, PageNode>().apply {
             fun process(parent: PageNode) {
                 parent.children.forEach { child ->
@@ -56,10 +58,10 @@ abstract class RootPageNode(val forceTopLevelName: Boolean = false) : PageNode {
         }
     }
 
-    fun transformPageNodeTree(operation: (PageNode) -> PageNode) =
+    public fun transformPageNodeTree(operation: (PageNode) -> PageNode): RootPageNode =
         this.transformNode(operation) as RootPageNode
 
-    fun transformContentPagesTree(operation: (ContentPage) -> ContentPage) = transformPageNodeTree {
+    public fun transformContentPagesTree(operation: (ContentPage) -> ContentPage): RootPageNode = transformPageNodeTree {
         if (it is ContentPage) operation(it) else it
     }
 
@@ -74,7 +76,7 @@ abstract class RootPageNode(val forceTopLevelName: Boolean = false) : PageNode {
     ): RootPageNode
 }
 
-class ModulePageNode(
+public class ModulePageNode(
     override val name: String,
     override val content: ContentNode,
     override val documentables: List<Documentable> = listOf(),
@@ -97,7 +99,7 @@ class ModulePageNode(
         else ModulePageNode(name, content, documentables, children, embeddedResources)
 }
 
-class PackagePageNode(
+public class PackagePageNode(
     override val name: String,
     override val content: ContentNode,
     override val dri: Set<DRI>,
@@ -124,7 +126,7 @@ class PackagePageNode(
         else PackagePageNode(name, content, dri, documentables, children, embeddedResources)
 }
 
-class ClasslikePageNode(
+public class ClasslikePageNode(
     override val name: String,
     override val content: ContentNode,
     override val dri: Set<DRI>,
@@ -146,7 +148,7 @@ class ClasslikePageNode(
         else ClasslikePageNode(name, content, dri, documentables, children, embeddedResources)
 }
 
-class MemberPageNode(
+public class MemberPageNode(
     override val name: String,
     override val content: ContentNode,
     override val dri: Set<DRI>,
@@ -169,12 +171,12 @@ class MemberPageNode(
 }
 
 
-class MultimoduleRootPageNode(
+public class MultimoduleRootPageNode(
     override val dri: Set<DRI>,
     override val content: ContentNode,
     override val embeddedResources: List<String> = emptyList()
 ) : RootPageNode(forceTopLevelName = true), MultimoduleRootPage {
-    override val name = "All modules"
+    override val name: String = "All modules"
 
     override val children: List<PageNode> = emptyList()
 
@@ -187,12 +189,12 @@ class MultimoduleRootPageNode(
         dri: Set<DRI>,
         embeddedResources: List<String>,
         children: List<PageNode>
-    ) =
+    ): ContentPage =
         if (name == this.name && content === this.content && embeddedResources === this.embeddedResources && children shallowEq this.children) this
         else MultimoduleRootPageNode(dri, content, embeddedResources)
 }
 
-inline fun <reified T : PageNode> PageNode.children() = children.filterIsInstance<T>()
+public inline fun <reified T : PageNode> PageNode.children(): List<T> = children.filterIsInstance<T>()
 
 private infix fun <T> List<T>.shallowEq(other: List<T>) =
     this === other || (this.size == other.size && (this zip other).all { (a, b) -> a === b })

--- a/core/src/main/kotlin/pages/Pages.kt
+++ b/core/src/main/kotlin/pages/Pages.kt
@@ -4,12 +4,12 @@
 
 package org.jetbrains.dokka.pages
 
-interface MultimoduleRootPage : ContentPage
+public interface MultimoduleRootPage : ContentPage
 
-interface ModulePage : ContentPage, WithDocumentables
+public interface ModulePage : ContentPage, WithDocumentables
 
-interface PackagePage : ContentPage, WithDocumentables
+public interface PackagePage : ContentPage, WithDocumentables
 
-interface ClasslikePage : ContentPage, WithDocumentables
+public interface ClasslikePage : ContentPage, WithDocumentables
 
-interface MemberPage : ContentPage, WithDocumentables
+public interface MemberPage : ContentPage, WithDocumentables

--- a/core/src/main/kotlin/pages/RendererSpecificPage.kt
+++ b/core/src/main/kotlin/pages/RendererSpecificPage.kt
@@ -9,14 +9,14 @@ import org.jetbrains.dokka.model.DisplaySourceSet
 import org.jetbrains.dokka.renderers.Renderer
 import kotlin.reflect.KClass
 
-fun interface DriResolver: (DRI, Set<DisplaySourceSet>) -> String?
-fun interface PageResolver: (PageNode, PageNode?) -> String?
+public fun interface DriResolver: (DRI, Set<DisplaySourceSet>) -> String?
+public fun interface PageResolver: (PageNode, PageNode?) -> String?
 
-interface RendererSpecificPage : PageNode {
-    val strategy: RenderingStrategy
+public interface RendererSpecificPage : PageNode {
+    public val strategy: RenderingStrategy
 }
 
-class RendererSpecificRootPage(
+public class RendererSpecificRootPage(
     override val name: String,
     override val children: List<PageNode>,
     override val strategy: RenderingStrategy
@@ -25,7 +25,7 @@ class RendererSpecificRootPage(
         RendererSpecificRootPage(name, children, strategy)
 }
 
-class RendererSpecificResourcePage(
+public class RendererSpecificResourcePage(
     override val name: String,
     override val children: List<PageNode>,
     override val strategy: RenderingStrategy
@@ -34,18 +34,19 @@ class RendererSpecificResourcePage(
         RendererSpecificResourcePage(name, children, strategy)
 }
 
-sealed class RenderingStrategy {
-    class Callback(val instructions: Renderer.(PageNode) -> String): RenderingStrategy()
-    data class Copy(val from: String) : RenderingStrategy()
-    data class Write(val text: String) : RenderingStrategy()
-    data class DriLocationResolvableWrite(val contentToResolve: (DriResolver) -> String) : RenderingStrategy()
-    data class PageLocationResolvableWrite(val contentToResolve: (PageResolver) -> String) : RenderingStrategy()
-    object DoNothing : RenderingStrategy()
+public sealed class RenderingStrategy {
+    public class Callback(public val instructions: Renderer.(PageNode) -> String): RenderingStrategy()
+    public data class Copy(val from: String) : RenderingStrategy()
+    public data class Write(val text: String) : RenderingStrategy()
+    public data class DriLocationResolvableWrite(val contentToResolve: (DriResolver) -> String) : RenderingStrategy()
+    public data class PageLocationResolvableWrite(val contentToResolve: (PageResolver) -> String) : RenderingStrategy()
+    public object DoNothing : RenderingStrategy()
 
-    companion object {
-        inline operator fun <reified T: Renderer> invoke(crossinline instructions: T.(PageNode) -> String) =
-            Callback { if (this is T) instructions(it) else throw WrongRendererTypeException(T::class) }
+    public companion object {
+        public inline operator fun <reified T: Renderer> invoke(crossinline instructions: T.(PageNode) -> String): RenderingStrategy {
+            return Callback { if (this is T) instructions(it) else throw WrongRendererTypeException(T::class) }
+        }
     }
 }
 
-data class WrongRendererTypeException(val expectedType: KClass<*>): Exception()
+public data class WrongRendererTypeException(val expectedType: KClass<*>): Exception()

--- a/core/src/main/kotlin/pages/contentNodeProperties.kt
+++ b/core/src/main/kotlin/pages/contentNodeProperties.kt
@@ -6,29 +6,32 @@ package org.jetbrains.dokka.pages
 
 import org.jetbrains.dokka.model.properties.ExtraProperty
 
-class SimpleAttr(val extraKey: String, val extraValue: String) : ExtraProperty<ContentNode> {
-    data class SimpleAttrKey(val key: String) : ExtraProperty.Key<ContentNode, SimpleAttr>
+public class SimpleAttr(
+    public val extraKey: String,
+    public val extraValue: String
+) : ExtraProperty<ContentNode> {
+    public data class SimpleAttrKey(val key: String) : ExtraProperty.Key<ContentNode, SimpleAttr>
     override val key: ExtraProperty.Key<ContentNode, SimpleAttr> = SimpleAttrKey(extraKey)
 
 }
 
-enum class BasicTabbedContentType : TabbedContentType {
+public enum class BasicTabbedContentType : TabbedContentType {
     TYPE, CONSTRUCTOR, FUNCTION, PROPERTY, ENTRY, EXTENSION_PROPERTY, EXTENSION_FUNCTION
 }
 
 /**
  * It is used only to mark content for tabs in HTML format
  */
-interface TabbedContentType
+public interface TabbedContentType
 
 /**
  * @see TabbedContentType
  */
-class TabbedContentTypeExtra(val value: TabbedContentType) : ExtraProperty<ContentNode> {
-    companion object : ExtraProperty.Key<ContentNode, TabbedContentTypeExtra>
+public class TabbedContentTypeExtra(public val value: TabbedContentType) : ExtraProperty<ContentNode> {
+    public companion object : ExtraProperty.Key<ContentNode, TabbedContentTypeExtra>
     override val key: ExtraProperty.Key<ContentNode, TabbedContentTypeExtra> = TabbedContentTypeExtra
 }
 
-object HtmlContent : ExtraProperty<ContentNode>, ExtraProperty.Key<ContentNode, HtmlContent> {
+public object HtmlContent : ExtraProperty<ContentNode>, ExtraProperty.Key<ContentNode, HtmlContent> {
     override val key: ExtraProperty.Key<ContentNode, *> = this
 }

--- a/core/src/main/kotlin/pages/utils.kt
+++ b/core/src/main/kotlin/pages/utils.kt
@@ -6,10 +6,10 @@ package org.jetbrains.dokka.pages
 
 import kotlin.reflect.KClass
 
-inline fun <reified T : ContentNode, R : ContentNode> R.mapTransform(noinline operation: (T) -> T): R =
+public inline fun <reified T : ContentNode, R : ContentNode> R.mapTransform(noinline operation: (T) -> T): R =
     mapTransform(T::class, operation)
 
-inline fun <reified T : ContentNode, R : ContentNode> R.recursiveMapTransform(noinline operation: (T) -> T): R =
+public inline fun <reified T : ContentNode, R : ContentNode> R.recursiveMapTransform(noinline operation: (T) -> T): R =
         recursiveMapTransform(T::class, operation)
 
 @PublishedApi

--- a/core/src/main/kotlin/plugability/DefaultExtensions.kt
+++ b/core/src/main/kotlin/plugability/DefaultExtensions.kt
@@ -1,4 +1,0 @@
-/*
- * Copyright 2014-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
- */
-

--- a/core/src/main/kotlin/plugability/DokkaContext.kt
+++ b/core/src/main/kotlin/plugability/DokkaContext.kt
@@ -12,20 +12,20 @@ import java.util.*
 import kotlin.reflect.KClass
 import kotlin.reflect.full.createInstance
 
-interface DokkaContext {
-    fun <T : DokkaPlugin> plugin(kclass: KClass<T>): T?
+public interface DokkaContext {
+    public fun <T : DokkaPlugin> plugin(kclass: KClass<T>): T?
 
-    operator fun <T, E> get(point: E): List<T>
+    public operator fun <T, E> get(point: E): List<T>
             where T : Any, E : ExtensionPoint<T>
 
-    fun <T, E> single(point: E): T where T : Any, E : ExtensionPoint<T>
+    public fun <T, E> single(point: E): T where T : Any, E : ExtensionPoint<T>
 
-    val logger: DokkaLogger
-    val configuration: DokkaConfiguration
-    val unusedPoints: Collection<ExtensionPoint<*>>
+    public val logger: DokkaLogger
+    public val configuration: DokkaConfiguration
+    public val unusedPoints: Collection<ExtensionPoint<*>>
 
-    companion object {
-        fun create(
+    public companion object {
+        public fun create(
             configuration: DokkaConfiguration,
             logger: DokkaLogger,
             pluginOverrides: List<DokkaPlugin>
@@ -44,11 +44,11 @@ interface DokkaContext {
     }
 }
 
-inline fun <reified T : DokkaPlugin> DokkaContext.plugin(): T = plugin(T::class)
+public inline fun <reified T : DokkaPlugin> DokkaContext.plugin(): T = plugin(T::class)
     ?: throw java.lang.IllegalStateException("Plugin ${T::class.qualifiedName} is not present in context.")
 
-fun interface DokkaContextConfiguration {
-    fun installExtension(extension: Extension<*, *, *>)
+public fun interface DokkaContextConfiguration {
+    public fun installExtension(extension: Extension<*, *, *>)
 }
 
 private class DokkaContextConfigurationImpl(

--- a/core/src/main/kotlin/plugability/DokkaJavaPlugin.kt
+++ b/core/src/main/kotlin/plugability/DokkaJavaPlugin.kt
@@ -6,17 +6,19 @@ package org.jetbrains.dokka.plugability
 
 import org.jetbrains.dokka.DokkaConfiguration
 
-class ExtensionBuilderStart internal constructor(){
-    fun <T: Any>  extensionPoint(ext: ExtensionPoint<T>): ProvidedExtension<T> = ProvidedExtension(ext)
+public class ExtensionBuilderStart internal constructor(){
+    public fun <T: Any>  extensionPoint(ext: ExtensionPoint<T>): ProvidedExtension<T> = ProvidedExtension(ext)
 }
 
-class ProvidedExtension<T: Any> internal constructor(val ext: ExtensionPoint<T>){
-    fun fromInstance(inst: T): ExtensionBuilder<T> = createBuilder(
+public class ProvidedExtension<T: Any> internal constructor(
+    public val ext: ExtensionPoint<T>
+) {
+    public fun fromInstance(inst: T): ExtensionBuilder<T> = createBuilder(
         LazyEvaluated.fromInstance(
             inst
         )
     )
-    fun fromRecipe(recipe: (DokkaContext) -> T): ExtensionBuilder<T> = createBuilder(
+    public fun fromRecipe(recipe: (DokkaContext) -> T): ExtensionBuilder<T> = createBuilder(
         LazyEvaluated.fromRecipe(recipe)
     )
 
@@ -28,7 +30,7 @@ class ProvidedExtension<T: Any> internal constructor(val ext: ExtensionPoint<T>)
             OverrideKind.None, emptyList())
 }
 
-data class ExtensionBuilder<T: Any> internal constructor(
+public data class ExtensionBuilder<T: Any> internal constructor(
     private val name: String,
     private val ext: ExtensionPoint<T>,
     private val action: LazyEvaluated<T>,
@@ -37,7 +39,7 @@ data class ExtensionBuilder<T: Any> internal constructor(
     private val override: OverrideKind = OverrideKind.None,
     private val conditions: List<(DokkaConfiguration) -> Boolean>
 ){
-    fun build(): Extension<T, *, *>  = Extension(
+    public fun build(): Extension<T, *, *>  = Extension(
         ext,
         javaClass.name,
         name,
@@ -50,27 +52,27 @@ data class ExtensionBuilder<T: Any> internal constructor(
         conditions
     )
 
-    fun overrideExtension(extension: Extension<T, *, *>) = copy(override = OverrideKind.Present(listOf(extension)))
+    public fun overrideExtension(extension: Extension<T, *, *>): ExtensionBuilder<T> = copy(override = OverrideKind.Present(listOf(extension)))
 
-    fun newOrdering(before: Array<out Extension<*, *, *>>, after: Array<out Extension<*, *, *>>) =
+    public fun newOrdering(before: Array<out Extension<*, *, *>>, after: Array<out Extension<*, *, *>>): ExtensionBuilder<T> =
         copy(before = this.before + before, after = this.after + after)
 
-    fun before(vararg exts: Extension<*, *, *>) = copy(before = this.before + exts)
+    public fun before(vararg exts: Extension<*, *, *>): ExtensionBuilder<T> = copy(before = this.before + exts)
 
-    fun after(vararg exts: Extension<*, *, *>) = copy(after = this.after + exts)
+    public fun after(vararg exts: Extension<*, *, *>): ExtensionBuilder<T> = copy(after = this.after + exts)
 
-    fun addCondition(c: (DokkaConfiguration) -> Boolean) = copy(conditions = conditions + c)
+    public fun addCondition(c: (DokkaConfiguration) -> Boolean): ExtensionBuilder<T> = copy(conditions = conditions + c)
 
-    fun name(name: String) = copy(name = name)
+    public fun name(name: String): ExtensionBuilder<T> = copy(name = name)
 }
 
-abstract class DokkaJavaPlugin: DokkaPlugin() {
+public abstract class DokkaJavaPlugin: DokkaPlugin() {
 
-    fun <T: DokkaPlugin> plugin(clazz: Class<T>): T =
+    public fun <T: DokkaPlugin> plugin(clazz: Class<T>): T =
         context?.plugin(clazz.kotlin) ?: throwIllegalQuery()
 
 
-    fun <T: Any> extend(func: (ExtensionBuilderStart) -> ExtensionBuilder<T>): Lazy<Extension<T, *, *>> =
+    public fun <T: Any> extend(func: (ExtensionBuilderStart) -> ExtensionBuilder<T>): Lazy<Extension<T, *, *>> =
         lazy { func(ExtensionBuilderStart()).build() }.also { unsafeInstall(it) }
 
 }

--- a/core/src/main/kotlin/plugability/DokkaPlugin.kt
+++ b/core/src/main/kotlin/plugability/DokkaPlugin.kt
@@ -22,16 +22,16 @@ import kotlin.reflect.KProperty1
 )
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.FIELD)
 @Retention(AnnotationRetention.BINARY)
-annotation class DokkaPluginApiPreview
+public annotation class DokkaPluginApiPreview
 
 /**
  * Acknowledgement for empty methods that inform users about [DokkaPluginApiPreview]
  * Also, it allows to not propagates the annotation in IDE by default when a user autogenerate methods.
  */
 @DokkaPluginApiPreview
-object PluginApiPreviewAcknowledgement
+public object PluginApiPreviewAcknowledgement
 
-abstract class DokkaPlugin {
+public abstract class DokkaPlugin {
     private val extensionDelegates = mutableListOf<KProperty<*>>()
     private val unsafePlugins = mutableListOf<Lazy<Extension<*, *, *>>>()
 
@@ -47,29 +47,36 @@ abstract class DokkaPlugin {
     protected abstract fun pluginApiPreviewAcknowledgement(): PluginApiPreviewAcknowledgement
     protected inline fun <reified T : DokkaPlugin> plugin(): T = context?.plugin(T::class) ?: throwIllegalQuery()
 
-    protected fun <T : Any> extensionPoint() = ReadOnlyProperty<DokkaPlugin, ExtensionPoint<T>> { thisRef, property ->
-        ExtensionPoint(
-            thisRef::class.qualifiedName ?: throw AssertionError("Plugin must be named class"),
-            property.name
-        )
+    protected fun <T : Any> extensionPoint(): ReadOnlyProperty<DokkaPlugin, ExtensionPoint<T>> {
+        return ReadOnlyProperty { thisRef, property ->
+            ExtensionPoint(
+                thisRef::class.qualifiedName ?: throw AssertionError("Plugin must be named class"),
+                property.name
+            )
+        }
     }
-    protected fun <T : Any> extending(definition: ExtendingDSL.() -> Extension<T, *, *>) = ExtensionProvider(definition)
+    protected fun <T : Any> extending(definition: ExtendingDSL.() -> Extension<T, *, *>): ExtensionProvider<T> {
+        return ExtensionProvider(definition)
+    }
 
     protected class ExtensionProvider<T : Any> internal constructor(
         private val definition: ExtendingDSL.() -> Extension<T, *, *>
     ) {
-        operator fun provideDelegate(thisRef: DokkaPlugin, property: KProperty<*>) = lazy {
-            ExtendingDSL(
-                thisRef::class.qualifiedName ?: throw AssertionError("Plugin must be named class"),
-                property.name
-            ).definition()
-        }.also { thisRef.extensionDelegates += property }
+        public operator fun provideDelegate(thisRef: DokkaPlugin, property: KProperty<*>): Lazy<Extension<T, *, *>> {
+            return lazy {
+                ExtendingDSL(
+                    thisRef::class.qualifiedName ?: throw AssertionError("Plugin must be named class"),
+                    property.name
+                ).definition()
+            }.also { thisRef.extensionDelegates += property }
+        }
     }
 
     internal fun internalInstall(ctx: DokkaContextConfiguration, configuration: DokkaConfiguration) {
         val extensionsToInstall = extensionDelegates.asSequence()
             .filterIsInstance<KProperty1<DokkaPlugin, Extension<*, *, *>>>() // should be always true
             .map { it.get(this) } + unsafePlugins.map { it.value }
+
         extensionsToInstall.forEach { if (configuration.(it.condition)()) ctx.installExtension(it) }
     }
 
@@ -78,22 +85,22 @@ abstract class DokkaPlugin {
     }
 }
 
-interface WithUnsafeExtensionSuppression {
-    val extensionsSuppressed: List<Extension<*, *, *>>
+public interface WithUnsafeExtensionSuppression {
+    public val extensionsSuppressed: List<Extension<*, *, *>>
 }
 
-interface ConfigurableBlock
+public interface ConfigurableBlock
 
-inline fun <reified P : DokkaPlugin, reified E : Any> P.query(extension: P.() -> ExtensionPoint<E>): List<E> =
+public inline fun <reified P : DokkaPlugin, reified E : Any> P.query(extension: P.() -> ExtensionPoint<E>): List<E> =
     context?.let { it[extension()] } ?: throwIllegalQuery()
 
-inline fun <reified P : DokkaPlugin, reified E : Any> P.querySingle(extension: P.() -> ExtensionPoint<E>): E =
+public inline fun <reified P : DokkaPlugin, reified E : Any> P.querySingle(extension: P.() -> ExtensionPoint<E>): E =
     context?.single(extension()) ?: throwIllegalQuery()
 
-fun throwIllegalQuery(): Nothing =
+public fun throwIllegalQuery(): Nothing =
     throw IllegalStateException("Querying about plugins is only possible with dokka context initialised")
 
-inline fun <reified T : DokkaPlugin, reified R : ConfigurableBlock> configuration(context: DokkaContext): R? =
+public inline fun <reified T : DokkaPlugin, reified R : ConfigurableBlock> configuration(context: DokkaContext): R? =
     context.configuration.pluginsConfiguration.firstOrNull { it.fqPluginName == T::class.qualifiedName }
         ?.let { configuration ->
             when (configuration.serializationFormat) {

--- a/core/src/main/kotlin/plugability/extensions.kt
+++ b/core/src/main/kotlin/plugability/extensions.kt
@@ -6,24 +6,29 @@ package org.jetbrains.dokka.plugability
 
 import org.jetbrains.dokka.DokkaConfiguration
 
-data class ExtensionPoint<T : Any> internal constructor(
+public data class ExtensionPoint<T : Any> internal constructor(
     internal val pluginClass: String,
     internal val pointName: String
 ) {
-    override fun toString() = "ExtensionPoint: $pluginClass/$pointName"
+    override fun toString(): String = "ExtensionPoint: $pluginClass/$pointName"
 }
 
-sealed class OrderingKind {
-    object None : OrderingKind()
-    class ByDsl(val block: (OrderDsl.() -> Unit)) : OrderingKind()
+public sealed class OrderingKind {
+    public object None : OrderingKind()
+
+    public class ByDsl(
+        public val block: (OrderDsl.() -> Unit)
+    ) : OrderingKind()
 }
 
-sealed class OverrideKind {
-    object None : OverrideKind()
-    class Present(val overriden: List<Extension<*, *, *>>) : OverrideKind()
+public sealed class OverrideKind {
+    public object None : OverrideKind()
+    public class Present(
+        public val overriden: List<Extension<*, *, *>>
+    ) : OverrideKind()
 }
 
-class Extension<T : Any, Ordering : OrderingKind, Override : OverrideKind> internal constructor(
+public class Extension<T : Any, Ordering : OrderingKind, Override : OverrideKind> internal constructor(
     internal val extensionPoint: ExtensionPoint<T>,
     internal val pluginClass: String,
     internal val extensionName: String,
@@ -32,15 +37,15 @@ class Extension<T : Any, Ordering : OrderingKind, Override : OverrideKind> inter
     internal val override: Override,
     internal val conditions: List<DokkaConfiguration.() -> Boolean>
 ) {
-    override fun toString() = "Extension: $pluginClass/$extensionName"
+    override fun toString(): String = "Extension: $pluginClass/$extensionName"
 
-    override fun equals(other: Any?) =
+    override fun equals(other: Any?): Boolean =
         if (other is Extension<*, *, *>) this.pluginClass == other.pluginClass && this.extensionName == other.extensionName
         else false
 
-    override fun hashCode() = listOf(pluginClass, extensionName).hashCode()
+    override fun hashCode(): Int = listOf(pluginClass, extensionName).hashCode()
 
-    val condition: DokkaConfiguration.() -> Boolean
+    public val condition: DokkaConfiguration.() -> Boolean
         get() = { conditions.all { it(this) } }
 }
 
@@ -52,44 +57,54 @@ internal fun <T : Any> Extension(
 ) = Extension(extensionPoint, pluginClass, extensionName, action, OrderingKind.None, OverrideKind.None, emptyList())
 
 @DslMarker
-annotation class ExtensionsDsl
+public annotation class ExtensionsDsl
 
 @ExtensionsDsl
-class ExtendingDSL(private val pluginClass: String, private val extensionName: String) {
+public class ExtendingDSL(private val pluginClass: String, private val extensionName: String) {
 
-    infix fun <T : Any> ExtensionPoint<T>.with(action: T) =
-        Extension(this, this@ExtendingDSL.pluginClass, extensionName, LazyEvaluated.fromInstance(action))
+    public infix fun <T : Any> ExtensionPoint<T>.with(action: T): Extension<T, OrderingKind.None, OverrideKind.None> {
+        return Extension(this, this@ExtendingDSL.pluginClass, extensionName, LazyEvaluated.fromInstance(action))
+    }
 
-    infix fun <T : Any> ExtensionPoint<T>.providing(action: (DokkaContext) -> T) =
-        Extension(this, this@ExtendingDSL.pluginClass, extensionName, LazyEvaluated.fromRecipe(action))
+    public infix fun <T : Any> ExtensionPoint<T>.providing(action: (DokkaContext) -> T): Extension<T, OrderingKind.None, OverrideKind.None> {
+        return Extension(this, this@ExtendingDSL.pluginClass, extensionName, LazyEvaluated.fromRecipe(action))
+    }
 
-    infix fun <T : Any, Override : OverrideKind> Extension<T, OrderingKind.None, Override>.order(
+    public infix fun <T : Any, Override : OverrideKind> Extension<T, OrderingKind.None, Override>.order(
         block: OrderDsl.() -> Unit
-    ) = Extension(extensionPoint, pluginClass, extensionName, action, OrderingKind.ByDsl(block), override, conditions)
+    ): Extension<T, OrderingKind.ByDsl, Override> {
+        return Extension(extensionPoint, pluginClass, extensionName, action, OrderingKind.ByDsl(block), override, conditions)
+    }
 
-    infix fun <T : Any, Override : OverrideKind, Ordering: OrderingKind> Extension<T, Ordering, Override>.applyIf(
+    public infix fun <T : Any, Override : OverrideKind, Ordering: OrderingKind> Extension<T, Ordering, Override>.applyIf(
         condition: DokkaConfiguration.() -> Boolean
-    ) = Extension(extensionPoint, pluginClass, extensionName, action, ordering, override, conditions + condition)
+    ): Extension<T, Ordering, Override> {
+        return Extension(extensionPoint, pluginClass, extensionName, action, ordering, override, conditions + condition)
+    }
 
-    infix fun <T : Any, Override : OverrideKind, Ordering: OrderingKind> Extension<T, Ordering, Override>.override(
+    public infix fun <T : Any, Override : OverrideKind, Ordering: OrderingKind> Extension<T, Ordering, Override>.override(
         overriden: List<Extension<T, *, *>>
-    ) = Extension(extensionPoint, pluginClass, extensionName, action, ordering, OverrideKind.Present(overriden), conditions)
+    ): Extension<T, Ordering, OverrideKind.Present> {
+        return Extension(extensionPoint, pluginClass, extensionName, action, ordering, OverrideKind.Present(overriden), conditions)
+    }
 
-    infix fun <T : Any, Override : OverrideKind, Ordering: OrderingKind> Extension<T, Ordering, Override>.override(
+    public infix fun <T : Any, Override : OverrideKind, Ordering: OrderingKind> Extension<T, Ordering, Override>.override(
         overriden: Extension<T, *, *>
-    ) = this.override(listOf(overriden))
+    ): Extension<T, Ordering, OverrideKind.Present> {
+        return this.override(listOf(overriden))
+    }
 }
 
 @ExtensionsDsl
-class OrderDsl {
+public class OrderDsl {
     internal val previous = mutableSetOf<Extension<*, *, *>>()
     internal val following = mutableSetOf<Extension<*, *, *>>()
 
-    fun after(vararg extensions: Extension<*, *, *>) {
+    public fun after(vararg extensions: Extension<*, *, *>) {
         previous += extensions
     }
 
-    fun before(vararg extensions: Extension<*, *, *>) {
+    public fun before(vararg extensions: Extension<*, *, *>) {
         following += extensions
     }
 }

--- a/core/src/main/kotlin/renderers/PostAction.kt
+++ b/core/src/main/kotlin/renderers/PostAction.kt
@@ -4,4 +4,4 @@
 
 package org.jetbrains.dokka.renderers
 
-fun interface PostAction : () -> Unit
+public fun interface PostAction : () -> Unit

--- a/core/src/main/kotlin/renderers/Renderer.kt
+++ b/core/src/main/kotlin/renderers/Renderer.kt
@@ -6,6 +6,6 @@ package org.jetbrains.dokka.renderers
 
 import org.jetbrains.dokka.pages.RootPageNode
 
-fun interface Renderer {
-    fun render(root: RootPageNode)
+public fun interface Renderer {
+    public fun render(root: RootPageNode)
 }

--- a/core/src/main/kotlin/transformers/documentation/DocumentableMerger.kt
+++ b/core/src/main/kotlin/transformers/documentation/DocumentableMerger.kt
@@ -6,6 +6,7 @@ package org.jetbrains.dokka.transformers.documentation
 
 import org.jetbrains.dokka.model.DModule
 
-fun interface DocumentableMerger {
-    operator fun invoke(modules: Collection<DModule>): DModule?
+public fun interface DocumentableMerger {
+    public operator fun invoke(modules: Collection<DModule>): DModule?
 }
+

--- a/core/src/main/kotlin/transformers/documentation/DocumentableToPageTranslator.kt
+++ b/core/src/main/kotlin/transformers/documentation/DocumentableToPageTranslator.kt
@@ -7,6 +7,7 @@ package org.jetbrains.dokka.transformers.documentation
 import org.jetbrains.dokka.model.DModule
 import org.jetbrains.dokka.pages.RootPageNode
 
-fun interface DocumentableToPageTranslator {
-    operator fun invoke(module: DModule): RootPageNode
+public fun interface DocumentableToPageTranslator {
+    public operator fun invoke(module: DModule): RootPageNode
 }
+

--- a/core/src/main/kotlin/transformers/documentation/DocumentableTransformer.kt
+++ b/core/src/main/kotlin/transformers/documentation/DocumentableTransformer.kt
@@ -7,6 +7,6 @@ package org.jetbrains.dokka.transformers.documentation
 import org.jetbrains.dokka.model.DModule
 import org.jetbrains.dokka.plugability.DokkaContext
 
-fun interface DocumentableTransformer {
-    operator fun invoke(original: DModule, context: DokkaContext): DModule
+public fun interface DocumentableTransformer {
+    public operator fun invoke(original: DModule, context: DokkaContext): DModule
 }

--- a/core/src/main/kotlin/transformers/documentation/PreMergeDocumentableTransformer.kt
+++ b/core/src/main/kotlin/transformers/documentation/PreMergeDocumentableTransformer.kt
@@ -8,33 +8,32 @@ import org.jetbrains.dokka.DokkaConfiguration.DokkaSourceSet
 import org.jetbrains.dokka.DokkaConfiguration.PackageOptions
 import org.jetbrains.dokka.model.DModule
 import org.jetbrains.dokka.model.Documentable
+import org.jetbrains.dokka.model.DocumentableSource
 import org.jetbrains.dokka.model.WithSources
 
-interface PreMergeDocumentableTransformer {
-    operator fun invoke(modules: List<DModule>): List<DModule>
+public interface PreMergeDocumentableTransformer {
+    public operator fun invoke(modules: List<DModule>): List<DModule>
 }
-
-/* Utils */
 
 /**
  * It is fair to assume that a given [Documentable] is not merged when seen by the [PreMergeDocumentableTransformer].
  * Therefore, it can also be assumed, that there is just a single source set connected to the given [documentable]
  * @return the single source set associated with this [documentable].
  */
-@Suppress("unused") // Receiver is used for scoping this function
-fun PreMergeDocumentableTransformer.sourceSet(documentable: Documentable): DokkaSourceSet {
+@Suppress("UnusedReceiverParameter") // Receiver is used for scoping this function
+public fun PreMergeDocumentableTransformer.sourceSet(documentable: Documentable): DokkaSourceSet {
     return documentable.sourceSets.single()
 }
 
 /**
  * @return The [PackageOptions] associated with this documentable, or null
  */
-fun PreMergeDocumentableTransformer.perPackageOptions(documentable: Documentable): PackageOptions? {
+public fun PreMergeDocumentableTransformer.perPackageOptions(documentable: Documentable): PackageOptions? {
     val packageName = documentable.dri.packageName ?: return null
     return sourceSet(documentable).perPackageOptions
         .sortedByDescending { packageOptions -> packageOptions.matchingRegex.length }
         .firstOrNull { packageOptions -> Regex(packageOptions.matchingRegex).matches(packageName) }
 }
 
-fun <T> PreMergeDocumentableTransformer.source(documentable: T) where T : Documentable, T : WithSources =
+public fun <T> PreMergeDocumentableTransformer.source(documentable: T): DocumentableSource where T : Documentable, T : WithSources =
     checkNotNull(documentable.sources[sourceSet(documentable)])

--- a/core/src/main/kotlin/transformers/pages/PageCreator.kt
+++ b/core/src/main/kotlin/transformers/pages/PageCreator.kt
@@ -6,10 +6,10 @@ package org.jetbrains.dokka.transformers.pages
 
 import org.jetbrains.dokka.pages.RootPageNode
 
-interface CreationContext
+public interface CreationContext
 
-object NoCreationContext : CreationContext
+public object NoCreationContext : CreationContext
 
-interface PageCreator<T: CreationContext> {
-    operator fun invoke(creationContext: T): RootPageNode
+public interface PageCreator<T: CreationContext> {
+    public operator fun invoke(creationContext: T): RootPageNode
 }

--- a/core/src/main/kotlin/transformers/pages/PageTransformer.kt
+++ b/core/src/main/kotlin/transformers/pages/PageTransformer.kt
@@ -6,6 +6,6 @@ package org.jetbrains.dokka.transformers.pages
 
 import org.jetbrains.dokka.pages.RootPageNode
 
-fun interface PageTransformer {
-    operator fun invoke(input: RootPageNode): RootPageNode
+public fun interface PageTransformer {
+    public operator fun invoke(input: RootPageNode): RootPageNode
 }

--- a/core/src/main/kotlin/transformers/pages/PageTransformerBuilders.kt
+++ b/core/src/main/kotlin/transformers/pages/PageTransformerBuilders.kt
@@ -7,14 +7,21 @@ package org.jetbrains.dokka.transformers.pages
 import org.jetbrains.dokka.pages.PageNode
 import org.jetbrains.dokka.pages.RootPageNode
 
-fun pageScanner(block: PageNode.() -> Unit) = PageTransformer { input -> input.invokeOnAll(block) as RootPageNode }
+public fun pageScanner(block: PageNode.() -> Unit): PageTransformer {
+    return PageTransformer { input -> input.invokeOnAll(block) as RootPageNode }
+}
 
-fun pageMapper(block: PageNode.() -> PageNode) = PageTransformer { input -> input.alterChildren(block) as RootPageNode }
+public fun pageMapper(block: PageNode.() -> PageNode): PageTransformer {
+    return PageTransformer { input -> input.alterChildren(block) as RootPageNode }
+}
 
-fun pageStructureTransformer(block: RootPageNode.() -> RootPageNode) = PageTransformer { input -> block(input) }
+public fun pageStructureTransformer(block: RootPageNode.() -> RootPageNode): PageTransformer {
+    return PageTransformer { input -> block(input) }
+}
 
-fun PageNode.invokeOnAll(block: PageNode.() -> Unit): PageNode =
+public fun PageNode.invokeOnAll(block: PageNode.() -> Unit): PageNode =
     this.also(block).also { it.children.forEach { it.invokeOnAll(block) } }
 
-fun PageNode.alterChildren(block: PageNode.() -> PageNode): PageNode =
+public fun PageNode.alterChildren(block: PageNode.() -> PageNode): PageNode =
     block(this).modified(children = this.children.map { it.alterChildren(block) })
+

--- a/core/src/main/kotlin/transformers/sources/AsyncSourceToDocumentableTranslator.kt
+++ b/core/src/main/kotlin/transformers/sources/AsyncSourceToDocumentableTranslator.kt
@@ -10,8 +10,8 @@ import org.jetbrains.dokka.DokkaConfiguration
 import org.jetbrains.dokka.model.DModule
 import org.jetbrains.dokka.plugability.DokkaContext
 
-interface AsyncSourceToDocumentableTranslator : SourceToDocumentableTranslator {
-    suspend fun invokeSuspending(sourceSet: DokkaConfiguration.DokkaSourceSet, context: DokkaContext): DModule
+public interface AsyncSourceToDocumentableTranslator : SourceToDocumentableTranslator {
+    public suspend fun invokeSuspending(sourceSet: DokkaConfiguration.DokkaSourceSet, context: DokkaContext): DModule
 
     override fun invoke(sourceSet: DokkaConfiguration.DokkaSourceSet, context: DokkaContext): DModule =
         runBlocking(Dispatchers.Default) {

--- a/core/src/main/kotlin/transformers/sources/SourceToDocumentableTranslator.kt
+++ b/core/src/main/kotlin/transformers/sources/SourceToDocumentableTranslator.kt
@@ -8,6 +8,6 @@ import org.jetbrains.dokka.DokkaConfiguration.DokkaSourceSet
 import org.jetbrains.dokka.model.DModule
 import org.jetbrains.dokka.plugability.DokkaContext
 
-fun interface SourceToDocumentableTranslator {
-    fun invoke(sourceSet: DokkaSourceSet, context: DokkaContext): DModule
+public fun interface SourceToDocumentableTranslator {
+    public fun invoke(sourceSet: DokkaSourceSet, context: DokkaContext): DModule
 }

--- a/core/src/main/kotlin/utilities/Collections.kt
+++ b/core/src/main/kotlin/utilities/Collections.kt
@@ -12,7 +12,7 @@ import org.jetbrains.dokka.InternalDokkaApi
  * locally for convenience.
  */
 @InternalDokkaApi
-inline fun <reified T : Any> Iterable<*>.firstIsInstanceOrNull(): T? {
+public inline fun <reified T : Any> Iterable<*>.firstIsInstanceOrNull(): T? {
     for (element in this) if (element is T) return element
     return null
 }
@@ -23,7 +23,7 @@ inline fun <reified T : Any> Iterable<*>.firstIsInstanceOrNull(): T? {
  * locally for convenience.
  */
 @InternalDokkaApi
-inline fun <reified T : Any> Sequence<*>.firstIsInstanceOrNull(): T? {
+public inline fun <reified T : Any> Sequence<*>.firstIsInstanceOrNull(): T? {
     for (element in this) if (element is T) return element
     return null
 }

--- a/core/src/main/kotlin/utilities/DokkaLogging.kt
+++ b/core/src/main/kotlin/utilities/DokkaLogging.kt
@@ -6,17 +6,18 @@ package org.jetbrains.dokka.utilities
 
 import java.util.concurrent.atomic.AtomicInteger
 
-interface DokkaLogger {
-    var warningsCount: Int
-    var errorsCount: Int
-    fun debug(message: String)
-    fun info(message: String)
-    fun progress(message: String)
-    fun warn(message: String)
-    fun error(message: String)
+public interface DokkaLogger {
+    public var warningsCount: Int
+    public var errorsCount: Int
+
+    public fun debug(message: String)
+    public fun info(message: String)
+    public fun progress(message: String)
+    public fun warn(message: String)
+    public fun error(message: String)
 }
 
-fun DokkaLogger.report() {
+public fun DokkaLogger.report() {
     if (warningsCount > 0 || errorsCount > 0) {
         info(
             "Generation completed with $warningsCount warning" +
@@ -29,20 +30,22 @@ fun DokkaLogger.report() {
     }
 }
 
-enum class LoggingLevel(val index: Int) {
+public enum class LoggingLevel(
+    public val index: Int
+) {
     DEBUG(0), PROGRESS(1), INFO(2), WARN(3), ERROR(4);
 }
 
 /**
  * Used to decouple the transport layer from logger and make it convenient for testing
  */
-fun interface MessageEmitter : (String) -> Unit {
-    companion object {
-        val consoleEmitter: MessageEmitter = MessageEmitter { message -> println(message) }
+public fun interface MessageEmitter : (String) -> Unit {
+    public companion object {
+        public val consoleEmitter: MessageEmitter = MessageEmitter { message -> println(message) }
     }
 }
 
-class DokkaConsoleLogger(
+public class DokkaConsoleLogger(
     private val minLevel: LoggingLevel = LoggingLevel.PROGRESS,
     private val emitter: MessageEmitter = MessageEmitter.consoleEmitter
 ) : DokkaLogger {

--- a/core/src/main/kotlin/utilities/Html.kt
+++ b/core/src/main/kotlin/utilities/Html.kt
@@ -13,11 +13,11 @@ import java.net.URLEncoder
  * Replaces & with &amp;, < with &lt; and > with &gt;
  */
 @InternalDokkaApi
-fun String.htmlEscape(): String = replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;")
+public fun String.htmlEscape(): String = replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;")
 
 @InternalDokkaApi
-fun String.urlEncoded(): String = URLEncoder.encode(this, "UTF-8")
+public fun String.urlEncoded(): String = URLEncoder.encode(this, "UTF-8")
 
 @InternalDokkaApi
-fun String.formatToEndWithHtml() =
+public fun String.formatToEndWithHtml(): String =
     if (endsWith(".html") || contains(Regex("\\.html#"))) this else "$this.html"

--- a/core/src/main/kotlin/utilities/SelfRepresentingSingletonSet.kt
+++ b/core/src/main/kotlin/utilities/SelfRepresentingSingletonSet.kt
@@ -9,7 +9,7 @@ import org.jetbrains.dokka.InternalDokkaApi
 @InternalDokkaApi
 @Suppress("DEPRECATION_ERROR")
 @Deprecated(message = "SelfRepresentingSingletonSet is an incorrect set implementation that breaks set invariants", level = DeprecationLevel.ERROR)
-interface SelfRepresentingSingletonSet<T : SelfRepresentingSingletonSet<T>> : Set<T> {
+public interface SelfRepresentingSingletonSet<T : SelfRepresentingSingletonSet<T>> : Set<T> {
     override val size: Int get() = 1
 
     override fun contains(element: T): Boolean = this == element

--- a/core/src/main/kotlin/utilities/ServiceLocator.kt
+++ b/core/src/main/kotlin/utilities/ServiceLocator.kt
@@ -13,19 +13,19 @@ import java.util.jar.JarFile
 import java.util.zip.ZipEntry
 
 @InternalDokkaApi
-data class ServiceDescriptor(val name: String, val category: String, val description: String?, val className: String)
+public data class ServiceDescriptor(val name: String, val category: String, val description: String?, val className: String)
 
 @InternalDokkaApi
-class ServiceLookupException(message: String) : Exception(message)
+public class ServiceLookupException(message: String) : Exception(message)
 
 @InternalDokkaApi
-object ServiceLocator {
-    fun <T : Any> lookup(clazz: Class<T>, category: String, implementationName: String): T {
+public object ServiceLocator {
+    public fun <T : Any> lookup(clazz: Class<T>, category: String, implementationName: String): T {
         val descriptor = lookupDescriptor(category, implementationName)
         return lookup(clazz, descriptor)
     }
 
-    fun <T : Any> lookup(
+    public fun <T : Any> lookup(
         clazz: Class<T>,
         descriptor: ServiceDescriptor
     ): T {
@@ -56,7 +56,7 @@ object ServiceLocator {
         return ServiceDescriptor(implementationName, category, properties["description"]?.toString(), className)
     }
 
-    fun URL.toFile(): File {
+    public fun URL.toFile(): File {
         assert(protocol == "file")
 
         return try {
@@ -66,7 +66,7 @@ object ServiceLocator {
         }
     }
 
-    fun allServices(category: String): List<ServiceDescriptor> {
+    public fun allServices(category: String): List<ServiceDescriptor> {
         val entries = this.javaClass.classLoader.getResources("dokka/$category")?.toList() ?: emptyList()
 
         return entries.flatMap {

--- a/core/src/main/kotlin/utilities/Uri.kt
+++ b/core/src/main/kotlin/utilities/Uri.kt
@@ -9,7 +9,7 @@ import java.net.URI
 
 @InternalDokkaApi
 @Deprecated("Deprecated for removal") // Unused in Dokka
-fun URI.relativeTo(uri: URI): URI {
+public fun URI.relativeTo(uri: URI): URI {
     // Normalize paths to remove . and .. segments
     val base = uri.normalize()
     val child = this.normalize()

--- a/core/src/main/kotlin/utilities/associateWithNotNull.kt
+++ b/core/src/main/kotlin/utilities/associateWithNotNull.kt
@@ -7,7 +7,7 @@ package org.jetbrains.dokka.utilities
 import org.jetbrains.dokka.InternalDokkaApi
 
 @InternalDokkaApi
-inline fun <K, V : Any> Iterable<K>.associateWithNotNull(valueSelector: (K) -> V?): Map<K, V> {
+public inline fun <K, V : Any> Iterable<K>.associateWithNotNull(valueSelector: (K) -> V?): Map<K, V> {
     @Suppress("UNCHECKED_CAST")
     return associateWith { valueSelector(it) }.filterValues { it != null } as Map<K, V>
 }

--- a/core/src/main/kotlin/utilities/cast.kt
+++ b/core/src/main/kotlin/utilities/cast.kt
@@ -7,6 +7,6 @@ package org.jetbrains.dokka.utilities
 import org.jetbrains.dokka.InternalDokkaApi
 
 @InternalDokkaApi
-inline fun <reified T> Any.cast(): T {
+public inline fun <reified T> Any.cast(): T {
     return this as T
 }

--- a/core/src/main/kotlin/utilities/parallelCollectionOperations.kt
+++ b/core/src/main/kotlin/utilities/parallelCollectionOperations.kt
@@ -11,16 +11,16 @@ import kotlinx.coroutines.launch
 import org.jetbrains.dokka.InternalDokkaApi
 
 @InternalDokkaApi
-suspend inline fun <A, B> Iterable<A>.parallelMap(crossinline f: suspend (A) -> B): List<B> = coroutineScope {
+public suspend inline fun <A, B> Iterable<A>.parallelMap(crossinline f: suspend (A) -> B): List<B> = coroutineScope {
     map { async { f(it) } }.awaitAll()
 }
 
 @InternalDokkaApi
-suspend inline fun <A, B> Iterable<A>.parallelMapNotNull(crossinline f: suspend (A) -> B?): List<B> = coroutineScope {
+public suspend inline fun <A, B> Iterable<A>.parallelMapNotNull(crossinline f: suspend (A) -> B?): List<B> = coroutineScope {
     map { async { f(it) } }.awaitAll().filterNotNull()
 }
 
 @InternalDokkaApi
-suspend inline fun <A> Iterable<A>.parallelForEach(crossinline f: suspend (A) -> Unit): Unit = coroutineScope {
+public suspend inline fun <A> Iterable<A>.parallelForEach(crossinline f: suspend (A) -> Unit): Unit = coroutineScope {
     forEach { launch { f(it) } }
 }

--- a/core/src/main/kotlin/validity/PreGenerationChecker.kt
+++ b/core/src/main/kotlin/validity/PreGenerationChecker.kt
@@ -4,13 +4,14 @@
 
 package org.jetbrains.dokka.validity
 
-fun interface PreGenerationChecker : () -> PreGenerationCheckerOutput {
+public fun interface PreGenerationChecker : () -> PreGenerationCheckerOutput {
 
     override fun invoke(): PreGenerationCheckerOutput
 }
 
-data class PreGenerationCheckerOutput(val result: Boolean, val messages: List<String>) {
+public data class PreGenerationCheckerOutput(val result: Boolean, val messages: List<String>) {
 
-    operator fun plus(pair: Pair<Boolean, List<String>>) =
-        Pair(result && pair.first, messages + pair.second)
+    public operator fun plus(pair: Pair<Boolean, List<String>>): Pair<Boolean, List<String>> {
+        return Pair(result && pair.first, messages + pair.second)
+    }
 }

--- a/core/test-api/api/test-api.api
+++ b/core/test-api/api/test-api.api
@@ -3,8 +3,7 @@ public final class org/jetbrains/dokka/testApi/context/MockContext : org/jetbrai
 	public synthetic fun <init> ([Lkotlin/Pair;Lorg/jetbrains/dokka/DokkaConfiguration;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun get (Lorg/jetbrains/dokka/plugability/ExtensionPoint;)Ljava/util/List;
 	public fun getConfiguration ()Lorg/jetbrains/dokka/DokkaConfiguration;
-	public fun getLogger ()Lorg/jetbrains/dokka/utilities/DokkaConsoleLogger;
-	public synthetic fun getLogger ()Lorg/jetbrains/dokka/utilities/DokkaLogger;
+	public fun getLogger ()Lorg/jetbrains/dokka/utilities/DokkaLogger;
 	public fun getUnusedPoints ()Ljava/util/Collection;
 	public fun plugin (Lkotlin/reflect/KClass;)Lorg/jetbrains/dokka/plugability/DokkaPlugin;
 	public fun single (Lorg/jetbrains/dokka/plugability/ExtensionPoint;)Ljava/lang/Object;

--- a/core/test-api/src/main/kotlin/testApi/context/MockContext.kt
+++ b/core/test-api/src/main/kotlin/testApi/context/MockContext.kt
@@ -9,13 +9,14 @@ import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.plugability.DokkaPlugin
 import org.jetbrains.dokka.plugability.ExtensionPoint
 import org.jetbrains.dokka.utilities.DokkaConsoleLogger
+import org.jetbrains.dokka.utilities.DokkaLogger
 import org.jetbrains.dokka.utilities.LoggingLevel
 import kotlin.reflect.KClass
 import kotlin.reflect.KMutableProperty
 import kotlin.reflect.full.memberProperties
 
 @Suppress("UNCHECKED_CAST") // It is only usable from tests so we do not care about safety
-class MockContext(
+public class MockContext(
     vararg extensions: Pair<ExtensionPoint<*>, (DokkaContext) -> Any>,
     private val testConfiguration: DokkaConfiguration? = null,
     private val unusedExtensionPoints: List<ExtensionPoint<*>>? = null
@@ -36,7 +37,7 @@ class MockContext(
 
     override fun <T : Any, E : ExtensionPoint<T>> single(point: E): T = get(point).single()
 
-    override val logger = DokkaConsoleLogger(LoggingLevel.DEBUG)
+    override val logger: DokkaLogger = DokkaConsoleLogger(LoggingLevel.DEBUG)
 
     override val configuration: DokkaConfiguration
         get() = testConfiguration ?: throw IllegalStateException("This mock context doesn't provide configuration")

--- a/core/test-api/src/main/kotlin/testApi/logger/TestLogger.kt
+++ b/core/test-api/src/main/kotlin/testApi/logger/TestLogger.kt
@@ -10,24 +10,24 @@ import java.util.*
 /*
  * Even in tests it be used in a concurrent environment, so needs to be thread safe
  */
-class TestLogger(private val logger: DokkaLogger) : DokkaLogger {
+public class TestLogger(private val logger: DokkaLogger) : DokkaLogger {
     override var warningsCount: Int by logger::warningsCount
     override var errorsCount: Int by logger::errorsCount
 
     private var _debugMessages = synchronizedMutableListOf<String>()
-    val debugMessages: List<String> get() = _debugMessages.toList()
+    public val debugMessages: List<String> get() = _debugMessages.toList()
 
     private var _infoMessages = synchronizedMutableListOf<String>()
-    val infoMessages: List<String> get() = _infoMessages.toList()
+    public val infoMessages: List<String> get() = _infoMessages.toList()
 
     private var _progressMessages = synchronizedMutableListOf<String>()
-    val progressMessages: List<String> get() = _progressMessages.toList()
+    public val progressMessages: List<String> get() = _progressMessages.toList()
 
     private var _warnMessages = synchronizedMutableListOf<String>()
-    val warnMessages: List<String> get() = _warnMessages.toList()
+    public val warnMessages: List<String> get() = _warnMessages.toList()
 
     private var _errorMessages = synchronizedMutableListOf<String>()
-    val errorMessages: List<String> get() = _errorMessages.toList()
+    public val errorMessages: List<String> get() = _errorMessages.toList()
 
     override fun debug(message: String) {
         _debugMessages.add(message)

--- a/core/test-api/src/main/kotlin/testApi/testRunner/TestDokkaConfigurationBuilder.kt
+++ b/core/test-api/src/main/kotlin/testApi/testRunner/TestDokkaConfigurationBuilder.kt
@@ -14,36 +14,37 @@ import org.jetbrains.dokka.model.doc.Text
 import org.jetbrains.dokka.model.properties.PropertyContainer
 import java.io.File
 
-fun dokkaConfiguration(block: TestDokkaConfigurationBuilder.() -> Unit): DokkaConfigurationImpl =
+public fun dokkaConfiguration(block: TestDokkaConfigurationBuilder.() -> Unit): DokkaConfigurationImpl =
     TestDokkaConfigurationBuilder().apply(block).build()
 
 @DslMarker
-annotation class DokkaConfigurationDsl
+public annotation class DokkaConfigurationDsl
 
+// TODO this class heavily relies on `DokkaSourceSetImpl`, should be refactored to `DokkaSourceSet`
 @DokkaConfigurationDsl
-class TestDokkaConfigurationBuilder {
+public class TestDokkaConfigurationBuilder {
 
-    var moduleName: String = "root"
+    public var moduleName: String = "root"
         set(value) {
             check(lazySourceSets.isEmpty()) { "Cannot set moduleName after adding source sets" }
             field = value
         }
-    var moduleVersion: String = "1.0-SNAPSHOT"
-    var outputDir: File = File("out")
-    var format: String = "html"
-    var offlineMode: Boolean = false
-    var cacheRoot: String? = null
-    var pluginsClasspath: List<File> = emptyList()
-    var pluginsConfigurations: MutableList<PluginConfigurationImpl> = mutableListOf()
-    var failOnWarning: Boolean = false
-    var modules: List<DokkaModuleDescriptionImpl> = emptyList()
-    var suppressObviousFunctions: Boolean = DokkaDefaults.suppressObviousFunctions
-    var includes: List<File> = emptyList()
-    var suppressInheritedMembers: Boolean = DokkaDefaults.suppressInheritedMembers
-    var delayTemplateSubstitution: Boolean = DokkaDefaults.delayTemplateSubstitution
+    public var moduleVersion: String = "1.0-SNAPSHOT"
+    public var outputDir: File = File("out")
+    public var format: String = "html"
+    public var offlineMode: Boolean = false
+    public var cacheRoot: String? = null
+    public var pluginsClasspath: List<File> = emptyList()
+    public var pluginsConfigurations: MutableList<PluginConfigurationImpl> = mutableListOf()
+    public var failOnWarning: Boolean = false
+    public var modules: List<DokkaModuleDescriptionImpl> = emptyList()
+    public var suppressObviousFunctions: Boolean = DokkaDefaults.suppressObviousFunctions
+    public var includes: List<File> = emptyList()
+    public var suppressInheritedMembers: Boolean = DokkaDefaults.suppressInheritedMembers
+    public var delayTemplateSubstitution: Boolean = DokkaDefaults.delayTemplateSubstitution
     private val lazySourceSets = mutableListOf<Lazy<DokkaSourceSetImpl>>()
 
-    fun build() = DokkaConfigurationImpl(
+    public fun build(): DokkaConfigurationImpl = DokkaConfigurationImpl(
         moduleName = moduleName,
         moduleVersion = moduleVersion,
         outputDir = outputDir,
@@ -61,82 +62,87 @@ class TestDokkaConfigurationBuilder {
         finalizeCoroutines = false
     )
 
-    fun sourceSets(block: SourceSetsBuilder.() -> Unit) {
+    public fun sourceSets(block: SourceSetsBuilder.() -> Unit) {
         lazySourceSets.addAll(SourceSetsBuilder(moduleName).apply(block))
     }
 
-    fun sourceSet(block: DokkaSourceSetBuilder.() -> Unit): Lazy<DokkaSourceSetImpl> {
+    public fun sourceSet(block: DokkaSourceSetBuilder.() -> Unit): Lazy<DokkaSourceSetImpl> {
         val lazySourceSet = lazy { DokkaSourceSetBuilder(moduleName).apply(block).build() }
         lazySourceSets.add(lazySourceSet)
         return lazySourceSet
     }
 
-    fun unattachedSourceSet(block: DokkaSourceSetBuilder.() -> Unit): DokkaSourceSetImpl {
+    public fun unattachedSourceSet(block: DokkaSourceSetBuilder.() -> Unit): DokkaSourceSetImpl {
         return DokkaSourceSetBuilder(moduleName).apply(block).build()
     }
 }
 
 @DokkaConfigurationDsl
-class SourceSetsBuilder(val moduleName: String) : ArrayList<Lazy<DokkaSourceSetImpl>>() {
-    fun sourceSet(block: DokkaSourceSetBuilder.() -> Unit): Lazy<DokkaConfiguration.DokkaSourceSet> =
-        lazy { DokkaSourceSetBuilder(moduleName).apply(block).build() }.apply(::add)
+public class SourceSetsBuilder(
+    public val moduleName: String
+) : ArrayList<Lazy<DokkaSourceSetImpl>>() {
+    public fun sourceSet(block: DokkaSourceSetBuilder.() -> Unit): Lazy<DokkaConfiguration.DokkaSourceSet> {
+        return lazy { DokkaSourceSetBuilder(moduleName).apply(block).build() }.apply(::add)
+    }
 }
 
 @DokkaConfigurationDsl
-class DokkaSourceSetBuilder(
+public class DokkaSourceSetBuilder(
     private val moduleName: String,
-    var name: String = "main",
-    var displayName: String = "JVM",
-    var classpath: List<String> = emptyList(),
-    var sourceRoots: List<String> = emptyList(),
-    var dependentSourceSets: Set<DokkaSourceSetID> = emptySet(),
-    var samples: List<String> = emptyList(),
-    var includes: List<String> = emptyList(),
+    public var name: String = "main",
+    public var displayName: String = "JVM",
+    public var classpath: List<String> = emptyList(),
+    public var sourceRoots: List<String> = emptyList(),
+    public var dependentSourceSets: Set<DokkaSourceSetID> = emptySet(),
+    public var samples: List<String> = emptyList(),
+    public var includes: List<String> = emptyList(),
     @Deprecated(message = "Use [documentedVisibilities] property for a more flexible control over documented visibilities")
-    var includeNonPublic: Boolean = false,
-    var documentedVisibilities: Set<DokkaConfiguration.Visibility> = DokkaDefaults.documentedVisibilities,
-    var reportUndocumented: Boolean = false,
-    var skipEmptyPackages: Boolean = false,
-    var skipDeprecated: Boolean = false,
-    var jdkVersion: Int = 8,
-    var languageVersion: String? = null,
-    var apiVersion: String? = null,
-    var noStdlibLink: Boolean = false,
-    var noJdkLink: Boolean = false,
-    var suppressedFiles: List<String> = emptyList(),
-    var analysisPlatform: String = "jvm",
-    var perPackageOptions: List<PackageOptionsImpl> = emptyList(),
-    var externalDocumentationLinks: List<ExternalDocumentationLinkImpl> = emptyList(),
-    var sourceLinks: List<SourceLinkDefinitionImpl> = emptyList()
+    public var includeNonPublic: Boolean = false,
+    public var documentedVisibilities: Set<DokkaConfiguration.Visibility> = DokkaDefaults.documentedVisibilities,
+    public var reportUndocumented: Boolean = false,
+    public var skipEmptyPackages: Boolean = false,
+    public var skipDeprecated: Boolean = false,
+    public var jdkVersion: Int = 8,
+    public var languageVersion: String? = null,
+    public var apiVersion: String? = null,
+    public var noStdlibLink: Boolean = false,
+    public var noJdkLink: Boolean = false,
+    public var suppressedFiles: List<String> = emptyList(),
+    public var analysisPlatform: String = "jvm",
+    public var perPackageOptions: List<PackageOptionsImpl> = emptyList(),
+    public var externalDocumentationLinks: List<ExternalDocumentationLinkImpl> = emptyList(),
+    public var sourceLinks: List<SourceLinkDefinitionImpl> = emptyList()
 ) {
     @Suppress("DEPRECATION")
-    fun build() = DokkaSourceSetImpl(
-        displayName = displayName,
-        sourceSetID = DokkaSourceSetID(moduleName, name),
-        classpath = classpath.map(::File),
-        sourceRoots = sourceRoots.map(::File).toSet(),
-        dependentSourceSets = dependentSourceSets,
-        samples = samples.map(::File).toSet(),
-        includes = includes.map(::File).toSet(),
-        includeNonPublic = includeNonPublic,
-        documentedVisibilities = documentedVisibilities,
-        reportUndocumented = reportUndocumented,
-        skipEmptyPackages = skipEmptyPackages,
-        skipDeprecated = skipDeprecated,
-        jdkVersion = jdkVersion,
-        sourceLinks = sourceLinks.toSet(),
-        perPackageOptions = perPackageOptions.toList(),
-        externalDocumentationLinks = externalDocumentationLinks.toSet(),
-        languageVersion = languageVersion,
-        apiVersion = apiVersion,
-        noStdlibLink = noStdlibLink,
-        noJdkLink = noJdkLink,
-        suppressedFiles = suppressedFiles.map(::File).toSet(),
-        analysisPlatform = Platform.fromString(analysisPlatform)
-    )
+    public fun build(): DokkaSourceSetImpl {
+        return DokkaSourceSetImpl(
+            displayName = displayName,
+            sourceSetID = DokkaSourceSetID(moduleName, name),
+            classpath = classpath.map(::File),
+            sourceRoots = sourceRoots.map(::File).toSet(),
+            dependentSourceSets = dependentSourceSets,
+            samples = samples.map(::File).toSet(),
+            includes = includes.map(::File).toSet(),
+            includeNonPublic = includeNonPublic,
+            documentedVisibilities = documentedVisibilities,
+            reportUndocumented = reportUndocumented,
+            skipEmptyPackages = skipEmptyPackages,
+            skipDeprecated = skipDeprecated,
+            jdkVersion = jdkVersion,
+            sourceLinks = sourceLinks.toSet(),
+            perPackageOptions = perPackageOptions.toList(),
+            externalDocumentationLinks = externalDocumentationLinks.toSet(),
+            languageVersion = languageVersion,
+            apiVersion = apiVersion,
+            noStdlibLink = noStdlibLink,
+            noJdkLink = noJdkLink,
+            suppressedFiles = suppressedFiles.map(::File).toSet(),
+            analysisPlatform = Platform.fromString(analysisPlatform)
+        )
+    }
 }
 
-val defaultSourceSet = DokkaSourceSetImpl(
+public val defaultSourceSet: DokkaSourceSetImpl = DokkaSourceSetImpl(
     displayName = "DEFAULT",
     sourceSetID = DokkaSourceSetID("DEFAULT", "DEFAULT"),
     classpath = emptyList(),
@@ -161,14 +167,14 @@ val defaultSourceSet = DokkaSourceSetImpl(
     analysisPlatform = Platform.DEFAULT
 )
 
-fun sourceSet(name: String): DokkaConfiguration.DokkaSourceSet {
+public fun sourceSet(name: String): DokkaConfiguration.DokkaSourceSet {
     return defaultSourceSet.copy(
         displayName = name,
         sourceSetID = defaultSourceSet.sourceSetID.copy(sourceSetName = name)
     )
 }
 
-fun dModule(
+public fun dModule(
     name: String,
     packages: List<DPackage> = emptyList(),
     documentation: SourceSetDependent<DocumentationNode> = emptyMap(),
@@ -184,7 +190,7 @@ fun dModule(
     extra = extra
 )
 
-fun dPackage(
+public fun dPackage(
     dri: DRI,
     functions: List<DFunction> = emptyList(),
     properties: List<DProperty> = emptyList(),
@@ -206,7 +212,7 @@ fun dPackage(
     extra = extra
 )
 
-fun documentationNode(vararg texts: String): DocumentationNode {
+public fun documentationNode(vararg texts: String): DocumentationNode {
     return DocumentationNode(
         texts.toList()
             .map { Description(CustomDocTag(listOf(Text(it)), name = "MARKDOWN_FILE")) })

--- a/core/test-api/src/main/kotlin/testApi/testRunner/TestRunner.kt
+++ b/core/test-api/src/main/kotlin/testApi/testRunner/TestRunner.kt
@@ -23,14 +23,15 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 // TODO: take dokka configuration from file
-abstract class AbstractTest<M : TestMethods, T : TestBuilder<M>, D : DokkaTestGenerator<M>>(
+public abstract class AbstractTest<M : TestMethods, T : TestBuilder<M>, D : DokkaTestGenerator<M>>(
     protected val testBuilder: () -> T,
     protected val dokkaTestGenerator: (DokkaConfiguration, DokkaLogger, M, List<DokkaPlugin>) -> D,
     protected val logger: TestLogger,
 ) {
-    protected fun getTestDataDir(name: String) =
-        File("src/test/resources/$name").takeIf { it.exists() }?.toPath()
+    protected fun getTestDataDir(name: String): Path {
+        return File("src/test/resources/$name").takeIf { it.exists() }?.toPath()
             ?: throw InvalidPathException(name, "Cannot be found")
+    }
 
     /**
      * @param cleanupOutput if set to true, any temporary files will be cleaned up after execution. If set to false,
@@ -198,38 +199,38 @@ abstract class AbstractTest<M : TestMethods, T : TestBuilder<M>, D : DokkaTestGe
             ?.replaceAfter(".jar", "")
     }
 
-    protected val stdlibExternalDocumentationLink = ExternalDocumentationLinkImpl(
+    protected val stdlibExternalDocumentationLink: ExternalDocumentationLinkImpl = ExternalDocumentationLinkImpl(
         URL("https://kotlinlang.org/api/latest/jvm/stdlib/"),
         URL("https://kotlinlang.org/api/latest/jvm/stdlib/package-list")
     )
 
-    companion object {
+    public companion object {
         private val filePathRegex = Regex("""[\n^](\/[\w|\-]+)+(\.\w+)?\s*\n""")
     }
 }
 
-interface TestMethods
+public interface TestMethods
 
-open class CoreTestMethods(
-    open val pluginsSetupStage: (DokkaContext) -> Unit,
-    open val verificationStage: (() -> Unit) -> Unit,
-    open val documentablesCreationStage: (List<DModule>) -> Unit,
-    open val documentablesMergingStage: (DModule) -> Unit,
-    open val documentablesTransformationStage: (DModule) -> Unit,
-    open val pagesGenerationStage: (RootPageNode) -> Unit,
-    open val pagesTransformationStage: (RootPageNode) -> Unit,
-    open val renderingStage: (RootPageNode, DokkaContext) -> Unit,
+public open class CoreTestMethods(
+    public open val pluginsSetupStage: (DokkaContext) -> Unit,
+    public open val verificationStage: (() -> Unit) -> Unit,
+    public open val documentablesCreationStage: (List<DModule>) -> Unit,
+    public open val documentablesMergingStage: (DModule) -> Unit,
+    public open val documentablesTransformationStage: (DModule) -> Unit,
+    public open val pagesGenerationStage: (RootPageNode) -> Unit,
+    public open val pagesTransformationStage: (RootPageNode) -> Unit,
+    public open val renderingStage: (RootPageNode, DokkaContext) -> Unit,
 ) : TestMethods
 
-abstract class TestBuilder<M : TestMethods> {
-    abstract fun build(): M
+public abstract class TestBuilder<M : TestMethods> {
+    public abstract fun build(): M
 }
 
-abstract class DokkaTestGenerator<T : TestMethods>(
+public abstract class DokkaTestGenerator<T : TestMethods>(
     protected val configuration: DokkaConfiguration,
     protected val logger: DokkaLogger,
     protected val testMethods: T,
     protected val additionalPlugins: List<DokkaPlugin> = emptyList(),
 ) {
-    abstract fun generate()
+    public abstract fun generate()
 }

--- a/integration-tests/cli/src/main/kotlin/org/jetbrains/dokka/it/cli/AbstractCliIntegrationTest.kt
+++ b/integration-tests/cli/src/main/kotlin/org/jetbrains/dokka/it/cli/AbstractCliIntegrationTest.kt
@@ -9,7 +9,7 @@ import java.io.File
 import kotlin.test.BeforeTest
 import kotlin.test.assertTrue
 
-abstract class AbstractCliIntegrationTest : AbstractIntegrationTest() {
+public abstract class AbstractCliIntegrationTest : AbstractIntegrationTest() {
 
     protected val cliJarFile: File by lazy {
         File(tempFolder, "dokka.jar")
@@ -20,7 +20,7 @@ abstract class AbstractCliIntegrationTest : AbstractIntegrationTest() {
     }
 
     @BeforeTest
-    fun copyJarFiles() {
+    public fun copyJarFiles() {
         val cliJarPathEnvironmentKey = "CLI_JAR_PATH"
         val cliJarFile = File(System.getenv(cliJarPathEnvironmentKey))
         assertTrue(

--- a/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleCachingIntegrationTest.kt
+++ b/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleCachingIntegrationTest.kt
@@ -6,7 +6,6 @@ package org.jetbrains.dokka.it.gradle
 
 import org.gradle.util.GradleVersion
 import java.io.File
-import kotlin.test.assertContains
 import kotlin.test.assertTrue
 
 abstract class AbstractGradleCachingIntegrationTest : AbstractGradleIntegrationTest() {
@@ -128,12 +127,13 @@ abstract class AbstractGradleCachingIntegrationTest : AbstractGradleIntegrationT
             "Anchors should not have hashes inside"
         )
 
-        assertContains(
-            stylesDir.resolve("logo-styles.css").readText(),
-            "--dokka-logo-image-url: url('https://upload.wikimedia.org/wikipedia/commons/9/9d/Ubuntu_logo.svg');",
+        assertTrue(
+            stylesDir.resolve("logo-styles.css").readText().contains(
+                "--dokka-logo-image-url: url('https://upload.wikimedia.org/wikipedia/commons/9/9d/Ubuntu_logo.svg');",
+            )
         )
         assertTrue(stylesDir.resolve("custom-style-to-add.css").isFile)
-        assertContains(stylesDir.resolve("custom-style-to-add.css").readText(), "/* custom stylesheet */")
+        assertTrue(stylesDir.resolve("custom-style-to-add.css").readText().contains("/* custom stylesheet */"))
         allHtmlFiles().forEach { file ->
             if(file.name != "navigation.html") assertTrue("custom-style-to-add.css" in file.readText(), "custom styles not added to html file ${file.name}")
         }

--- a/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/BasicGradleIntegrationTest.kt
+++ b/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/BasicGradleIntegrationTest.kt
@@ -134,12 +134,13 @@ class BasicGradleIntegrationTest : AbstractGradleIntegrationTest() {
             "Anchors should not have hashes inside"
         )
 
-        assertContains(
-            stylesDir.resolve("logo-styles.css").readText(),
-            "--dokka-logo-image-url: url('https://upload.wikimedia.org/wikipedia/commons/9/9d/Ubuntu_logo.svg');",
+        assertTrue(
+            stylesDir.resolve("logo-styles.css").readText().contains(
+                "--dokka-logo-image-url: url('https://upload.wikimedia.org/wikipedia/commons/9/9d/Ubuntu_logo.svg');",
+            )
         )
         assertTrue(stylesDir.resolve("custom-style-to-add.css").isFile)
-        assertContains(stylesDir.resolve("custom-style-to-add.css").readText(), "/* custom stylesheet */")
+        assertTrue(stylesDir.resolve("custom-style-to-add.css").readText().contains("/* custom stylesheet */"))
         allHtmlFiles().forEach { file ->
             if (file.name != "navigation.html") assertTrue(
                 "custom-style-to-add.css" in file.readText(),

--- a/integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleIntegrationTest.kt
+++ b/integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleIntegrationTest.kt
@@ -14,17 +14,17 @@ import java.io.File
 import java.net.URI
 import kotlin.test.BeforeTest
 
-abstract class AbstractGradleIntegrationTest : AbstractIntegrationTest() {
+public abstract class AbstractGradleIntegrationTest : AbstractIntegrationTest() {
 
     @BeforeTest
-    fun copyTemplates() {
+    public fun copyTemplates() {
         File("projects").listFiles().orEmpty()
             .filter { it.isFile }
             .filter { it.name.startsWith("template.") }
             .forEach { file -> file.copyTo(File(tempFolder, file.name)) }
     }
 
-    fun createGradleRunner(
+    public fun createGradleRunner(
         buildVersions: BuildVersions,
         vararg arguments: String,
         jvmArgs: List<String> = listOf("-Xmx2G", "-XX:MaxMetaspaceSize=1G")
@@ -47,7 +47,7 @@ abstract class AbstractGradleIntegrationTest : AbstractIntegrationTest() {
             .withJvmArguments(jvmArgs)
     }
 
-    fun GradleRunner.buildRelaxed(): BuildResult {
+    public fun GradleRunner.buildRelaxed(): BuildResult {
         return try {
             build()
         } catch (e: Throwable) {

--- a/integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/BuildVersions.kt
+++ b/integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/BuildVersions.kt
@@ -6,12 +6,12 @@ package org.jetbrains.dokka.it.gradle
 
 import org.gradle.util.GradleVersion
 
-data class BuildVersions(
+public data class BuildVersions(
     val gradleVersion: GradleVersion,
     val kotlinVersion: String,
     val androidGradlePluginVersion: String? = null,
 ) {
-    constructor(
+    public constructor(
         gradleVersion: String,
         kotlinVersion: String,
         androidGradlePluginVersion: String? = null
@@ -30,8 +30,8 @@ data class BuildVersions(
         }
     }
 
-    companion object {
-        fun permutations(
+    public companion object {
+        public fun permutations(
             gradleVersions: List<String>,
             kotlinVersions: List<String>,
             androidGradlePluginVersions: List<String?> = listOf(null)

--- a/integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/TestEnvironment.kt
+++ b/integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/TestEnvironment.kt
@@ -4,8 +4,8 @@
 
 package org.jetbrains.dokka.it.gradle
 
-object TestEnvironment {
-    val isExhaustive = checkNotNull(System.getenv("isExhaustive")) {
+public object TestEnvironment {
+    public val isExhaustive: Boolean = checkNotNull(System.getenv("isExhaustive")) {
         "Missing `isExhaustive` environment variable"
     }.toBoolean()
 }
@@ -13,6 +13,6 @@ object TestEnvironment {
 /**
  * Will only return values if [TestEnvironment.isExhaustive] is set to true
  */
-inline fun <reified T> ifExhaustive(vararg values: T): Array<out T> {
+public inline fun <reified T> ifExhaustive(vararg values: T): Array<out T> {
     return if (TestEnvironment.isExhaustive) values else emptyArray()
 }

--- a/integration-tests/maven/src/integrationTest/kotlin/org/jetbrains/dokka/it/maven/MavenIntegrationTest.kt
+++ b/integration-tests/maven/src/integrationTest/kotlin/org/jetbrains/dokka/it/maven/MavenIntegrationTest.kt
@@ -60,15 +60,16 @@ class MavenIntegrationTest : AbstractIntegrationTest() {
             assertNoEmptySpans(file)
         }
 
-        assertContains(
-            stylesDir.resolve("logo-styles.css").readText(),
-            "--dokka-logo-image-url: url('https://upload.wikimedia.org/wikipedia/commons/9/9d/Ubuntu_logo.svg');",
+        assertTrue(
+            stylesDir.resolve("logo-styles.css").readText().contains(
+                "--dokka-logo-image-url: url('https://upload.wikimedia.org/wikipedia/commons/9/9d/Ubuntu_logo.svg');",
+            )
         )
         assertTrue(stylesDir.resolve("custom-style-to-add.css").isFile)
         projectDir.allHtmlFiles().forEach { file ->
             if(file.name != "navigation.html") assertTrue("custom-style-to-add.css" in file.readText(), "custom styles not added to html file ${file.name}")
         }
-        assertContains(stylesDir.resolve("custom-style-to-add.css").readText(), """/* custom stylesheet */""")
+        assertTrue(stylesDir.resolve("custom-style-to-add.css").readText().contains("""/* custom stylesheet */"""))
         assertTrue(imagesDir.resolve("custom-resource.svg").isFile)
 
         assertConfiguredVisibility(projectDir)

--- a/integration-tests/src/main/kotlin/org/jetbrains/dokka/it/AbstractIntegrationTest.kt
+++ b/integration-tests/src/main/kotlin/org/jetbrains/dokka/it/AbstractIntegrationTest.kt
@@ -13,19 +13,19 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
-abstract class AbstractIntegrationTest {
+public abstract class AbstractIntegrationTest {
 
     @field:TempDir
-    lateinit var tempFolder: File
+    public lateinit var tempFolder: File
 
-    val projectDir get() = File(tempFolder, "project")
+    public val projectDir: File get() = File(tempFolder, "project")
 
-    fun File.allDescendentsWithExtension(extension: String): Sequence<File> =
+    public fun File.allDescendentsWithExtension(extension: String): Sequence<File> =
         this.walkTopDown().filter { it.isFile && it.extension == extension }
 
-    fun File.allHtmlFiles(): Sequence<File> = allDescendentsWithExtension("html")
+    public fun File.allHtmlFiles(): Sequence<File> = allDescendentsWithExtension("html")
 
-    fun File.allGfmFiles(): Sequence<File> = allDescendentsWithExtension("md")
+    public fun File.allGfmFiles(): Sequence<File> = allDescendentsWithExtension("md")
 
     protected fun assertContainsNoErrorClass(file: File) {
         val fileText = file.readText()

--- a/integration-tests/src/main/kotlin/org/jetbrains/dokka/it/TestOutputCopier.kt
+++ b/integration-tests/src/main/kotlin/org/jetbrains/dokka/it/TestOutputCopier.kt
@@ -7,11 +7,11 @@ package org.jetbrains.dokka.it
 import java.io.File
 import kotlin.test.AfterTest
 
-interface TestOutputCopier {
-    val projectOutputLocation: File
+public interface TestOutputCopier {
+    public val projectOutputLocation: File
 
     @AfterTest
-    fun copyToLocation() {
+    public fun copyToLocation() {
         System.getenv("DOKKA_TEST_OUTPUT_PATH")?.also { location ->
             println("Copying to ${File(location).absolutePath}")
             projectOutputLocation.copyRecursively(File(location))

--- a/integration-tests/src/main/kotlin/org/jetbrains/dokka/it/gitSubmoduleUtils.kt
+++ b/integration-tests/src/main/kotlin/org/jetbrains/dokka/it/gitSubmoduleUtils.kt
@@ -9,13 +9,14 @@ import org.eclipse.jgit.storage.file.FileRepositoryBuilder
 import java.io.File
 import java.nio.file.Path
 
-fun AbstractIntegrationTest.copyAndApplyGitDiff(diffFile: File) =
+public fun AbstractIntegrationTest.copyAndApplyGitDiff(diffFile: File) {
     copyGitDiffFileToParent(diffFile).let(::applyGitDiffFromFile)
+}
 
-fun AbstractIntegrationTest.copyGitDiffFileToParent(originalDiffFile: File) =
+public fun AbstractIntegrationTest.copyGitDiffFileToParent(originalDiffFile: File): File =
     originalDiffFile.copyTo(File(projectDir.parent, originalDiffFile.name))
 
-fun AbstractIntegrationTest.applyGitDiffFromFile(diffFile: File) {
+public fun AbstractIntegrationTest.applyGitDiffFromFile(diffFile: File) {
     val projectGitFile = projectDir.resolve(".git")
     val git = if (projectGitFile.exists()) {
         if (projectGitFile.isFile) {
@@ -38,7 +39,7 @@ fun AbstractIntegrationTest.applyGitDiffFromFile(diffFile: File) {
 private fun removeGitFile(repository: Path) =
     repository.toFile()
         .listFiles().orEmpty()
-        .filter { it.name.lowercase() == ".git" }
+        .filter { it.name.toLowerCase() == ".git" }
         .forEach { it.delete() }
 
 

--- a/integration-tests/src/main/kotlin/org/jetbrains/dokka/it/processUtils.kt
+++ b/integration-tests/src/main/kotlin/org/jetbrains/dokka/it/processUtils.kt
@@ -9,12 +9,12 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import kotlin.concurrent.thread
 
-class ProcessResult(
-    val exitCode: Int,
-    val output: String
+public class ProcessResult(
+    public val exitCode: Int,
+    public val output: String
 )
 
-fun Process.awaitProcessResult() = runBlocking {
+public fun Process.awaitProcessResult(): ProcessResult = runBlocking {
     val exitCode = async { awaitExitCode() }
     val output = async { awaitOutput() }
     ProcessResult(

--- a/plugins/all-modules-page/api/all-modules-page.api
+++ b/plugins/all-modules-page/api/all-modules-page.api
@@ -30,7 +30,6 @@ public final class org/jetbrains/dokka/allModulesPage/AllModulesPagePlugin : org
 	public final fun getAllModulesPageGeneration ()Lorg/jetbrains/dokka/plugability/Extension;
 	public final fun getAllModulesPageTransformer ()Lorg/jetbrains/dokka/plugability/ExtensionPoint;
 	public final fun getBaseLocationProviderFactory ()Lorg/jetbrains/dokka/plugability/Extension;
-	public final fun getDokkaBase ()Lorg/jetbrains/dokka/base/DokkaBase;
 	public final fun getExternalModuleLinkResolver ()Lorg/jetbrains/dokka/plugability/ExtensionPoint;
 	public final fun getMultiModuleLinkResolver ()Lorg/jetbrains/dokka/plugability/Extension;
 	public final fun getMultimoduleLocationProvider ()Lorg/jetbrains/dokka/plugability/Extension;
@@ -62,8 +61,7 @@ public class org/jetbrains/dokka/allModulesPage/MultimoduleLocationProvider : or
 
 public final class org/jetbrains/dokka/allModulesPage/MultimoduleLocationProvider$Factory : org/jetbrains/dokka/base/resolvers/local/LocationProviderFactory {
 	public fun <init> (Lorg/jetbrains/dokka/plugability/DokkaContext;)V
-	public fun getLocationProvider (Lorg/jetbrains/dokka/pages/RootPageNode;)Lorg/jetbrains/dokka/allModulesPage/MultimoduleLocationProvider;
-	public synthetic fun getLocationProvider (Lorg/jetbrains/dokka/pages/RootPageNode;)Lorg/jetbrains/dokka/base/resolvers/local/LocationProvider;
+	public fun getLocationProvider (Lorg/jetbrains/dokka/pages/RootPageNode;)Lorg/jetbrains/dokka/base/resolvers/local/LocationProvider;
 }
 
 public final class org/jetbrains/dokka/allModulesPage/MultimodulePageCreator : org/jetbrains/dokka/transformers/pages/PageCreator {

--- a/plugins/all-modules-page/src/main/kotlin/AllModulesPageGeneration.kt
+++ b/plugins/all-modules-page/src/main/kotlin/AllModulesPageGeneration.kt
@@ -16,7 +16,7 @@ import org.jetbrains.dokka.templates.TemplatingPlugin
 import org.jetbrains.dokka.templates.TemplatingResult
 import org.jetbrains.dokka.transformers.pages.CreationContext
 
-class AllModulesPageGeneration(private val context: DokkaContext) : Generation {
+public class AllModulesPageGeneration(private val context: DokkaContext) : Generation {
 
     private val allModulesPagePlugin by lazy { context.plugin<AllModulesPagePlugin>() }
     private val templatingPlugin by lazy { context.plugin<TemplatingPlugin>() }
@@ -44,34 +44,37 @@ class AllModulesPageGeneration(private val context: DokkaContext) : Generation {
         runPostActions()
     }
 
-    override val generationName = "index page for project"
+    override val generationName: String = "index page for project"
 
-    fun createAllModulesPage(allModulesContext: DefaultAllModulesContext) =
+    public fun createAllModulesPage(allModulesContext: DefaultAllModulesContext): RootPageNode =
         allModulesPagePlugin.querySingle { allModulesPageCreator }.invoke(allModulesContext)
 
-    fun transformAllModulesPage(pages: RootPageNode) =
+    public fun transformAllModulesPage(pages: RootPageNode): RootPageNode =
         allModulesPagePlugin.query { allModulesPageTransformer }.fold(pages) { acc, t -> t(acc) }
 
-    fun render(transformedPages: RootPageNode) {
+    public fun render(transformedPages: RootPageNode) {
         context.single(CoreExtensions.renderer).render(transformedPages)
     }
 
-    fun runPostActions() {
+    public fun runPostActions() {
         context[CoreExtensions.postActions].forEach { it() }
     }
 
-    fun processSubmodules() =
-        templatingPlugin.querySingle { submoduleTemplateProcessor }
+    public fun processSubmodules(): DefaultAllModulesContext {
+        return templatingPlugin.querySingle { submoduleTemplateProcessor }
             .process(context.configuration.modules)
             .let { DefaultAllModulesContext(it) }
+    }
 
-    fun processMultiModule(root: RootPageNode) =
+    public fun processMultiModule(root: RootPageNode) {
         templatingPlugin.querySingle { multimoduleTemplateProcessor }.process(root)
+    }
 
-    fun finishProcessingSubmodules() =
+    public fun finishProcessingSubmodules() {
         templatingPlugin.query { templateProcessingStrategy }.forEach { it.finish(context.configuration.outputDir) }
+    }
 
-    data class DefaultAllModulesContext(val nonEmptyModules: List<String>) : CreationContext {
-        constructor(templating: TemplatingResult) : this(templating.modules)
+    public data class DefaultAllModulesContext(val nonEmptyModules: List<String>) : CreationContext {
+        public constructor(templating: TemplatingResult) : this(templating.modules)
     }
 }

--- a/plugins/all-modules-page/src/main/kotlin/AllModulesPagePlugin.kt
+++ b/plugins/all-modules-page/src/main/kotlin/AllModulesPagePlugin.kt
@@ -8,47 +8,47 @@ import org.jetbrains.dokka.CoreExtensions
 import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.base.resolvers.local.DokkaLocationProviderFactory
 import org.jetbrains.dokka.base.resolvers.local.LocationProviderFactory
-import org.jetbrains.dokka.plugability.DokkaPlugin
-import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
-import org.jetbrains.dokka.plugability.PluginApiPreviewAcknowledgement
+import org.jetbrains.dokka.generation.Generation
+import org.jetbrains.dokka.plugability.*
+import org.jetbrains.dokka.templates.CommandHandler
 import org.jetbrains.dokka.templates.TemplatingPlugin
 import org.jetbrains.dokka.transformers.pages.PageCreator
 import org.jetbrains.dokka.transformers.pages.PageTransformer
 
-class AllModulesPagePlugin : DokkaPlugin() {
+public class AllModulesPagePlugin : DokkaPlugin() {
 
-    val partialLocationProviderFactory by extensionPoint<LocationProviderFactory>()
-    val allModulesPageCreator by extensionPoint<PageCreator<AllModulesPageGeneration.DefaultAllModulesContext>>()
-    val allModulesPageTransformer by extensionPoint<PageTransformer>()
-    val externalModuleLinkResolver by extensionPoint<ExternalModuleLinkResolver>()
+    public val partialLocationProviderFactory: ExtensionPoint<LocationProviderFactory> by extensionPoint()
+    public val allModulesPageCreator: ExtensionPoint<PageCreator<AllModulesPageGeneration.DefaultAllModulesContext>> by extensionPoint()
+    public val allModulesPageTransformer: ExtensionPoint<PageTransformer> by extensionPoint()
+    public val externalModuleLinkResolver: ExtensionPoint<ExternalModuleLinkResolver> by extensionPoint()
 
-    val allModulesPageCreators by extending {
+    public val allModulesPageCreators: Extension<PageCreator<AllModulesPageGeneration.DefaultAllModulesContext>, *, *> by extending {
         allModulesPageCreator providing ::MultimodulePageCreator
     }
 
-    val dokkaBase by lazy { plugin<DokkaBase>() }
+    private val dokkaBase: DokkaBase by lazy { plugin<DokkaBase>() }
 
-    val multimoduleLocationProvider by extending {
+    public val multimoduleLocationProvider: Extension<LocationProviderFactory, *, *> by extending {
         (dokkaBase.locationProviderFactory
                 providing MultimoduleLocationProvider::Factory
                 override plugin<DokkaBase>().locationProvider)
     }
 
-    val baseLocationProviderFactory by extending {
+    public val baseLocationProviderFactory: Extension<LocationProviderFactory, *, *> by extending {
         partialLocationProviderFactory providing ::DokkaLocationProviderFactory
     }
 
-    val allModulesPageGeneration by extending {
+    public val allModulesPageGeneration: Extension<Generation, *, *> by extending {
         (CoreExtensions.generation
                 providing ::AllModulesPageGeneration
                 override dokkaBase.singleGeneration)
     }
 
-    val resolveLinkCommandHandler by extending {
+    public val resolveLinkCommandHandler: Extension<CommandHandler, *, *> by extending {
         plugin<TemplatingPlugin>().directiveBasedCommandHandlers providing ::ResolveLinkCommandHandler
     }
 
-    val multiModuleLinkResolver by extending {
+    public val multiModuleLinkResolver: Extension<ExternalModuleLinkResolver, *, *> by extending {
         externalModuleLinkResolver providing ::DefaultExternalModuleLinkResolver
     }
 

--- a/plugins/all-modules-page/src/main/kotlin/ExternalModuleLinkResolver.kt
+++ b/plugins/all-modules-page/src/main/kotlin/ExternalModuleLinkResolver.kt
@@ -16,12 +16,14 @@ import org.jetbrains.dokka.plugability.query
 import java.io.File
 import java.net.URL
 
-interface ExternalModuleLinkResolver {
-    fun resolve(dri: DRI, fileContext: File): String?
-    fun resolveLinkToModuleIndex(moduleName: String): String?
+public interface ExternalModuleLinkResolver {
+    public fun resolve(dri: DRI, fileContext: File): String?
+    public fun resolveLinkToModuleIndex(moduleName: String): String?
 }
 
-class DefaultExternalModuleLinkResolver(val context: DokkaContext) : ExternalModuleLinkResolver {
+public class DefaultExternalModuleLinkResolver(
+    public val context: DokkaContext
+) : ExternalModuleLinkResolver {
     private val elpFactory = context.plugin<DokkaBase>().query { externalLocationProviderFactory }
     private val externalDocumentations by lazy(::setupExternalDocumentations)
     private val elps by lazy {

--- a/plugins/all-modules-page/src/main/kotlin/MultimoduleLocationProvider.kt
+++ b/plugins/all-modules-page/src/main/kotlin/MultimoduleLocationProvider.kt
@@ -6,6 +6,7 @@ package org.jetbrains.dokka.allModulesPage
 
 import org.jetbrains.dokka.allModulesPage.MultimodulePageCreator.Companion.MULTIMODULE_PACKAGE_PLACEHOLDER
 import org.jetbrains.dokka.base.resolvers.local.DokkaBaseLocationProvider
+import org.jetbrains.dokka.base.resolvers.local.LocationProvider
 import org.jetbrains.dokka.base.resolvers.local.LocationProviderFactory
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.model.DisplaySourceSet
@@ -16,9 +17,10 @@ import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.plugability.plugin
 import org.jetbrains.dokka.plugability.querySingle
 
-open class MultimoduleLocationProvider(private val root: RootPageNode, dokkaContext: DokkaContext,
-                                       val extension: String = ".html") :
-    DokkaBaseLocationProvider(root, dokkaContext) {
+public open class MultimoduleLocationProvider(
+    private val root: RootPageNode, dokkaContext: DokkaContext,
+    public val extension: String = ".html"
+) : DokkaBaseLocationProvider(root, dokkaContext) {
 
     private val defaultLocationProvider =
         dokkaContext.plugin<AllModulesPagePlugin>().querySingle { partialLocationProviderFactory }
@@ -26,21 +28,32 @@ open class MultimoduleLocationProvider(private val root: RootPageNode, dokkaCont
     private val externalModuleLinkResolver =
         dokkaContext.plugin<AllModulesPagePlugin>().querySingle { externalModuleLinkResolver }
 
-    override fun resolve(dri: DRI, sourceSets: Set<DisplaySourceSet>, context: PageNode?) =
-        if (dri == MultimodulePageCreator.MULTIMODULE_ROOT_DRI) pathToRoot(root) + "index"
-        else dri.takeIf { it.packageName == MULTIMODULE_PACKAGE_PLACEHOLDER }?.classNames
-            ?.let(externalModuleLinkResolver::resolveLinkToModuleIndex)
+    override fun resolve(dri: DRI, sourceSets: Set<DisplaySourceSet>, context: PageNode?): String? {
+        return if (dri == MultimodulePageCreator.MULTIMODULE_ROOT_DRI) {
+            pathToRoot(root) + "index"
+        } else {
+            dri.takeIf { it.packageName == MULTIMODULE_PACKAGE_PLACEHOLDER }
+                ?.classNames
+                ?.let(externalModuleLinkResolver::resolveLinkToModuleIndex)
+        }
+    }
 
-    override fun resolve(node: PageNode, context: PageNode?, skipExtension: Boolean) =
-        if (node is ContentPage && MultimodulePageCreator.MULTIMODULE_ROOT_DRI in node.dri) pathToRoot(root) + "index" + if (!skipExtension) extension else ""
-        else defaultLocationProvider.resolve(node, context, skipExtension)
+    override fun resolve(node: PageNode, context: PageNode?, skipExtension: Boolean): String? {
+        return if (node is ContentPage && MultimodulePageCreator.MULTIMODULE_ROOT_DRI in node.dri) {
+            pathToRoot(root) + "index" + if (!skipExtension) extension else ""
+        } else {
+            defaultLocationProvider.resolve(node, context, skipExtension)
+        }
+    }
 
     override fun pathToRoot(from: PageNode): String = defaultLocationProvider.pathToRoot(from)
 
     override fun ancestors(node: PageNode): List<PageNode> = listOf(root)
 
-    class Factory(private val context: DokkaContext) : LocationProviderFactory {
-        override fun getLocationProvider(pageNode: RootPageNode) =
+    public class Factory(
+        private val context: DokkaContext
+    ) : LocationProviderFactory {
+        override fun getLocationProvider(pageNode: RootPageNode): LocationProvider =
             MultimoduleLocationProvider(pageNode, context)
     }
 }

--- a/plugins/all-modules-page/src/main/kotlin/MultimodulePageCreator.kt
+++ b/plugins/all-modules-page/src/main/kotlin/MultimodulePageCreator.kt
@@ -25,11 +25,9 @@ import org.jetbrains.dokka.utilities.DokkaLogger
 import org.jetbrains.dokka.analysis.kotlin.internal.InternalKotlinAnalysisPlugin
 import java.io.File
 
-class MultimodulePageCreator(
+public class MultimodulePageCreator(
     private val context: DokkaContext,
 ) : PageCreator<AllModulesPageGeneration.DefaultAllModulesContext> {
-    private val logger: DokkaLogger = context.logger
-
     private val commentsConverter by lazy { context.plugin<DokkaBase>().querySingle { commentsToContentConverter } }
     private val signatureProvider by lazy { context.plugin<DokkaBase>().querySingle { signatureProvider } }
     private val moduleDocumentationReader by lazy { context.plugin<InternalKotlinAnalysisPlugin>().querySingle { moduleAndPackageDocumentationReader } }
@@ -109,8 +107,9 @@ class MultimodulePageCreator(
         else firstChildParagraph
     }
 
-    companion object {
-        const val MULTIMODULE_PACKAGE_PLACEHOLDER = ".ext"
-        val MULTIMODULE_ROOT_DRI = DRI(packageName = MULTIMODULE_PACKAGE_PLACEHOLDER, classNames = "allModules")
+    public companion object {
+        public const val MULTIMODULE_PACKAGE_PLACEHOLDER: String = ".ext"
+        public val MULTIMODULE_ROOT_DRI: DRI =
+            DRI(packageName = MULTIMODULE_PACKAGE_PLACEHOLDER, classNames = "allModules")
     }
 }

--- a/plugins/all-modules-page/src/main/kotlin/ResolveLinkCommandHandler.kt
+++ b/plugins/all-modules-page/src/main/kotlin/ResolveLinkCommandHandler.kt
@@ -15,7 +15,7 @@ import org.jsoup.nodes.Element
 import org.jsoup.parser.Tag
 import java.io.File
 
-class ResolveLinkCommandHandler(context: DokkaContext) : CommandHandler {
+public class ResolveLinkCommandHandler(context: DokkaContext) : CommandHandler {
 
     private val externalModuleLinkResolver =
         context.plugin<AllModulesPagePlugin>().querySingle { externalModuleLinkResolver }

--- a/plugins/android-documentation/src/main/kotlin/AndroidDocumentationPlugin.kt
+++ b/plugins/android-documentation/src/main/kotlin/AndroidDocumentationPlugin.kt
@@ -8,12 +8,15 @@ import org.jetbrains.dokka.android.transformers.HideTagDocumentableFilter
 import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.plugability.DokkaPlugin
 import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
+import org.jetbrains.dokka.plugability.Extension
 import org.jetbrains.dokka.plugability.PluginApiPreviewAcknowledgement
+import org.jetbrains.dokka.transformers.documentation.PreMergeDocumentableTransformer
 
-class AndroidDocumentationPlugin : DokkaPlugin() {
+public class AndroidDocumentationPlugin : DokkaPlugin() {
+
     private val dokkaBase by lazy { plugin<DokkaBase>() }
 
-    val suppressedByHideTagDocumentableFilter by extending {
+    public val suppressedByHideTagDocumentableFilter: Extension<PreMergeDocumentableTransformer, *, *> by extending {
         dokkaBase.preMergeDocumentableTransformer providing ::HideTagDocumentableFilter order { before(dokkaBase.emptyPackagesFilter) }
     }
 

--- a/plugins/android-documentation/src/main/kotlin/transformers/HideTagDocumentableFilter.kt
+++ b/plugins/android-documentation/src/main/kotlin/transformers/HideTagDocumentableFilter.kt
@@ -10,7 +10,7 @@ import org.jetbrains.dokka.model.dfs
 import org.jetbrains.dokka.model.doc.CustomTagWrapper
 import org.jetbrains.dokka.plugability.DokkaContext
 
-class HideTagDocumentableFilter(val dokkaContext: DokkaContext) :
+public class HideTagDocumentableFilter(public val dokkaContext: DokkaContext) :
     SuppressedByConditionDocumentableFilterTransformer(dokkaContext) {
 
     override fun shouldBeSuppressed(d: Documentable): Boolean =

--- a/plugins/base/api/base.api
+++ b/plugins/base/api/base.api
@@ -1,7 +1,6 @@
 public final class org/jetbrains/dokka/analysis/AnalysisContext : java/io/Closeable {
 	public fun <init> (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V
-	public fun close ()Ljava/lang/Void;
-	public synthetic fun close ()V
+	public fun close ()V
 	public final fun component1 ()Ljava/lang/Object;
 	public final fun component2 ()Ljava/lang/Object;
 	public final fun getEnvironment ()Ljava/lang/Object;
@@ -277,8 +276,7 @@ public final class org/jetbrains/dokka/base/renderers/PackageListService$Compani
 
 public final class org/jetbrains/dokka/base/renderers/RootCreator : org/jetbrains/dokka/transformers/pages/PageTransformer {
 	public static final field INSTANCE Lorg/jetbrains/dokka/base/renderers/RootCreator;
-	public fun invoke (Lorg/jetbrains/dokka/pages/RootPageNode;)Lorg/jetbrains/dokka/pages/RendererSpecificRootPage;
-	public synthetic fun invoke (Lorg/jetbrains/dokka/pages/RootPageNode;)Lorg/jetbrains/dokka/pages/RootPageNode;
+	public fun invoke (Lorg/jetbrains/dokka/pages/RootPageNode;)Lorg/jetbrains/dokka/pages/RootPageNode;
 }
 
 public abstract interface class org/jetbrains/dokka/base/renderers/TabSortingStrategy {
@@ -412,8 +410,7 @@ public final class org/jetbrains/dokka/base/renderers/html/NavigationPage : org/
 	public final fun getModuleName ()Ljava/lang/String;
 	public fun getName ()Ljava/lang/String;
 	public final fun getRoot ()Lorg/jetbrains/dokka/base/renderers/html/NavigationNode;
-	public fun getStrategy ()Lorg/jetbrains/dokka/pages/RenderingStrategy$Callback;
-	public synthetic fun getStrategy ()Lorg/jetbrains/dokka/pages/RenderingStrategy;
+	public fun getStrategy ()Lorg/jetbrains/dokka/pages/RenderingStrategy;
 	public fun modified (Ljava/lang/String;Ljava/util/List;)Lorg/jetbrains/dokka/base/renderers/html/NavigationPage;
 	public synthetic fun modified (Ljava/lang/String;Ljava/util/List;)Lorg/jetbrains/dokka/pages/PageNode;
 }
@@ -1103,7 +1100,7 @@ public final class org/jetbrains/dokka/base/transformers/documentables/CallableE
 
 public final class org/jetbrains/dokka/base/transformers/documentables/CallableExtensions$Key : org/jetbrains/dokka/model/properties/ExtraProperty$Key {
 	public synthetic fun mergeStrategyFor (Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
-	public fun mergeStrategyFor (Lorg/jetbrains/dokka/base/transformers/documentables/CallableExtensions;Lorg/jetbrains/dokka/base/transformers/documentables/CallableExtensions;)Lorg/jetbrains/dokka/model/properties/MergeStrategy$Replace;
+	public fun mergeStrategyFor (Lorg/jetbrains/dokka/base/transformers/documentables/CallableExtensions;Lorg/jetbrains/dokka/base/transformers/documentables/CallableExtensions;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
 }
 
 public final class org/jetbrains/dokka/base/transformers/documentables/ClashingDriIdentifier : org/jetbrains/dokka/model/properties/ExtraProperty {
@@ -1504,8 +1501,8 @@ public class org/jetbrains/dokka/base/translators/documentables/PageContentBuild
 	public static synthetic fun link$default (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Ljava/lang/String;Ljava/lang/String;Lorg/jetbrains/dokka/pages/Kind;Ljava/util/Set;Ljava/util/Set;Lorg/jetbrains/dokka/model/properties/PropertyContainer;ILjava/lang/Object;)V
 	public static synthetic fun link$default (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Ljava/lang/String;Lorg/jetbrains/dokka/links/DRI;Lorg/jetbrains/dokka/pages/Kind;Ljava/util/Set;Ljava/util/Set;Lorg/jetbrains/dokka/model/properties/PropertyContainer;ILjava/lang/Object;)V
 	public static synthetic fun link$default (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/links/DRI;Lorg/jetbrains/dokka/pages/Kind;Ljava/util/Set;Ljava/util/Set;Lorg/jetbrains/dokka/model/properties/PropertyContainer;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public final fun linkNode (Ljava/lang/String;Lorg/jetbrains/dokka/links/DRI;Lorg/jetbrains/dokka/pages/DCI;Ljava/util/Set;Ljava/util/Set;Lorg/jetbrains/dokka/model/properties/PropertyContainer;)Lorg/jetbrains/dokka/pages/ContentDRILink;
-	public static synthetic fun linkNode$default (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Ljava/lang/String;Lorg/jetbrains/dokka/links/DRI;Lorg/jetbrains/dokka/pages/DCI;Ljava/util/Set;Ljava/util/Set;Lorg/jetbrains/dokka/model/properties/PropertyContainer;ILjava/lang/Object;)Lorg/jetbrains/dokka/pages/ContentDRILink;
+	public final fun linkNode (Ljava/lang/String;Lorg/jetbrains/dokka/links/DRI;Lorg/jetbrains/dokka/pages/DCI;Ljava/util/Set;Ljava/util/Set;Lorg/jetbrains/dokka/model/properties/PropertyContainer;)Lorg/jetbrains/dokka/pages/ContentLink;
+	public static synthetic fun linkNode$default (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Ljava/lang/String;Lorg/jetbrains/dokka/links/DRI;Lorg/jetbrains/dokka/pages/DCI;Ljava/util/Set;Ljava/util/Set;Lorg/jetbrains/dokka/model/properties/PropertyContainer;ILjava/lang/Object;)Lorg/jetbrains/dokka/pages/ContentLink;
 	public final fun list (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Lkotlin/jvm/functions/Function2;)V
 	public static synthetic fun list$default (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 	public final fun multiBlock (Ljava/lang/String;ILorg/jetbrains/dokka/pages/Kind;Ljava/lang/Iterable;Ljava/util/Set;Ljava/util/Set;Lorg/jetbrains/dokka/model/properties/PropertyContainer;ZZLjava/util/List;ZLkotlin/jvm/functions/Function3;)V

--- a/plugins/base/base-test-utils/src/main/kotlin/renderers/JsoupUtils.kt
+++ b/plugins/base/base-test-utils/src/main/kotlin/renderers/JsoupUtils.kt
@@ -8,7 +8,7 @@ import org.jsoup.nodes.Element
 import org.jsoup.nodes.Node
 import org.jsoup.nodes.TextNode
 
-fun Element.match(vararg matchers: Any, ignoreSpanWithTokenStyle:Boolean = false): Unit =
+public fun Element.match(vararg matchers: Any, ignoreSpanWithTokenStyle:Boolean = false): Unit =
     childNodes()
         .let { list ->
             if(ignoreSpanWithTokenStyle) {
@@ -25,25 +25,28 @@ fun Element.match(vararg matchers: Any, ignoreSpanWithTokenStyle:Boolean = false
         .zip(matchers)
         .forEach { (n, m) -> m.accepts(n, ignoreSpan = ignoreSpanWithTokenStyle) }
 
-open class Tag(val name: String, vararg val matchers: Any, val expectedClasses: List<String> = emptyList())
-class Div(vararg matchers: Any) : Tag("div", *matchers)
-class P(vararg matchers: Any) : Tag("p", *matchers)
-class Span(vararg matchers: Any) : Tag("span", *matchers)
-class A(vararg matchers: Any) : Tag("a", *matchers)
-class B(vararg matchers: Any) : Tag("b", *matchers)
-class I(vararg matchers: Any) : Tag("i", *matchers)
-class STRIKE(vararg matchers: Any) : Tag("strike", *matchers)
+public open class Tag(
+    public val name: String,
+    public vararg val matchers: Any,
+    public val expectedClasses: List<String> = emptyList()
+)
+public class Div(vararg matchers: Any) : Tag("div", *matchers)
+public class P(vararg matchers: Any) : Tag("p", *matchers)
+public class Span(vararg matchers: Any) : Tag("span", *matchers)
+public class A(vararg matchers: Any) : Tag("a", *matchers)
+public class B(vararg matchers: Any) : Tag("b", *matchers)
+public class I(vararg matchers: Any) : Tag("i", *matchers)
+public class STRIKE(vararg matchers: Any) : Tag("strike", *matchers)
+public class BlockQuote(vararg matchers: Any) : Tag("blockquote", *matchers)
+public class Dl(vararg matchers: Any) : Tag("dl", *matchers)
+public class Dt(vararg matchers: Any) : Tag("dt", *matchers)
+public class Dd(vararg matchers: Any) : Tag("dd", *matchers)
+public class Var(vararg matchers: Any) : Tag("var", *matchers)
+public class U(vararg matchers: Any) : Tag("u", *matchers)
+public object Wbr : Tag("wbr")
+public object Br : Tag("br")
 
-class BlockQuote(vararg matchers: Any) : Tag("blockquote", *matchers)
-class Dl(vararg matchers: Any) : Tag("dl", *matchers)
-class Dt(vararg matchers: Any) : Tag("dt", *matchers)
-class Dd(vararg matchers: Any) : Tag("dd", *matchers)
-class Var(vararg matchers: Any) : Tag("var", *matchers)
-class U(vararg matchers: Any) : Tag("u", *matchers)
-object Wbr : Tag("wbr")
-object Br : Tag("br")
-
-fun Tag.withClasses(vararg classes: String) = Tag(name, *matchers, expectedClasses = classes.toList())
+public fun Tag.withClasses(vararg classes: String): Tag = Tag(name, *matchers, expectedClasses = classes.toList())
 
 private fun Any.accepts(n: Node, ignoreSpan:Boolean = true) {
     when (this) {

--- a/plugins/base/base-test-utils/src/main/kotlin/renderers/RenderingOnlyTestBase.kt
+++ b/plugins/base/base-test-utils/src/main/kotlin/renderers/RenderingOnlyTestBase.kt
@@ -6,7 +6,7 @@ package renderers
 
 import org.jetbrains.dokka.testApi.context.MockContext
 
-abstract class RenderingOnlyTestBase<T> {
-    abstract val context: MockContext
-    abstract val renderedContent: T
+public abstract class RenderingOnlyTestBase<T> {
+    public abstract val context: MockContext
+    public abstract val renderedContent: T
 }

--- a/plugins/base/base-test-utils/src/main/kotlin/renderers/SignatureUtils.kt
+++ b/plugins/base/base-test-utils/src/main/kotlin/renderers/SignatureUtils.kt
@@ -10,14 +10,14 @@ import org.jsoup.select.Elements
 import utils.Tag
 import utils.TestOutputWriter
 
-fun TestOutputWriter.renderedContent(path: String = "root/example.html"): Element =
+public fun TestOutputWriter.renderedContent(path: String = "root/example.html"): Element =
     contents.getValue(path).let { Jsoup.parse(it) }.select("#content")
         .single()
 
-fun Element.signature(): Elements = select("div.symbol.monospace")
-fun Element.tab(tabName: String): Elements = select("div[data-togglable=\"$tabName\"]")
-fun Element.firstSignature(): Element = signature().first() ?: throw NoSuchElementException("No signature found")
-fun Element.lastSignature(): Element = signature().last() ?: throw NoSuchElementException("No signature found")
+public fun Element.signature(): Elements = select("div.symbol.monospace")
+public fun Element.tab(tabName: String): Elements = select("div[data-togglable=\"$tabName\"]")
+public fun Element.firstSignature(): Element = signature().first() ?: throw NoSuchElementException("No signature found")
+public fun Element.lastSignature(): Element = signature().last() ?: throw NoSuchElementException("No signature found")
 
-class Parameters(vararg matchers: Any) : Tag("span", *matchers, expectedClasses = listOf("parameters"))
-class Parameter(vararg matchers: Any) : Tag("span", *matchers, expectedClasses = listOf("parameter"))
+public class Parameters(vararg matchers: Any) : Tag("span", *matchers, expectedClasses = listOf("parameters"))
+public class Parameter(vararg matchers: Any) : Tag("span", *matchers, expectedClasses = listOf("parameter"))

--- a/plugins/base/base-test-utils/src/main/kotlin/renderers/TestPage.kt
+++ b/plugins/base/base-test-utils/src/main/kotlin/renderers/TestPage.kt
@@ -15,7 +15,7 @@ import org.jetbrains.dokka.pages.*
 import org.jetbrains.dokka.utilities.DokkaConsoleLogger
 import org.jetbrains.dokka.utilities.LoggingLevel
 
-fun testPage(callback: PageContentBuilder.DocumentableContentBuilder.() -> Unit): RawTestPage {
+public fun testPage(callback: PageContentBuilder.DocumentableContentBuilder.() -> Unit): RawTestPage {
     val content = PageContentBuilder(
         EmptyCommentConverter,
         KotlinSignatureProvider(EmptyCommentConverter, DokkaConsoleLogger(LoggingLevel.DEBUG)),
@@ -29,7 +29,7 @@ fun testPage(callback: PageContentBuilder.DocumentableContentBuilder.() -> Unit)
     return RawTestPage(content)
 }
 
-class RawTestPage(
+public class RawTestPage(
     override val content: ContentNode,
     override val name: String = "testPage",
     override val dri: Set<DRI> = setOf(DRI.topLevel),

--- a/plugins/base/base-test-utils/src/main/kotlin/testRunner/baseTestApi.kt
+++ b/plugins/base/base-test-utils/src/main/kotlin/testRunner/baseTestApi.kt
@@ -21,52 +21,54 @@ import org.jetbrains.dokka.utilities.DokkaConsoleLogger
 import org.jetbrains.dokka.utilities.DokkaLogger
 import org.jetbrains.dokka.utilities.LoggingLevel
 
-class BaseDokkaTestGenerator(
+public class BaseDokkaTestGenerator(
     configuration: DokkaConfiguration,
     logger: DokkaLogger,
     testMethods: BaseTestMethods,
     additionalPlugins: List<DokkaPlugin> = emptyList()
 ) : DokkaTestGenerator<BaseTestMethods>(configuration, logger, testMethods, additionalPlugins) {
 
-    override fun generate() = with(testMethods) {
-        val dokkaGenerator = DokkaGenerator(configuration, logger)
+    override fun generate() {
+        with(testMethods) {
+            val dokkaGenerator = DokkaGenerator(configuration, logger)
 
-        val context =
-            dokkaGenerator.initializePlugins(configuration, logger, additionalPlugins)
-        pluginsSetupStage(context)
+            val context =
+                dokkaGenerator.initializePlugins(configuration, logger, additionalPlugins)
+            pluginsSetupStage(context)
 
-        val singleModuleGeneration = context.single(CoreExtensions.generation) as SingleModuleGeneration
+            val singleModuleGeneration = context.single(CoreExtensions.generation) as SingleModuleGeneration
 
-        val modulesFromPlatforms = singleModuleGeneration.createDocumentationModels()
-        documentablesCreationStage(modulesFromPlatforms)
+            val modulesFromPlatforms = singleModuleGeneration.createDocumentationModels()
+            documentablesCreationStage(modulesFromPlatforms)
 
-        verificationStage { singleModuleGeneration.validityCheck(context) }
+            verificationStage { singleModuleGeneration.validityCheck(context) }
 
-        val filteredModules = singleModuleGeneration.transformDocumentationModelBeforeMerge(modulesFromPlatforms)
-        documentablesFirstTransformationStep(filteredModules)
+            val filteredModules = singleModuleGeneration.transformDocumentationModelBeforeMerge(modulesFromPlatforms)
+            documentablesFirstTransformationStep(filteredModules)
 
-        val documentationModel = singleModuleGeneration.mergeDocumentationModels(filteredModules)
-        documentablesMergingStage(documentationModel!!)
+            val documentationModel = singleModuleGeneration.mergeDocumentationModels(filteredModules)
+            documentablesMergingStage(documentationModel!!)
 
-        val transformedDocumentation = singleModuleGeneration.transformDocumentationModelAfterMerge(documentationModel)
-        documentablesTransformationStage(transformedDocumentation)
+            val transformedDocumentation = singleModuleGeneration.transformDocumentationModelAfterMerge(documentationModel)
+            documentablesTransformationStage(transformedDocumentation)
 
-        val pages = singleModuleGeneration.createPages(transformedDocumentation)
-        pagesGenerationStage(pages)
+            val pages = singleModuleGeneration.createPages(transformedDocumentation)
+            pagesGenerationStage(pages)
 
-        val transformedPages = singleModuleGeneration.transformPages(pages)
-        pagesTransformationStage(transformedPages)
+            val transformedPages = singleModuleGeneration.transformPages(pages)
+            pagesTransformationStage(transformedPages)
 
-        singleModuleGeneration.render(transformedPages)
-        renderingStage(transformedPages, context)
+            singleModuleGeneration.render(transformedPages)
+            renderingStage(transformedPages, context)
 
-        singleModuleGeneration.runPostActions()
+            singleModuleGeneration.runPostActions()
 
-        singleModuleGeneration.reportAfterRendering()
+            singleModuleGeneration.reportAfterRendering()
+        }
     }
 }
 
-data class BaseTestMethods(
+public data class BaseTestMethods(
     override val pluginsSetupStage: (DokkaContext) -> Unit,
     override val verificationStage: (() -> Unit) -> Unit,
     override val documentablesCreationStage: (List<DModule>) -> Unit,
@@ -87,31 +89,35 @@ data class BaseTestMethods(
     renderingStage,
 )
 
-class BaseTestBuilder : TestBuilder<BaseTestMethods>() {
-    var pluginsSetupStage: (DokkaContext) -> Unit = {}
-    var verificationStage: (() -> Unit) -> Unit = {}
-    var documentablesCreationStage: (List<DModule>) -> Unit = {}
-    var preMergeDocumentablesTransformationStage: (List<DModule>) -> Unit = {}
-    var documentablesMergingStage: (DModule) -> Unit = {}
-    var documentablesTransformationStage: (DModule) -> Unit = {}
-    var pagesGenerationStage: (RootPageNode) -> Unit = {}
-    var pagesTransformationStage: (RootPageNode) -> Unit = {}
-    var renderingStage: (RootPageNode, DokkaContext) -> Unit = { _, _ -> }
+public class BaseTestBuilder : TestBuilder<BaseTestMethods>() {
+    public var pluginsSetupStage: (DokkaContext) -> Unit = {}
+    public var verificationStage: (() -> Unit) -> Unit = {}
+    public var documentablesCreationStage: (List<DModule>) -> Unit = {}
+    public var preMergeDocumentablesTransformationStage: (List<DModule>) -> Unit = {}
+    public var documentablesMergingStage: (DModule) -> Unit = {}
+    public var documentablesTransformationStage: (DModule) -> Unit = {}
+    public var pagesGenerationStage: (RootPageNode) -> Unit = {}
+    public var pagesTransformationStage: (RootPageNode) -> Unit = {}
+    public var renderingStage: (RootPageNode, DokkaContext) -> Unit = { _, _ -> }
 
-    override fun build() = BaseTestMethods(
-        pluginsSetupStage,
-        verificationStage,
-        documentablesCreationStage,
-        preMergeDocumentablesTransformationStage,
-        documentablesMergingStage,
-        documentablesTransformationStage,
-        pagesGenerationStage,
-        pagesTransformationStage,
-        renderingStage
-    )
+    override fun build(): BaseTestMethods {
+        return BaseTestMethods(
+            pluginsSetupStage,
+            verificationStage,
+            documentablesCreationStage,
+            preMergeDocumentablesTransformationStage,
+            documentablesMergingStage,
+            documentablesTransformationStage,
+            pagesGenerationStage,
+            pagesTransformationStage,
+            renderingStage
+        )
+    }
 }
 
-abstract class BaseAbstractTest(logger: TestLogger = TestLogger(DokkaConsoleLogger(LoggingLevel.DEBUG))) : AbstractTest<BaseTestMethods, BaseTestBuilder, BaseDokkaTestGenerator>(
+public abstract class BaseAbstractTest(
+    logger: TestLogger = TestLogger(DokkaConsoleLogger(LoggingLevel.DEBUG))
+) : AbstractTest<BaseTestMethods, BaseTestBuilder, BaseDokkaTestGenerator>(
     ::BaseTestBuilder,
     ::BaseDokkaTestGenerator,
     logger,

--- a/plugins/base/base-test-utils/src/main/kotlin/utils/TestOutputWriter.kt
+++ b/plugins/base/base-test-utils/src/main/kotlin/utils/TestOutputWriter.kt
@@ -8,15 +8,16 @@ import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.base.renderers.OutputWriter
 import org.jetbrains.dokka.plugability.DokkaPlugin
 import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
+import org.jetbrains.dokka.plugability.Extension
 import org.jetbrains.dokka.plugability.PluginApiPreviewAcknowledgement
 import java.util.*
 
-class TestOutputWriterPlugin(failOnOverwrite: Boolean = true) : DokkaPlugin() {
-    val writer = TestOutputWriter(failOnOverwrite)
+public class TestOutputWriterPlugin(failOnOverwrite: Boolean = true) : DokkaPlugin() {
+    public val writer: TestOutputWriter = TestOutputWriter(failOnOverwrite)
 
     private val dokkaBase by lazy { plugin<DokkaBase>() }
 
-    val testWriter by extending {
+    public val testWriter: Extension<OutputWriter, *, *> by extending {
         (dokkaBase.outputWriter
                 with writer
                 override dokkaBase.fileWriter)
@@ -27,10 +28,12 @@ class TestOutputWriterPlugin(failOnOverwrite: Boolean = true) : DokkaPlugin() {
         PluginApiPreviewAcknowledgement
 }
 
-class TestOutputWriter(private val failOnOverwrite: Boolean = true) : OutputWriter {
-    val contents: Map<String, String> get() = _contents
-
+public class TestOutputWriter(
+    private val failOnOverwrite: Boolean = true
+) : OutputWriter {
+    public val contents: Map<String, String> get() = _contents
     private val _contents = Collections.synchronizedMap(mutableMapOf<String, String>())
+
     override suspend fun write(path: String, text: String, ext: String) {
         val fullPath = "$path$ext"
         _contents.putIfAbsent(fullPath, text)?.also {
@@ -38,6 +41,7 @@ class TestOutputWriter(private val failOnOverwrite: Boolean = true) : OutputWrit
         }
     }
 
-    override suspend fun writeResources(pathFrom: String, pathTo: String) =
+    override suspend fun writeResources(pathFrom: String, pathTo: String) {
         write(pathTo, "*** content of $pathFrom ***", "")
+    }
 }

--- a/plugins/base/base-test-utils/src/main/kotlin/utils/assertHtmlEqualsIgnoringWhitespace.kt
+++ b/plugins/base/base-test-utils/src/main/kotlin/utils/assertHtmlEqualsIgnoringWhitespace.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertEquals
  * Parses it using JSOUP, trims whitespace at the end of the line and asserts if they are equal
  * parsing is required to unify the formatting
  */
-fun assertHtmlEqualsIgnoringWhitespace(expected: String, actual: String) {
+public fun assertHtmlEqualsIgnoringWhitespace(expected: String, actual: String) {
     val ignoreFormattingSettings = Document.OutputSettings().indentAmount(0).outline(true)
     assertEquals(
         Jsoup.parse(expected).outputSettings(ignoreFormattingSettings).outerHtml().trimSpacesAtTheEndOfLine(),

--- a/plugins/base/src/main/kotlin/DokkaBase.kt
+++ b/plugins/base/src/main/kotlin/DokkaBase.kt
@@ -30,67 +30,70 @@ import org.jetbrains.dokka.base.transformers.pages.sourcelinks.SourceLinksTransf
 import org.jetbrains.dokka.base.transformers.pages.tags.CustomTagContentProvider
 import org.jetbrains.dokka.base.transformers.pages.tags.SinceKotlinTagContentProvider
 import org.jetbrains.dokka.base.translators.documentables.DefaultDocumentableToPageTranslator
-import org.jetbrains.dokka.plugability.DokkaPlugin
-import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
-import org.jetbrains.dokka.plugability.PluginApiPreviewAcknowledgement
+import org.jetbrains.dokka.generation.Generation
+import org.jetbrains.dokka.plugability.*
+import org.jetbrains.dokka.renderers.Renderer
+import org.jetbrains.dokka.transformers.documentation.DocumentableMerger
+import org.jetbrains.dokka.transformers.documentation.DocumentableToPageTranslator
+import org.jetbrains.dokka.transformers.documentation.DocumentableTransformer
 import org.jetbrains.dokka.transformers.documentation.PreMergeDocumentableTransformer
 import org.jetbrains.dokka.transformers.pages.PageTransformer
 
 @Suppress("unused")
-class DokkaBase : DokkaPlugin() {
+public class DokkaBase : DokkaPlugin() {
 
-    val preMergeDocumentableTransformer by extensionPoint<PreMergeDocumentableTransformer>()
-    val pageMergerStrategy by extensionPoint<PageMergerStrategy>()
-    val commentsToContentConverter by extensionPoint<CommentsToContentConverter>()
-    val customTagContentProvider by extensionPoint<CustomTagContentProvider>()
-    val signatureProvider by extensionPoint<SignatureProvider>()
-    val locationProviderFactory by extensionPoint<LocationProviderFactory>()
-    val externalLocationProviderFactory by extensionPoint<ExternalLocationProviderFactory>()
-    val outputWriter by extensionPoint<OutputWriter>()
-    val htmlPreprocessors by extensionPoint<PageTransformer>()
+    public val preMergeDocumentableTransformer: ExtensionPoint<PreMergeDocumentableTransformer> by extensionPoint()
+    public val pageMergerStrategy: ExtensionPoint<PageMergerStrategy> by extensionPoint()
+    public val commentsToContentConverter: ExtensionPoint<CommentsToContentConverter> by extensionPoint()
+    public val customTagContentProvider: ExtensionPoint<CustomTagContentProvider> by extensionPoint()
+    public val signatureProvider: ExtensionPoint<SignatureProvider> by extensionPoint()
+    public val locationProviderFactory: ExtensionPoint<LocationProviderFactory> by extensionPoint()
+    public val externalLocationProviderFactory: ExtensionPoint<ExternalLocationProviderFactory> by extensionPoint()
+    public val outputWriter: ExtensionPoint<OutputWriter> by extensionPoint()
+    public val htmlPreprocessors: ExtensionPoint<PageTransformer> by extensionPoint()
 
     @Deprecated("It is not used anymore")
-    val tabSortingStrategy by extensionPoint<TabSortingStrategy>()
-    val immediateHtmlCommandConsumer by extensionPoint<ImmediateHtmlCommandConsumer>()
+    public val tabSortingStrategy: ExtensionPoint<TabSortingStrategy> by extensionPoint()
+    public val immediateHtmlCommandConsumer: ExtensionPoint<ImmediateHtmlCommandConsumer> by extensionPoint()
 
 
-    val singleGeneration by extending {
+    public val singleGeneration: Extension<Generation, *, *> by extending {
         CoreExtensions.generation providing ::SingleModuleGeneration
     }
 
-    val documentableMerger by extending {
+    public val documentableMerger: Extension<DocumentableMerger, *, *> by extending {
         CoreExtensions.documentableMerger providing ::DefaultDocumentableMerger
     }
 
-    val deprecatedDocumentableFilter by extending {
+    public val deprecatedDocumentableFilter: Extension<PreMergeDocumentableTransformer, *, *> by extending {
         preMergeDocumentableTransformer providing ::DeprecatedDocumentableFilterTransformer
     }
 
-    val suppressedDocumentableFilter by extending {
+    public val suppressedDocumentableFilter: Extension<PreMergeDocumentableTransformer, *, *> by extending {
         preMergeDocumentableTransformer providing ::SuppressedByConfigurationDocumentableFilterTransformer
     }
 
-    val suppressedBySuppressTagDocumentableFilter by extending {
+    public val suppressedBySuppressTagDocumentableFilter: Extension<PreMergeDocumentableTransformer, *, *> by extending {
         preMergeDocumentableTransformer providing ::SuppressTagDocumentableFilter
     }
 
-    val documentableVisibilityFilter by extending {
+    public val documentableVisibilityFilter: Extension<PreMergeDocumentableTransformer, *, *> by extending {
         preMergeDocumentableTransformer providing ::DocumentableVisibilityFilterTransformer
     }
 
-    val obviousFunctionsVisbilityFilter by extending {
+    public val obviousFunctionsVisbilityFilter: Extension<PreMergeDocumentableTransformer, *, *> by extending {
         preMergeDocumentableTransformer providing ::ObviousFunctionsDocumentableFilterTransformer
     }
 
-    val inheritedEntriesVisbilityFilter by extending {
+    public val inheritedEntriesVisbilityFilter: Extension<PreMergeDocumentableTransformer, *, *> by extending {
         preMergeDocumentableTransformer providing ::InheritedEntriesDocumentableFilterTransformer
     }
 
-    val kotlinArrayDocumentableReplacer by extending {
+    public val kotlinArrayDocumentableReplacer: Extension<PreMergeDocumentableTransformer, *, *> by extending {
         preMergeDocumentableTransformer providing ::KotlinArrayDocumentableReplacerTransformer
     }
 
-    val emptyPackagesFilter by extending {
+    public val emptyPackagesFilter: Extension<PreMergeDocumentableTransformer, *, *> by extending {
         preMergeDocumentableTransformer providing ::EmptyPackagesFilterTransformer order {
             after(
                 deprecatedDocumentableFilter,
@@ -103,124 +106,127 @@ class DokkaBase : DokkaPlugin() {
         }
     }
 
-    val emptyModulesFilter by extending {
+    public val emptyModulesFilter: Extension<PreMergeDocumentableTransformer, *, *> by extending {
         preMergeDocumentableTransformer with EmptyModulesFilterTransformer() order {
             after(emptyPackagesFilter)
         }
     }
 
-    val modulesAndPackagesDocumentation by extending {
+    public val modulesAndPackagesDocumentation: Extension<PreMergeDocumentableTransformer, *, *> by extending {
         preMergeDocumentableTransformer providing ::ModuleAndPackageDocumentationTransformer
     }
 
-    val actualTypealiasAdder by extending {
+    public val actualTypealiasAdder: Extension<DocumentableTransformer, *, *> by extending {
         CoreExtensions.documentableTransformer with ActualTypealiasAdder()
     }
 
-    val kotlinSignatureProvider by extending {
+    public val kotlinSignatureProvider: Extension<SignatureProvider, *, *> by extending {
         signatureProvider providing ::KotlinSignatureProvider
     }
 
-    val sinceKotlinTransformer by extending {
-        CoreExtensions.documentableTransformer providing ::SinceKotlinTransformer applyIf { SinceKotlinTransformer.shouldDisplaySinceKotlin() } order {
+    public val sinceKotlinTransformer: Extension<DocumentableTransformer, *, *> by extending {
+        CoreExtensions.documentableTransformer providing ::SinceKotlinTransformer applyIf {
+            SinceKotlinTransformer.shouldDisplaySinceKotlin()
+        } order {
             before(extensionsExtractor)
         }
     }
 
-    val inheritorsExtractor by extending {
+    public val inheritorsExtractor: Extension<DocumentableTransformer, *, *> by extending {
         CoreExtensions.documentableTransformer with InheritorsExtractorTransformer()
     }
 
-    val undocumentedCodeReporter by extending {
+    public val undocumentedCodeReporter: Extension<DocumentableTransformer, *, *> by extending {
         CoreExtensions.documentableTransformer with ReportUndocumentedTransformer()
     }
 
-    val extensionsExtractor by extending {
+    public val extensionsExtractor: Extension<DocumentableTransformer, *, *> by extending {
         CoreExtensions.documentableTransformer with ExtensionExtractorTransformer()
     }
 
-    val documentableToPageTranslator by extending {
+    public val documentableToPageTranslator: Extension<DocumentableToPageTranslator, *, *> by extending {
         CoreExtensions.documentableToPageTranslator providing ::DefaultDocumentableToPageTranslator
     }
 
-    val docTagToContentConverter by extending {
+    public val docTagToContentConverter: Extension<CommentsToContentConverter, *, *> by extending {
         commentsToContentConverter with DocTagToContentConverter()
     }
 
-    val sinceKotlinTagContentProvider by extending {
-        customTagContentProvider with SinceKotlinTagContentProvider applyIf { SinceKotlinTransformer.shouldDisplaySinceKotlin() }
-    }
-
-    val pageMerger by extending {
-        CoreExtensions.pageTransformer providing ::PageMerger order {
+    public val sinceKotlinTagContentProvider: Extension<CustomTagContentProvider, *, *> by extending {
+        customTagContentProvider with SinceKotlinTagContentProvider applyIf {
+            SinceKotlinTransformer.shouldDisplaySinceKotlin()
         }
     }
 
-    val sourceSetMerger by extending {
+    public val pageMerger: Extension<PageTransformer, *, *> by extending {
+        CoreExtensions.pageTransformer providing ::PageMerger
+    }
+
+    public val sourceSetMerger: Extension<PageTransformer, *, *> by extending {
         CoreExtensions.pageTransformer providing ::SourceSetMergingPageTransformer
     }
 
-    val fallbackMerger by extending {
+    public val fallbackMerger: Extension<PageMergerStrategy, *, *> by extending {
         pageMergerStrategy providing { ctx -> FallbackPageMergerStrategy(ctx.logger) }
     }
 
-    val sameMethodNameMerger by extending {
+    public val sameMethodNameMerger: Extension<PageMergerStrategy, *, *> by extending {
         pageMergerStrategy providing { ctx -> SameMethodNamePageMergerStrategy(ctx.logger) } order {
             before(fallbackMerger)
         }
     }
 
-    val htmlRenderer by extending {
+    public val htmlRenderer: Extension<Renderer, *, *> by extending {
         CoreExtensions.renderer providing ::HtmlRenderer
     }
 
-    val locationProvider by extending {
+    public val locationProvider: Extension<LocationProviderFactory, *, *> by extending {
         locationProviderFactory providing ::DokkaLocationProviderFactory
     }
 
-    val javadocLocationProvider by extending {
+    public val javadocLocationProvider: Extension<ExternalLocationProviderFactory, *, *> by extending {
         externalLocationProviderFactory providing ::JavadocExternalLocationProviderFactory
     }
 
-    val dokkaLocationProvider by extending {
+    public val dokkaLocationProvider: Extension<ExternalLocationProviderFactory, *, *> by extending {
         externalLocationProviderFactory providing ::DefaultExternalLocationProviderFactory
     }
 
-    val fileWriter by extending {
+    public val fileWriter: Extension<OutputWriter, *, *> by extending {
         outputWriter providing ::FileWriter
     }
 
-    val rootCreator by extending {
+    public val rootCreator: Extension<PageTransformer, *, *> by extending {
         htmlPreprocessors with RootCreator applyIf { !delayTemplateSubstitution }
     }
 
-    val defaultSamplesTransformer by extending {
+    public val defaultSamplesTransformer: Extension<PageTransformer, *, *> by extending {
         CoreExtensions.pageTransformer providing ::DefaultSamplesTransformer order {
             before(pageMerger)
         }
     }
 
-    val sourceLinksTransformer by extending {
+    public val sourceLinksTransformer: Extension<PageTransformer, *, *> by extending {
         htmlPreprocessors providing ::SourceLinksTransformer order { after(rootCreator) }
     }
 
-    val navigationPageInstaller by extending {
+    public val navigationPageInstaller: Extension<PageTransformer, *, *> by extending {
         htmlPreprocessors providing ::NavigationPageInstaller order { after(rootCreator) }
     }
 
-    val scriptsInstaller by extending {
+    public val scriptsInstaller: Extension<PageTransformer, *, *> by extending {
         htmlPreprocessors providing ::ScriptsInstaller order { after(rootCreator) }
     }
 
-    val stylesInstaller by extending {
+    public val stylesInstaller: Extension<PageTransformer, *, *> by extending {
         htmlPreprocessors providing ::StylesInstaller order { after(rootCreator) }
     }
 
-    val assetsInstaller by extending {
+    public val assetsInstaller: Extension<PageTransformer, *, *> by extending {
         htmlPreprocessors with AssetsInstaller order { after(rootCreator) } applyIf { !delayTemplateSubstitution }
     }
 
-    val customResourceInstaller by extending {
+    public val customResourceInstaller: Extension<PageTransformer, *, *> by extending {
         htmlPreprocessors providing { ctx -> CustomResourceInstaller(ctx) } order {
             after(stylesInstaller)
             after(scriptsInstaller)
@@ -228,65 +234,65 @@ class DokkaBase : DokkaPlugin() {
         }
     }
 
-    val packageListCreator by extending {
+    public val packageListCreator: Extension<PageTransformer, *, *> by extending {
         htmlPreprocessors providing {
             PackageListCreator(it, RecognizedLinkFormat.DokkaHtml)
         } order { after(rootCreator) }
     }
 
-    val sourcesetDependencyAppender by extending {
+    public val sourcesetDependencyAppender: Extension<PageTransformer, *, *> by extending {
         htmlPreprocessors providing ::SourcesetDependencyAppender order { after(rootCreator) }
     }
 
-    val resolveLinkConsumer by extending {
+    public val resolveLinkConsumer: Extension<ImmediateHtmlCommandConsumer, *, *> by extending {
         immediateHtmlCommandConsumer with ResolveLinkConsumer
     }
-    val replaceVersionConsumer by extending {
+    public val replaceVersionConsumer: Extension<ImmediateHtmlCommandConsumer, *, *> by extending {
         immediateHtmlCommandConsumer providing ::ReplaceVersionsConsumer
     }
-    val pathToRootConsumer by extending {
+    public val pathToRootConsumer: Extension<ImmediateHtmlCommandConsumer, *, *> by extending {
         immediateHtmlCommandConsumer with PathToRootConsumer
     }
-    val baseSearchbarDataInstaller by extending {
+    public val baseSearchbarDataInstaller: Extension<PageTransformer, *, *> by extending {
         htmlPreprocessors providing ::SearchbarDataInstaller order { after(sourceLinksTransformer) }
     }
 
     //<editor-fold desc="Deprecated API left for compatibility">
     @Suppress("DEPRECATION_ERROR")
     @Deprecated(message = org.jetbrains.dokka.base.deprecated.ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-    val kotlinAnalysis by extensionPoint<org.jetbrains.dokka.analysis.KotlinAnalysis>()
+    public val kotlinAnalysis: ExtensionPoint<org.jetbrains.dokka.analysis.KotlinAnalysis> by extensionPoint()
 
     @Suppress("DEPRECATION_ERROR")
     @Deprecated(message = org.jetbrains.dokka.base.deprecated.ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-    val externalDocumentablesProvider by extensionPoint<org.jetbrains.dokka.base.translators.descriptors.ExternalDocumentablesProvider>()
+    public val externalDocumentablesProvider: ExtensionPoint<org.jetbrains.dokka.base.translators.descriptors.ExternalDocumentablesProvider> by extensionPoint()
 
     @Suppress("DEPRECATION_ERROR")
     @Deprecated(message = org.jetbrains.dokka.base.deprecated.ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-    val externalClasslikesTranslator by extensionPoint<org.jetbrains.dokka.base.translators.descriptors.ExternalClasslikesTranslator>()
+    public val externalClasslikesTranslator: ExtensionPoint<org.jetbrains.dokka.base.translators.descriptors.ExternalClasslikesTranslator> by extensionPoint()
 
     @Suppress("DeprecatedCallableAddReplaceWith")
     @Deprecated(message = org.jetbrains.dokka.base.deprecated.ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-    val descriptorToDocumentableTranslator: org.jetbrains.dokka.plugability.Extension<org.jetbrains.dokka.transformers.sources.SourceToDocumentableTranslator, *, *>
+    public val descriptorToDocumentableTranslator: org.jetbrains.dokka.plugability.Extension<org.jetbrains.dokka.transformers.sources.SourceToDocumentableTranslator, *, *>
         get() = throw org.jetbrains.dokka.base.deprecated.AnalysisApiDeprecatedError()
 
     @Suppress("DeprecatedCallableAddReplaceWith")
     @Deprecated(message = org.jetbrains.dokka.base.deprecated.ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-    val psiToDocumentableTranslator: org.jetbrains.dokka.plugability.Extension<org.jetbrains.dokka.transformers.sources.SourceToDocumentableTranslator, *, *>
+    public val psiToDocumentableTranslator: org.jetbrains.dokka.plugability.Extension<org.jetbrains.dokka.transformers.sources.SourceToDocumentableTranslator, *, *>
         get() = throw org.jetbrains.dokka.base.deprecated.AnalysisApiDeprecatedError()
 
     @Suppress("DEPRECATION_ERROR", "DeprecatedCallableAddReplaceWith")
     @Deprecated(message = org.jetbrains.dokka.base.deprecated.ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-    val defaultKotlinAnalysis: org.jetbrains.dokka.plugability.Extension<org.jetbrains.dokka.analysis.KotlinAnalysis, *, *>
+    public val defaultKotlinAnalysis: org.jetbrains.dokka.plugability.Extension<org.jetbrains.dokka.analysis.KotlinAnalysis, *, *>
         get() = throw org.jetbrains.dokka.base.deprecated.AnalysisApiDeprecatedError()
 
     @Suppress("DEPRECATION_ERROR", "DeprecatedCallableAddReplaceWith")
     @Deprecated(message = org.jetbrains.dokka.base.deprecated.ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-    val defaultExternalDocumentablesProvider: org.jetbrains.dokka.plugability.Extension<org.jetbrains.dokka.base.translators.descriptors.ExternalDocumentablesProvider, *, *>
+    public val defaultExternalDocumentablesProvider: org.jetbrains.dokka.plugability.Extension<org.jetbrains.dokka.base.translators.descriptors.ExternalDocumentablesProvider, *, *>
         get() = throw org.jetbrains.dokka.base.deprecated.AnalysisApiDeprecatedError()
 
     @Suppress("DEPRECATION_ERROR", "DeprecatedCallableAddReplaceWith")
     @Deprecated(message = org.jetbrains.dokka.base.deprecated.ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-    val defaultExternalClasslikesTranslator: org.jetbrains.dokka.plugability.Extension<org.jetbrains.dokka.base.translators.descriptors.ExternalClasslikesTranslator, *, *>
+    public val defaultExternalClasslikesTranslator: org.jetbrains.dokka.plugability.Extension<org.jetbrains.dokka.base.translators.descriptors.ExternalClasslikesTranslator, *, *>
         get() = throw org.jetbrains.dokka.base.deprecated.AnalysisApiDeprecatedError()
     //</editor-fold>
 

--- a/plugins/base/src/main/kotlin/DokkaBaseConfiguration.kt
+++ b/plugins/base/src/main/kotlin/DokkaBaseConfiguration.kt
@@ -8,7 +8,7 @@ import org.jetbrains.dokka.plugability.ConfigurableBlock
 import java.io.File
 import java.time.Year
 
-data class DokkaBaseConfiguration(
+public data class DokkaBaseConfiguration(
     var customStyleSheets: List<File> = defaultCustomStyleSheets,
     var customAssets: List<File> = defaultCustomAssets,
     var separateInheritedMembers: Boolean = separateInheritedMembersDefault,
@@ -16,12 +16,12 @@ data class DokkaBaseConfiguration(
     var mergeImplicitExpectActualDeclarations: Boolean = mergeImplicitExpectActualDeclarationsDefault,
     var templatesDir: File? = defaultTemplatesDir
 ) : ConfigurableBlock {
-    companion object {
-        val defaultFooterMessage = "© ${Year.now().value} Copyright"
-        val defaultCustomStyleSheets: List<File> = emptyList()
-        val defaultCustomAssets: List<File> = emptyList()
-        const val separateInheritedMembersDefault: Boolean = false
-        const val mergeImplicitExpectActualDeclarationsDefault: Boolean = false
-        val defaultTemplatesDir: File? = null
+    public companion object {
+        public val defaultFooterMessage: String = "© ${Year.now().value} Copyright"
+        public val defaultCustomStyleSheets: List<File> = emptyList()
+        public val defaultCustomAssets: List<File> = emptyList()
+        public const val separateInheritedMembersDefault: Boolean = false
+        public const val mergeImplicitExpectActualDeclarationsDefault: Boolean = false
+        public val defaultTemplatesDir: File? = null
     }
 }

--- a/plugins/base/src/main/kotlin/deprecated/AnalysisApiDeprecatedError.kt
+++ b/plugins/base/src/main/kotlin/deprecated/AnalysisApiDeprecatedError.kt
@@ -13,4 +13,4 @@ internal const val ANALYSIS_API_DEPRECATION_MESSAGE =
             "https://github.com/Kotlin/dokka/issues/3099"
 
 @InternalDokkaApi
-class AnalysisApiDeprecatedError : Error(ANALYSIS_API_DEPRECATION_MESSAGE)
+public class AnalysisApiDeprecatedError : Error(ANALYSIS_API_DEPRECATION_MESSAGE)

--- a/plugins/base/src/main/kotlin/deprecated/KotlinAnalysisDeprecatedApi.kt
+++ b/plugins/base/src/main/kotlin/deprecated/KotlinAnalysisDeprecatedApi.kt
@@ -17,58 +17,58 @@ import org.jetbrains.dokka.utilities.DokkaLogger
 import java.io.Closeable
 
 @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-abstract class KotlinAnalysis(
+public abstract class KotlinAnalysis(
     private val parent: KotlinAnalysis? = null
 ) : Closeable {
     @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-    operator fun get(key: DokkaConfiguration.DokkaSourceSet): AnalysisContext = throw AnalysisApiDeprecatedError()
+    public operator fun get(key: DokkaConfiguration.DokkaSourceSet): AnalysisContext = throw AnalysisApiDeprecatedError()
 
     @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-    operator fun get(key: DokkaSourceSetID): AnalysisContext = throw AnalysisApiDeprecatedError()
+    public operator fun get(key: DokkaSourceSetID): AnalysisContext = throw AnalysisApiDeprecatedError()
 
     @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
     protected abstract fun find(sourceSetID: DokkaSourceSetID): AnalysisContext?
 }
 
-class AnalysisContext(environment: Any, facade: Any, private val analysisEnvironment: Any) : Closeable {
+public class AnalysisContext(environment: Any, facade: Any, private val analysisEnvironment: Any) : Closeable {
     @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-    val environment: Any get() = throw AnalysisApiDeprecatedError()
+    public val environment: Any get() = throw AnalysisApiDeprecatedError()
 
     @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-    val facade: Any get() = throw AnalysisApiDeprecatedError()
+    public val facade: Any get() = throw AnalysisApiDeprecatedError()
 
     @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-    operator fun component1(): Any = throw AnalysisApiDeprecatedError()
+    public operator fun component1(): Any = throw AnalysisApiDeprecatedError()
 
     @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-    operator fun component2(): Any = throw AnalysisApiDeprecatedError()
+    public operator fun component2(): Any = throw AnalysisApiDeprecatedError()
 
     @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-    override fun close() = throw AnalysisApiDeprecatedError()
+    override fun close() { throw AnalysisApiDeprecatedError() }
 }
 
 @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-class DokkaAnalysisConfiguration(val ignoreCommonBuiltIns: Boolean = false)
+public class DokkaAnalysisConfiguration(public val ignoreCommonBuiltIns: Boolean = false)
 
 @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-fun KotlinAnalysis(context: DokkaContext): KotlinAnalysis = throw AnalysisApiDeprecatedError()
+public fun KotlinAnalysis(context: DokkaContext): KotlinAnalysis = throw AnalysisApiDeprecatedError()
 
 @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-fun KotlinAnalysis(
+public fun KotlinAnalysis(
     sourceSets: List<DokkaConfiguration.DokkaSourceSet>,
     logger: DokkaLogger,
     analysisConfiguration: DokkaAnalysisConfiguration = DokkaAnalysisConfiguration()
 ): KotlinAnalysis = throw AnalysisApiDeprecatedError()
 
 @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-fun ProjectKotlinAnalysis(
+public fun ProjectKotlinAnalysis(
     sourceSets: List<DokkaConfiguration.DokkaSourceSet>,
     logger: DokkaLogger,
     analysisConfiguration: DokkaAnalysisConfiguration = DokkaAnalysisConfiguration()
 ): KotlinAnalysis = throw AnalysisApiDeprecatedError()
 
 @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-fun SamplesKotlinAnalysis(
+public fun SamplesKotlinAnalysis(
     sourceSets: List<DokkaConfiguration.DokkaSourceSet>,
     logger: DokkaLogger,
     projectKotlinAnalysis: KotlinAnalysis,

--- a/plugins/base/src/main/kotlin/deprecated/ParsersDeprecatedAPI.kt
+++ b/plugins/base/src/main/kotlin/deprecated/ParsersDeprecatedAPI.kt
@@ -14,25 +14,25 @@ import org.jetbrains.dokka.model.doc.DocumentationNode
 import org.jetbrains.dokka.model.doc.TagWrapper
 
 @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-abstract class Parser {
+public abstract class Parser {
     @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-    open fun parseStringToDocNode(extractedString: String): DocTag = throw AnalysisApiDeprecatedError()
+    public open fun parseStringToDocNode(extractedString: String): DocTag = throw AnalysisApiDeprecatedError()
 
     @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-    open fun preparse(text: String): String = throw AnalysisApiDeprecatedError()
+    public open fun preparse(text: String): String = throw AnalysisApiDeprecatedError()
 
     @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-    open fun parseTagWithBody(tagName: String, content: String): TagWrapper = throw AnalysisApiDeprecatedError()
+    public open fun parseTagWithBody(tagName: String, content: String): TagWrapper = throw AnalysisApiDeprecatedError()
 }
 
 @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-open class MarkdownParser(
+public open class MarkdownParser(
     private val externalDri: (String) -> DRI?,
     private val kdocLocation: String?,
 ) : Parser() {
-    companion object {
+    public companion object {
         @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-        fun parseFromKDocTag(
+        public fun parseFromKDocTag(
             @Suppress("UNUSED_PARAMETER") kDocTag: Any?,
             @Suppress("UNUSED_PARAMETER") externalDri: (String) -> DRI?,
             @Suppress("UNUSED_PARAMETER") kdocLocation: String?,

--- a/plugins/base/src/main/kotlin/deprecated/ParsersFactoriesDeprecatedAPI.kt
+++ b/plugins/base/src/main/kotlin/deprecated/ParsersFactoriesDeprecatedAPI.kt
@@ -12,9 +12,9 @@ import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.model.doc.DocTag
 
 @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-object DocTagsFromStringFactory {
+public object DocTagsFromStringFactory {
     @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-    fun getInstance(
+    public fun getInstance(
         @Suppress("UNUSED_PARAMETER") name: String,
         @Suppress("UNUSED_PARAMETER") children: List<DocTag> = emptyList(),
         @Suppress("UNUSED_PARAMETER") params: Map<String, String> = emptyMap(),

--- a/plugins/base/src/main/kotlin/deprecated/TranslatorDescriptorsDeprecatedAPI.kt
+++ b/plugins/base/src/main/kotlin/deprecated/TranslatorDescriptorsDeprecatedAPI.kt
@@ -16,13 +16,13 @@ import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.transformers.sources.AsyncSourceToDocumentableTranslator
 
 @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-fun interface ExternalDocumentablesProvider {
+public fun interface ExternalDocumentablesProvider {
     @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-    fun findClasslike(dri: DRI, sourceSet: DokkaConfiguration.DokkaSourceSet): DClasslike?
+    public fun findClasslike(dri: DRI, sourceSet: DokkaConfiguration.DokkaSourceSet): DClasslike?
 }
 
 @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-class DefaultExternalDocumentablesProvider(
+public class DefaultExternalDocumentablesProvider(
     @Suppress("UNUSED_PARAMETER") context: DokkaContext
 ) : ExternalDocumentablesProvider {
     @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
@@ -31,13 +31,13 @@ class DefaultExternalDocumentablesProvider(
 }
 
 @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-fun interface ExternalClasslikesTranslator {
+public fun interface ExternalClasslikesTranslator {
     @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-    fun translateClassDescriptor(descriptor: Any, sourceSet: DokkaConfiguration.DokkaSourceSet): DClasslike
+    public fun translateClassDescriptor(descriptor: Any, sourceSet: DokkaConfiguration.DokkaSourceSet): DClasslike
 }
 
 @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-class DefaultDescriptorToDocumentableTranslator(
+public class DefaultDescriptorToDocumentableTranslator(
     private val context: DokkaContext
 ) : AsyncSourceToDocumentableTranslator, ExternalClasslikesTranslator {
     @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)

--- a/plugins/base/src/main/kotlin/deprecated/TranslatorPsiDeprecatedAPI.kt
+++ b/plugins/base/src/main/kotlin/deprecated/TranslatorPsiDeprecatedAPI.kt
@@ -14,7 +14,7 @@ import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.transformers.sources.AsyncSourceToDocumentableTranslator
 
 @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
-class DefaultPsiToDocumentableTranslator(
+public class DefaultPsiToDocumentableTranslator(
     @Suppress("UNUSED_PARAMETER") context: DokkaContext,
 ) : AsyncSourceToDocumentableTranslator {
     @Deprecated(message = ANALYSIS_API_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)

--- a/plugins/base/src/main/kotlin/generation/SingleModuleGeneration.kt
+++ b/plugins/base/src/main/kotlin/generation/SingleModuleGeneration.kt
@@ -22,7 +22,7 @@ import org.jetbrains.dokka.transformers.sources.AsyncSourceToDocumentableTransla
 import org.jetbrains.dokka.utilities.parallelMap
 import org.jetbrains.dokka.utilities.report
 
-class SingleModuleGeneration(private val context: DokkaContext) : Generation {
+public class SingleModuleGeneration(private val context: DokkaContext) : Generation {
 
     override fun Timer.generate() {
         report("Validity check")
@@ -59,38 +59,40 @@ class SingleModuleGeneration(private val context: DokkaContext) : Generation {
         reportAfterRendering()
     }
 
-    override val generationName = "documentation for ${context.configuration.moduleName}"
+    override val generationName: String = "documentation for ${context.configuration.moduleName}"
 
-    fun createDocumentationModels(): List<DModule> = runBlocking(Dispatchers.Default) {
+    public fun createDocumentationModels(): List<DModule> = runBlocking(Dispatchers.Default) {
         context.configuration.sourceSets.parallelMap { sourceSet -> translateSources(sourceSet, context) }.flatten()
             .also { modules -> if (modules.isEmpty()) exitGenerationGracefully("Nothing to document") }
     }
 
-    fun transformDocumentationModelBeforeMerge(modulesFromPlatforms: List<DModule>) =
-        context.plugin<DokkaBase>().query { preMergeDocumentableTransformer }
+    public fun transformDocumentationModelBeforeMerge(modulesFromPlatforms: List<DModule>): List<DModule> {
+        return context.plugin<DokkaBase>()
+            .query { preMergeDocumentableTransformer }
             .fold(modulesFromPlatforms) { acc, t -> t(acc) }
+    }
 
-    fun mergeDocumentationModels(modulesFromPlatforms: List<DModule>) =
+    public fun mergeDocumentationModels(modulesFromPlatforms: List<DModule>): DModule? =
         context.single(CoreExtensions.documentableMerger).invoke(modulesFromPlatforms)
 
-    fun transformDocumentationModelAfterMerge(documentationModel: DModule) =
+    public fun transformDocumentationModelAfterMerge(documentationModel: DModule): DModule =
         context[CoreExtensions.documentableTransformer].fold(documentationModel) { acc, t -> t(acc, context) }
 
-    fun createPages(transformedDocumentation: DModule): RootPageNode =
+    public fun createPages(transformedDocumentation: DModule): RootPageNode =
         context.single(CoreExtensions.documentableToPageTranslator).invoke(transformedDocumentation)
 
-    fun transformPages(pages: RootPageNode): RootPageNode =
+    public fun transformPages(pages: RootPageNode): RootPageNode =
         context[CoreExtensions.pageTransformer].fold(pages) { acc, t -> t(acc) }
 
-    fun render(transformedPages: RootPageNode) {
+    public fun render(transformedPages: RootPageNode) {
         context.single(CoreExtensions.renderer).render(transformedPages)
     }
 
-    fun runPostActions() {
+    public fun runPostActions() {
         context[CoreExtensions.postActions].forEach { it() }
     }
 
-    fun validityCheck(context: DokkaContext) {
+    public fun validityCheck(context: DokkaContext) {
         val (preGenerationCheckResult, checkMessages) = context[CoreExtensions.preGenerationCheck].fold(
             Pair(true, emptyList<String>())
         ) { acc, checker -> checker() + acc }
@@ -99,7 +101,7 @@ class SingleModuleGeneration(private val context: DokkaContext) : Generation {
         )
     }
 
-    fun reportAfterRendering() {
+    public fun reportAfterRendering() {
         context.unusedPoints.takeIf { it.isNotEmpty() }?.also {
             context.logger.info("Unused extension points found: ${it.joinToString(", ")}")
         }

--- a/plugins/base/src/main/kotlin/renderers/DefaultRenderer.kt
+++ b/plugins/base/src/main/kotlin/renderers/DefaultRenderer.kt
@@ -19,61 +19,68 @@ import org.jetbrains.dokka.plugability.querySingle
 import org.jetbrains.dokka.renderers.Renderer
 import org.jetbrains.dokka.transformers.pages.PageTransformer
 
-abstract class DefaultRenderer<T>(
+public abstract class DefaultRenderer<T>(
     protected val context: DokkaContext
 ) : Renderer {
 
-    protected val outputWriter = context.plugin<DokkaBase>().querySingle { outputWriter }
+    protected val outputWriter: OutputWriter = context.plugin<DokkaBase>().querySingle { outputWriter }
 
     protected lateinit var locationProvider: LocationProvider
         private set
 
     protected open val preprocessors: Iterable<PageTransformer> = emptyList()
 
-    abstract fun T.buildHeader(level: Int, node: ContentHeader, content: T.() -> Unit)
-    abstract fun T.buildLink(address: String, content: T.() -> Unit)
-    abstract fun T.buildList(
+    public abstract fun T.buildHeader(level: Int, node: ContentHeader, content: T.() -> Unit)
+    public abstract fun T.buildLink(address: String, content: T.() -> Unit)
+    public abstract fun T.buildList(
         node: ContentList,
         pageContext: ContentPage,
         sourceSetRestriction: Set<DisplaySourceSet>? = null
     )
 
-    abstract fun T.buildLineBreak()
-    open fun T.buildLineBreak(node: ContentBreakLine, pageContext: ContentPage) = buildLineBreak()
+    public abstract fun T.buildLineBreak()
+    public open fun T.buildLineBreak(node: ContentBreakLine, pageContext: ContentPage) {
+        buildLineBreak()
+    }
 
-    abstract fun T.buildResource(node: ContentEmbeddedResource, pageContext: ContentPage)
-    abstract fun T.buildTable(
+    public abstract fun T.buildResource(node: ContentEmbeddedResource, pageContext: ContentPage)
+    public abstract fun T.buildTable(
         node: ContentTable,
         pageContext: ContentPage,
         sourceSetRestriction: Set<DisplaySourceSet>? = null
     )
 
-    abstract fun T.buildText(textNode: ContentText)
-    abstract fun T.buildNavigation(page: PageNode)
+    public abstract fun T.buildText(textNode: ContentText)
+    public abstract fun T.buildNavigation(page: PageNode)
 
-    abstract fun buildPage(page: ContentPage, content: (T, ContentPage) -> Unit): String
-    abstract fun buildError(node: ContentNode)
+    public abstract fun buildPage(page: ContentPage, content: (T, ContentPage) -> Unit): String
+    public abstract fun buildError(node: ContentNode)
 
-    open fun T.buildPlatformDependent(
+    public open fun T.buildPlatformDependent(
         content: PlatformHintedContent,
         pageContext: ContentPage,
         sourceSetRestriction: Set<DisplaySourceSet>?
-    ) = buildContentNode(content.inner, pageContext)
+    ) {
+        buildContentNode(content.inner, pageContext)
+    }
 
-    open fun T.buildGroup(
+    public open fun T.buildGroup(
         node: ContentGroup,
         pageContext: ContentPage,
         sourceSetRestriction: Set<DisplaySourceSet>? = null
-    ) =
+    ) {
         wrapGroup(node, pageContext) { node.children.forEach { it.build(this, pageContext, sourceSetRestriction) } }
+    }
 
-    open fun T.buildDivergent(node: ContentDivergentGroup, pageContext: ContentPage) =
+    public open fun T.buildDivergent(node: ContentDivergentGroup, pageContext: ContentPage) {
         node.children.forEach { it.build(this, pageContext) }
+    }
 
-    open fun T.wrapGroup(node: ContentGroup, pageContext: ContentPage, childrenCallback: T.() -> Unit) =
+    public open fun T.wrapGroup(node: ContentGroup, pageContext: ContentPage, childrenCallback: T.() -> Unit) {
         childrenCallback()
+    }
 
-    open fun T.buildText(
+    public open fun T.buildText(
         nodes: List<ContentNode>,
         pageContext: ContentPage,
         sourceSetRestriction: Set<DisplaySourceSet>? = null
@@ -81,15 +88,15 @@ abstract class DefaultRenderer<T>(
         nodes.forEach { it.build(this, pageContext, sourceSetRestriction) }
     }
 
-    open fun T.buildCodeBlock(code: ContentCodeBlock, pageContext: ContentPage) {
+    public open fun T.buildCodeBlock(code: ContentCodeBlock, pageContext: ContentPage) {
         code.children.forEach { it.build(this, pageContext) }
     }
 
-    open fun T.buildCodeInline(code: ContentCodeInline, pageContext: ContentPage) {
+    public open fun T.buildCodeInline(code: ContentCodeInline, pageContext: ContentPage) {
         code.children.forEach { it.build(this, pageContext) }
     }
 
-    open fun T.buildHeader(
+    public open fun T.buildHeader(
         node: ContentHeader,
         pageContext: ContentPage,
         sourceSetRestriction: Set<DisplaySourceSet>? = null
@@ -97,19 +104,23 @@ abstract class DefaultRenderer<T>(
         buildHeader(node.level, node) { node.children.forEach { it.build(this, pageContext, sourceSetRestriction) } }
     }
 
-    open fun ContentNode.build(
+    public open fun ContentNode.build(
         builder: T,
         pageContext: ContentPage,
         sourceSetRestriction: Set<DisplaySourceSet>? = null
-    ) = builder.buildContentNode(this, pageContext, sourceSetRestriction)
+    ) {
+        builder.buildContentNode(this, pageContext, sourceSetRestriction)
+    }
 
-    fun T.buildContentNode(
+    public fun T.buildContentNode(
         node: ContentNode,
         pageContext: ContentPage,
         sourceSetRestriction: DisplaySourceSet
-    ) = buildContentNode(node, pageContext, setOf(sourceSetRestriction))
+    ) {
+        buildContentNode(node, pageContext, setOf(sourceSetRestriction))
+    }
 
-    open fun T.buildContentNode(
+    public open fun T.buildContentNode(
         node: ContentNode,
         pageContext: ContentPage,
         sourceSetRestriction: Set<DisplaySourceSet>? = null
@@ -135,7 +146,7 @@ abstract class DefaultRenderer<T>(
         }
     }
 
-    open fun T.buildDRILink(
+    public open fun T.buildDRILink(
         node: ContentDRILink,
         pageContext: ContentPage,
         sourceSetRestriction: Set<DisplaySourceSet>?
@@ -147,7 +158,7 @@ abstract class DefaultRenderer<T>(
         } ?: buildText(node.children, pageContext, sourceSetRestriction)
     }
 
-    open fun T.buildResolvedLink(
+    public open fun T.buildResolvedLink(
         node: ContentResolvedLink,
         pageContext: ContentPage,
         sourceSetRestriction: Set<DisplaySourceSet>?
@@ -157,18 +168,18 @@ abstract class DefaultRenderer<T>(
         }
     }
 
-    open fun T.buildDivergentInstance(node: ContentDivergentInstance, pageContext: ContentPage) {
+    public open fun T.buildDivergentInstance(node: ContentDivergentInstance, pageContext: ContentPage) {
         node.before?.build(this, pageContext)
         node.divergent.build(this, pageContext)
         node.after?.build(this, pageContext)
     }
 
-    open fun buildPageContent(context: T, page: ContentPage) {
+    public open fun buildPageContent(context: T, page: ContentPage) {
         context.buildNavigation(page)
         page.content.build(context, page)
     }
 
-    open suspend fun renderPage(page: PageNode) {
+    public open suspend fun renderPage(page: PageNode) {
         val path by lazy {
             locationProvider.resolve(page, skipExtension = true)
                 ?: throw DokkaException("Cannot resolve path for ${page.name}")
@@ -243,4 +254,4 @@ abstract class DefaultRenderer<T>(
 internal typealias SerializedBeforeAndAfter = Pair<String, String>
 internal typealias InstanceWithSource = Pair<ContentDivergentInstance, DisplaySourceSet>
 
-fun ContentPage.sourceSets() = this.content.sourceSets
+public fun ContentPage.sourceSets(): Set<DisplaySourceSet> = this.content.sourceSets

--- a/plugins/base/src/main/kotlin/renderers/FileWriter.kt
+++ b/plugins/base/src/main/kotlin/renderers/FileWriter.kt
@@ -14,7 +14,9 @@ import java.io.IOException
 import java.net.URI
 import java.nio.file.*
 
-class FileWriter(val context: DokkaContext): OutputWriter {
+public class FileWriter(
+    public val context: DokkaContext
+): OutputWriter {
     private val createdFiles: MutableSet<String> = mutableSetOf()
     private val createdFilesMutex = Mutex()
     private val jarUriPrefix = "jar:file:"
@@ -44,12 +46,13 @@ class FileWriter(val context: DokkaContext): OutputWriter {
         return false
     }
 
-    override suspend fun writeResources(pathFrom: String, pathTo: String) =
+    override suspend fun writeResources(pathFrom: String, pathTo: String) {
         if (javaClass.getResource(pathFrom)?.toURI()?.toString()?.startsWith(jarUriPrefix) == true) {
             copyFromJar(pathFrom, pathTo)
         } else {
             copyFromDirectory(pathFrom, pathTo)
         }
+    }
 
 
     private suspend fun copyFromDirectory(pathFrom: String, pathTo: String) {

--- a/plugins/base/src/main/kotlin/renderers/OutputWriter.kt
+++ b/plugins/base/src/main/kotlin/renderers/OutputWriter.kt
@@ -4,8 +4,8 @@
 
 package org.jetbrains.dokka.base.renderers
 
-interface OutputWriter {
+public interface OutputWriter {
 
-    suspend fun write(path: String, text: String, ext: String)
-    suspend fun writeResources(pathFrom: String, pathTo: String)
+    public suspend fun write(path: String, text: String, ext: String)
+    public suspend fun writeResources(pathFrom: String, pathTo: String)
 }

--- a/plugins/base/src/main/kotlin/renderers/PackageListService.kt
+++ b/plugins/base/src/main/kotlin/renderers/PackageListService.kt
@@ -15,9 +15,12 @@ import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.plugability.plugin
 import org.jetbrains.dokka.plugability.querySingle
 
-class PackageListService(val context: DokkaContext, val rootPage: RootPageNode) {
+public class PackageListService(
+    public val context: DokkaContext,
+    public val rootPage: RootPageNode
+) {
 
-    fun createPackageList(module: ModulePage, format: LinkFormat): String {
+    public fun createPackageList(module: ModulePage, format: LinkFormat): String {
 
         val packages = mutableSetOf<String>()
         val nonStandardLocations = mutableMapOf<String, String>()
@@ -46,11 +49,21 @@ class PackageListService(val context: DokkaContext, val rootPage: RootPageNode) 
         }
 
         visit(module)
-        return renderPackageList(nonStandardLocations, mapOf(SINGLE_MODULE_NAME to packages), format.formatName, format.linkExtension)
+        return renderPackageList(
+            nonStandardLocations = nonStandardLocations,
+            modules = mapOf(SINGLE_MODULE_NAME to packages),
+            format = format.formatName,
+            linkExtension = format.linkExtension
+        )
     }
 
-    companion object {
-        fun renderPackageList(nonStandardLocations: Map<String, String>, modules: Map<String, Set<String>>, format: String, linkExtension: String): String = buildString {
+    public companion object {
+        public fun renderPackageList(
+            nonStandardLocations: Map<String, String>,
+            modules: Map<String, Set<String>>,
+            format: String,
+            linkExtension: String
+        ): String = buildString {
             appendLine("$DOKKA_PARAM_PREFIX.format:${format}")
             appendLine("$DOKKA_PARAM_PREFIX.linkExtension:${linkExtension}")
             nonStandardLocations.map { (signature, location) ->

--- a/plugins/base/src/main/kotlin/renderers/TabSortingStrategy.kt
+++ b/plugins/base/src/main/kotlin/renderers/TabSortingStrategy.kt
@@ -6,6 +6,6 @@ package org.jetbrains.dokka.base.renderers
 
 import org.jetbrains.dokka.pages.ContentNode
 
-interface TabSortingStrategy {
-    fun <T: ContentNode> sort(tabs: Collection<T>) : List<T>
+public interface TabSortingStrategy {
+    public fun <T: ContentNode> sort(tabs: Collection<T>) : List<T>
 }

--- a/plugins/base/src/main/kotlin/renderers/contentTypeChecking.kt
+++ b/plugins/base/src/main/kotlin/renderers/contentTypeChecking.kt
@@ -8,16 +8,17 @@ import org.jetbrains.dokka.base.renderers.HtmlFileExtensions.imageExtensions
 import org.jetbrains.dokka.pages.ContentEmbeddedResource
 import java.io.File
 
-fun ContentEmbeddedResource.isImage(): Boolean {
+public fun ContentEmbeddedResource.isImage(): Boolean {
     return File(address).extension.toLowerCase() in imageExtensions
 }
 
-val String.URIExtension: String
+public val String.URIExtension: String
     get() = substringBefore('?').substringAfterLast('.')
 
-fun String.isImage(): Boolean =
+public fun String.isImage(): Boolean =
     URIExtension in imageExtensions
 
-object HtmlFileExtensions {
-    val imageExtensions = setOf("png", "jpg", "jpeg", "gif", "bmp", "tif", "webp", "svg")
+public object HtmlFileExtensions {
+    public val imageExtensions: Set<String> = setOf("png", "jpg", "jpeg", "gif", "bmp", "tif", "webp", "svg")
 }
+

--- a/plugins/base/src/main/kotlin/renderers/html/NavigationDataProvider.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/NavigationDataProvider.kt
@@ -17,15 +17,15 @@ import org.jetbrains.dokka.plugability.querySingle
 import org.jetbrains.dokka.analysis.kotlin.internal.DocumentableLanguage
 import org.jetbrains.dokka.analysis.kotlin.internal.InternalKotlinAnalysisPlugin
 
-abstract class NavigationDataProvider(
+public abstract class NavigationDataProvider(
     dokkaContext: DokkaContext
 ) {
     private val documentableSourceLanguageParser = dokkaContext.plugin<InternalKotlinAnalysisPlugin>().querySingle { documentableSourceLanguageParser }
 
-    open fun navigableChildren(input: RootPageNode): NavigationNode = input.withDescendants()
+    public open fun navigableChildren(input: RootPageNode): NavigationNode = input.withDescendants()
         .first { it is ModulePage || it is MultimoduleRootPage }.let { visit(it as ContentPage) }
 
-    open fun visit(page: ContentPage): NavigationNode =
+    public open fun visit(page: ContentPage): NavigationNode =
         NavigationNode(
             name = page.displayableName(),
             dri = page.dri.first(),

--- a/plugins/base/src/main/kotlin/renderers/html/NavigationPage.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/NavigationPage.kt
@@ -16,19 +16,19 @@ import org.jetbrains.dokka.model.WithChildren
 import org.jetbrains.dokka.pages.*
 import org.jetbrains.dokka.plugability.DokkaContext
 
-class NavigationPage(
-    val root: NavigationNode,
-    val moduleName: String,
-    val context: DokkaContext
+public class NavigationPage(
+    public val root: NavigationNode,
+    public val moduleName: String,
+    public val context: DokkaContext
 ) : RendererSpecificPage {
 
-    override val name = "navigation"
+    override val name: String = "navigation"
 
-    override val children = emptyList<PageNode>()
+    override val children: List<PageNode> = emptyList()
 
-    override fun modified(name: String, children: List<PageNode>) = this
+    override fun modified(name: String, children: List<PageNode>): NavigationPage = this
 
-    override val strategy = RenderingStrategy<HtmlRenderer> {
+    override val strategy: RenderingStrategy = RenderingStrategy<HtmlRenderer> {
         createHTML().visit(root, this)
     }
 
@@ -86,7 +86,7 @@ class NavigationPage(
     }
 }
 
-data class NavigationNode(
+public data class NavigationNode(
     val name: String,
     val dri: DRI,
     val sourceSets: Set<DisplaySourceSet>,
@@ -99,7 +99,7 @@ data class NavigationNode(
  * [CLASS] represents a neutral (a.k.a Java-style) icon,
  * whereas [CLASS_KT] should be Kotlin-styled
  */
-enum class NavigationNodeIcon(
+public enum class NavigationNodeIcon(
     private val cssClass: String
 ) {
     CLASS("class"),
@@ -122,8 +122,8 @@ enum class NavigationNodeIcon(
     internal fun style(): String = "nav-icon $cssClass"
 }
 
-fun NavigationPage.transform(block: (NavigationNode) -> NavigationNode) =
+public fun NavigationPage.transform(block: (NavigationNode) -> NavigationNode): NavigationPage =
     NavigationPage(root.transform(block), moduleName, context)
 
-fun NavigationNode.transform(block: (NavigationNode) -> NavigationNode) =
+public fun NavigationNode.transform(block: (NavigationNode) -> NavigationNode): NavigationNode =
     run(block).let { NavigationNode(it.name, it.dri, it.sourceSets, it.icon, it.styles, it.children.map(block)) }

--- a/plugins/base/src/main/kotlin/renderers/html/SearchbarDataInstaller.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/SearchbarDataInstaller.kt
@@ -16,19 +16,23 @@ import org.jetbrains.dokka.pages.*
 import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.transformers.pages.PageTransformer
 
-data class SearchRecord(
+public data class SearchRecord(
     val name: String,
     val description: String? = null,
     val location: String,
     val searchKeys: List<String> = listOf(name)
 ) {
-    companion object
+    public companion object
 }
 
-open class SearchbarDataInstaller(val context: DokkaContext) : PageTransformer {
-    data class DRIWithSourceSets(val dri: DRI, val sourceSet: Set<DisplaySourceSet>)
-    data class SignatureWithId(val driWithSourceSets: DRIWithSourceSets, val displayableSignature: String) {
-        constructor(dri: DRI, page: ContentPage) : this( DRIWithSourceSets(dri, page.sourceSets()),
+public open class SearchbarDataInstaller(
+    public val context: DokkaContext
+) : PageTransformer {
+
+    public data class DRIWithSourceSets(val dri: DRI, val sourceSet: Set<DisplaySourceSet>)
+
+    public data class SignatureWithId(val driWithSourceSets: DRIWithSourceSets, val displayableSignature: String) {
+        public constructor(dri: DRI, page: ContentPage) : this( DRIWithSourceSets(dri, page.sourceSets()),
             getSymbolSignature(page, dri)?.let { flattenToText(it) } ?: page.name)
 
         val id: String
@@ -43,7 +47,10 @@ open class SearchbarDataInstaller(val context: DokkaContext) : PageTransformer {
 
     private val mapper = jacksonObjectMapper()
 
-    open fun generatePagesList(pages: List<SignatureWithId>, locationResolver: DriResolver): List<SearchRecord> =
+    public open fun generatePagesList(
+        pages: List<SignatureWithId>,
+        locationResolver: DriResolver
+    ): List<SearchRecord> =
         pages.map { pageWithId ->
             createSearchRecord(
                 name = pageWithId.displayableSignature,
@@ -57,7 +64,7 @@ open class SearchbarDataInstaller(val context: DokkaContext) : PageTransformer {
             )
         }.sortedWith(compareBy({ it.name }, { it.description }))
 
-    open fun createSearchRecord(
+    public open fun createSearchRecord(
         name: String,
         description: String?,
         location: String,
@@ -65,7 +72,7 @@ open class SearchbarDataInstaller(val context: DokkaContext) : PageTransformer {
     ): SearchRecord =
         SearchRecord(name, description, location, searchKeys)
 
-    open fun processPage(page: PageNode): List<SignatureWithId> =
+    public open fun processPage(page: PageNode): List<SignatureWithId> =
         when (page) {
             is ContentPage -> page.takeIf { page !is ModulePageNode && page !is PackagePageNode }?.dri
                 ?.map { dri -> SignatureWithId(dri, page) }.orEmpty()

--- a/plugins/base/src/main/kotlin/renderers/html/Tags.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/Tags.kt
@@ -10,14 +10,14 @@ import org.jetbrains.dokka.base.renderers.html.command.consumers.ImmediateResolu
 import org.jetbrains.dokka.base.templating.Command
 import org.jetbrains.dokka.base.templating.toJsonString
 
-typealias TemplateBlock = TemplateCommand.() -> Unit
+public typealias TemplateBlock = TemplateCommand.() -> Unit
 
 @HtmlTagMarker
-fun FlowOrPhrasingContent.wbr(classes: String? = null, block: WBR.() -> Unit = {}): Unit =
+public fun FlowOrPhrasingContent.wbr(classes: String? = null, block: WBR.() -> Unit = {}): Unit =
     WBR(attributesMapOf("class", classes), consumer).visit(block)
 
 @Suppress("unused")
-open class WBR(initialAttributes: Map<String, String>, consumer: TagConsumer<*>) :
+public open class WBR(initialAttributes: Map<String, String>, consumer: TagConsumer<*>) :
     HTMLTag("wbr", consumer, initialAttributes, namespace = null, inlineTag = true, emptyTag = false),
     HtmlBlockInlineTag
 
@@ -25,22 +25,22 @@ open class WBR(initialAttributes: Map<String, String>, consumer: TagConsumer<*>)
  * Work-around until next version of kotlinx.html doesn't come out
  */
 @HtmlTagMarker
-inline fun FlowOrPhrasingContent.strike(classes : String? = null, crossinline block : STRIKE.() -> Unit = {}) : Unit = STRIKE(attributesMapOf("class", classes), consumer).visit(block)
+public inline fun FlowOrPhrasingContent.strike(classes : String? = null, crossinline block : STRIKE.() -> Unit = {}) : Unit = STRIKE(attributesMapOf("class", classes), consumer).visit(block)
 
-open class STRIKE(initialAttributes: Map<String, String>, override val consumer: TagConsumer<*>) :
+public open class STRIKE(initialAttributes: Map<String, String>, override val consumer: TagConsumer<*>) :
     HTMLTag("strike", consumer, initialAttributes, null, false, false), HtmlBlockInlineTag
 
 @HtmlTagMarker
-inline fun FlowOrPhrasingContent.underline(classes : String? = null, crossinline block : UNDERLINE.() -> Unit = {}) : Unit = UNDERLINE(attributesMapOf("class", classes), consumer).visit(block)
+public inline fun FlowOrPhrasingContent.underline(classes : String? = null, crossinline block : UNDERLINE.() -> Unit = {}) : Unit = UNDERLINE(attributesMapOf("class", classes), consumer).visit(block)
 
-open class UNDERLINE(initialAttributes: Map<String, String>, override val consumer: TagConsumer<*>) :
+public open class UNDERLINE(initialAttributes: Map<String, String>, override val consumer: TagConsumer<*>) :
     HTMLTag("u", consumer, initialAttributes, null, false, false), HtmlBlockInlineTag
 
-const val TEMPLATE_COMMAND_SEPARATOR = ":"
-const val TEMPLATE_COMMAND_BEGIN_BORDER  = "[+]cmd"
-const val TEMPLATE_COMMAND_END_BORDER  = "[-]cmd"
+public const val TEMPLATE_COMMAND_SEPARATOR: String = ":"
+public const val TEMPLATE_COMMAND_BEGIN_BORDER: String = "[+]cmd"
+public const val TEMPLATE_COMMAND_END_BORDER: String = "[-]cmd"
 
-fun FlowOrMetaDataContent.templateCommandAsHtmlComment(data: Command, block: FlowOrMetaDataContent.() -> Unit = {}): Unit =
+public fun FlowOrMetaDataContent.templateCommandAsHtmlComment(data: Command, block: FlowOrMetaDataContent.() -> Unit = {}): Unit =
     (consumer as? ImmediateResolutionTagConsumer)?.processCommand(data, block)
         ?:  let{
             comment( "$TEMPLATE_COMMAND_BEGIN_BORDER$TEMPLATE_COMMAND_SEPARATOR${toJsonString(data)}")
@@ -48,24 +48,24 @@ fun FlowOrMetaDataContent.templateCommandAsHtmlComment(data: Command, block: Flo
             comment(TEMPLATE_COMMAND_END_BORDER)
         }
 
-fun <T: Appendable> T.templateCommandAsHtmlComment(command: Command, action: T.() -> Unit ) {
+public fun <T: Appendable> T.templateCommandAsHtmlComment(command: Command, action: T.() -> Unit ) {
     append("<!--$TEMPLATE_COMMAND_BEGIN_BORDER$TEMPLATE_COMMAND_SEPARATOR${toJsonString(command)}-->")
     action()
     append("<!--$TEMPLATE_COMMAND_END_BORDER-->")
 }
 
-fun FlowOrMetaDataContent.templateCommand(data: Command, block: TemplateBlock = {}): Unit =
+public fun FlowOrMetaDataContent.templateCommand(data: Command, block: TemplateBlock = {}): Unit =
     (consumer as? ImmediateResolutionTagConsumer)?.processCommand(data, block)
         ?: TemplateCommand(attributesMapOf("data", toJsonString(data)), consumer).visit(block)
 
-fun <T> TagConsumer<T>.templateCommand(data: Command, block: TemplateBlock = {}): T =
+public fun <T> TagConsumer<T>.templateCommand(data: Command, block: TemplateBlock = {}): T =
     (this as? ImmediateResolutionTagConsumer)?.processCommandAndFinalize(data, block)
         ?: TemplateCommand(attributesMapOf("data", toJsonString(data)), this).visitAndFinalize(this, block)
 
-fun templateCommandFor(data: Command, consumer: TagConsumer<*>) =
+public fun templateCommandFor(data: Command, consumer: TagConsumer<*>): TemplateCommand =
     TemplateCommand(attributesMapOf("data", toJsonString(data)), consumer)
 
-class TemplateCommand(initialAttributes: Map<String, String>, consumer: TagConsumer<*>) :
+public class TemplateCommand(initialAttributes: Map<String, String>, consumer: TagConsumer<*>) :
     HTMLTag(
         "dokka-template-command",
         consumer,
@@ -77,6 +77,6 @@ class TemplateCommand(initialAttributes: Map<String, String>, consumer: TagConsu
     CommonAttributeGroupFacadeFlowInteractivePhrasingContent
 
 // This hack is outrageous. I hate it but I cannot find any other way around `kotlinx.html` type system.
-fun TemplateBlock.buildAsInnerHtml(): String = createHTML(prettyPrint = false).run {
+public fun TemplateBlock.buildAsInnerHtml(): String = createHTML(prettyPrint = false).run {
     TemplateCommand(emptyMap, this).visitAndFinalize(this, this@buildAsInnerHtml).substringAfter(">").substringBeforeLast("<")
 }

--- a/plugins/base/src/main/kotlin/renderers/html/command/consumers/ImmediateResolutionTagConsumer.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/command/consumers/ImmediateResolutionTagConsumer.kt
@@ -15,21 +15,23 @@ import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.plugability.plugin
 import org.jetbrains.dokka.plugability.query
 
-class ImmediateResolutionTagConsumer<out R>(
+public class ImmediateResolutionTagConsumer<out R>(
     private val downstream: TagConsumer<R>,
     private val context: DokkaContext
 ): TagConsumer<R> by downstream {
-    fun processCommand(command: Command, block: TemplateBlock) {
+
+    public fun processCommand(command: Command, block: TemplateBlock) {
         context.plugin<DokkaBase>().query { immediateHtmlCommandConsumer }
             .find { it.canProcess(command) }
             ?.processCommand(command, block, this)
             ?: run { templateCommandFor(command, downstream).visit(block) }
     }
 
-    fun processCommandAndFinalize(command: Command, block: TemplateBlock): R =
-        context.plugin<DokkaBase>().query { immediateHtmlCommandConsumer }
+    public fun processCommandAndFinalize(command: Command, block: TemplateBlock): R {
+        return context.plugin<DokkaBase>().query { immediateHtmlCommandConsumer }
             .find { it.canProcess(command) }
             ?.processCommandAndFinalize(command, block, this)
             ?: downstream.templateCommand(command, block)
+    }
 }
 

--- a/plugins/base/src/main/kotlin/renderers/html/command/consumers/PathToRootConsumer.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/command/consumers/PathToRootConsumer.kt
@@ -10,8 +10,8 @@ import org.jetbrains.dokka.base.templating.Command
 import org.jetbrains.dokka.base.templating.ImmediateHtmlCommandConsumer
 import org.jetbrains.dokka.base.templating.PathToRootSubstitutionCommand
 
-object PathToRootConsumer: ImmediateHtmlCommandConsumer {
-    override fun canProcess(command: Command) = command is PathToRootSubstitutionCommand
+public object PathToRootConsumer: ImmediateHtmlCommandConsumer {
+    override fun canProcess(command: Command): Boolean = command is PathToRootSubstitutionCommand
 
     override fun <R> processCommand(command: Command, block: TemplateBlock, tagConsumer: ImmediateResolutionTagConsumer<R>) {
         command as PathToRootSubstitutionCommand

--- a/plugins/base/src/main/kotlin/renderers/html/command/consumers/ReplaceVersionsConsumer.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/command/consumers/ReplaceVersionsConsumer.kt
@@ -10,8 +10,8 @@ import org.jetbrains.dokka.base.templating.ImmediateHtmlCommandConsumer
 import org.jetbrains.dokka.base.templating.ReplaceVersionsCommand
 import org.jetbrains.dokka.plugability.DokkaContext
 
-class ReplaceVersionsConsumer(private val context: DokkaContext) : ImmediateHtmlCommandConsumer {
-    override fun canProcess(command: Command) = command is ReplaceVersionsCommand
+public class ReplaceVersionsConsumer(private val context: DokkaContext) : ImmediateHtmlCommandConsumer {
+    override fun canProcess(command: Command): Boolean = command is ReplaceVersionsCommand
 
     override fun <R> processCommand(
         command: Command,

--- a/plugins/base/src/main/kotlin/renderers/html/command/consumers/ResolveLinkConsumer.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/command/consumers/ResolveLinkConsumer.kt
@@ -15,8 +15,8 @@ import org.jetbrains.dokka.base.templating.ImmediateHtmlCommandConsumer
 import org.jetbrains.dokka.base.templating.ResolveLinkCommand
 import org.jetbrains.dokka.utilities.htmlEscape
 
-object ResolveLinkConsumer: ImmediateHtmlCommandConsumer {
-    override fun canProcess(command: Command) = command is ResolveLinkCommand
+public object ResolveLinkConsumer: ImmediateHtmlCommandConsumer {
+    override fun canProcess(command: Command): Boolean = command is ResolveLinkCommand
 
     override fun <R> processCommand(command: Command, block: TemplateBlock, tagConsumer: ImmediateResolutionTagConsumer<R>) {
         command as ResolveLinkCommand

--- a/plugins/base/src/main/kotlin/renderers/html/htmlFormatingUtils.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/htmlFormatingUtils.kt
@@ -7,7 +7,7 @@ package org.jetbrains.dokka.base.renderers.html
 import kotlinx.html.FlowContent
 import kotlinx.html.span
 
-fun FlowContent.buildTextBreakableAfterCapitalLetters(name: String, hasLastElement: Boolean = false) {
+public fun FlowContent.buildTextBreakableAfterCapitalLetters(name: String, hasLastElement: Boolean = false) {
     if (name.contains(" ")) {
         val withOutSpaces = name.split(" ")
         withOutSpaces.dropLast(1).forEach {
@@ -23,7 +23,7 @@ fun FlowContent.buildTextBreakableAfterCapitalLetters(name: String, hasLastEleme
     }
 }
 
-fun FlowContent.buildBreakableDotSeparatedHtml(name: String) {
+public fun FlowContent.buildBreakableDotSeparatedHtml(name: String) {
     val phrases = name.split(".")
     phrases.forEachIndexed { i, e ->
         val elementWithOptionalDot = e.takeIf { i == phrases.lastIndex } ?: "$e."
@@ -61,6 +61,7 @@ private fun FlowContent.buildBreakableHtmlElement(element: String, last: Boolean
     }
 }
 
-fun FlowContent.buildBreakableText(name: String) =
+public fun FlowContent.buildBreakableText(name: String) {
     if (name.contains(".")) buildBreakableDotSeparatedHtml(name)
     else buildTextBreakableAfterCapitalLetters(name, hasLastElement = true)
+}

--- a/plugins/base/src/main/kotlin/renderers/html/htmlPreprocessors.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/htmlPreprocessors.kt
@@ -15,7 +15,9 @@ import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.plugability.configuration
 import org.jetbrains.dokka.transformers.pages.PageTransformer
 
-open class NavigationPageInstaller(val context: DokkaContext) : NavigationDataProvider(context), PageTransformer {
+public open class NavigationPageInstaller(
+    public val context: DokkaContext
+) : NavigationDataProvider(context), PageTransformer {
     override fun invoke(input: RootPageNode): RootPageNode =
         input.modified(
             children = input.children + NavigationPage(
@@ -26,7 +28,9 @@ open class NavigationPageInstaller(val context: DokkaContext) : NavigationDataPr
         )
 }
 
-class CustomResourceInstaller(val dokkaContext: DokkaContext) : PageTransformer {
+public class CustomResourceInstaller(
+    public val dokkaContext: DokkaContext
+) : PageTransformer {
     private val configuration = configuration<DokkaBase, DokkaBaseConfiguration>(dokkaContext)
 
     private val customAssets = configuration?.customAssets?.map {
@@ -48,7 +52,7 @@ class CustomResourceInstaller(val dokkaContext: DokkaContext) : PageTransformer 
     }
 }
 
-class ScriptsInstaller(private val dokkaContext: DokkaContext) : PageTransformer {
+public class ScriptsInstaller(private val dokkaContext: DokkaContext) : PageTransformer {
 
     // scripts ending with `_deferred.js` are loaded with `defer`, otherwise `async`
     private val scriptsPages = listOf(
@@ -76,7 +80,7 @@ class ScriptsInstaller(private val dokkaContext: DokkaContext) : PageTransformer
         }
 }
 
-class StylesInstaller(private val dokkaContext: DokkaContext) : PageTransformer {
+public class StylesInstaller(private val dokkaContext: DokkaContext) : PageTransformer {
     private val stylesPages = listOf(
         "styles/style.css",
         "styles/main.css",
@@ -96,7 +100,7 @@ class StylesInstaller(private val dokkaContext: DokkaContext) : PageTransformer 
         }
 }
 
-object AssetsInstaller : PageTransformer {
+public object AssetsInstaller : PageTransformer {
     private val imagesPages = listOf(
         "images/arrow_down.svg",
         "images/logo-icon.svg",
@@ -127,7 +131,7 @@ object AssetsInstaller : PageTransformer {
         "images/nav-icons/typealias-kotlin.svg",
     )
 
-    override fun invoke(input: RootPageNode) = input.modified(
+    override fun invoke(input: RootPageNode): RootPageNode = input.modified(
         children = input.children + imagesPages.toRenderSpecificResourcePage()
     )
 }
@@ -135,7 +139,9 @@ object AssetsInstaller : PageTransformer {
 private fun List<String>.toRenderSpecificResourcePage(): List<RendererSpecificResourcePage> =
     map { RendererSpecificResourcePage(it, emptyList(), RenderingStrategy.Copy("/dokka/$it")) }
 
-class SourcesetDependencyAppender(val context: DokkaContext) : PageTransformer {
+public class SourcesetDependencyAppender(
+    public val context: DokkaContext
+) : PageTransformer {
     private val name = "scripts/sourceset_dependencies.js"
     override fun invoke(input: RootPageNode): RootPageNode {
         val dependenciesMap = context.configuration.sourceSets.associate {

--- a/plugins/base/src/main/kotlin/renderers/html/innerTemplating/DefaultTemplateModelFactory.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/innerTemplating/DefaultTemplateModelFactory.kt
@@ -30,7 +30,9 @@ import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.plugability.configuration
 import java.net.URI
 
-class DefaultTemplateModelFactory(val context: DokkaContext) : TemplateModelFactory {
+public class DefaultTemplateModelFactory(
+    public val context: DokkaContext
+) : TemplateModelFactory {
     private val configuration = configuration<DokkaBase, DokkaBaseConfiguration>(context)
     private val isPartial = context.configuration.delayTemplateSubstitution
 
@@ -38,7 +40,7 @@ class DefaultTemplateModelFactory(val context: DokkaContext) : TemplateModelFact
         if (context.configuration.delayTemplateSubstitution || this is ImmediateResolutionTagConsumer) this
         else ImmediateResolutionTagConsumer(this, context)
 
-    data class SourceSetModel(val name: String, val platform: String, val filter: String)
+    public data class SourceSetModel(val name: String, val platform: String, val filter: String)
 
     override fun buildModel(
         page: PageNode,

--- a/plugins/base/src/main/kotlin/renderers/html/innerTemplating/DefaultTemplateModelMerger.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/innerTemplating/DefaultTemplateModelMerger.kt
@@ -4,7 +4,7 @@
 
 package org.jetbrains.dokka.base.renderers.html.innerTemplating
 
-class DefaultTemplateModelMerger : TemplateModelMerger {
+public class DefaultTemplateModelMerger : TemplateModelMerger {
     override fun invoke(
         factories: List<TemplateModelFactory>,
         buildModel: TemplateModelFactory.() -> TemplateMap

--- a/plugins/base/src/main/kotlin/renderers/html/innerTemplating/HtmlTemplater.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/innerTemplating/HtmlTemplater.kt
@@ -17,13 +17,15 @@ import org.jetbrains.dokka.plugability.configuration
 import java.io.StringWriter
 
 
-enum class DokkaTemplateTypes(val path: String) {
+public enum class DokkaTemplateTypes(
+    public val path: String
+) {
     BASE("base.ftl")
 }
 
-typealias TemplateMap = Map<String, Any?>
+public typealias TemplateMap = Map<String, Any?>
 
-class HtmlTemplater(
+public class HtmlTemplater(
     context: DokkaContext
 ) {
 
@@ -60,11 +62,11 @@ class HtmlTemplater(
         templateUpdateDelayMilliseconds = Long.MAX_VALUE
     }
 
-    fun setupSharedModel(model: TemplateMap) {
+    public fun setupSharedModel(model: TemplateMap) {
         templaterConfiguration.setSharedVariables(model)
     }
 
-    fun renderFromTemplate(
+    public fun renderFromTemplate(
         templateType: DokkaTemplateTypes,
         generateModel: () -> TemplateMap
     ): String {

--- a/plugins/base/src/main/kotlin/renderers/html/innerTemplating/TemplateModelFactory.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/innerTemplating/TemplateModelFactory.kt
@@ -7,13 +7,13 @@ package org.jetbrains.dokka.base.renderers.html.innerTemplating
 import org.jetbrains.dokka.base.resolvers.local.LocationProvider
 import org.jetbrains.dokka.pages.PageNode
 
-interface TemplateModelFactory {
-    fun buildModel(
+public interface TemplateModelFactory {
+    public fun buildModel(
         page: PageNode,
         resources: List<String>,
         locationProvider: LocationProvider,
         content: String
     ): TemplateMap
 
-    fun buildSharedModel(): TemplateMap
+    public fun buildSharedModel(): TemplateMap
 }

--- a/plugins/base/src/main/kotlin/renderers/html/innerTemplating/TemplateModelMerger.kt
+++ b/plugins/base/src/main/kotlin/renderers/html/innerTemplating/TemplateModelMerger.kt
@@ -4,6 +4,6 @@
 
 package org.jetbrains.dokka.base.renderers.html.innerTemplating
 
-fun interface TemplateModelMerger {
-    fun invoke(factories: List<TemplateModelFactory>, buildModel: TemplateModelFactory.() -> TemplateMap): TemplateMap
+public fun interface TemplateModelMerger {
+    public fun invoke(factories: List<TemplateModelFactory>, buildModel: TemplateModelFactory.() -> TemplateMap): TemplateMap
 }

--- a/plugins/base/src/main/kotlin/renderers/preprocessors.kt
+++ b/plugins/base/src/main/kotlin/renderers/preprocessors.kt
@@ -9,19 +9,21 @@ import org.jetbrains.dokka.pages.*
 import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.transformers.pages.PageTransformer
 
-object RootCreator : PageTransformer {
-    override fun invoke(input: RootPageNode) =
+public object RootCreator : PageTransformer {
+    override fun invoke(input: RootPageNode): RootPageNode =
         RendererSpecificRootPage("", listOf(input), RenderingStrategy.DoNothing)
 }
 
-class PackageListCreator(
-    val context: DokkaContext,
-    val format: LinkFormat,
-    val outputFilesNames: List<String> = listOf("package-list")
+public class PackageListCreator(
+    public val context: DokkaContext,
+    public val format: LinkFormat,
+    public val outputFilesNames: List<String> = listOf("package-list")
 ) : PageTransformer {
-    override fun invoke(input: RootPageNode) = input.transformPageNodeTree { pageNode ->
+    override fun invoke(input: RootPageNode): RootPageNode {
+        return input.transformPageNodeTree { pageNode ->
             pageNode.takeIf { it is ModulePage }?.let { it.modified(children = it.children + packageList(input, it as ModulePage)) } ?: pageNode
         }
+    }
 
     private fun packageList(rootPageNode: RootPageNode, module: ModulePage): List<RendererSpecificPage> {
         val content = PackageListService(context, rootPageNode).createPackageList(

--- a/plugins/base/src/main/kotlin/resolvers/anchors/AnchorsHint.kt
+++ b/plugins/base/src/main/kotlin/resolvers/anchors/AnchorsHint.kt
@@ -9,11 +9,11 @@ import org.jetbrains.dokka.model.properties.ExtraProperty
 import org.jetbrains.dokka.pages.ContentNode
 import org.jetbrains.dokka.pages.Kind
 
-data class SymbolAnchorHint(val anchorName: String, val contentKind: Kind) : ExtraProperty<ContentNode> {
+public data class SymbolAnchorHint(val anchorName: String, val contentKind: Kind) : ExtraProperty<ContentNode> {
     override val key: ExtraProperty.Key<ContentNode, SymbolAnchorHint> = SymbolAnchorHint
 
-    companion object : ExtraProperty.Key<ContentNode, SymbolAnchorHint> {
-        fun from(d: Documentable, contentKind: Kind): SymbolAnchorHint? =
+    public companion object : ExtraProperty.Key<ContentNode, SymbolAnchorHint> {
+        public fun from(d: Documentable, contentKind: Kind): SymbolAnchorHint? =
             d.name?.let { SymbolAnchorHint(it, contentKind) }
     }
 }

--- a/plugins/base/src/main/kotlin/resolvers/external/DefaultExternalLocationProvider.kt
+++ b/plugins/base/src/main/kotlin/resolvers/external/DefaultExternalLocationProvider.kt
@@ -9,12 +9,12 @@ import org.jetbrains.dokka.base.resolvers.shared.ExternalDocumentation
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.plugability.DokkaContext
 
-open class DefaultExternalLocationProvider(
-    val externalDocumentation: ExternalDocumentation,
-    val extension: String,
-    val dokkaContext: DokkaContext
+public open class DefaultExternalLocationProvider(
+    public val externalDocumentation: ExternalDocumentation,
+    public val extension: String,
+    public val dokkaContext: DokkaContext
 ) : ExternalLocationProvider {
-    val docURL = externalDocumentation.documentationURL.toString().removeSuffix("/") + "/"
+    public val docURL: String = externalDocumentation.documentationURL.toString().removeSuffix("/") + "/"
 
     override fun resolve(dri: DRI): String? {
         externalDocumentation.packageList.locations[dri.toString()]?.let { path -> return "$docURL$path" }

--- a/plugins/base/src/main/kotlin/resolvers/external/DefaultExternalLocationProviderFactory.kt
+++ b/plugins/base/src/main/kotlin/resolvers/external/DefaultExternalLocationProviderFactory.kt
@@ -7,17 +7,22 @@ package org.jetbrains.dokka.base.resolvers.external
 import org.jetbrains.dokka.base.resolvers.shared.RecognizedLinkFormat
 import org.jetbrains.dokka.plugability.DokkaContext
 
-class DefaultExternalLocationProviderFactory(val context: DokkaContext) :
-    ExternalLocationProviderFactory by ExternalLocationProviderFactoryWithCache(
-        { doc ->
-            when (doc.packageList.linkFormat) {
-                RecognizedLinkFormat.KotlinWebsite,
-                RecognizedLinkFormat.KotlinWebsiteHtml,
-                RecognizedLinkFormat.DokkaOldHtml -> Dokka010ExternalLocationProvider(doc, ".html", context)
-                RecognizedLinkFormat.DokkaHtml -> DefaultExternalLocationProvider(doc, ".html", context)
-                RecognizedLinkFormat.DokkaGFM,
-                RecognizedLinkFormat.DokkaJekyll -> DefaultExternalLocationProvider(doc, ".md", context)
-                else -> null
-            }
+public class DefaultExternalLocationProviderFactory(
+    public val context: DokkaContext,
+) : ExternalLocationProviderFactory by ExternalLocationProviderFactoryWithCache(
+    { doc ->
+        when (doc.packageList.linkFormat) {
+            RecognizedLinkFormat.KotlinWebsite,
+            RecognizedLinkFormat.KotlinWebsiteHtml,
+            RecognizedLinkFormat.DokkaOldHtml,
+            -> Dokka010ExternalLocationProvider(doc, ".html", context)
+
+            RecognizedLinkFormat.DokkaHtml -> DefaultExternalLocationProvider(doc, ".html", context)
+            RecognizedLinkFormat.DokkaGFM,
+            RecognizedLinkFormat.DokkaJekyll,
+            -> DefaultExternalLocationProvider(doc, ".md", context)
+
+            else -> null
         }
-    )
+    }
+)

--- a/plugins/base/src/main/kotlin/resolvers/external/Dokka010ExternalLocationProvider.kt
+++ b/plugins/base/src/main/kotlin/resolvers/external/Dokka010ExternalLocationProvider.kt
@@ -10,12 +10,12 @@ import org.jetbrains.dokka.links.Callable
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.plugability.DokkaContext
 
-open class Dokka010ExternalLocationProvider(
-    val externalDocumentation: ExternalDocumentation,
-    val extension: String,
-    val dokkaContext: DokkaContext
+public open class Dokka010ExternalLocationProvider(
+    public val externalDocumentation: ExternalDocumentation,
+    public val extension: String,
+    public val dokkaContext: DokkaContext
 ) : ExternalLocationProvider {
-    val docURL = externalDocumentation.documentationURL.toString().removeSuffix("/") + "/"
+    public val docURL: String = externalDocumentation.documentationURL.toString().removeSuffix("/") + "/"
 
     override fun resolve(dri: DRI): String? {
 

--- a/plugins/base/src/main/kotlin/resolvers/external/ExternalLocationProvider.kt
+++ b/plugins/base/src/main/kotlin/resolvers/external/ExternalLocationProvider.kt
@@ -9,10 +9,10 @@ import org.jetbrains.dokka.links.DRI
 /**
  * Provides the path to the page documenting a [DRI] in an external documentation source
  */
-fun interface ExternalLocationProvider {
+public fun interface ExternalLocationProvider {
     /**
      * @return Path to the page containing the [dri] or null if the path cannot be created
      * (eg. when the package-list does not contain [dri]'s package)
      */
-    fun resolve(dri: DRI): String?
+    public fun resolve(dri: DRI): String?
 }

--- a/plugins/base/src/main/kotlin/resolvers/external/ExternalLocationProviderFactory.kt
+++ b/plugins/base/src/main/kotlin/resolvers/external/ExternalLocationProviderFactory.kt
@@ -6,6 +6,6 @@ package org.jetbrains.dokka.base.resolvers.external
 
 import org.jetbrains.dokka.base.resolvers.shared.ExternalDocumentation
 
-fun interface ExternalLocationProviderFactory {
-    fun getExternalLocationProvider(doc: ExternalDocumentation): ExternalLocationProvider?
+public fun interface ExternalLocationProviderFactory {
+    public fun getExternalLocationProvider(doc: ExternalDocumentation): ExternalLocationProvider?
 }

--- a/plugins/base/src/main/kotlin/resolvers/external/ExternalLocationProviderFactoryWithCache.kt
+++ b/plugins/base/src/main/kotlin/resolvers/external/ExternalLocationProviderFactoryWithCache.kt
@@ -7,8 +7,9 @@ package org.jetbrains.dokka.base.resolvers.external
 import org.jetbrains.dokka.base.resolvers.shared.ExternalDocumentation
 import java.util.concurrent.ConcurrentHashMap
 
-class ExternalLocationProviderFactoryWithCache(val ext: ExternalLocationProviderFactory) :
-    ExternalLocationProviderFactory {
+public class ExternalLocationProviderFactoryWithCache(
+    public val ext: ExternalLocationProviderFactory
+) : ExternalLocationProviderFactory {
 
     private val locationProviders = ConcurrentHashMap<ExternalDocumentation, CacheWrapper>()
 

--- a/plugins/base/src/main/kotlin/resolvers/external/javadoc/AndroidExternalLocationProvider.kt
+++ b/plugins/base/src/main/kotlin/resolvers/external/javadoc/AndroidExternalLocationProvider.kt
@@ -8,11 +8,11 @@ import org.jetbrains.dokka.base.resolvers.shared.ExternalDocumentation
 import org.jetbrains.dokka.links.Callable
 import org.jetbrains.dokka.plugability.DokkaContext
 
-open class AndroidExternalLocationProvider(
+public open class AndroidExternalLocationProvider(
     externalDocumentation: ExternalDocumentation,
     dokkaContext: DokkaContext
 ) : JavadocExternalLocationProvider(externalDocumentation, "", "", dokkaContext) {
 
-    override fun anchorPart(callable: Callable) = callable.name.toLowerCase()
+    override fun anchorPart(callable: Callable): String = callable.name.toLowerCase()
 
 }

--- a/plugins/base/src/main/kotlin/resolvers/external/javadoc/JavadocExternalLocationProvider.kt
+++ b/plugins/base/src/main/kotlin/resolvers/external/javadoc/JavadocExternalLocationProvider.kt
@@ -13,10 +13,10 @@ import org.jetbrains.dokka.links.EnumEntryDRIExtra
 import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.utilities.htmlEscape
 
-open class JavadocExternalLocationProvider(
+public open class JavadocExternalLocationProvider(
         externalDocumentation: ExternalDocumentation,
-        val brackets: String,
-        val separator: String,
+        public val brackets: String,
+        public val separator: String,
         dokkaContext: DokkaContext
 ) : DefaultExternalLocationProvider(externalDocumentation, ".html", dokkaContext) {
 
@@ -53,9 +53,10 @@ open class JavadocExternalLocationProvider(
         return ("$docWithModule$classLink#" + anchorPart(callableChecked)).htmlEscape()
     }
 
-    protected open fun anchorPart(callable: Callable) = callable.name +
-            "${brackets.first()}" +
-            callable.params.joinToString(separator) +
-            "${brackets.last()}"
-
+    protected open fun anchorPart(callable: Callable): String {
+        return callable.name +
+                "${brackets.first()}" +
+                callable.params.joinToString(separator) +
+                "${brackets.last()}"
+    }
 }

--- a/plugins/base/src/main/kotlin/resolvers/external/javadoc/JavadocExternalLocationProviderFactory.kt
+++ b/plugins/base/src/main/kotlin/resolvers/external/javadoc/JavadocExternalLocationProviderFactory.kt
@@ -12,24 +12,28 @@ import org.jetbrains.dokka.base.resolvers.external.ExternalLocationProviderFacto
 import org.jetbrains.dokka.base.resolvers.shared.RecognizedLinkFormat
 import org.jetbrains.dokka.plugability.DokkaContext
 
-class JavadocExternalLocationProviderFactory(val context: DokkaContext) :
-    ExternalLocationProviderFactory by ExternalLocationProviderFactoryWithCache(
-        { doc ->
-            when (doc.packageList.url) {
-                DokkaConfiguration.ExternalDocumentationLink.androidX().packageListUrl,
-                DokkaConfiguration.ExternalDocumentationLink.androidSdk().packageListUrl ->
-                    AndroidExternalLocationProvider(doc, context)
-                else ->
-                    when (doc.packageList.linkFormat) {
-                        RecognizedLinkFormat.Javadoc1 ->
-                            JavadocExternalLocationProvider(doc, "()", ", ", context) // Covers JDK 1 - 7
-                        RecognizedLinkFormat.Javadoc8 ->
-                            JavadocExternalLocationProvider(doc, "--", "-", context) // Covers JDK 8 - 9
-                        RecognizedLinkFormat.Javadoc10,
-                        RecognizedLinkFormat.DokkaJavadoc ->
-                            JavadocExternalLocationProvider(doc, "()", ",", context) // Covers JDK 10
-                        else -> null
-                    }
-            }
+public class JavadocExternalLocationProviderFactory(
+    public val context: DokkaContext,
+) : ExternalLocationProviderFactory by ExternalLocationProviderFactoryWithCache(
+    { doc ->
+        when (doc.packageList.url) {
+            DokkaConfiguration.ExternalDocumentationLink.androidX().packageListUrl,
+            DokkaConfiguration.ExternalDocumentationLink.androidSdk().packageListUrl,
+            ->
+                AndroidExternalLocationProvider(doc, context)
+
+            else ->
+                when (doc.packageList.linkFormat) {
+                    RecognizedLinkFormat.Javadoc1 ->
+                        JavadocExternalLocationProvider(doc, "()", ", ", context) // Covers JDK 1 - 7
+                    RecognizedLinkFormat.Javadoc8 ->
+                        JavadocExternalLocationProvider(doc, "--", "-", context) // Covers JDK 8 - 9
+                    RecognizedLinkFormat.Javadoc10,
+                    RecognizedLinkFormat.DokkaJavadoc,
+                    ->
+                        JavadocExternalLocationProvider(doc, "()", ",", context) // Covers JDK 10
+                    else -> null
+                }
         }
-    )
+    }
+)

--- a/plugins/base/src/main/kotlin/resolvers/local/DefaultLocationProvider.kt
+++ b/plugins/base/src/main/kotlin/resolvers/local/DefaultLocationProvider.kt
@@ -8,6 +8,7 @@ import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.base.resolvers.external.DefaultExternalLocationProvider
 import org.jetbrains.dokka.base.resolvers.external.Dokka010ExternalLocationProvider
 import org.jetbrains.dokka.base.resolvers.external.ExternalLocationProvider
+import org.jetbrains.dokka.base.resolvers.external.ExternalLocationProviderFactory
 import org.jetbrains.dokka.base.resolvers.external.javadoc.AndroidExternalLocationProvider
 import org.jetbrains.dokka.base.resolvers.external.javadoc.JavadocExternalLocationProvider
 import org.jetbrains.dokka.base.resolvers.shared.ExternalDocumentation
@@ -19,11 +20,11 @@ import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.plugability.plugin
 import org.jetbrains.dokka.plugability.query
 
-abstract class DefaultLocationProvider(
+public abstract class DefaultLocationProvider(
     protected val pageGraphRoot: RootPageNode,
     protected val dokkaContext: DokkaContext
 ) : LocationProvider {
-    protected val externalLocationProviderFactories =
+    protected val externalLocationProviderFactories: List<ExternalLocationProviderFactory> =
         dokkaContext.plugin<DokkaBase>().query { externalLocationProviderFactory }
 
     protected val externalLocationProviders: Map<ExternalDocumentation, ExternalLocationProvider?> = dokkaContext

--- a/plugins/base/src/main/kotlin/resolvers/local/DokkaBaseLocationProvider.kt
+++ b/plugins/base/src/main/kotlin/resolvers/local/DokkaBaseLocationProvider.kt
@@ -11,7 +11,7 @@ import org.jetbrains.dokka.pages.RootPageNode
 import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.utilities.urlEncoded
 
-abstract class DokkaBaseLocationProvider(
+public abstract class DokkaBaseLocationProvider(
     pageGraphRoot: RootPageNode,
     dokkaContext: DokkaContext
 ) : DefaultLocationProvider(pageGraphRoot, dokkaContext) {
@@ -21,7 +21,7 @@ abstract class DokkaBaseLocationProvider(
      * The idea is to make them as short as possible and just use a hashCode from sourcesets in order to match the
      * 2040 characters limit
      */
-    open fun anchorForDCI(dci: DCI, sourceSets: Set<DisplaySourceSet>): String =
+    public open fun anchorForDCI(dci: DCI, sourceSets: Set<DisplaySourceSet>): String =
         (dci.dri.shortenToUrl().toString() + "/" + dci.kind + "/" + sourceSets.shortenToUrl()).urlEncoded()
 
 }

--- a/plugins/base/src/main/kotlin/resolvers/local/DokkaLocationProvider.kt
+++ b/plugins/base/src/main/kotlin/resolvers/local/DokkaLocationProvider.kt
@@ -13,12 +13,12 @@ import org.jetbrains.dokka.pages.*
 import org.jetbrains.dokka.plugability.DokkaContext
 import java.util.*
 
-open class DokkaLocationProvider(
+public open class DokkaLocationProvider(
     pageGraphRoot: RootPageNode,
     dokkaContext: DokkaContext,
-    val extension: String = ".html"
+    public val extension: String = ".html"
 ) : DokkaBaseLocationProvider(pageGraphRoot, dokkaContext) {
-    protected open val PAGE_WITH_CHILDREN_SUFFIX = "index"
+    protected open val PAGE_WITH_CHILDREN_SUFFIX: String = "index"
 
     protected open val pathsIndex: Map<PageNode, List<String>> = IdentityHashMap<PageNode, List<String>>().apply {
         fun registerPath(page: PageNode, prefix: List<String>) {
@@ -75,7 +75,7 @@ open class DokkaLocationProvider(
                     }
             }.toMap()
 
-    override fun resolve(node: PageNode, context: PageNode?, skipExtension: Boolean) =
+    override fun resolve(node: PageNode, context: PageNode?, skipExtension: Boolean): String =
         pathTo(node, context) + if (!skipExtension) extension else ""
 
     override fun resolve(dri: DRI, sourceSets: Set<DisplaySourceSet>, context: PageNode?): String? =
@@ -158,13 +158,13 @@ open class DokkaLocationProvider(
 
     protected data class PageWithKind(val page: ContentPage, val kind: Kind)
 
-    companion object {
-        val reservedFilenames = setOf("index", "con", "aux", "lst", "prn", "nul", "eof", "inp", "out")
+    public companion object {
+        public val reservedFilenames: Set<String> = setOf("index", "con", "aux", "lst", "prn", "nul", "eof", "inp", "out")
 
         //Taken from: https://stackoverflow.com/questions/1976007/what-characters-are-forbidden-in-windows-and-linux-directory-names
         internal val reservedCharacters = setOf('|', '>', '<', '*', ':', '"', '?', '%')
 
-        fun identifierToFilename(name: String): String {
+        public fun identifierToFilename(name: String): String {
             if (name.isEmpty()) return "--root--"
             return sanitizeFileName(name, reservedFilenames, reservedCharacters)
         }

--- a/plugins/base/src/main/kotlin/resolvers/local/DokkaLocationProviderFactory.kt
+++ b/plugins/base/src/main/kotlin/resolvers/local/DokkaLocationProviderFactory.kt
@@ -8,11 +8,15 @@ import org.jetbrains.dokka.pages.RootPageNode
 import org.jetbrains.dokka.plugability.DokkaContext
 import java.util.concurrent.ConcurrentHashMap
 
-class DokkaLocationProviderFactory(private val context: DokkaContext) : LocationProviderFactory {
+public class DokkaLocationProviderFactory(
+    private val context: DokkaContext
+) : LocationProviderFactory {
     private val cache = ConcurrentHashMap<CacheWrapper, LocationProvider>()
 
-    override fun getLocationProvider(pageNode: RootPageNode) = cache.computeIfAbsent(CacheWrapper(pageNode)) {
-        DokkaLocationProvider(pageNode, context)
+    override fun getLocationProvider(pageNode: RootPageNode): LocationProvider {
+        return cache.computeIfAbsent(CacheWrapper(pageNode)) {
+            DokkaLocationProvider(pageNode, context)
+        }
     }
 
     private class CacheWrapper(val pageNode: RootPageNode) {

--- a/plugins/base/src/main/kotlin/resolvers/local/LocationProvider.kt
+++ b/plugins/base/src/main/kotlin/resolvers/local/LocationProvider.kt
@@ -10,11 +10,11 @@ import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.model.DisplaySourceSet
 import org.jetbrains.dokka.pages.PageNode
 
-interface LocationProvider {
-    fun resolve(dri: DRI, sourceSets: Set<DisplaySourceSet>, context: PageNode? = null): String?
-    fun resolve(node: PageNode, context: PageNode? = null, skipExtension: Boolean = false): String?
-    fun pathToRoot(from: PageNode): String
-    fun ancestors(node: PageNode): List<PageNode>
+public interface LocationProvider {
+    public fun resolve(dri: DRI, sourceSets: Set<DisplaySourceSet>, context: PageNode? = null): String?
+    public fun resolve(node: PageNode, context: PageNode? = null, skipExtension: Boolean = false): String?
+    public fun pathToRoot(from: PageNode): String
+    public fun ancestors(node: PageNode): List<PageNode>
 
     /**
      * This method should return guessed filesystem location for a given [DRI]
@@ -22,17 +22,26 @@ interface LocationProvider {
      * generated package-list so it is ok if the path differs from the one returned by [resolve]
      * @return Path to a giver [DRI] or null if path should not be considered for relocations
      */
-    fun expectedLocationForDri(dri: DRI): String =
+    public fun expectedLocationForDri(dri: DRI): String =
         (listOf(dri.packageName) +
                 dri.classNames?.split(".")?.map { identifierToFilename(it) }.orEmpty() +
                 listOf(dri.callable?.let { identifierToFilename(it.name) } ?: "index")
                 ).filterNotNull().joinToString("/")
 }
 
-fun LocationProvider.resolveOrThrow(dri: DRI, sourceSets: Set<DisplaySourceSet>, context: PageNode? = null): String =
-    resolve(dri = dri, sourceSets = sourceSets, context = context)
+public fun LocationProvider.resolveOrThrow(
+    dri: DRI, sourceSets: Set<DisplaySourceSet>,
+    context: PageNode? = null
+): String {
+    return resolve(dri = dri, sourceSets = sourceSets, context = context)
         ?: throw DokkaException("Cannot resolve path for $dri")
+}
 
-fun LocationProvider.resolveOrThrow(node: PageNode, context: PageNode? = null, skipExtension: Boolean = false): String =
-    resolve(node = node, context = context, skipExtension = skipExtension)
+public fun LocationProvider.resolveOrThrow(
+    node: PageNode,
+    context: PageNode? = null,
+    skipExtension: Boolean = false
+): String {
+    return resolve(node = node, context = context, skipExtension = skipExtension)
         ?: throw DokkaException("Cannot resolve path for ${node.name}")
+}

--- a/plugins/base/src/main/kotlin/resolvers/local/LocationProviderFactory.kt
+++ b/plugins/base/src/main/kotlin/resolvers/local/LocationProviderFactory.kt
@@ -6,6 +6,6 @@ package org.jetbrains.dokka.base.resolvers.local
 
 import org.jetbrains.dokka.pages.RootPageNode
 
-fun interface LocationProviderFactory {
-    fun getLocationProvider(pageNode: RootPageNode): LocationProvider
+public fun interface LocationProviderFactory {
+    public fun getLocationProvider(pageNode: RootPageNode): LocationProvider
 }

--- a/plugins/base/src/main/kotlin/resolvers/shared/ExternalDocumentation.kt
+++ b/plugins/base/src/main/kotlin/resolvers/shared/ExternalDocumentation.kt
@@ -6,4 +6,4 @@ package org.jetbrains.dokka.base.resolvers.shared
 
 import java.net.URL
 
-data class ExternalDocumentation(val documentationURL: URL, val packageList: PackageList)
+public data class ExternalDocumentation(val documentationURL: URL, val packageList: PackageList)

--- a/plugins/base/src/main/kotlin/resolvers/shared/LinkFormat.kt
+++ b/plugins/base/src/main/kotlin/resolvers/shared/LinkFormat.kt
@@ -4,7 +4,7 @@
 
 package org.jetbrains.dokka.base.resolvers.shared
 
-interface LinkFormat {
-    val formatName: String
-    val linkExtension: String
+public interface LinkFormat {
+    public val formatName: String
+    public val linkExtension: String
 }

--- a/plugins/base/src/main/kotlin/resolvers/shared/PackageList.kt
+++ b/plugins/base/src/main/kotlin/resolvers/shared/PackageList.kt
@@ -6,9 +6,9 @@ package org.jetbrains.dokka.base.resolvers.shared
 
 import java.net.URL
 
-typealias Module = String
+public typealias Module = String
 
-data class PackageList(
+public data class PackageList(
     val linkFormat: RecognizedLinkFormat,
     val modules: Map<Module, Set<String>>,
     val locations: Map<String, String>,
@@ -17,17 +17,19 @@ data class PackageList(
     val packages: Set<String>
         get() = modules.values.flatten().toSet()
 
-    fun moduleFor(packageName: String) = modules.asSequence()
+    public fun moduleFor(packageName: String): Module? {
+        return modules.asSequence()
             .filter { it.value.contains(packageName) }
             .firstOrNull()?.key
+    }
 
-    companion object {
-        const val PACKAGE_LIST_NAME = "package-list"
-        const val MODULE_DELIMITER = "module:"
-        const val DOKKA_PARAM_PREFIX = "\$dokka"
-        const val SINGLE_MODULE_NAME = ""
+    public companion object {
+        public const val PACKAGE_LIST_NAME: String = "package-list"
+        public const val MODULE_DELIMITER: String = "module:"
+        public const val DOKKA_PARAM_PREFIX: String = "\$dokka"
+        public const val SINGLE_MODULE_NAME: String = ""
 
-        fun load(url: URL, jdkVersion: Int, offlineMode: Boolean = false): PackageList? {
+        public fun load(url: URL, jdkVersion: Int, offlineMode: Boolean = false): PackageList? {
             if (offlineMode && url.protocol.toLowerCase() != "file")
                 return null
 

--- a/plugins/base/src/main/kotlin/resolvers/shared/RecognizedLinkFormat.kt
+++ b/plugins/base/src/main/kotlin/resolvers/shared/RecognizedLinkFormat.kt
@@ -4,7 +4,10 @@
 
 package org.jetbrains.dokka.base.resolvers.shared
 
-enum class RecognizedLinkFormat(override val formatName: String, override val linkExtension: String) : LinkFormat {
+public enum class RecognizedLinkFormat(
+    override val formatName: String,
+    override val linkExtension: String
+) : LinkFormat {
     DokkaHtml("html-v1", "html"),
     DokkaJavadoc("javadoc-v1", "html"),
     DokkaGFM("gfm-v1", "md"),
@@ -16,8 +19,11 @@ enum class RecognizedLinkFormat(override val formatName: String, override val li
     KotlinWebsite("kotlin-website", "html"),
     KotlinWebsiteHtml("kotlin-website-html", "html");
 
-    companion object {
-        fun fromString(formatName: String) =
-            values().firstOrNull { it.formatName == formatName }
+    public companion object {
+        private val values = values()
+
+        public fun fromString(formatName: String): RecognizedLinkFormat? {
+            return values.firstOrNull { it.formatName == formatName }
+        }
     }
 }

--- a/plugins/base/src/main/kotlin/signatures/JvmSignatureUtils.kt
+++ b/plugins/base/src/main/kotlin/signatures/JvmSignatureUtils.kt
@@ -13,35 +13,39 @@ import org.jetbrains.dokka.model.AnnotationTarget
 import org.jetbrains.dokka.model.properties.WithExtraProperties
 import org.jetbrains.dokka.pages.*
 
-interface JvmSignatureUtils {
+public interface JvmSignatureUtils {
 
-    fun PageContentBuilder.DocumentableContentBuilder.annotationsBlock(d: AnnotationTarget)
+    public fun PageContentBuilder.DocumentableContentBuilder.annotationsBlock(d: AnnotationTarget)
 
-    fun PageContentBuilder.DocumentableContentBuilder.annotationsInline(d: AnnotationTarget)
+    public fun PageContentBuilder.DocumentableContentBuilder.annotationsInline(d: AnnotationTarget)
 
-    fun <T : Documentable> WithExtraProperties<T>.modifiers(): SourceSetDependent<Set<ExtraModifiers>>
+    public fun <T : Documentable> WithExtraProperties<T>.modifiers(): SourceSetDependent<Set<ExtraModifiers>>
 
-    fun Collection<ExtraModifiers>.toSignatureString(): String =
+    public fun Collection<ExtraModifiers>.toSignatureString(): String =
         joinToString("") { it.name.toLowerCase() + " " }
 
     @Suppress("UNCHECKED_CAST")
-    fun Documentable.annotations() = (this as? WithExtraProperties<Documentable>)?.annotations() ?: emptyMap()
+    public fun Documentable.annotations(): Map<DokkaSourceSet, List<Annotations.Annotation>> {
+        return (this as? WithExtraProperties<Documentable>)?.annotations() ?: emptyMap()
+    }
 
-    fun <T : AnnotationTarget> WithExtraProperties<T>.annotations(): SourceSetDependent<List<Annotations.Annotation>> =
+    public fun <T : AnnotationTarget> WithExtraProperties<T>.annotations(): SourceSetDependent<List<Annotations.Annotation>> =
         extra[Annotations]?.directAnnotations ?: emptyMap()
 
     @Suppress("UNCHECKED_CAST")
-    operator fun <T : Iterable<*>> SourceSetDependent<T>.plus(other: SourceSetDependent<T>): SourceSetDependent<T> =
-        LinkedHashMap(this).apply {
+    public operator fun <T : Iterable<*>> SourceSetDependent<T>.plus(other: SourceSetDependent<T>): SourceSetDependent<T> {
+        return LinkedHashMap(this).apply {
             for ((k, v) in other) {
                 put(k, get(k).let { if (it != null) (it + v) as T else v })
             }
         }
+    }
 
-    fun DProperty.annotations(): SourceSetDependent<List<Annotations.Annotation>> =
-        (extra[Annotations]?.directAnnotations ?: emptyMap()) +
-        (getter?.annotations() ?: emptyMap()).mapValues { it.value.map { it.copy( scope = Annotations.AnnotationScope.GETTER) } } +
-        (setter?.annotations() ?: emptyMap()).mapValues { it.value.map { it.copy( scope = Annotations.AnnotationScope.SETTER) } }
+    public fun DProperty.annotations(): SourceSetDependent<List<Annotations.Annotation>> {
+        return (extra[Annotations]?.directAnnotations ?: emptyMap()) +
+                (getter?.annotations() ?: emptyMap()).mapValues { it.value.map { it.copy( scope = Annotations.AnnotationScope.GETTER) } } +
+                (setter?.annotations() ?: emptyMap()).mapValues { it.value.map { it.copy( scope = Annotations.AnnotationScope.SETTER) } }
+    }
 
     private fun PageContentBuilder.DocumentableContentBuilder.annotations(
         d: AnnotationTarget,
@@ -77,7 +81,7 @@ interface JvmSignatureUtils {
         }
     } ?: Unit
 
-    fun PageContentBuilder.DocumentableContentBuilder.toSignatureString(
+    public fun PageContentBuilder.DocumentableContentBuilder.toSignatureString(
         a: Annotations.Annotation,
         renderAtStrategy: AtStrategy,
         listBrackets: Pair<Char, Char>,
@@ -143,7 +147,7 @@ interface JvmSignatureUtils {
         listBrackets?.let{ punctuation(it.second.toString()) }
     }
 
-    fun PageContentBuilder.DocumentableContentBuilder.annotationsBlockWithIgnored(
+    public fun PageContentBuilder.DocumentableContentBuilder.annotationsBlockWithIgnored(
         d: AnnotationTarget,
         ignored: Set<Annotations.Annotation>,
         renderAtStrategy: AtStrategy,
@@ -157,7 +161,7 @@ interface JvmSignatureUtils {
         }
     }
 
-    fun PageContentBuilder.DocumentableContentBuilder.annotationsInlineWithIgnored(
+    public fun PageContentBuilder.DocumentableContentBuilder.annotationsInlineWithIgnored(
         d: AnnotationTarget,
         ignored: Set<Annotations.Annotation>,
         renderAtStrategy: AtStrategy,
@@ -170,7 +174,7 @@ interface JvmSignatureUtils {
         }
     }
 
-    fun <T : Documentable> WithExtraProperties<T>.stylesIfDeprecated(sourceSetData: DokkaSourceSet): Set<TextStyle> {
+    public fun <T : Documentable> WithExtraProperties<T>.stylesIfDeprecated(sourceSetData: DokkaSourceSet): Set<TextStyle> {
         val directAnnotations = extra[Annotations]?.directAnnotations?.get(sourceSetData) ?: emptyList()
         val hasAnyDeprecatedAnnotation =
             directAnnotations.any { it.dri == DRI("kotlin", "Deprecated") || it.dri == DRI("java.lang", "Deprecated") }
@@ -178,7 +182,7 @@ interface JvmSignatureUtils {
         return if (hasAnyDeprecatedAnnotation) setOf(TextStyle.Strikethrough) else emptySet()
     }
 
-    infix fun DFunction.uses(typeParameter: DTypeParameter): Boolean {
+    public infix fun DFunction.uses(typeParameter: DTypeParameter): Boolean {
         val parameterDris = parameters.flatMap { listOf(it.dri) + it.type.drisOfAllNestedBounds }
         val receiverDris =
             listOfNotNull(
@@ -203,8 +207,9 @@ interface JvmSignatureUtils {
      * ```
      * Wrapping and indentation of parameters is applied conditionally, see [shouldWrapParams]
      */
-    fun PageContentBuilder.DocumentableContentBuilder.parametersBlock(
-        function: DFunction, paramBuilder: PageContentBuilder.DocumentableContentBuilder.(DParameter) -> Unit
+    public fun PageContentBuilder.DocumentableContentBuilder.parametersBlock(
+        function: DFunction,
+        paramBuilder: PageContentBuilder.DocumentableContentBuilder.(DParameter) -> Unit
     ) {
         group(kind = SymbolContentKind.Parameters, styles = emptySet()) {
             function.parameters.dropLast(1).forEach {
@@ -220,7 +225,7 @@ interface JvmSignatureUtils {
     }
 }
 
-sealed class AtStrategy
-object All : AtStrategy()
-object OnlyOnce : AtStrategy()
-object Never : AtStrategy()
+public sealed class AtStrategy
+public object All : AtStrategy()
+public object OnlyOnce : AtStrategy()
+public object Never : AtStrategy()

--- a/plugins/base/src/main/kotlin/signatures/KotlinSignatureProvider.kt
+++ b/plugins/base/src/main/kotlin/signatures/KotlinSignatureProvider.kt
@@ -23,13 +23,16 @@ import org.jetbrains.dokka.plugability.querySingle
 import org.jetbrains.dokka.utilities.DokkaLogger
 import kotlin.text.Typography.nbsp
 
-class KotlinSignatureProvider(ctcc: CommentsToContentConverter, logger: DokkaLogger)
-    : SignatureProvider, JvmSignatureUtils by KotlinSignatureUtils {
+public class KotlinSignatureProvider(
+    ctcc: CommentsToContentConverter,
+    logger: DokkaLogger
+) : SignatureProvider, JvmSignatureUtils by KotlinSignatureUtils {
 
-    constructor(context: DokkaContext) : this(
+    public constructor(context: DokkaContext) : this(
         context.plugin<DokkaBase>().querySingle { commentsToContentConverter },
         context.logger,
     )
+
     private val contentBuilder = PageContentBuilder(ctcc, this, logger)
 
     private val ignoredVisibilities = setOf(JavaVisibility.Public, KotlinVisibility.Public)

--- a/plugins/base/src/main/kotlin/signatures/KotlinSignatureUtils.kt
+++ b/plugins/base/src/main/kotlin/signatures/KotlinSignatureUtils.kt
@@ -4,6 +4,7 @@
 
 package org.jetbrains.dokka.base.signatures
 
+import org.jetbrains.dokka.DokkaConfiguration
 import org.jetbrains.dokka.base.transformers.pages.annotations.SinceKotlinTransformer
 import org.jetbrains.dokka.base.translators.documentables.PageContentBuilder
 import org.jetbrains.dokka.links.DRI
@@ -14,7 +15,7 @@ import org.jetbrains.dokka.model.AnnotationTarget
 import org.jetbrains.dokka.model.properties.WithExtraProperties
 import org.jetbrains.dokka.pages.ContentKind
 
-object KotlinSignatureUtils : JvmSignatureUtils {
+public object KotlinSignatureUtils : JvmSignatureUtils {
 
     private const val classExtension = "::class"
     private val strategy = OnlyOnce
@@ -34,21 +35,24 @@ object KotlinSignatureUtils : JvmSignatureUtils {
     )
 
 
-    override fun PageContentBuilder.DocumentableContentBuilder.annotationsBlock(d: AnnotationTarget) =
+    override fun PageContentBuilder.DocumentableContentBuilder.annotationsBlock(d: AnnotationTarget) {
         annotationsBlockWithIgnored(d, ignoredAnnotations, strategy, listBrackets, classExtension)
+    }
 
-    override fun PageContentBuilder.DocumentableContentBuilder.annotationsInline(d: AnnotationTarget) =
+    override fun PageContentBuilder.DocumentableContentBuilder.annotationsInline(d: AnnotationTarget) {
         annotationsInlineWithIgnored(d, ignoredAnnotations, strategy, listBrackets, classExtension)
+    }
 
-    override fun <T : Documentable> WithExtraProperties<T>.modifiers() =
-        extra[AdditionalModifiers]?.content?.entries?.associate {
+    override fun <T : Documentable> WithExtraProperties<T>.modifiers(): SourceSetDependent<Set<ExtraModifiers>> {
+        return extra[AdditionalModifiers]?.content?.entries?.associate {
             it.key to it.value.filterIsInstance<ExtraModifiers.KotlinOnlyModifiers>().toSet()
         } ?: emptyMap()
+    }
 
 
-    val PrimitiveJavaType.dri: DRI get() = DRI("kotlin", name.capitalize())
+    public val PrimitiveJavaType.dri: DRI get() = DRI("kotlin", name.capitalize())
 
-    val Bound.driOrNull: DRI?
+    public val Bound.driOrNull: DRI?
         get() {
             return when (this) {
                 is TypeParameter -> dri
@@ -64,7 +68,7 @@ object KotlinSignatureUtils : JvmSignatureUtils {
             }
         }
 
-    val Projection.drisOfAllNestedBounds: List<DRI> get() = when (this) {
+    public val Projection.drisOfAllNestedBounds: List<DRI> get() = when (this) {
         is TypeParameter -> listOf(dri)
         is TypeConstructor -> listOf(dri) + projections.flatMap { it.drisOfAllNestedBounds }
         is Nullable -> inner.drisOfAllNestedBounds

--- a/plugins/base/src/main/kotlin/signatures/SignatureProvider.kt
+++ b/plugins/base/src/main/kotlin/signatures/SignatureProvider.kt
@@ -7,6 +7,6 @@ package org.jetbrains.dokka.base.signatures
 import org.jetbrains.dokka.model.Documentable
 import org.jetbrains.dokka.pages.ContentNode
 
-fun interface SignatureProvider {
-    fun signature(documentable: Documentable): List<ContentNode>
+public fun interface SignatureProvider {
+    public fun signature(documentable: Documentable): List<ContentNode>
 }

--- a/plugins/base/src/main/kotlin/templating/AddToNavigationCommand.kt
+++ b/plugins/base/src/main/kotlin/templating/AddToNavigationCommand.kt
@@ -4,4 +4,6 @@
 
 package org.jetbrains.dokka.base.templating
 
-class AddToNavigationCommand(val moduleName: String) : Command
+public class AddToNavigationCommand(
+    public val moduleName: String
+) : Command

--- a/plugins/base/src/main/kotlin/templating/AddToSearch.kt
+++ b/plugins/base/src/main/kotlin/templating/AddToSearch.kt
@@ -6,4 +6,7 @@ package org.jetbrains.dokka.base.templating
 
 import org.jetbrains.dokka.base.renderers.html.SearchRecord
 
-data class AddToSearch(val moduleName: String, val elements: List<SearchRecord>): Command
+public data class AddToSearch(
+    val moduleName: String,
+    val elements: List<SearchRecord>
+): Command

--- a/plugins/base/src/main/kotlin/templating/AddToSourcesetDependencies.kt
+++ b/plugins/base/src/main/kotlin/templating/AddToSourcesetDependencies.kt
@@ -4,4 +4,7 @@
 
 package org.jetbrains.dokka.base.templating
 
-data class AddToSourcesetDependencies(val moduleName: String, val content: Map<String, List<String>>) : Command
+public data class AddToSourcesetDependencies(
+    val moduleName: String,
+    val content: Map<String, List<String>>
+) : Command

--- a/plugins/base/src/main/kotlin/templating/Command.kt
+++ b/plugins/base/src/main/kotlin/templating/Command.kt
@@ -8,8 +8,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS
 
 @JsonTypeInfo(use = CLASS)
-interface Command
+public interface Command
 
-abstract class SubstitutionCommand : Command {
-    abstract val pattern: String
+public abstract class SubstitutionCommand : Command {
+    public abstract val pattern: String
 }

--- a/plugins/base/src/main/kotlin/templating/ImmediateHtmlCommandConsumer.kt
+++ b/plugins/base/src/main/kotlin/templating/ImmediateHtmlCommandConsumer.kt
@@ -7,11 +7,11 @@ package org.jetbrains.dokka.base.templating
 import org.jetbrains.dokka.base.renderers.html.TemplateBlock
 import org.jetbrains.dokka.base.renderers.html.command.consumers.ImmediateResolutionTagConsumer
 
-interface ImmediateHtmlCommandConsumer {
-    fun canProcess(command: Command): Boolean
+public interface ImmediateHtmlCommandConsumer {
+    public fun canProcess(command: Command): Boolean
 
-    fun <R> processCommand(command: Command, block: TemplateBlock, tagConsumer: ImmediateResolutionTagConsumer<R>)
+    public fun <R> processCommand(command: Command, block: TemplateBlock, tagConsumer: ImmediateResolutionTagConsumer<R>)
 
-    fun <R> processCommandAndFinalize(command: Command, block: TemplateBlock, tagConsumer: ImmediateResolutionTagConsumer<R>): R
+    public fun <R> processCommandAndFinalize(command: Command, block: TemplateBlock, tagConsumer: ImmediateResolutionTagConsumer<R>): R
 }
 

--- a/plugins/base/src/main/kotlin/templating/InsertTemplateExtra.kt
+++ b/plugins/base/src/main/kotlin/templating/InsertTemplateExtra.kt
@@ -7,9 +7,9 @@ package org.jetbrains.dokka.base.templating
 import org.jetbrains.dokka.model.properties.ExtraProperty
 import org.jetbrains.dokka.pages.ContentNode
 
-data class InsertTemplateExtra(val command: Command) : ExtraProperty<ContentNode> {
+public data class InsertTemplateExtra(val command: Command) : ExtraProperty<ContentNode> {
 
-    companion object : ExtraProperty.Key<ContentNode, InsertTemplateExtra>
+    public companion object : ExtraProperty.Key<ContentNode, InsertTemplateExtra>
 
     override val key: ExtraProperty.Key<ContentNode, *>
         get() = Companion

--- a/plugins/base/src/main/kotlin/templating/PathToRootSubstitutionCommand.kt
+++ b/plugins/base/src/main/kotlin/templating/PathToRootSubstitutionCommand.kt
@@ -4,4 +4,7 @@
 
 package org.jetbrains.dokka.base.templating
 
-data class PathToRootSubstitutionCommand(override val pattern: String, val default: String): SubstitutionCommand()
+public data class PathToRootSubstitutionCommand(
+    override val pattern: String,
+    val default: String
+): SubstitutionCommand()

--- a/plugins/base/src/main/kotlin/templating/ProjectNameSubstitutionCommand.kt
+++ b/plugins/base/src/main/kotlin/templating/ProjectNameSubstitutionCommand.kt
@@ -4,4 +4,7 @@
 
 package org.jetbrains.dokka.base.templating
 
-data class ProjectNameSubstitutionCommand(override val pattern: String, val default: String): SubstitutionCommand()
+public data class ProjectNameSubstitutionCommand(
+    override val pattern: String,
+    val default: String
+): SubstitutionCommand()

--- a/plugins/base/src/main/kotlin/templating/ReplaceVersionsCommand.kt
+++ b/plugins/base/src/main/kotlin/templating/ReplaceVersionsCommand.kt
@@ -4,4 +4,4 @@
 
 package org.jetbrains.dokka.base.templating
 
-data class ReplaceVersionsCommand(val location: String = ""): Command
+public data class ReplaceVersionsCommand(val location: String = ""): Command

--- a/plugins/base/src/main/kotlin/templating/ResolveLinkCommand.kt
+++ b/plugins/base/src/main/kotlin/templating/ResolveLinkCommand.kt
@@ -6,4 +6,6 @@ package org.jetbrains.dokka.base.templating
 
 import org.jetbrains.dokka.links.DRI
 
-class ResolveLinkCommand(val dri: DRI): Command
+public class ResolveLinkCommand(
+    public val dri: DRI
+): Command

--- a/plugins/base/src/main/kotlin/templating/jsonMapperForPlugins.kt
+++ b/plugins/base/src/main/kotlin/templating/jsonMapperForPlugins.kt
@@ -40,9 +40,9 @@ internal class TypeReference<T> @PublishedApi internal constructor(
     }
 }
 
-fun toJsonString(value: Any): String = objectMapper.writeValueAsString(value)
+public fun toJsonString(value: Any): String = objectMapper.writeValueAsString(value)
 
-inline fun <reified T : Any> parseJson(json: String): T = parseJson(json, TypeReference())
+public inline fun <reified T : Any> parseJson(json: String): T = parseJson(json, TypeReference())
 
 @PublishedApi
 internal fun <T : Any> parseJson(json: String, typeReference: TypeReference<T>): T =

--- a/plugins/base/src/main/kotlin/transformers/documentables/ActualTypealiasAdder.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/ActualTypealiasAdder.kt
@@ -17,10 +17,14 @@ import org.jetbrains.dokka.transformers.documentation.DocumentableTransformer
  * The transformer should be applied after merging all documentables
  */
 // TODO assign actual [DTypeAlias.expectPresentInSet] an expect source set, currently, [DTypeAlias.expectPresentInSet] always = null
-class ActualTypealiasAdder : DocumentableTransformer {
+public class ActualTypealiasAdder : DocumentableTransformer {
 
-    override fun invoke(original: DModule, context: DokkaContext) = original.generateTypealiasesMap().let { aliases ->
-        original.copy(packages = original.packages.map { it.copy(classlikes = addActualTypeAliasToClasslikes(it.classlikes, aliases)) })
+    override fun invoke(original: DModule, context: DokkaContext): DModule {
+        return original.generateTypealiasesMap().let { aliases ->
+            original.copy(packages = original.packages.map {
+                it.copy(classlikes = addActualTypeAliasToClasslikes(it.classlikes, aliases))
+            })
+        }
     }
 
     private fun DModule.generateTypealiasesMap(): Map<DRI, DTypeAlias> =

--- a/plugins/base/src/main/kotlin/transformers/documentables/DefaultDocumentableMerger.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/DefaultDocumentableMerger.kt
@@ -274,8 +274,8 @@ internal class DefaultDocumentableMerger(val context: DokkaContext) : Documentab
     ).mergeExtras(this, other)
 }
 
-data class ClashingDriIdentifier(val value: Set<DokkaConfiguration.DokkaSourceSet>) : ExtraProperty<Documentable> {
-    companion object : ExtraProperty.Key<Documentable, ClashingDriIdentifier> {
+public data class ClashingDriIdentifier(val value: Set<DokkaConfiguration.DokkaSourceSet>) : ExtraProperty<Documentable> {
+    public companion object : ExtraProperty.Key<Documentable, ClashingDriIdentifier> {
         override fun mergeStrategyFor(
             left: ClashingDriIdentifier,
             right: ClashingDriIdentifier

--- a/plugins/base/src/main/kotlin/transformers/documentables/DeprecatedDocumentableFilterTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/DeprecatedDocumentableFilterTransformer.kt
@@ -22,8 +22,9 @@ import org.jetbrains.dokka.transformers.documentation.sourceSet
  * Documentables with [kotlin.Deprecated.level] set to [DeprecationLevel.HIDDEN]
  * are suppressed regardless of global and package options.
  */
-class DeprecatedDocumentableFilterTransformer(context: DokkaContext) :
-    SuppressedByConditionDocumentableFilterTransformer(context) {
+public class DeprecatedDocumentableFilterTransformer(
+    context: DokkaContext
+) : SuppressedByConditionDocumentableFilterTransformer(context) {
 
     override fun shouldBeSuppressed(d: Documentable): Boolean {
         val annotations = (d as? WithExtraProperties<*>)?.annotations() ?: return false

--- a/plugins/base/src/main/kotlin/transformers/documentables/DocumentableReplacerTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/DocumentableReplacerTransformer.kt
@@ -8,8 +8,9 @@ import org.jetbrains.dokka.model.*
 import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.transformers.documentation.PreMergeDocumentableTransformer
 
-abstract class DocumentableReplacerTransformer(val context: DokkaContext) :
-    PreMergeDocumentableTransformer {
+public abstract class DocumentableReplacerTransformer(
+    public val context: DokkaContext
+) : PreMergeDocumentableTransformer {
     override fun invoke(modules: List<DModule>): List<DModule> =
         modules.map { module ->
             val (documentable, wasChanged) = processModule(module)
@@ -170,10 +171,12 @@ abstract class DocumentableReplacerTransformer(val context: DokkaContext) :
         )).let { AnyWithChanges(it, wasChanged) }
     }
 
-    protected open fun processBound(bound: Bound) = when(bound) {
-        is GenericTypeConstructor -> processGenericTypeConstructor(bound)
-        is FunctionalTypeConstructor -> processFunctionalTypeConstructor(bound)
-        else -> AnyWithChanges(bound, false)
+    protected open fun processBound(bound: Bound): AnyWithChanges<Bound> {
+        return when(bound) {
+            is GenericTypeConstructor -> processGenericTypeConstructor(bound)
+            is FunctionalTypeConstructor -> processFunctionalTypeConstructor(bound)
+            else -> AnyWithChanges(bound, false)
+        }
     }
 
     protected open fun processVariance(variance: Variance<*>): AnyWithChanges<Variance<*>> {
@@ -198,7 +201,9 @@ abstract class DocumentableReplacerTransformer(val context: DokkaContext) :
             else -> AnyWithChanges(projection, false)
         }
 
-    protected open fun processGenericTypeConstructor(genericTypeConstructor: GenericTypeConstructor): AnyWithChanges<GenericTypeConstructor> {
+    protected open fun processGenericTypeConstructor(
+        genericTypeConstructor: GenericTypeConstructor
+    ): AnyWithChanges<GenericTypeConstructor> {
         val projections = genericTypeConstructor.projections.map { processProjection(it) }
 
         val wasChanged = projections.any { it.changed }
@@ -207,7 +212,9 @@ abstract class DocumentableReplacerTransformer(val context: DokkaContext) :
         )).let { AnyWithChanges(it, wasChanged) }
     }
 
-    protected open fun processFunctionalTypeConstructor(functionalTypeConstructor: FunctionalTypeConstructor): AnyWithChanges<FunctionalTypeConstructor> {
+    protected open fun processFunctionalTypeConstructor(
+        functionalTypeConstructor: FunctionalTypeConstructor
+    ): AnyWithChanges<FunctionalTypeConstructor> {
         val projections = functionalTypeConstructor.projections.map { processProjection(it) }
 
         val wasChanged = projections.any { it.changed }

--- a/plugins/base/src/main/kotlin/transformers/documentables/DocumentableVisibilityFilterTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/DocumentableVisibilityFilterTransformer.kt
@@ -11,12 +11,16 @@ import org.jetbrains.dokka.model.*
 import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.transformers.documentation.PreMergeDocumentableTransformer
 
-class DocumentableVisibilityFilterTransformer(val context: DokkaContext) : PreMergeDocumentableTransformer {
+public class DocumentableVisibilityFilterTransformer(
+    public val context: DokkaContext
+) : PreMergeDocumentableTransformer {
 
-    override fun invoke(modules: List<DModule>) = modules.map { original ->
-        val sourceSet = original.sourceSets.single()
-        val packageOptions = sourceSet.perPackageOptions
-        DocumentableVisibilityFilter(packageOptions, sourceSet).processModule(original)
+    override fun invoke(modules: List<DModule>): List<DModule> {
+        return modules.map { original ->
+            val sourceSet = original.sourceSets.single()
+            val packageOptions = sourceSet.perPackageOptions
+            DocumentableVisibilityFilter(packageOptions, sourceSet).processModule(original)
+        }
     }
 
     private class DocumentableVisibilityFilter(

--- a/plugins/base/src/main/kotlin/transformers/documentables/EmptyModulesFilterTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/EmptyModulesFilterTransformer.kt
@@ -7,7 +7,7 @@ package org.jetbrains.dokka.base.transformers.documentables
 import org.jetbrains.dokka.model.DModule
 import org.jetbrains.dokka.transformers.documentation.PreMergeDocumentableTransformer
 
-class EmptyModulesFilterTransformer : PreMergeDocumentableTransformer {
+public class EmptyModulesFilterTransformer : PreMergeDocumentableTransformer {
     override fun invoke(modules: List<DModule>): List<DModule> {
         return modules.filter { it.children.isNotEmpty() }
     }

--- a/plugins/base/src/main/kotlin/transformers/documentables/EmptyPackagesFilterTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/EmptyPackagesFilterTransformer.kt
@@ -9,7 +9,9 @@ import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.transformers.documentation.PreMergeDocumentableTransformer
 import org.jetbrains.dokka.transformers.documentation.sourceSet
 
-class EmptyPackagesFilterTransformer(val context: DokkaContext) : PreMergeDocumentableTransformer {
+public class EmptyPackagesFilterTransformer(
+    public val context: DokkaContext
+) : PreMergeDocumentableTransformer {
     override fun invoke(modules: List<DModule>): List<DModule> {
         return modules.mapNotNull(::filterModule)
     }

--- a/plugins/base/src/main/kotlin/transformers/documentables/ExtensionExtractorTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/ExtensionExtractorTransformer.kt
@@ -20,8 +20,7 @@ import org.jetbrains.dokka.utilities.parallelForEach
 import org.jetbrains.dokka.utilities.parallelMap
 import org.jetbrains.dokka.analysis.kotlin.internal.InternalKotlinAnalysisPlugin
 
-
-class ExtensionExtractorTransformer : DocumentableTransformer {
+public class ExtensionExtractorTransformer : DocumentableTransformer {
     override fun invoke(original: DModule, context: DokkaContext): DModule = runBlocking(Dispatchers.Default) {
         val classGraph = async {
             if (!context.configuration.suppressInheritedMembers)
@@ -151,11 +150,11 @@ class ExtensionExtractorTransformer : DocumentableTransformer {
         groupBy(Pair<T, *>::first, Pair<*, U>::second)
 }
 
-data class CallableExtensions(val extensions: Set<Callable>) : ExtraProperty<Documentable> {
-    companion object Key : ExtraProperty.Key<Documentable, CallableExtensions> {
-        override fun mergeStrategyFor(left: CallableExtensions, right: CallableExtensions) =
+public data class CallableExtensions(val extensions: Set<Callable>) : ExtraProperty<Documentable> {
+    public companion object Key : ExtraProperty.Key<Documentable, CallableExtensions> {
+        override fun mergeStrategyFor(left: CallableExtensions, right: CallableExtensions): MergeStrategy<Documentable> =
             MergeStrategy.Replace(CallableExtensions(left.extensions + right.extensions))
     }
 
-    override val key = Key
+    override val key: Key = Key
 }

--- a/plugins/base/src/main/kotlin/transformers/documentables/InheritedEntriesDocumentableFilterTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/InheritedEntriesDocumentableFilterTransformer.kt
@@ -9,8 +9,9 @@ import org.jetbrains.dokka.model.InheritedMember
 import org.jetbrains.dokka.model.properties.WithExtraProperties
 import org.jetbrains.dokka.plugability.DokkaContext
 
-class InheritedEntriesDocumentableFilterTransformer(context: DokkaContext) :
-    SuppressedByConditionDocumentableFilterTransformer(context) {
+public class InheritedEntriesDocumentableFilterTransformer(
+    context: DokkaContext
+) : SuppressedByConditionDocumentableFilterTransformer(context) {
 
     override fun shouldBeSuppressed(d: Documentable): Boolean {
         @Suppress("UNCHECKED_CAST")

--- a/plugins/base/src/main/kotlin/transformers/documentables/InheritorsExtractorTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/InheritorsExtractorTransformer.kt
@@ -12,7 +12,7 @@ import org.jetbrains.dokka.model.properties.MergeStrategy
 import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.transformers.documentation.DocumentableTransformer
 
-class InheritorsExtractorTransformer : DocumentableTransformer {
+public class InheritorsExtractorTransformer : DocumentableTransformer {
     override fun invoke(original: DModule, context: DokkaContext): DModule =
         original.generateInheritanceMap().let { inheritanceMap -> original.appendInheritors(inheritanceMap) as DModule }
 
@@ -72,8 +72,10 @@ class InheritorsExtractorTransformer : DocumentableTransformer {
 
 }
 
-class InheritorsInfo(val value: SourceSetDependent<List<DRI>>) : ExtraProperty<Documentable> {
-    companion object : ExtraProperty.Key<Documentable, InheritorsInfo> {
+public class InheritorsInfo(
+    public val value: SourceSetDependent<List<DRI>>
+) : ExtraProperty<Documentable> {
+    public companion object : ExtraProperty.Key<Documentable, InheritorsInfo> {
         override fun mergeStrategyFor(left: InheritorsInfo, right: InheritorsInfo): MergeStrategy<Documentable> =
             MergeStrategy.Replace(
                 InheritorsInfo(

--- a/plugins/base/src/main/kotlin/transformers/documentables/KotlinArrayDocumentableReplacerTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/KotlinArrayDocumentableReplacerTransformer.kt
@@ -9,8 +9,9 @@ import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.model.*
 import org.jetbrains.dokka.plugability.DokkaContext
 
-class KotlinArrayDocumentableReplacerTransformer(context: DokkaContext):
-    DocumentableReplacerTransformer(context) {
+public class KotlinArrayDocumentableReplacerTransformer(
+    context: DokkaContext
+): DocumentableReplacerTransformer(context) {
 
     private fun Documentable.isJVM() =
         sourceSets.any{ it.analysisPlatform == Platform.jvm }

--- a/plugins/base/src/main/kotlin/transformers/documentables/ObviousFunctionsDocumentableFilterTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/ObviousFunctionsDocumentableFilterTransformer.kt
@@ -9,7 +9,9 @@ import org.jetbrains.dokka.model.Documentable
 import org.jetbrains.dokka.model.ObviousMember
 import org.jetbrains.dokka.plugability.DokkaContext
 
-class ObviousFunctionsDocumentableFilterTransformer(context: DokkaContext) : SuppressedByConditionDocumentableFilterTransformer(context) {
+public class ObviousFunctionsDocumentableFilterTransformer(
+    context: DokkaContext
+) : SuppressedByConditionDocumentableFilterTransformer(context) {
     override fun shouldBeSuppressed(d: Documentable): Boolean =
         context.configuration.suppressObviousFunctions && d is DFunction && d.extra[ObviousMember] != null
 }

--- a/plugins/base/src/main/kotlin/transformers/documentables/SuppressTagDocumentableFilter.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/SuppressTagDocumentableFilter.kt
@@ -9,8 +9,9 @@ import org.jetbrains.dokka.model.dfs
 import org.jetbrains.dokka.model.doc.Suppress
 import org.jetbrains.dokka.plugability.DokkaContext
 
-class SuppressTagDocumentableFilter(val dokkaContext: DokkaContext) :
-    SuppressedByConditionDocumentableFilterTransformer(dokkaContext) {
+public class SuppressTagDocumentableFilter(
+    public val dokkaContext: DokkaContext
+) : SuppressedByConditionDocumentableFilterTransformer(dokkaContext) {
     override fun shouldBeSuppressed(d: Documentable): Boolean =
         d.documentation.any { (_, docs) -> docs.dfs { it is Suppress } != null }
 }

--- a/plugins/base/src/main/kotlin/transformers/documentables/SuppressedByConditionDocumentableFilterTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/SuppressedByConditionDocumentableFilterTransformer.kt
@@ -8,15 +8,16 @@ import org.jetbrains.dokka.model.*
 import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.transformers.documentation.PreMergeDocumentableTransformer
 
-abstract class SuppressedByConditionDocumentableFilterTransformer(val context: DokkaContext) :
-    PreMergeDocumentableTransformer {
+public abstract class SuppressedByConditionDocumentableFilterTransformer(
+    public val context: DokkaContext
+) : PreMergeDocumentableTransformer {
     override fun invoke(modules: List<DModule>): List<DModule> =
         modules.map { module ->
             val (documentable, wasChanged) = processModule(module)
             documentable.takeIf { wasChanged } ?: module
         }
 
-    abstract fun shouldBeSuppressed(d: Documentable): Boolean
+    public abstract fun shouldBeSuppressed(d: Documentable): Boolean
 
     private fun processModule(module: DModule): DocumentableWithChanges<DModule> {
         val afterProcessing = module.packages.map { processPackage(it) }

--- a/plugins/base/src/main/kotlin/transformers/documentables/SuppressedByConfigurationDocumentableFilterTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/SuppressedByConfigurationDocumentableFilterTransformer.kt
@@ -12,7 +12,9 @@ import org.jetbrains.dokka.transformers.documentation.source
 import org.jetbrains.dokka.transformers.documentation.sourceSet
 import java.io.File
 
-class SuppressedByConfigurationDocumentableFilterTransformer(val context: DokkaContext) : PreMergeDocumentableTransformer {
+public class SuppressedByConfigurationDocumentableFilterTransformer(
+    public val context: DokkaContext
+) : PreMergeDocumentableTransformer {
     override fun invoke(modules: List<DModule>): List<DModule> {
         return modules.mapNotNull(::filterModule)
     }

--- a/plugins/base/src/main/kotlin/transformers/documentables/utils.kt
+++ b/plugins/base/src/main/kotlin/transformers/documentables/utils.kt
@@ -9,11 +9,11 @@ import org.jetbrains.dokka.model.Documentable
 import org.jetbrains.dokka.model.ExceptionInSupertypes
 import org.jetbrains.dokka.model.properties.WithExtraProperties
 
-val <T : Documentable> WithExtraProperties<T>.isException: Boolean
+public val <T : Documentable> WithExtraProperties<T>.isException: Boolean
     get() = extra[ExceptionInSupertypes] != null
 
 
-val <T : Documentable> WithExtraProperties<T>.deprecatedAnnotation
+public val <T : Documentable> WithExtraProperties<T>.deprecatedAnnotation: Annotations.Annotation?
     get() = extra[Annotations]?.let { annotations ->
         annotations.directAnnotations.values.flatten().firstOrNull {
             it.isDeprecated()
@@ -24,11 +24,12 @@ val <T : Documentable> WithExtraProperties<T>.deprecatedAnnotation
  * @return true if [T] has [kotlin.Deprecated] or [java.lang.Deprecated]
  *         annotation for **any** source set
  */
-fun <T : Documentable> WithExtraProperties<T>.isDeprecated() = deprecatedAnnotation != null
+public fun <T : Documentable> WithExtraProperties<T>.isDeprecated(): Boolean = deprecatedAnnotation != null
 
 /**
  * @return true for [kotlin.Deprecated] and [java.lang.Deprecated]
  */
-fun Annotations.Annotation.isDeprecated() =
-    (this.dri.packageName == "kotlin" && this.dri.classNames == "Deprecated") ||
+public fun Annotations.Annotation.isDeprecated(): Boolean {
+    return (this.dri.packageName == "kotlin" && this.dri.classNames == "Deprecated") ||
             (this.dri.packageName == "java.lang" && this.dri.classNames == "Deprecated")
+}

--- a/plugins/base/src/main/kotlin/transformers/pages/annotations/SinceKotlinTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/pages/annotations/SinceKotlinTransformer.kt
@@ -18,7 +18,7 @@ import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.transformers.documentation.DocumentableTransformer
 import org.jetbrains.dokka.utilities.associateWithNotNull
 
-class SinceKotlinVersion constructor(str: String) : Comparable<SinceKotlinVersion> {
+public class SinceKotlinVersion(str: String) : Comparable<SinceKotlinVersion> {
     private val parts: List<Int> = str.split(".").map { it.toInt() }
 
     /**
@@ -39,7 +39,9 @@ class SinceKotlinVersion constructor(str: String) : Comparable<SinceKotlinVersio
     override fun toString(): String = parts.joinToString(".")
 }
 
-class SinceKotlinTransformer(val context: DokkaContext) : DocumentableTransformer {
+public class SinceKotlinTransformer(
+    public val context: DokkaContext
+) : DocumentableTransformer {
 
     private val minSinceKotlinVersionOfPlatform = mapOf(
         Platform.common to SinceKotlinVersion("1.0"),
@@ -49,7 +51,7 @@ class SinceKotlinTransformer(val context: DokkaContext) : DocumentableTransforme
         Platform.wasm to SinceKotlinVersion("1.8"),
     )
 
-    override fun invoke(original: DModule, context: DokkaContext) = original.transform() as DModule
+    override fun invoke(original: DModule, context: DokkaContext): DModule = original.transform() as DModule
 
     private fun <T : Documentable> T.transform(parent: SourceSetDependent<SinceKotlinVersion>? = null): Documentable {
         val versions = calculateVersions(parent)

--- a/plugins/base/src/main/kotlin/transformers/pages/comments/CommentsToContentConverter.kt
+++ b/plugins/base/src/main/kotlin/transformers/pages/comments/CommentsToContentConverter.kt
@@ -11,8 +11,8 @@ import org.jetbrains.dokka.pages.ContentNode
 import org.jetbrains.dokka.pages.DCI
 import org.jetbrains.dokka.pages.Style
 
-interface CommentsToContentConverter {
-    fun buildContent(
+public interface CommentsToContentConverter {
+    public fun buildContent(
         docTag: DocTag,
         dci: DCI,
         sourceSets: Set<DokkaSourceSet>,

--- a/plugins/base/src/main/kotlin/transformers/pages/comments/DocTagToContentConverter.kt
+++ b/plugins/base/src/main/kotlin/transformers/pages/comments/DocTagToContentConverter.kt
@@ -14,7 +14,7 @@ import org.jetbrains.dokka.model.toDisplaySourceSets
 import org.jetbrains.dokka.pages.*
 import org.jetbrains.dokka.utilities.firstIsInstanceOrNull
 
-open class DocTagToContentConverter : CommentsToContentConverter {
+public open class DocTagToContentConverter : CommentsToContentConverter {
     override fun buildContent(
         docTag: DocTag,
         dci: DCI,

--- a/plugins/base/src/main/kotlin/transformers/pages/merger/FallbackPageMergerStrategy.kt
+++ b/plugins/base/src/main/kotlin/transformers/pages/merger/FallbackPageMergerStrategy.kt
@@ -8,7 +8,9 @@ import org.jetbrains.dokka.pages.ContentPage
 import org.jetbrains.dokka.pages.PageNode
 import org.jetbrains.dokka.utilities.DokkaLogger
 
-class FallbackPageMergerStrategy(private val logger: DokkaLogger) : PageMergerStrategy {
+public class FallbackPageMergerStrategy(
+    private val logger: DokkaLogger
+) : PageMergerStrategy {
     override fun tryMerge(pages: List<PageNode>, path: List<String>): List<PageNode> {
         pages.map {
             (it as? ContentPage)

--- a/plugins/base/src/main/kotlin/transformers/pages/merger/PageMerger.kt
+++ b/plugins/base/src/main/kotlin/transformers/pages/merger/PageMerger.kt
@@ -12,7 +12,7 @@ import org.jetbrains.dokka.plugability.plugin
 import org.jetbrains.dokka.plugability.query
 import org.jetbrains.dokka.transformers.pages.PageTransformer
 
-class PageMerger(context: DokkaContext) : PageTransformer {
+public class PageMerger(context: DokkaContext) : PageTransformer {
 
     private val strategies: Iterable<PageMergerStrategy> = context.plugin<DokkaBase>().query { pageMergerStrategy }
 

--- a/plugins/base/src/main/kotlin/transformers/pages/merger/PageMergerStrategy.kt
+++ b/plugins/base/src/main/kotlin/transformers/pages/merger/PageMergerStrategy.kt
@@ -6,8 +6,8 @@ package org.jetbrains.dokka.base.transformers.pages.merger
 
 import org.jetbrains.dokka.pages.PageNode
 
-fun interface PageMergerStrategy {
+public fun interface PageMergerStrategy {
 
-    fun tryMerge(pages: List<PageNode>, path: List<String>): List<PageNode>
+    public fun tryMerge(pages: List<PageNode>, path: List<String>): List<PageNode>
 
 }

--- a/plugins/base/src/main/kotlin/transformers/pages/merger/SameMethodNamePageMergerStrategy.kt
+++ b/plugins/base/src/main/kotlin/transformers/pages/merger/SameMethodNamePageMergerStrategy.kt
@@ -17,7 +17,9 @@ import org.jetbrains.dokka.utilities.DokkaLogger
  * Merges [MemberPage] elements that have the same name.
  * That includes **both** properties and functions.
  */
-class SameMethodNamePageMergerStrategy(val logger: DokkaLogger) : PageMergerStrategy {
+public class SameMethodNamePageMergerStrategy(
+    public val logger: DokkaLogger
+) : PageMergerStrategy {
     override fun tryMerge(pages: List<PageNode>, path: List<String>): List<PageNode> {
         val members = pages
             .filterIsInstance<MemberPageNode>()

--- a/plugins/base/src/main/kotlin/transformers/pages/merger/SourceSetMergingPageTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/pages/merger/SourceSetMergingPageTransformer.kt
@@ -13,7 +13,7 @@ import org.jetbrains.dokka.pages.RootPageNode
 import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.transformers.pages.PageTransformer
 
-class SourceSetMergingPageTransformer(context: DokkaContext) : PageTransformer {
+public class SourceSetMergingPageTransformer(context: DokkaContext) : PageTransformer {
 
     private val mergedSourceSets = context.configuration.sourceSets.toDisplaySourceSets()
         .associateBy { sourceSet -> sourceSet.key }

--- a/plugins/base/src/main/kotlin/transformers/pages/sourcelinks/SourceLinksTransformer.kt
+++ b/plugins/base/src/main/kotlin/transformers/pages/sourcelinks/SourceLinksTransformer.kt
@@ -17,7 +17,9 @@ import org.jetbrains.dokka.plugability.querySingle
 import org.jetbrains.dokka.transformers.pages.PageTransformer
 import java.io.File
 
-class SourceLinksTransformer(val context: DokkaContext) : PageTransformer {
+public class SourceLinksTransformer(
+    public val context: DokkaContext
+) : PageTransformer {
 
     private val builder : PageContentBuilder = PageContentBuilder(
         context.plugin<DokkaBase>().querySingle { commentsToContentConverter },
@@ -120,8 +122,16 @@ class SourceLinksTransformer(val context: DokkaContext) : PageTransformer {
     }
 }
 
-data class SourceLink(val path: String, val url: String, val lineSuffix: String?, val sourceSetData: DokkaSourceSet) {
-    constructor(sourceLinkDefinition: DokkaConfiguration.SourceLinkDefinition, sourceSetData: DokkaSourceSet) : this(
+public data class SourceLink(
+    val path: String,
+    val url: String,
+    val lineSuffix: String?,
+    val sourceSetData: DokkaSourceSet
+) {
+    public constructor(
+        sourceLinkDefinition: DokkaConfiguration.SourceLinkDefinition,
+        sourceSetData: DokkaSourceSet
+    ) : this(
         sourceLinkDefinition.localDirectory,
         sourceLinkDefinition.remoteUrl.toExternalForm(),
         sourceLinkDefinition.remoteLineSuffix,

--- a/plugins/base/src/main/kotlin/transformers/pages/tags/CustomTagContentProvider.kt
+++ b/plugins/base/src/main/kotlin/transformers/pages/tags/CustomTagContentProvider.kt
@@ -23,21 +23,21 @@ import org.jetbrains.dokka.model.doc.DocTag
  * Using this provider, we can map custom tags  (such as `@usesMathJax`) and generate content for it that
  * will be displayed on the pages.
  */
-interface CustomTagContentProvider {
+public interface CustomTagContentProvider {
 
     /**
      * Whether this content provider supports given [CustomTagWrapper].
      *
      * Tags can be filtered out either by name or by nested [DocTag] type
      */
-    fun isApplicable(customTag: CustomTagWrapper): Boolean
+    public fun isApplicable(customTag: CustomTagWrapper): Boolean
 
     /**
      * Full blown content description, most likely to be on a separate page
      * dedicated to just one element (i.e one class/function), so any
      * amount of detail should be fine.
      */
-    fun DocumentableContentBuilder.contentForDescription(
+    public fun DocumentableContentBuilder.contentForDescription(
         sourceSet: DokkaSourceSet,
         customTag: CustomTagWrapper
     ) {}
@@ -56,7 +56,7 @@ interface CustomTagContentProvider {
      * sense to include `@usesMathjax` here, as this information seems
      * to be more specific and detailed than is needed for a brief.
      */
-    fun DocumentableContentBuilder.contentForBrief(
+    public fun DocumentableContentBuilder.contentForBrief(
         sourceSet: DokkaSourceSet,
         customTag: CustomTagWrapper
     ) {}

--- a/plugins/base/src/main/kotlin/transformers/pages/tags/SinceKotlinTagContentProvider.kt
+++ b/plugins/base/src/main/kotlin/transformers/pages/tags/SinceKotlinTagContentProvider.kt
@@ -10,11 +10,11 @@ import org.jetbrains.dokka.base.translators.documentables.PageContentBuilder.Doc
 import org.jetbrains.dokka.model.doc.CustomTagWrapper
 import org.jetbrains.dokka.pages.TextStyle
 
-object SinceKotlinTagContentProvider : CustomTagContentProvider {
+public object SinceKotlinTagContentProvider : CustomTagContentProvider {
 
     private const val SINCE_KOTLIN_TAG_NAME = "Since Kotlin"
 
-    override fun isApplicable(customTag: CustomTagWrapper) = customTag.name == SINCE_KOTLIN_TAG_NAME
+    override fun isApplicable(customTag: CustomTagWrapper): Boolean = customTag.name == SINCE_KOTLIN_TAG_NAME
 
     override fun DocumentableContentBuilder.contentForDescription(
         sourceSet: DokkaConfiguration.DokkaSourceSet,

--- a/plugins/base/src/main/kotlin/translators/documentables/DefaultDocumentableToPageTranslator.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DefaultDocumentableToPageTranslator.kt
@@ -12,7 +12,7 @@ import org.jetbrains.dokka.plugability.*
 import org.jetbrains.dokka.transformers.documentation.DocumentableToPageTranslator
 import org.jetbrains.dokka.analysis.kotlin.internal.InternalKotlinAnalysisPlugin
 
-class DefaultDocumentableToPageTranslator(
+public class DefaultDocumentableToPageTranslator(
     context: DokkaContext
 ) : DocumentableToPageTranslator {
     private val configuration = configuration<DokkaBase, DokkaBaseConfiguration>(context)

--- a/plugins/base/src/main/kotlin/translators/documentables/DriClashAwareName.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/DriClashAwareName.kt
@@ -7,7 +7,7 @@ package org.jetbrains.dokka.base.translators.documentables
 import org.jetbrains.dokka.model.Documentable
 import org.jetbrains.dokka.model.properties.ExtraProperty
 
-data class DriClashAwareName(val value: String?): ExtraProperty<Documentable> {
-    companion object : ExtraProperty.Key<Documentable, DriClashAwareName>
+public data class DriClashAwareName(val value: String?): ExtraProperty<Documentable> {
+    public companion object : ExtraProperty.Key<Documentable, DriClashAwareName>
     override val key: ExtraProperty.Key<Documentable, *> = Companion
 }

--- a/plugins/base/src/main/kotlin/translators/documentables/PageContentBuilder.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/PageContentBuilder.kt
@@ -19,14 +19,14 @@ import org.jetbrains.dokka.pages.*
 import org.jetbrains.dokka.utilities.DokkaLogger
 
 @DslMarker
-annotation class ContentBuilderMarker
+public annotation class ContentBuilderMarker
 
-open class PageContentBuilder(
-    val commentsConverter: CommentsToContentConverter,
-    val signatureProvider: SignatureProvider,
-    val logger: DokkaLogger
+public open class PageContentBuilder(
+    public val commentsConverter: CommentsToContentConverter,
+    public val signatureProvider: SignatureProvider,
+    public val logger: DokkaLogger
 ) {
-    fun contentFor(
+    public fun contentFor(
         dri: DRI,
         sourceSets: Set<DokkaSourceSet>,
         kind: Kind = ContentKind.Main,
@@ -38,7 +38,7 @@ open class PageContentBuilder(
             .apply(block)
             .build(sourceSets, kind, styles, extra)
 
-    fun contentFor(
+    public fun contentFor(
         dri: Set<DRI>,
         sourceSets: Set<DokkaSourceSet>,
         kind: Kind = ContentKind.Main,
@@ -50,7 +50,7 @@ open class PageContentBuilder(
             .apply(block)
             .build(sourceSets, kind, styles, extra)
 
-    fun contentFor(
+    public fun contentFor(
         d: Documentable,
         kind: Kind = ContentKind.Main,
         styles: Set<Style> = emptySet(),
@@ -63,36 +63,38 @@ open class PageContentBuilder(
             .build(sourceSets, kind, styles, extra)
 
     @ContentBuilderMarker
-    open inner class DocumentableContentBuilder(
-        val mainDRI: Set<DRI>,
-        val mainSourcesetData: Set<DokkaSourceSet>,
-        val mainStyles: Set<Style>,
-        val mainExtra: PropertyContainer<ContentNode>
+    public open inner class DocumentableContentBuilder(
+        public val mainDRI: Set<DRI>,
+        public val mainSourcesetData: Set<DokkaSourceSet>,
+        public val mainStyles: Set<Style>,
+        public val mainExtra: PropertyContainer<ContentNode>
     ) {
-        protected val contents = mutableListOf<ContentNode>()
+        protected val contents: MutableList<ContentNode> = mutableListOf<ContentNode>()
 
-        fun build(
+        public fun build(
             sourceSets: Set<DokkaSourceSet>,
             kind: Kind,
             styles: Set<Style>,
             extra: PropertyContainer<ContentNode>
-        ) = ContentGroup(
-            contents.toList(),
-            DCI(mainDRI, kind),
-            sourceSets.toDisplaySourceSets(),
-            styles,
-            extra
-        )
+        ): ContentGroup {
+            return ContentGroup(
+                children = contents.toList(),
+                dci = DCI(mainDRI, kind),
+                sourceSets = sourceSets.toDisplaySourceSets(),
+                style = styles,
+                extra = extra
+            )
+        }
 
-        operator fun ContentNode.unaryPlus() {
+        public operator fun ContentNode.unaryPlus() {
             contents += this
         }
 
-        operator fun Collection<ContentNode>.unaryPlus() {
+        public operator fun Collection<ContentNode>.unaryPlus() {
             contents += this
         }
 
-        fun header(
+        public fun header(
             level: Int,
             text: String,
             kind: Kind = ContentKind.Main,
@@ -116,7 +118,7 @@ open class PageContentBuilder(
             )
         }
 
-        fun cover(
+        public fun cover(
             text: String,
             sourceSets: Set<DokkaSourceSet> = mainSourcesetData,
             styles: Set<Style> = mainStyles + TextStyle.Cover,
@@ -126,14 +128,31 @@ open class PageContentBuilder(
             header(1, text, sourceSets = sourceSets, styles = styles, extra = extra, block = block)
         }
 
-        fun constant(text: String) = text(text, styles = mainStyles + TokenStyle.Constant)
-        fun keyword(text: String) = text(text, styles = mainStyles + TokenStyle.Keyword)
-        fun stringLiteral(text: String) = text(text, styles = mainStyles + TokenStyle.String)
-        fun booleanLiteral(value: Boolean) = text(value.toString(), styles = mainStyles + TokenStyle.Boolean)
-        fun punctuation(text: String) = text(text, styles = mainStyles + TokenStyle.Punctuation)
-        fun operator(text: String) = text(text, styles = mainStyles + TokenStyle.Operator)
+        public fun constant(text: String) {
+            text(text, styles = mainStyles + TokenStyle.Constant)
+        }
 
-        fun text(
+        public fun keyword(text: String) {
+            text(text, styles = mainStyles + TokenStyle.Keyword)
+        }
+
+        public fun stringLiteral(text: String) {
+            text(text, styles = mainStyles + TokenStyle.String)
+        }
+
+        public fun booleanLiteral(value: Boolean) {
+            text(value.toString(), styles = mainStyles + TokenStyle.Boolean)
+        }
+
+        public fun punctuation(text: String) {
+            text(text, styles = mainStyles + TokenStyle.Punctuation)
+        }
+
+        public fun operator(text: String) {
+            text(text, styles = mainStyles + TokenStyle.Operator)
+        }
+
+        public fun text(
             text: String,
             kind: Kind = ContentKind.Main,
             sourceSets: Set<DokkaSourceSet> = mainSourcesetData,
@@ -143,13 +162,13 @@ open class PageContentBuilder(
             contents += createText(text, kind, sourceSets, styles, extra)
         }
 
-        fun breakLine(sourceSets: Set<DokkaSourceSet> = mainSourcesetData) {
+        public fun breakLine(sourceSets: Set<DokkaSourceSet> = mainSourcesetData) {
             contents += ContentBreakLine(sourceSets.toDisplaySourceSets())
         }
 
-        fun buildSignature(d: Documentable) = signatureProvider.signature(d)
+        public fun buildSignature(d: Documentable): List<ContentNode> = signatureProvider.signature(d)
 
-        fun table(
+        public fun table(
             kind: Kind = ContentKind.Main,
             sourceSets: Set<DokkaSourceSet> = mainSourcesetData,
             styles: Set<Style> = mainStyles,
@@ -161,7 +180,7 @@ open class PageContentBuilder(
             }.build()
         }
 
-        fun unorderedList(
+        public fun unorderedList(
             kind: Kind = ContentKind.Main,
             sourceSets: Set<DokkaSourceSet> = mainSourcesetData,
             styles: Set<Style> = mainStyles,
@@ -171,7 +190,7 @@ open class PageContentBuilder(
             contents += ListBuilder(false, mainDRI, sourceSets, kind, styles, extra).apply(operation).build()
         }
 
-        fun orderedList(
+        public fun orderedList(
             kind: Kind = ContentKind.Main,
             sourceSets: Set<DokkaSourceSet> = mainSourcesetData,
             styles: Set<Style> = mainStyles,
@@ -181,7 +200,7 @@ open class PageContentBuilder(
             contents += ListBuilder(true, mainDRI, sourceSets, kind, styles, extra).apply(operation).build()
         }
 
-        fun descriptionList(
+        public fun descriptionList(
             kind: Kind = ContentKind.Main,
             sourceSets: Set<DokkaSourceSet> = mainSourcesetData,
             styles: Set<Style> = mainStyles,
@@ -197,7 +216,7 @@ open class PageContentBuilder(
             label.forEach { text(it) }
         }
 
-        fun <T : Documentable> block(
+        public fun <T : Documentable> block(
             name: String,
             level: Int,
             kind: Kind = ContentKind.Main,
@@ -235,7 +254,7 @@ open class PageContentBuilder(
             }
         }
 
-        fun <T : Pair<String, List<Documentable>>> multiBlock(
+        public fun <T : Pair<String, List<Documentable>>> multiBlock(
             name: String,
             level: Int,
             kind: Kind = ContentKind.Main,
@@ -286,7 +305,7 @@ open class PageContentBuilder(
             }
         }
 
-        fun <T> list(
+        public fun <T> list(
             elements: List<T>,
             prefix: String = "",
             suffix: String = "",
@@ -307,7 +326,7 @@ open class PageContentBuilder(
             }
         }
 
-        fun link(
+        public fun link(
             text: String,
             address: DRI,
             kind: Kind = ContentKind.Main,
@@ -318,22 +337,24 @@ open class PageContentBuilder(
             contents += linkNode(text, address, DCI(mainDRI, kind), sourceSets, styles, extra)
         }
 
-        fun linkNode(
+        public fun linkNode(
             text: String,
             address: DRI,
             dci: DCI = DCI(mainDRI, ContentKind.Main),
             sourceSets: Set<DokkaSourceSet> = mainSourcesetData,
             styles: Set<Style> = mainStyles,
             extra: PropertyContainer<ContentNode> = mainExtra
-        ) = ContentDRILink(
-            listOf(createText(text, dci.kind, sourceSets, styles, extra)),
-            address,
-            dci,
-            sourceSets.toDisplaySourceSets(),
-            extra = extra
-        )
+        ): ContentLink {
+            return ContentDRILink(
+                listOf(createText(text, dci.kind, sourceSets, styles, extra)),
+                address,
+                dci,
+                sourceSets.toDisplaySourceSets(),
+                extra = extra
+            )
+        }
 
-        fun link(
+        public fun link(
             text: String,
             address: String,
             kind: Kind = ContentKind.Main,
@@ -351,7 +372,7 @@ open class PageContentBuilder(
             )
         }
 
-        fun link(
+        public fun link(
             address: DRI,
             kind: Kind = ContentKind.Main,
             sourceSets: Set<DokkaSourceSet> = mainSourcesetData,
@@ -368,7 +389,7 @@ open class PageContentBuilder(
             )
         }
 
-        fun comment(
+        public fun comment(
             docTag: DocTag,
             kind: Kind = ContentKind.Comment,
             sourceSets: Set<DokkaSourceSet> = mainSourcesetData,
@@ -383,7 +404,7 @@ open class PageContentBuilder(
             contents += ContentGroup(content, DCI(mainDRI, kind), sourceSets.toDisplaySourceSets(), styles, extra)
         }
 
-        fun codeBlock(
+        public fun codeBlock(
             language: String = "",
             kind: Kind = ContentKind.Main,
             sourceSets: Set<DokkaSourceSet> = mainSourcesetData,
@@ -401,7 +422,7 @@ open class PageContentBuilder(
             )
         }
 
-        fun codeInline(
+        public fun codeInline(
             language: String = "",
             kind: Kind = ContentKind.Main,
             sourceSets: Set<DokkaSourceSet> = mainSourcesetData,
@@ -419,7 +440,7 @@ open class PageContentBuilder(
             )
         }
 
-        fun firstParagraphComment(
+        public fun firstParagraphComment(
             content: DocTag,
             kind: Kind = ContentKind.Comment,
             sourceSets: Set<DokkaSourceSet> = mainSourcesetData,
@@ -443,7 +464,7 @@ open class PageContentBuilder(
             }
         }
 
-        fun firstSentenceComment(
+        public fun firstSentenceComment(
             content: DocTag,
             kind: Kind = ContentKind.Comment,
             sourceSets: Set<DokkaSourceSet> = mainSourcesetData,
@@ -465,7 +486,7 @@ open class PageContentBuilder(
             )
         }
 
-        fun group(
+        public fun group(
             dri: Set<DRI> = mainDRI,
             sourceSets: Set<DokkaSourceSet> = mainSourcesetData,
             kind: Kind = ContentKind.Main,
@@ -476,7 +497,7 @@ open class PageContentBuilder(
             contents += buildGroup(dri, sourceSets, kind, styles, extra, block)
         }
 
-        fun divergentGroup(
+        public fun divergentGroup(
             groupID: ContentDivergentGroup.GroupID,
             dri: Set<DRI> = mainDRI,
             kind: Kind = ContentKind.Main,
@@ -491,7 +512,7 @@ open class PageContentBuilder(
                     .build(groupID = groupID, implicitlySourceSetHinted = implicitlySourceSetHinted)
         }
 
-        fun buildGroup(
+        public fun buildGroup(
             dri: Set<DRI> = mainDRI,
             sourceSets: Set<DokkaSourceSet> = mainSourcesetData,
             kind: Kind = ContentKind.Main,
@@ -500,7 +521,7 @@ open class PageContentBuilder(
             block: DocumentableContentBuilder.() -> Unit
         ): ContentGroup = contentFor(dri, sourceSets, kind, styles, extra, block)
 
-        fun sourceSetDependentHint(
+        public fun sourceSetDependentHint(
             dri: Set<DRI> = mainDRI,
             sourceSets: Set<DokkaSourceSet> = mainSourcesetData,
             kind: Kind = ContentKind.Main,
@@ -514,7 +535,7 @@ open class PageContentBuilder(
             )
         }
 
-        fun sourceSetDependentHint(
+        public fun sourceSetDependentHint(
             dri: DRI,
             sourcesetData: Set<DokkaSourceSet> = mainSourcesetData,
             kind: Kind = ContentKind.Main,
@@ -534,23 +555,26 @@ open class PageContentBuilder(
             sourceSets: Set<DokkaSourceSet>,
             styles: Set<Style>,
             extra: PropertyContainer<ContentNode>
-        ) =
-            ContentText(text, DCI(mainDRI, kind), sourceSets.toDisplaySourceSets(), styles, extra)
+        ): ContentText {
+            return ContentText(text, DCI(mainDRI, kind), sourceSets.toDisplaySourceSets(), styles, extra)
+        }
 
-        fun <T> sourceSetDependentText(
+        public fun <T> sourceSetDependentText(
             value: SourceSetDependent<T>,
             sourceSets: Set<DokkaSourceSet> = value.keys,
             styles: Set<Style> = mainStyles,
             transform: (T) -> String
-        ) = value.entries.filter { it.key in sourceSets }.mapNotNull { (p, v) ->
-            transform(v).takeIf { it.isNotBlank() }?.let { it to p }
-        }.groupBy({ it.first }) { it.second }.forEach {
-            text(it.key, sourceSets = it.value.toSet(), styles = styles)
+        ) {
+            value.entries
+                .filter { it.key in sourceSets }
+                .mapNotNull { (p, v) -> transform(v).takeIf { it.isNotBlank() }?.let { it to p } }
+                .groupBy({ it.first }) { it.second }
+                    .forEach { text(it.key, sourceSets = it.value.toSet(), styles = styles) }
         }
     }
 
     @ContentBuilderMarker
-    open inner class TableBuilder(
+    public open inner class TableBuilder(
         private val mainDRI: Set<DRI>,
         private val mainSourceSets: Set<DokkaSourceSet>,
         private val mainKind: Kind,
@@ -561,7 +585,7 @@ open class PageContentBuilder(
         private val rows: MutableList<ContentGroup> = mutableListOf()
         private var caption: ContentGroup? = null
 
-        fun header(
+        public fun header(
             dri: Set<DRI> = mainDRI,
             sourceSets: Set<DokkaSourceSet> = mainSourceSets,
             kind: Kind = mainKind,
@@ -572,7 +596,7 @@ open class PageContentBuilder(
             headerRows += contentFor(dri, sourceSets, kind, styles, extra, block)
         }
 
-        fun row(
+        public fun row(
             dri: Set<DRI> = mainDRI,
             sourceSets: Set<DokkaSourceSet> = mainSourceSets,
             kind: Kind = mainKind,
@@ -583,7 +607,7 @@ open class PageContentBuilder(
             rows += contentFor(dri, sourceSets, kind, styles, extra, block)
         }
 
-        fun caption(
+        public fun caption(
             dri: Set<DRI> = mainDRI,
             sourceSets: Set<DokkaSourceSet> = mainSourceSets,
             kind: Kind = mainKind,
@@ -594,30 +618,33 @@ open class PageContentBuilder(
             caption = contentFor(dri, sourceSets, kind, styles, extra, block)
         }
 
-        fun build(
+        public fun build(
             sourceSets: Set<DokkaSourceSet> = mainSourceSets,
             kind: Kind = mainKind,
             styles: Set<Style> = mainStyles,
             extra: PropertyContainer<ContentNode> = mainExtra
-        ) = ContentTable(
-            headerRows,
-            caption,
-            rows,
-            DCI(mainDRI, kind),
-            sourceSets.toDisplaySourceSets(),
-            styles, extra
-        )
+        ): ContentTable {
+            return ContentTable(
+                headerRows,
+                caption,
+                rows,
+                DCI(mainDRI, kind),
+                sourceSets.toDisplaySourceSets(),
+                styles, extra
+            )
+        }
     }
 
     @ContentBuilderMarker
-    open inner class DivergentBuilder(
+    public open inner class DivergentBuilder(
         private val mainDRI: Set<DRI>,
         private val mainKind: Kind,
         private val mainStyles: Set<Style>,
         private val mainExtra: PropertyContainer<ContentNode>
     ) {
         private val instances: MutableList<ContentDivergentInstance> = mutableListOf()
-        fun instance(
+
+        public fun instance(
             dri: Set<DRI>,
             sourceSets: Set<DokkaSourceSet>,  // Having correct sourcesetData is crucial here, that's why there's no default
             kind: Kind = mainKind,
@@ -630,24 +657,26 @@ open class PageContentBuilder(
                 .build(kind)
         }
 
-        fun build(
+        public fun build(
             groupID: ContentDivergentGroup.GroupID,
             implicitlySourceSetHinted: Boolean,
             kind: Kind = mainKind,
             styles: Set<Style> = mainStyles,
             extra: PropertyContainer<ContentNode> = mainExtra
-        ) = ContentDivergentGroup(
-            instances.toList(),
-            DCI(mainDRI, kind),
-            styles,
-            extra,
-            groupID,
-            implicitlySourceSetHinted
-        )
+        ): ContentDivergentGroup {
+            return ContentDivergentGroup(
+                children = instances.toList(),
+                dci = DCI(mainDRI, kind),
+                style = styles,
+                extra = extra,
+                groupID = groupID,
+                implicitlySourceSetHinted = implicitlySourceSetHinted
+            )
+        }
     }
 
     @ContentBuilderMarker
-    open inner class DivergentInstanceBuilder(
+    public open inner class DivergentInstanceBuilder(
         private val mainDRI: Set<DRI>,
         private val mainSourceSets: Set<DokkaSourceSet>,
         private val mainStyles: Set<Style>,
@@ -657,7 +686,7 @@ open class PageContentBuilder(
         private var divergent: ContentNode? = null
         private var after: ContentNode? = null
 
-        fun before(
+        public fun before(
             dri: Set<DRI> = mainDRI,
             sourceSets: Set<DokkaSourceSet> = mainSourceSets,
             kind: Kind = ContentKind.Main,
@@ -670,7 +699,7 @@ open class PageContentBuilder(
                 .also { before = it }
         }
 
-        fun divergent(
+        public fun divergent(
             dri: Set<DRI> = mainDRI,
             sourceSets: Set<DokkaSourceSet> = mainSourceSets,
             kind: Kind = ContentKind.Main,
@@ -681,7 +710,7 @@ open class PageContentBuilder(
             divergent = contentFor(dri, sourceSets, kind, styles, extra, block)
         }
 
-        fun after(
+        public fun after(
             dri: Set<DRI> = mainDRI,
             sourceSets: Set<DokkaSourceSet> = mainSourceSets,
             kind: Kind = ContentKind.Main,
@@ -694,14 +723,13 @@ open class PageContentBuilder(
                 .also { after = it }
         }
 
-
-        fun build(
+        public fun build(
             kind: Kind,
             sourceSets: Set<DokkaSourceSet> = mainSourceSets,
             styles: Set<Style> = mainStyles,
             extra: PropertyContainer<ContentNode> = mainExtra
-        ) =
-            ContentDivergentInstance(
+        ): ContentDivergentInstance {
+            return ContentDivergentInstance(
                 before,
                 divergent ?: throw IllegalStateException("Divergent block needs divergent part"),
                 after,
@@ -710,11 +738,12 @@ open class PageContentBuilder(
                 styles,
                 extra
             )
+        }
     }
 
     @ContentBuilderMarker
-    open inner class ListBuilder(
-        val ordered: Boolean,
+    public open inner class ListBuilder(
+        public val ordered: Boolean,
         private val mainDRI: Set<DRI>,
         private val mainSourceSets: Set<DokkaSourceSet>,
         private val mainKind: Kind,
@@ -723,7 +752,7 @@ open class PageContentBuilder(
     ) {
         private val contentNodes: MutableList<ContentNode> = mutableListOf()
 
-        fun item(
+        public fun item(
             dri: Set<DRI> = mainDRI,
             sourceSets: Set<DokkaSourceSet> = mainSourceSets,
             kind: Kind = mainKind,
@@ -734,17 +763,19 @@ open class PageContentBuilder(
             contentNodes += contentFor(dri, sourceSets, kind, styles, extra, block)
         }
 
-        fun build(
+        public fun build(
             sourceSets: Set<DokkaSourceSet> = mainSourceSets,
             kind: Kind = mainKind,
             styles: Set<Style> = mainStyles,
             extra: PropertyContainer<ContentNode> = mainExtra
-        ) = ContentList(
-            contentNodes,
-            ordered,
-            DCI(mainDRI, kind),
-            sourceSets.toDisplaySourceSets(),
-            styles, extra
-        )
+        ): ContentList {
+            return ContentList(
+                contentNodes,
+                ordered,
+                DCI(mainDRI, kind),
+                sourceSets.toDisplaySourceSets(),
+                styles, extra
+            )
+        }
     }
 }

--- a/plugins/base/src/main/kotlin/translators/documentables/briefFromContentNodes.kt
+++ b/plugins/base/src/main/kotlin/translators/documentables/briefFromContentNodes.kt
@@ -12,7 +12,7 @@ import org.jetbrains.dokka.model.doc.Text
 import org.jetbrains.dokka.model.withDescendants
 import org.jetbrains.dokka.pages.*
 
-fun firstParagraphBrief(docTag: DocTag): DocTag? =
+public fun firstParagraphBrief(docTag: DocTag): DocTag? =
     when(docTag){
         is P -> docTag
         is CustomDocTag -> docTag.children.firstNotNullOfOrNull { firstParagraphBrief(it) }
@@ -20,7 +20,7 @@ fun firstParagraphBrief(docTag: DocTag): DocTag? =
         else -> null
     }
 
-fun firstSentenceBriefFromContentNodes(description: List<ContentNode>): List<ContentNode> {
+public fun firstSentenceBriefFromContentNodes(description: List<ContentNode>): List<ContentNode> {
     val firstSentenceRegex = """^((?:[^.?!]|[.!?](?!\s))*[.!?])""".toRegex()
 
     //Description that is entirely based on html content. In html it is hard to define a brief so we render all of it

--- a/plugins/base/src/main/kotlin/translators/psi/parsers/InheritDocResolver.kt
+++ b/plugins/base/src/main/kotlin/translators/psi/parsers/InheritDocResolver.kt
@@ -1,4 +1,0 @@
-/*
- * Copyright 2014-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
- */
-

--- a/plugins/base/src/main/kotlin/translators/psi/parsers/JavadocParser.kt
+++ b/plugins/base/src/main/kotlin/translators/psi/parsers/JavadocParser.kt
@@ -1,4 +1,0 @@
-/*
- * Copyright 2014-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
- */
-

--- a/plugins/base/src/main/kotlin/translators/psi/parsers/JavadocTag.kt
+++ b/plugins/base/src/main/kotlin/translators/psi/parsers/JavadocTag.kt
@@ -1,4 +1,0 @@
-/*
- * Copyright 2014-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
- */
-

--- a/plugins/gfm/api/gfm.api
+++ b/plugins/gfm/api/gfm.api
@@ -30,8 +30,7 @@ public final class org/jetbrains/dokka/gfm/location/MarkdownLocationProvider : o
 
 public final class org/jetbrains/dokka/gfm/location/MarkdownLocationProvider$Factory : org/jetbrains/dokka/base/resolvers/local/LocationProviderFactory {
 	public fun <init> (Lorg/jetbrains/dokka/plugability/DokkaContext;)V
-	public synthetic fun getLocationProvider (Lorg/jetbrains/dokka/pages/RootPageNode;)Lorg/jetbrains/dokka/base/resolvers/local/LocationProvider;
-	public fun getLocationProvider (Lorg/jetbrains/dokka/pages/RootPageNode;)Lorg/jetbrains/dokka/gfm/location/MarkdownLocationProvider;
+	public fun getLocationProvider (Lorg/jetbrains/dokka/pages/RootPageNode;)Lorg/jetbrains/dokka/base/resolvers/local/LocationProvider;
 }
 
 public final class org/jetbrains/dokka/gfm/renderer/BriefCommentPreprocessor : org/jetbrains/dokka/transformers/pages/PageTransformer {

--- a/plugins/gfm/gfm-template-processing/src/main/kotlin/org/jetbrains/dokka/gfm/templateProcessing/GfmTemplateProcessingPlugin.kt
+++ b/plugins/gfm/gfm-template-processing/src/main/kotlin/org/jetbrains/dokka/gfm/templateProcessing/GfmTemplateProcessingPlugin.kt
@@ -7,33 +7,34 @@ package org.jetbrains.dokka.gfm.templateProcessing
 import org.jetbrains.dokka.allModulesPage.AllModulesPagePlugin
 import org.jetbrains.dokka.allModulesPage.MultimoduleLocationProvider
 import org.jetbrains.dokka.base.DokkaBase
+import org.jetbrains.dokka.base.resolvers.local.LocationProviderFactory
 import org.jetbrains.dokka.gfm.GfmPlugin
 import org.jetbrains.dokka.gfm.location.MarkdownLocationProvider
 import org.jetbrains.dokka.plugability.DokkaPlugin
 import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
+import org.jetbrains.dokka.plugability.Extension
 import org.jetbrains.dokka.plugability.PluginApiPreviewAcknowledgement
+import org.jetbrains.dokka.templates.TemplateProcessingStrategy
 import org.jetbrains.dokka.templates.TemplatingPlugin
 
-class GfmTemplateProcessingPlugin : DokkaPlugin() {
+public class GfmTemplateProcessingPlugin : DokkaPlugin() {
 
     private val allModulesPagePlugin by lazy { plugin<AllModulesPagePlugin>() }
     private val templateProcessingPlugin by lazy { plugin<TemplatingPlugin>() }
-
     private val gfmPlugin by lazy { plugin<GfmPlugin>() }
-
     private val dokkaBase by lazy { plugin<DokkaBase>()}
 
-    val gfmTemplateProcessingStrategy by extending {
+    public val gfmTemplateProcessingStrategy: Extension<TemplateProcessingStrategy, *, *> by extending {
         (templateProcessingPlugin.templateProcessingStrategy
                 providing ::GfmTemplateProcessingStrategy
                 order { before(templateProcessingPlugin.fallbackProcessingStrategy) })
     }
 
-    val gfmLocationProvider by extending {
+    public val gfmLocationProvider: Extension<LocationProviderFactory, *, *> by extending {
         dokkaBase.locationProviderFactory providing MultimoduleLocationProvider::Factory override listOf(gfmPlugin.locationProvider, allModulesPagePlugin.multimoduleLocationProvider)
     }
 
-    val gfmPartialLocationProvider by extending {
+    public val gfmPartialLocationProvider: Extension<LocationProviderFactory, *, *> by extending {
         allModulesPagePlugin.partialLocationProviderFactory providing MarkdownLocationProvider::Factory override allModulesPagePlugin.baseLocationProviderFactory
     }
 

--- a/plugins/gfm/gfm-template-processing/src/main/kotlin/org/jetbrains/dokka/gfm/templateProcessing/GfmTemplateProcessingStrategy.kt
+++ b/plugins/gfm/gfm-template-processing/src/main/kotlin/org/jetbrains/dokka/gfm/templateProcessing/GfmTemplateProcessingStrategy.kt
@@ -20,7 +20,9 @@ import org.jetbrains.dokka.templates.TemplateProcessingStrategy
 import java.io.BufferedWriter
 import java.io.File
 
-class GfmTemplateProcessingStrategy(val context: DokkaContext) : TemplateProcessingStrategy {
+public class GfmTemplateProcessingStrategy(
+    public val context: DokkaContext
+) : TemplateProcessingStrategy {
 
     private val externalModuleLinkResolver =
         context.plugin<AllModulesPagePlugin>().querySingle { externalModuleLinkResolver }

--- a/plugins/gfm/src/main/kotlin/org/jetbrains/dokka/gfm/GfmPlugin.kt
+++ b/plugins/gfm/src/main/kotlin/org/jetbrains/dokka/gfm/GfmPlugin.kt
@@ -8,39 +8,39 @@ import org.jetbrains.dokka.CoreExtensions
 import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.base.renderers.PackageListCreator
 import org.jetbrains.dokka.base.renderers.RootCreator
+import org.jetbrains.dokka.base.resolvers.local.LocationProviderFactory
 import org.jetbrains.dokka.base.resolvers.shared.RecognizedLinkFormat
 import org.jetbrains.dokka.gfm.location.MarkdownLocationProvider
 import org.jetbrains.dokka.gfm.renderer.BriefCommentPreprocessor
 import org.jetbrains.dokka.gfm.renderer.CommonmarkRenderer
-import org.jetbrains.dokka.plugability.DokkaPlugin
-import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
-import org.jetbrains.dokka.plugability.PluginApiPreviewAcknowledgement
+import org.jetbrains.dokka.plugability.*
 import org.jetbrains.dokka.renderers.PostAction
+import org.jetbrains.dokka.renderers.Renderer
 import org.jetbrains.dokka.transformers.pages.PageTransformer
 
-class GfmPlugin : DokkaPlugin() {
+public class GfmPlugin : DokkaPlugin() {
 
-    val gfmPreprocessors by extensionPoint<PageTransformer>()
+    public val gfmPreprocessors: ExtensionPoint<PageTransformer> by extensionPoint<PageTransformer>()
 
     private val dokkaBase by lazy { plugin<DokkaBase>() }
 
-    val renderer by extending {
+    public val renderer: Extension<Renderer, *, *> by extending {
         CoreExtensions.renderer providing ::CommonmarkRenderer override dokkaBase.htmlRenderer
     }
 
-    val locationProvider by extending {
+    public val locationProvider: Extension<LocationProviderFactory, *, *> by extending {
         dokkaBase.locationProviderFactory providing MarkdownLocationProvider::Factory override dokkaBase.locationProvider
     }
 
-    val rootCreator by extending {
+    public val rootCreator: Extension<PageTransformer, *, *> by extending {
         gfmPreprocessors with RootCreator
     }
 
-    val briefCommentPreprocessor by extending {
+    public val briefCommentPreprocessor: Extension<PageTransformer, *, *> by extending {
         gfmPreprocessors with BriefCommentPreprocessor()
     }
 
-    val packageListCreator by extending {
+    public val packageListCreator: Extension<PageTransformer, *, *> by extending {
         (gfmPreprocessors
                 providing { PackageListCreator(it, RecognizedLinkFormat.DokkaGFM) }
                 order { after(rootCreator) })

--- a/plugins/gfm/src/main/kotlin/org/jetbrains/dokka/gfm/gfmTemplating.kt
+++ b/plugins/gfm/src/main/kotlin/org/jetbrains/dokka/gfm/gfmTemplating.kt
@@ -10,16 +10,21 @@ import org.jetbrains.dokka.base.templating.toJsonString
 import org.jetbrains.dokka.links.DRI
 
 @JsonTypeInfo(use = CLASS)
-sealed class GfmCommand {
-    companion object {
+public sealed class GfmCommand {
+
+    public companion object {
         private const val delimiter = "\u1680"
-        val templateCommandRegex: Regex =
+
+        public val templateCommandRegex: Regex =
             Regex("<!---$delimiter GfmCommand ([^$delimiter ]*)$delimiter--->(.+?)(?=<!---$delimiter)<!---$delimiter--->")
-        val MatchResult.command
+
+        public val MatchResult.command: String
             get() = groupValues[1]
-        val MatchResult.label
+
+        public val MatchResult.label: String
             get() = groupValues[2]
-        fun Appendable.templateCommand(command: GfmCommand, content: Appendable.() -> Unit) {
+
+        public fun Appendable.templateCommand(command: GfmCommand, content: Appendable.() -> Unit) {
             append("<!---$delimiter GfmCommand ${toJsonString(command)}$delimiter--->")
             content()
             append("<!---$delimiter--->")
@@ -27,6 +32,8 @@ sealed class GfmCommand {
     }
 }
 
-class ResolveLinkGfmCommand(val dri: DRI) : GfmCommand()
+public class ResolveLinkGfmCommand(
+    public val dri: DRI
+) : GfmCommand()
 
 

--- a/plugins/gfm/src/main/kotlin/org/jetbrains/dokka/gfm/location/MarkdownLocationProvider.kt
+++ b/plugins/gfm/src/main/kotlin/org/jetbrains/dokka/gfm/location/MarkdownLocationProvider.kt
@@ -5,17 +5,18 @@
 package org.jetbrains.dokka.gfm.location
 
 import org.jetbrains.dokka.base.resolvers.local.DokkaLocationProvider
+import org.jetbrains.dokka.base.resolvers.local.LocationProvider
 import org.jetbrains.dokka.base.resolvers.local.LocationProviderFactory
 import org.jetbrains.dokka.pages.RootPageNode
 import org.jetbrains.dokka.plugability.DokkaContext
 
-class MarkdownLocationProvider(
+public class MarkdownLocationProvider(
     pageGraphRoot: RootPageNode,
     dokkaContext: DokkaContext
 ) : DokkaLocationProvider(pageGraphRoot, dokkaContext, ".md") {
 
-    class Factory(private val context: DokkaContext) : LocationProviderFactory {
-        override fun getLocationProvider(pageNode: RootPageNode) =
+    public class Factory(private val context: DokkaContext) : LocationProviderFactory {
+        override fun getLocationProvider(pageNode: RootPageNode): LocationProvider =
             MarkdownLocationProvider(pageNode, context)
     }
 }

--- a/plugins/gfm/src/main/kotlin/org/jetbrains/dokka/gfm/renderer/BriefCommentPreprocessor.kt
+++ b/plugins/gfm/src/main/kotlin/org/jetbrains/dokka/gfm/renderer/BriefCommentPreprocessor.kt
@@ -7,14 +7,16 @@ package org.jetbrains.dokka.gfm.renderer
 import org.jetbrains.dokka.pages.*
 import org.jetbrains.dokka.transformers.pages.PageTransformer
 
-class BriefCommentPreprocessor : PageTransformer {
-    override fun invoke(input: RootPageNode) = input.transformContentPagesTree { contentPage ->
-        contentPage.modified(content = contentPage.content.recursiveMapTransform<ContentGroup, ContentNode> {
-            if (it.dci.kind == ContentKind.BriefComment) {
-                it.copy(style = it.style + setOf(TextStyle.Block))
-            } else {
-                it
-            }
-        })
+public class BriefCommentPreprocessor : PageTransformer {
+    override fun invoke(input: RootPageNode): RootPageNode {
+        return input.transformContentPagesTree { contentPage ->
+            contentPage.modified(content = contentPage.content.recursiveMapTransform<ContentGroup, ContentNode> {
+                if (it.dci.kind == ContentKind.BriefComment) {
+                    it.copy(style = it.style + setOf(TextStyle.Block))
+                } else {
+                    it
+                }
+            })
+        }
     }
 }

--- a/plugins/gfm/src/main/kotlin/org/jetbrains/dokka/gfm/renderer/CommonmarkRenderer.kt
+++ b/plugins/gfm/src/main/kotlin/org/jetbrains/dokka/gfm/renderer/CommonmarkRenderer.kt
@@ -15,13 +15,14 @@ import org.jetbrains.dokka.pages.*
 import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.plugability.plugin
 import org.jetbrains.dokka.plugability.query
+import org.jetbrains.dokka.transformers.pages.PageTransformer
 import org.jetbrains.dokka.utilities.htmlEscape
 
-open class CommonmarkRenderer(
+public open class CommonmarkRenderer(
     context: DokkaContext
 ) : DefaultRenderer<StringBuilder>(context) {
 
-    override val preprocessors = context.plugin<GfmPlugin>().query { gfmPreprocessors }
+    override val preprocessors: List<PageTransformer> = context.plugin<GfmPlugin>().query { gfmPreprocessors }
 
     private val isPartial = context.configuration.delayTemplateSubstitution
 

--- a/plugins/javadoc/api/javadoc.api
+++ b/plugins/javadoc/api/javadoc.api
@@ -16,14 +16,12 @@ public final class org/jetbrains/dokka/javadoc/JavadocPlugin : org/jetbrains/dok
 	public final fun getAllClassessPageInstaller ()Lorg/jetbrains/dokka/plugability/Extension;
 	public final fun getDeprecatedPageCreator ()Lorg/jetbrains/dokka/plugability/Extension;
 	public final fun getDocumentableSourceSetFilter ()Lorg/jetbrains/dokka/plugability/Extension;
-	public final fun getDokkaBasePlugin ()Lorg/jetbrains/dokka/base/DokkaBase;
 	public final fun getDokkaJavadocPlugin ()Lorg/jetbrains/dokka/plugability/Extension;
 	public final fun getIndexGenerator ()Lorg/jetbrains/dokka/plugability/Extension;
 	public final fun getJavadocLocationProviderFactory ()Lorg/jetbrains/dokka/plugability/Extension;
 	public final fun getJavadocMultiplatformCheck ()Lorg/jetbrains/dokka/plugability/Extension;
 	public final fun getJavadocPreprocessors ()Lorg/jetbrains/dokka/plugability/ExtensionPoint;
 	public final fun getJavadocSignatureProvider ()Lorg/jetbrains/dokka/plugability/Extension;
-	public final fun getKotinAsJavaPlugin ()Lorg/jetbrains/dokka/kotlinAsJava/KotlinAsJavaPlugin;
 	public final fun getLocationProviderFactory ()Lorg/jetbrains/dokka/plugability/ExtensionPoint;
 	public final fun getPackageListCreator ()Lorg/jetbrains/dokka/plugability/Extension;
 	public final fun getPageTranslator ()Lorg/jetbrains/dokka/plugability/Extension;
@@ -45,8 +43,7 @@ public final class org/jetbrains/dokka/javadoc/location/JavadocLocationProvider 
 
 public final class org/jetbrains/dokka/javadoc/location/JavadocLocationProviderFactory : org/jetbrains/dokka/base/resolvers/local/LocationProviderFactory {
 	public fun <init> (Lorg/jetbrains/dokka/plugability/DokkaContext;)V
-	public synthetic fun getLocationProvider (Lorg/jetbrains/dokka/pages/RootPageNode;)Lorg/jetbrains/dokka/base/resolvers/local/LocationProvider;
-	public fun getLocationProvider (Lorg/jetbrains/dokka/pages/RootPageNode;)Lorg/jetbrains/dokka/javadoc/location/JavadocLocationProvider;
+	public fun getLocationProvider (Lorg/jetbrains/dokka/pages/RootPageNode;)Lorg/jetbrains/dokka/base/resolvers/local/LocationProvider;
 }
 
 public final class org/jetbrains/dokka/javadoc/pages/AllClassesPage : org/jetbrains/dokka/javadoc/pages/JavadocPageNode {

--- a/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/JavadocDocumentableToPageTranslator.kt
+++ b/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/JavadocDocumentableToPageTranslator.kt
@@ -9,7 +9,7 @@ import org.jetbrains.dokka.pages.RootPageNode
 import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.transformers.documentation.DocumentableToPageTranslator
 
-class JavadocDocumentableToPageTranslator(
+public class JavadocDocumentableToPageTranslator(
     private val context: DokkaContext
 ) : DocumentableToPageTranslator {
     override fun invoke(module: DModule): RootPageNode = JavadocPageCreator(context).pageForModule(module)

--- a/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/JavadocPageCreator.kt
+++ b/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/JavadocPageCreator.kt
@@ -20,25 +20,27 @@ import org.jetbrains.dokka.plugability.plugin
 import org.jetbrains.dokka.plugability.querySingle
 import kotlin.reflect.KClass
 
-open class JavadocPageCreator(context: DokkaContext) {
+public open class JavadocPageCreator(context: DokkaContext) {
     private val signatureProvider: SignatureProvider = context.plugin<DokkaBase>().querySingle { signatureProvider }
     private val documentationVersion = context.configuration.moduleVersion
 
-    fun pageForModule(m: DModule): JavadocModulePageNode =
-        JavadocModulePageNode(
+    public fun pageForModule(m: DModule): JavadocModulePageNode {
+        return JavadocModulePageNode(
             name = m.name.ifEmpty { "root" },
             content = contentForModule(m),
             children = m.packages.map { pageForPackage(it) },
             dri = setOf(m.dri),
             extra = ((m as? WithExtraProperties<DModule>)?.extra ?: PropertyContainer.empty())
         )
+    }
 
-    fun pageForPackage(p: DPackage) =
-        JavadocPackagePageNode(p.name, contentForPackage(p), setOf(p.dri), listOf(p),
+    public fun pageForPackage(p: DPackage): JavadocPackagePageNode {
+        return JavadocPackagePageNode(p.name, contentForPackage(p), setOf(p.dri), listOf(p),
             p.classlikes.mapNotNull { pageForClasslike(it) }
         )
+    }
 
-    fun pageForClasslike(c: DClasslike): JavadocClasslikePageNode? {
+    public fun pageForClasslike(c: DClasslike): JavadocClasslikePageNode? {
         return c.highestJvmSourceSet?.let { jvm ->
             @Suppress("UNCHECKED_CAST")
             val extra = ((c as? WithExtraProperties<Documentable>)?.extra ?: PropertyContainer.empty())
@@ -209,9 +211,10 @@ open class JavadocPageCreator(context: DokkaContext) {
             )
         }
 
-    fun List<ContentNode>.nodeForJvm(jvm: DokkaSourceSet): ContentNode =
-        firstOrNull { jvm.sourceSetID in it.sourceSets.computeSourceSetIds() }
+    public fun List<ContentNode>.nodeForJvm(jvm: DokkaSourceSet): ContentNode {
+        return firstOrNull { jvm.sourceSetID in it.sourceSets.computeSourceSetIds() }
             ?: throw IllegalStateException("No source set found for ${jvm.sourceSetID} ")
+    }
 
     private fun Documentable.brief(sourceSet: DokkaSourceSet? = highestJvmSourceSet): List<ContentNode> =
         firstSentenceBriefFromContentNodes(descriptionToContentNodes(sourceSet))

--- a/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/JavadocPlugin.kt
+++ b/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/JavadocPlugin.kt
@@ -8,8 +8,10 @@ import org.jetbrains.dokka.CoreExtensions
 import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.base.renderers.PackageListCreator
 import org.jetbrains.dokka.base.renderers.RootCreator
+import org.jetbrains.dokka.base.resolvers.local.LocationProviderFactory
 import org.jetbrains.dokka.base.resolvers.shared.PackageList.Companion.PACKAGE_LIST_NAME
 import org.jetbrains.dokka.base.resolvers.shared.RecognizedLinkFormat
+import org.jetbrains.dokka.base.signatures.SignatureProvider
 import org.jetbrains.dokka.javadoc.location.JavadocLocationProviderFactory
 import org.jetbrains.dokka.javadoc.pages.*
 import org.jetbrains.dokka.javadoc.renderer.KorteJavadocRenderer
@@ -17,49 +19,52 @@ import org.jetbrains.dokka.javadoc.signatures.JavadocSignatureProvider
 import org.jetbrains.dokka.javadoc.transformers.documentables.JavadocDocumentableJVMSourceSetFilter
 import org.jetbrains.dokka.javadoc.validity.MultiplatformConfiguredChecker
 import org.jetbrains.dokka.kotlinAsJava.KotlinAsJavaPlugin
-import org.jetbrains.dokka.plugability.DokkaPlugin
-import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
-import org.jetbrains.dokka.plugability.PluginApiPreviewAcknowledgement
+import org.jetbrains.dokka.plugability.*
 import org.jetbrains.dokka.renderers.PostAction
+import org.jetbrains.dokka.renderers.Renderer
+import org.jetbrains.dokka.transformers.documentation.DocumentableToPageTranslator
+import org.jetbrains.dokka.transformers.documentation.PreMergeDocumentableTransformer
 import org.jetbrains.dokka.transformers.pages.PageTransformer
+import org.jetbrains.dokka.validity.PreGenerationChecker
 
-class JavadocPlugin : DokkaPlugin() {
+public class JavadocPlugin : DokkaPlugin() {
 
-    val dokkaBasePlugin by lazy { plugin<DokkaBase>() }
-    val kotinAsJavaPlugin by lazy { plugin<KotlinAsJavaPlugin>() }
-    val locationProviderFactory by lazy { dokkaBasePlugin.locationProviderFactory }
-    val javadocPreprocessors by extensionPoint<PageTransformer>()
+    private val dokkaBasePlugin: DokkaBase by lazy { plugin<DokkaBase>() }
+    private val kotinAsJavaPlugin: KotlinAsJavaPlugin by lazy { plugin<KotlinAsJavaPlugin>() }
 
-    val dokkaJavadocPlugin by extending {
+    public val locationProviderFactory: ExtensionPoint<LocationProviderFactory> by lazy { dokkaBasePlugin.locationProviderFactory }
+    public val javadocPreprocessors: ExtensionPoint<PageTransformer> by extensionPoint<PageTransformer>()
+
+    public val dokkaJavadocPlugin: Extension<Renderer, *, *> by extending {
         CoreExtensions.renderer providing { ctx -> KorteJavadocRenderer(ctx, "views") } override dokkaBasePlugin.htmlRenderer
     }
 
-    val javadocMultiplatformCheck by extending {
+    public val javadocMultiplatformCheck: Extension<PreGenerationChecker, *, *> by extending {
         CoreExtensions.preGenerationCheck providing ::MultiplatformConfiguredChecker
     }
 
-    val pageTranslator by extending {
+    public val pageTranslator: Extension<DocumentableToPageTranslator, *, *> by extending {
         CoreExtensions.documentableToPageTranslator providing ::JavadocDocumentableToPageTranslator override
                 kotinAsJavaPlugin.kotlinAsJavaDocumentableToPageTranslator
     }
 
-    val documentableSourceSetFilter by extending {
+    public val documentableSourceSetFilter: Extension<PreMergeDocumentableTransformer, *, *> by extending {
         dokkaBasePlugin.preMergeDocumentableTransformer providing ::JavadocDocumentableJVMSourceSetFilter
     }
 
-    val javadocLocationProviderFactory by extending {
+    public val javadocLocationProviderFactory: Extension<LocationProviderFactory, *, *> by extending {
         dokkaBasePlugin.locationProviderFactory providing ::JavadocLocationProviderFactory override dokkaBasePlugin.locationProvider
     }
 
-    val javadocSignatureProvider by extending {
+    public val javadocSignatureProvider: Extension<SignatureProvider, *, *> by extending {
         dokkaBasePlugin.signatureProvider providing ::JavadocSignatureProvider override kotinAsJavaPlugin.javaSignatureProvider
     }
 
-    val rootCreator by extending {
+    public val rootCreator: Extension<PageTransformer, *, *> by extending {
         javadocPreprocessors with RootCreator
     }
 
-    val packageListCreator by extending {
+    public val packageListCreator: Extension<PageTransformer, *, *> by extending {
         javadocPreprocessors providing {
             PackageListCreator(
                 context = it,
@@ -69,23 +74,23 @@ class JavadocPlugin : DokkaPlugin() {
         } order { after(rootCreator) }
     }
 
-    val resourcesInstaller by extending {
+    public val resourcesInstaller: Extension<PageTransformer, *, *> by extending {
         javadocPreprocessors with ResourcesInstaller order { after(rootCreator) }
     }
 
-    val treeViewInstaller by extending {
+    public val treeViewInstaller: Extension<PageTransformer, *, *> by extending {
         javadocPreprocessors providing ::TreeViewInstaller order { after(rootCreator) }
     }
 
-    val allClassessPageInstaller by extending {
+    public val allClassessPageInstaller: Extension<PageTransformer, *, *> by extending {
         javadocPreprocessors with AllClassesPageInstaller order { before(rootCreator) }
     }
 
-    val indexGenerator by extending {
+    public val indexGenerator: Extension<PageTransformer, *, *> by extending {
         javadocPreprocessors with IndexGenerator order { before(rootCreator) }
     }
 
-    val deprecatedPageCreator by extending {
+    public val deprecatedPageCreator: Extension<PageTransformer, *, *> by extending {
         javadocPreprocessors with DeprecatedPageCreator order { before(rootCreator) }
     }
 

--- a/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/location/JavadocLocationProvider.kt
+++ b/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/location/JavadocLocationProvider.kt
@@ -16,8 +16,10 @@ import org.jetbrains.dokka.pages.RootPageNode
 import org.jetbrains.dokka.plugability.DokkaContext
 import java.util.*
 
-class JavadocLocationProvider(pageRoot: RootPageNode, dokkaContext: DokkaContext) :
-    DefaultLocationProvider(pageRoot, dokkaContext) {
+public class JavadocLocationProvider(
+    pageRoot: RootPageNode,
+    dokkaContext: DokkaContext
+) : DefaultLocationProvider(pageRoot, dokkaContext) {
 
     private val pathIndex = IdentityHashMap<PageNode, List<String>>().apply {
         fun registerPath(page: PageNode, prefix: List<String> = emptyList()) {
@@ -103,15 +105,16 @@ class JavadocLocationProvider(pageRoot: RootPageNode, dokkaContext: DokkaContext
             })"
         } ?: dri.classNames.orEmpty()
 
-    override fun resolve(node: PageNode, context: PageNode?, skipExtension: Boolean) =
-        pathIndex[node]?.relativeTo(pathIndex[context].orEmpty())?.let {
+    override fun resolve(node: PageNode, context: PageNode?, skipExtension: Boolean): String {
+        return pathIndex[node]?.relativeTo(pathIndex[context].orEmpty())?.let {
             if (skipExtension) it.removeSuffix(".html") else it
         } ?: run {
             throw IllegalStateException("Path for ${node::class.java.canonicalName}:${node.name} not found")
         }
+    }
 
-    fun resolve(link: LinkJavadocListEntry, contextRoot: PageNode? = null, skipExtension: Boolean = true) =
-        pathIndex[link.dri.first()]?.let {
+    public fun resolve(link: LinkJavadocListEntry, contextRoot: PageNode? = null, skipExtension: Boolean = true): String {
+        return pathIndex[link.dri.first()]?.let {
             when (link.kind) {
                 JavadocContentKind.Class -> it
                 JavadocContentKind.OverviewSummary -> it.dropLast(1) + "index"
@@ -123,6 +126,7 @@ class JavadocLocationProvider(pageRoot: RootPageNode, dokkaContext: DokkaContext
                 else -> it
             }
         }?.relativeTo(pathIndex[contextRoot].orEmpty())?.let { if (skipExtension) "$it.html" else it }.orEmpty()
+    }
 
     override fun pathToRoot(from: PageNode): String {
         TODO("Not yet implemented")

--- a/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/location/JavadocLocationProviderFactory.kt
+++ b/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/location/JavadocLocationProviderFactory.kt
@@ -4,11 +4,14 @@
 
 package org.jetbrains.dokka.javadoc.location
 
+import org.jetbrains.dokka.base.resolvers.local.LocationProvider
 import org.jetbrains.dokka.base.resolvers.local.LocationProviderFactory
 import org.jetbrains.dokka.pages.RootPageNode
 import org.jetbrains.dokka.plugability.DokkaContext
 
-class JavadocLocationProviderFactory(private val context: DokkaContext) : LocationProviderFactory {
-    override fun getLocationProvider(pageNode: RootPageNode) =
+public class JavadocLocationProviderFactory(
+    private val context: DokkaContext
+) : LocationProviderFactory {
+    override fun getLocationProvider(pageNode: RootPageNode): LocationProvider =
         JavadocLocationProvider(pageNode, context)
 }

--- a/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/pages/JavadocContentNodes.kt
+++ b/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/pages/JavadocContentNodes.kt
@@ -9,11 +9,11 @@ import org.jetbrains.dokka.model.DisplaySourceSet
 import org.jetbrains.dokka.model.properties.PropertyContainer
 import org.jetbrains.dokka.pages.*
 
-enum class JavadocContentKind : Kind {
+public enum class JavadocContentKind : Kind {
     AllClasses, OverviewSummary, PackageSummary, Class, OverviewTree, PackageTree, IndexPage
 }
 
-abstract class JavadocContentNode(
+public abstract class JavadocContentNode(
     dri: Set<DRI>,
     kind: Kind,
     override val sourceSets: Set<DisplaySourceSet>
@@ -24,17 +24,17 @@ abstract class JavadocContentNode(
     override fun withNewExtras(newExtras: PropertyContainer<ContentNode>): ContentNode = this
 }
 
-interface JavadocList {
-    val tabTitle: String
-    val colTitle: String
-    val children: List<JavadocListEntry>
+public interface JavadocList {
+    public val tabTitle: String
+    public val colTitle: String
+    public val children: List<JavadocListEntry>
 }
 
-interface JavadocListEntry {
-    val stringTag: String
+public interface JavadocListEntry {
+    public val stringTag: String
 }
 
-data class EmptyNode(
+public data class EmptyNode(
     val dri: DRI,
     val kind: Kind,
     override val sourceSets: Set<DisplaySourceSet>,
@@ -51,15 +51,15 @@ data class EmptyNode(
     override fun hasAnyContent(): Boolean = false
 }
 
-data class JavadocContentGroup(
+public data class JavadocContentGroup(
     val dri: Set<DRI>,
     val kind: Kind,
     override val sourceSets: Set<DisplaySourceSet>,
     override val children: List<JavadocContentNode>
 ) : JavadocContentNode(dri, kind, sourceSets) {
 
-    companion object {
-        operator fun invoke(
+    public companion object {
+        public operator fun invoke(
             dri: Set<DRI>,
             kind: Kind,
             sourceSets: Set<DisplaySourceSet>,
@@ -76,11 +76,13 @@ data class JavadocContentGroup(
         copy(sourceSets = sourceSets)
 }
 
-class JavaContentGroupBuilder(val sourceSets: Set<DisplaySourceSet>) {
-    val list = mutableListOf<JavadocContentNode>()
+public class JavaContentGroupBuilder(
+    public val sourceSets: Set<DisplaySourceSet>
+) {
+    public val list: MutableList<JavadocContentNode> = mutableListOf<JavadocContentNode>()
 }
 
-data class TitleNode(
+public data class TitleNode(
     val title: String,
     val subtitle: List<ContentNode>,
     val version: String?,
@@ -97,7 +99,7 @@ data class TitleNode(
         copy(sourceSets = sourceSets)
 }
 
-fun JavaContentGroupBuilder.title(
+public fun JavaContentGroupBuilder.title(
     title: String,
     subtitle: List<ContentNode>,
     version: String? = null,
@@ -108,7 +110,7 @@ fun JavaContentGroupBuilder.title(
     list.add(TitleNode(title, subtitle, version, parent, dri, kind, sourceSets))
 }
 
-data class RootListNode(
+public data class RootListNode(
     val entries: List<LeafListNode>,
     val dri: Set<DRI>,
     val kind: Kind,
@@ -121,7 +123,7 @@ data class RootListNode(
         copy(sourceSets = sourceSets)
 }
 
-data class LeafListNode(
+public data class LeafListNode(
     val tabTitle: String,
     val colTitle: String,
     val entries: List<JavadocListEntry>,
@@ -135,7 +137,7 @@ data class LeafListNode(
 }
 
 
-fun JavaContentGroupBuilder.rootList(
+public fun JavaContentGroupBuilder.rootList(
     dri: Set<DRI>,
     kind: Kind,
     rootList: List<JavadocList>
@@ -146,7 +148,7 @@ fun JavaContentGroupBuilder.rootList(
     list.add(RootListNode(children, dri, kind, sourceSets))
 }
 
-fun JavaContentGroupBuilder.leafList(
+public fun JavaContentGroupBuilder.leafList(
     dri: Set<DRI>,
     kind: Kind,
     leafList: JavadocList
@@ -154,36 +156,41 @@ fun JavaContentGroupBuilder.leafList(
     list.add(LeafListNode(leafList.tabTitle, leafList.colTitle, leafList.children, dri, kind, sourceSets))
 }
 
-fun JavadocList(tabTitle: String, colTitle: String, children: List<JavadocListEntry>) = object : JavadocList {
-    override val tabTitle = tabTitle
-    override val colTitle = colTitle
-    override val children = children
+public fun JavadocList(tabTitle: String, colTitle: String, children: List<JavadocListEntry>): JavadocList {
+    return object : JavadocList {
+        override val tabTitle = tabTitle
+        override val colTitle = colTitle
+        override val children = children
+    }
 }
 
-class LinkJavadocListEntry(
-    val name: String,
-    val dri: Set<DRI>,
-    val kind: Kind = ContentKind.Symbol,
-    val sourceSets: Set<DisplaySourceSet>
-) :
-    JavadocListEntry {
+public class LinkJavadocListEntry(
+    public val name: String,
+    public val dri: Set<DRI>,
+    public val kind: Kind = ContentKind.Symbol,
+    public val sourceSets: Set<DisplaySourceSet>
+) : JavadocListEntry {
     override val stringTag: String
-        get() = if (builtString == null)
-            throw IllegalStateException("stringTag for LinkJavadocListEntry accessed before build() call")
-        else builtString!!
+        get() {
+            return if (builtString == null) {
+                throw IllegalStateException("stringTag for LinkJavadocListEntry accessed before build() call")
+            } else {
+                builtString!!
+            }
+        }
 
     private var builtString: String? = null
 
-    fun build(body: (String, Set<DRI>, Kind, List<DisplaySourceSet>) -> String) {
+    public fun build(body: (String, Set<DRI>, Kind, List<DisplaySourceSet>) -> String) {
         builtString = body(name, dri, kind, sourceSets.toList())
     }
 }
 
-data class RowJavadocListEntry(val link: LinkJavadocListEntry, val doc: List<ContentNode>) : JavadocListEntry {
+public data class RowJavadocListEntry(val link: LinkJavadocListEntry, val doc: List<ContentNode>) : JavadocListEntry {
     override val stringTag: String = ""
 }
 
-data class JavadocSignatureContentNode(
+public data class JavadocSignatureContentNode(
     val dri: DRI,
     val kind: Kind = ContentKind.Symbol,
     val annotations: ContentNode?,

--- a/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/pages/JavadocIndexExtra.kt
+++ b/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/pages/JavadocIndexExtra.kt
@@ -8,7 +8,7 @@ import org.jetbrains.dokka.model.Documentable
 import org.jetbrains.dokka.model.properties.ExtraProperty
 import org.jetbrains.dokka.pages.ContentNode
 
-data class JavadocIndexExtra(val index: List<ContentNode>) : ExtraProperty<Documentable> {
+public data class JavadocIndexExtra(val index: List<ContentNode>) : ExtraProperty<Documentable> {
     override val key: ExtraProperty.Key<Documentable, *> = JavadocIndexExtra
-    companion object : ExtraProperty.Key<Documentable, JavadocIndexExtra>
+    public companion object : ExtraProperty.Key<Documentable, JavadocIndexExtra>
 }

--- a/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/pages/JavadocPageNodes.kt
+++ b/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/pages/JavadocPageNodes.kt
@@ -14,22 +14,22 @@ import org.jetbrains.dokka.pages.*
 import org.jetbrains.dokka.analysis.kotlin.internal.InheritanceBuilder
 import org.jetbrains.dokka.analysis.kotlin.internal.InheritanceNode
 
-interface JavadocPageNode : ContentPage, WithDocumentables
+public interface JavadocPageNode : ContentPage, WithDocumentables
 
-interface WithJavadocExtra<T : Documentable> : WithExtraProperties<T> {
+public interface WithJavadocExtra<T : Documentable> : WithExtraProperties<T> {
     override fun withNewExtras(newExtras: PropertyContainer<T>): T =
         throw IllegalStateException("Merging extras is not applicable for javadoc")
 }
 
-fun interface WithNavigable {
-    fun getAllNavigables(): List<NavigableJavadocNode>
+public fun interface WithNavigable {
+    public fun getAllNavigables(): List<NavigableJavadocNode>
 }
 
-interface WithBrief {
-    val brief: List<ContentNode>
+public interface WithBrief {
+    public val brief: List<ContentNode>
 }
 
-class JavadocModulePageNode(
+public class JavadocModulePageNode(
     override val name: String,
     override val content: JavadocContentNode,
     override val children: List<PageNode>,
@@ -60,7 +60,7 @@ class JavadocModulePageNode(
     override fun getDRI(): DRI = dri.first()
 }
 
-class JavadocPackagePageNode(
+public class JavadocPackagePageNode(
     override val name: String,
     override val content: JavadocContentNode,
     override val dri: Set<DRI>,
@@ -116,17 +116,20 @@ class JavadocPackagePageNode(
     override fun getDRI(): DRI = dri.first()
 }
 
-interface NavigableJavadocNode {
-    fun getId(): String
-    fun getDRI(): DRI
+public interface NavigableJavadocNode {
+    public fun getId(): String
+    public fun getDRI(): DRI
 }
 
-sealed class AnchorableJavadocNode(open val name: String, open val dri: DRI) : NavigableJavadocNode {
+public sealed class AnchorableJavadocNode(
+    public open val name: String,
+    public open val dri: DRI
+) : NavigableJavadocNode {
     override fun getId(): String = name
     override fun getDRI(): DRI = dri
 }
 
-data class JavadocEntryNode(
+public data class JavadocEntryNode(
     override val dri: DRI,
     override val name: String,
     val signature: JavadocSignatureContentNode,
@@ -134,7 +137,7 @@ data class JavadocEntryNode(
     override val extra: PropertyContainer<DEnumEntry> = PropertyContainer.empty()
 ) : AnchorableJavadocNode(name, dri), WithJavadocExtra<DEnumEntry>, WithBrief
 
-data class JavadocParameterNode(
+public data class JavadocParameterNode(
     override val dri: DRI,
     override val name: String,
     val type: ContentNode,
@@ -143,7 +146,7 @@ data class JavadocParameterNode(
     override val extra: PropertyContainer<DParameter> = PropertyContainer.empty()
 ) : AnchorableJavadocNode(name, dri), WithJavadocExtra<DParameter>
 
-data class JavadocPropertyNode(
+public data class JavadocPropertyNode(
     override val dri: DRI,
     override val name: String,
     val signature: JavadocSignatureContentNode,
@@ -152,7 +155,7 @@ data class JavadocPropertyNode(
     override val extra: PropertyContainer<DProperty> = PropertyContainer.empty()
 ) : AnchorableJavadocNode(name, dri), WithJavadocExtra<DProperty>, WithBrief
 
-data class JavadocFunctionNode(
+public data class JavadocFunctionNode(
     val signature: JavadocSignatureContentNode,
     override val brief: List<ContentNode>,
     val description: List<ContentNode>,
@@ -174,21 +177,21 @@ data class JavadocFunctionNode(
         }
 }
 
-class JavadocClasslikePageNode(
+public class JavadocClasslikePageNode(
     override val name: String,
     override val content: JavadocContentNode,
     override val dri: Set<DRI>,
-    val signature: JavadocSignatureContentNode,
-    val description: List<ContentNode>,
-    val constructors: List<JavadocFunctionNode>,
-    val methods: List<JavadocFunctionNode>,
-    val entries: List<JavadocEntryNode>,
-    val classlikes: List<JavadocClasslikePageNode>,
-    val properties: List<JavadocPropertyNode>,
+    public val signature: JavadocSignatureContentNode,
+    public val description: List<ContentNode>,
+    public val constructors: List<JavadocFunctionNode>,
+    public val methods: List<JavadocFunctionNode>,
+    public val entries: List<JavadocEntryNode>,
+    public val classlikes: List<JavadocClasslikePageNode>,
+    public val properties: List<JavadocPropertyNode>,
     override val brief: List<ContentNode>,
 
-    val sinceTagContent: List<List<ContentNode>>,
-    val authorTagContent: List<List<ContentNode>>,
+    public val sinceTagContent: List<List<ContentNode>>,
+    public val authorTagContent: List<List<ContentNode>>,
 
     override val documentables: List<Documentable> = emptyList(),
     override val children: List<PageNode> = emptyList(),
@@ -199,11 +202,11 @@ class JavadocClasslikePageNode(
     override fun getAllNavigables(): List<NavigableJavadocNode> =
         methods + entries + classlikes.map { it.getAllNavigables() }.flatten() + this
 
-    fun getAnchorables(): List<AnchorableJavadocNode> =
+    public fun getAnchorables(): List<AnchorableJavadocNode> =
         constructors + methods + entries + properties
 
-    val kind: String? = documentables.firstOrNull()?.kind()
-    val packageName = dri.first().packageName
+    public val kind: String? = documentables.firstOrNull()?.kind()
+    public val packageName: String? = dri.first().packageName
 
     override fun getId(): String = name
     override fun getDRI(): DRI = dri.first()
@@ -259,8 +262,10 @@ class JavadocClasslikePageNode(
         )
 }
 
-class AllClassesPage(val classes: List<JavadocClasslikePageNode>) : JavadocPageNode {
-    val classEntries =
+public class AllClassesPage(
+    public val classes: List<JavadocClasslikePageNode>
+) : JavadocPageNode {
+    public val classEntries: List<LinkJavadocListEntry> =
         classes.map { LinkJavadocListEntry(it.name, it.dri, ContentKind.Classlikes, it.sourceSets().toSet()) }
 
     override val name: String = "All Classes"
@@ -291,8 +296,8 @@ class AllClassesPage(val classes: List<JavadocClasslikePageNode>) : JavadocPageN
 
 }
 
-class DeprecatedPage(
-    val elements: Map<DeprecatedPageSection, Set<DeprecatedNode>>,
+public class DeprecatedPage(
+    public val elements: Map<DeprecatedPageSection, Set<DeprecatedNode>>,
     sourceSet: Set<DisplaySourceSet>
 ) : JavadocPageNode {
     override val name: String = "deprecated"
@@ -322,14 +327,22 @@ class DeprecatedPage(
 
 }
 
-class DeprecatedNode(val name: String, val address: DRI, val description: List<ContentNode>) {
+public class DeprecatedNode(
+    public val name: String,
+    public val address: DRI,
+    public val description: List<ContentNode>
+) {
     override fun equals(other: Any?): Boolean =
         (other as? DeprecatedNode)?.address == address
 
     override fun hashCode(): Int = address.hashCode()
 }
 
-enum class DeprecatedPageSection(val id: String, val caption: String, val header: String) {
+public enum class DeprecatedPageSection(
+    public val id: String,
+    public val caption: String,
+    public val header: String,
+) {
     DeprecatedModules("module", "Modules", "Module"),
     DeprecatedInterfaces("interface", "Interfaces", "Interface"),
     DeprecatedClasses("class", "Classes", "Class"),
@@ -344,10 +357,11 @@ enum class DeprecatedPageSection(val id: String, val caption: String, val header
     internal fun getPosition() = ordinal
 }
 
-class IndexPage(
-    val id: Int,
-    val elements: List<NavigableJavadocNode>,
-    val keys: List<Char>,
+public class IndexPage(
+    public val id: Int,
+    public val elements: List<NavigableJavadocNode>,
+    public val keys: List<Char>,
+
     sourceSet: Set<DisplaySourceSet>
 
 ) : JavadocPageNode {
@@ -356,7 +370,7 @@ class IndexPage(
     override val documentables: List<Documentable> = emptyList()
     override val children: List<PageNode> = emptyList()
     override val embeddedResources: List<String> = listOf()
-    val title: String = "${keys[id - 1]}-index"
+    public val title: String = "${keys[id - 1]}-index"
 
     override val content: ContentNode = EmptyNode(
         DRI.topLevel,
@@ -379,14 +393,14 @@ class IndexPage(
 
 }
 
-class TreeViewPage(
+public class TreeViewPage(
     override val name: String,
-    val packages: List<JavadocPackagePageNode>?,
-    val classes: List<JavadocClasslikePageNode>?,
+    public val packages: List<JavadocPackagePageNode>?,
+    public val classes: List<JavadocClasslikePageNode>?,
     override val dri: Set<DRI>,
     override val documentables: List<Documentable> = emptyList(),
-    val root: PageNode,
-    val inheritanceBuilder: InheritanceBuilder
+    public val root: PageNode,
+    public val inheritanceBuilder: InheritanceBuilder
 ) : JavadocPageNode {
     init {
         assert(packages == null || classes == null)
@@ -403,12 +417,12 @@ class TreeViewPage(
 
     override val children: List<PageNode> = emptyList()
 
-    val title = when (documentables.firstOrNull()) {
+    public val title: String = when (documentables.firstOrNull()) {
         is DPackage -> "$name Class Hierarchy"
         else -> "All packages"
     }
 
-    val kind = when (documentables.firstOrNull()) {
+    public val kind: String = when (documentables.firstOrNull()) {
         is DPackage -> "package"
         else -> "main"
     }

--- a/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/pages/htmlPreprocessors.kt
+++ b/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/pages/htmlPreprocessors.kt
@@ -18,7 +18,8 @@ import org.jetbrains.dokka.plugability.querySingle
 import org.jetbrains.dokka.transformers.pages.PageTransformer
 import org.jetbrains.dokka.analysis.kotlin.internal.InternalKotlinAnalysisPlugin
 
-object ResourcesInstaller : PageTransformer {
+public object ResourcesInstaller : PageTransformer {
+
     override fun invoke(input: RootPageNode): RootPageNode = input.modified(
         children = input.children +
                 RendererSpecificResourcePage(
@@ -29,7 +30,10 @@ object ResourcesInstaller : PageTransformer {
     )
 }
 
-class TreeViewInstaller(private val context: DokkaContext) : PageTransformer {
+public class TreeViewInstaller(
+    private val context: DokkaContext
+) : PageTransformer {
+
     override fun invoke(input: RootPageNode): RootPageNode = install(input, input) as RootPageNode
 
     private fun install(node: PageNode, root: RootPageNode): PageNode = when (node) {
@@ -73,7 +77,8 @@ class TreeViewInstaller(private val context: DokkaContext) : PageTransformer {
     }
 }
 
-object AllClassesPageInstaller : PageTransformer {
+public object AllClassesPageInstaller : PageTransformer {
+
     override fun invoke(input: RootPageNode): RootPageNode {
         val classes = (input as JavadocModulePageNode).children.filterIsInstance<JavadocPackagePageNode>().flatMap {
             it.children.filterIsInstance<JavadocClasslikePageNode>()
@@ -83,7 +88,8 @@ object AllClassesPageInstaller : PageTransformer {
     }
 }
 
-object IndexGenerator : PageTransformer {
+public object IndexGenerator : PageTransformer {
+
     override fun invoke(input: RootPageNode): RootPageNode {
         val elements = HashMap<Char, MutableSet<NavigableJavadocNode>>()
         (input as JavadocModulePageNode).children.filterIsInstance<JavadocPackagePageNode>().forEach {
@@ -125,7 +131,8 @@ object IndexGenerator : PageTransformer {
     }
 }
 
-object DeprecatedPageCreator : PageTransformer {
+public object DeprecatedPageCreator : PageTransformer {
+
     override fun invoke(input: RootPageNode): RootPageNode {
         val elements = HashMap<DeprecatedPageSection, MutableSet<DeprecatedNode>>().apply {
 

--- a/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/renderer/JavadocContentToHtmlTranslator.kt
+++ b/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/renderer/JavadocContentToHtmlTranslator.kt
@@ -31,7 +31,7 @@ internal class JavadocContentToHtmlTranslator(
             else -> ""
         }
 
-    fun htmlForText(node: ContentText): String {
+    private fun htmlForText(node: ContentText): String {
         val escapedText = node.text.htmlEscape()
         return when {
             node.style.contains(ContentStyle.InDocumentationAnchor) -> """<em><a id="$escapedText" class="searchTagResult">${escapedText}</a></em>"""

--- a/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/renderer/KorteJavadocRenderer.kt
+++ b/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/renderer/KorteJavadocRenderer.kt
@@ -29,10 +29,11 @@ import org.jetbrains.dokka.renderers.Renderer
 import org.jetbrains.dokka.analysis.kotlin.internal.InheritanceNode
 import java.time.LocalDate
 
-typealias TemplateMap = Map<String, Any?>
+public typealias TemplateMap = Map<String, Any?>
 
-class KorteJavadocRenderer(val context: DokkaContext, resourceDir: String) :
-    Renderer {
+public class KorteJavadocRenderer(
+    public val context: DokkaContext, resourceDir: String
+) : Renderer {
     private val outputWriter: OutputWriter = context.plugin<DokkaBase>().querySingle { outputWriter }
     private lateinit var locationProvider: JavadocLocationProvider
     private val registeredPreprocessors = context.plugin<JavadocPlugin>().query { javadocPreprocessors }
@@ -45,11 +46,13 @@ class KorteJavadocRenderer(val context: DokkaContext, resourceDir: String) :
         JavadocContentToTemplateMapTranslator(locationProvider, context)
     }
 
-    override fun render(root: RootPageNode) = root.let { registeredPreprocessors.fold(root) { r, t -> t.invoke(r) } }.let { newRoot ->
-        locationProvider = context.plugin<JavadocPlugin>().querySingle { locationProviderFactory }.getLocationProvider(newRoot) as JavadocLocationProvider
-        runBlocking(Dispatchers.IO) {
-            renderPage(newRoot)
-            SearchScriptsCreator(locationProvider).invoke(newRoot).forEach { renderSpecificPage(it, "") }
+    override fun render(root: RootPageNode) {
+        root.let { registeredPreprocessors.fold(root) { r, t -> t.invoke(r) } }.let { newRoot ->
+            locationProvider = context.plugin<JavadocPlugin>().querySingle { locationProviderFactory }.getLocationProvider(newRoot) as JavadocLocationProvider
+            runBlocking(Dispatchers.IO) {
+                renderPage(newRoot)
+                SearchScriptsCreator(locationProvider).invoke(newRoot).forEach { renderSpecificPage(it, "") }
+            }
         }
     }
 

--- a/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/renderer/SearchScriptsCreator.kt
+++ b/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/renderer/SearchScriptsCreator.kt
@@ -15,9 +15,11 @@ import org.jetbrains.dokka.model.Documentable
 import org.jetbrains.dokka.pages.*
 import org.jetbrains.dokka.utilities.formatToEndWithHtml
 
-class SearchScriptsCreator(private val locationProvider: LocationProvider) {
+public class SearchScriptsCreator(
+    private val locationProvider: LocationProvider
+) {
 
-    fun invoke(input: RootPageNode): List<RendererSpecificPage> {
+    public fun invoke(input: RootPageNode): List<RendererSpecificPage> {
         val data = when (input) {
             is JavadocModulePageNode -> processModules(listOf(input))
             else -> processModules(input.children.filterIsInstance<JavadocModulePageNode>())

--- a/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/signatures/JavadocSignatureProvider.kt
+++ b/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/signatures/JavadocSignatureProvider.kt
@@ -23,12 +23,16 @@ import org.jetbrains.dokka.plugability.plugin
 import org.jetbrains.dokka.plugability.querySingle
 import org.jetbrains.dokka.utilities.DokkaLogger
 
-class JavadocSignatureProvider(ctcc: CommentsToContentConverter, logger: DokkaLogger) : SignatureProvider,
-    JvmSignatureUtils by JavaSignatureUtils {
-    constructor(context: DokkaContext) : this(
+public class JavadocSignatureProvider(
+    ctcc: CommentsToContentConverter,
+    logger: DokkaLogger
+) : SignatureProvider, JvmSignatureUtils by JavaSignatureUtils {
+
+    public constructor(context: DokkaContext) : this(
         context.plugin<DokkaBase>().querySingle { commentsToContentConverter },
         context.logger
     )
+
     private val contentBuilder = JavadocPageContentBuilder(ctcc, this, logger)
 
     private val ignoredVisibilities = setOf(JavaVisibility.Default)

--- a/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/transformers/documentables/JavadocDocumentableJVMSourceSetFilter.kt
+++ b/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/transformers/documentables/JavadocDocumentableJVMSourceSetFilter.kt
@@ -10,7 +10,9 @@ import org.jetbrains.dokka.model.DModule
 import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.transformers.documentation.PreMergeDocumentableTransformer
 
-class JavadocDocumentableJVMSourceSetFilter(val context: DokkaContext) : PreMergeDocumentableTransformer {
+public class JavadocDocumentableJVMSourceSetFilter(
+    public val context: DokkaContext
+) : PreMergeDocumentableTransformer {
 
     private val allowedSourceSets = context.configuration.sourceSets.filter { it.analysisPlatform == Platform.jvm }
         .flatMap { it.getAllDependentSourceSets() }.distinct()

--- a/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/translators/documentables/JavadocPageContentBuilder.kt
+++ b/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/translators/documentables/JavadocPageContentBuilder.kt
@@ -15,13 +15,13 @@ import org.jetbrains.dokka.pages.ContentKind
 import org.jetbrains.dokka.pages.ContentNode
 import org.jetbrains.dokka.utilities.DokkaLogger
 
-class JavadocPageContentBuilder(
+public class JavadocPageContentBuilder(
     commentsConverter: CommentsToContentConverter,
     signatureProvider: SignatureProvider,
     logger: DokkaLogger
 ) : PageContentBuilder(commentsConverter, signatureProvider, logger) {
 
-    fun PageContentBuilder.DocumentableContentBuilder.javadocGroup(
+    public fun PageContentBuilder.DocumentableContentBuilder.javadocGroup(
         dri: DRI = mainDRI.first(),
         sourceSets: Set<DokkaConfiguration.DokkaSourceSet> = mainSourcesetData,
         extra: PropertyContainer<ContentNode> = mainExtra,
@@ -34,31 +34,31 @@ class JavadocPageContentBuilder(
         ).apply(block).build()
     }
 
-    open inner class JavadocContentBuilder(
+    public open inner class JavadocContentBuilder(
         private val mainDri: DRI,
         private val mainExtra: PropertyContainer<ContentNode>,
         private val mainSourceSet: Set<DokkaConfiguration.DokkaSourceSet>,
     ) {
-        var annotations: ContentNode? = null
-        var modifiers: ContentNode? = null
-        var signatureWithoutModifiers: ContentNode? = null
-        var supertypes: ContentNode? = null
+        public var annotations: ContentNode? = null
+        public var modifiers: ContentNode? = null
+        public var signatureWithoutModifiers: ContentNode? = null
+        public var supertypes: ContentNode? = null
 
-        fun annotations(block: PageContentBuilder.DocumentableContentBuilder.() -> Unit) {
+        public fun annotations(block: PageContentBuilder.DocumentableContentBuilder.() -> Unit) {
             val built = buildContentForBlock(block)
             if(built.hasAnyContent()) annotations = built
         }
 
-        fun modifiers(block: PageContentBuilder.DocumentableContentBuilder.() -> Unit) {
+        public fun modifiers(block: PageContentBuilder.DocumentableContentBuilder.() -> Unit) {
             val built = buildContentForBlock(block)
             if(built.hasAnyContent()) modifiers = built
         }
 
-        fun signatureWithoutModifiers(block: PageContentBuilder.DocumentableContentBuilder.() -> Unit) {
+        public fun signatureWithoutModifiers(block: PageContentBuilder.DocumentableContentBuilder.() -> Unit) {
             signatureWithoutModifiers = buildContentForBlock(block)
         }
 
-        fun supertypes(block: PageContentBuilder.DocumentableContentBuilder.() -> Unit) {
+        public fun supertypes(block: PageContentBuilder.DocumentableContentBuilder.() -> Unit) {
             val built = buildContentForBlock(block)
             if(built.hasAnyContent()) supertypes = built
         }
@@ -72,7 +72,7 @@ class JavadocPageContentBuilder(
                 block = block
             )
 
-        fun build(): JavadocSignatureContentNode = JavadocSignatureContentNode(
+        public fun build(): JavadocSignatureContentNode = JavadocSignatureContentNode(
             dri = mainDri,
             annotations = annotations,
             modifiers = modifiers,

--- a/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/validity/MultiplatformConfiguredChecker.kt
+++ b/plugins/javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/validity/MultiplatformConfiguredChecker.kt
@@ -9,7 +9,9 @@ import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.validity.PreGenerationChecker
 import org.jetbrains.dokka.validity.PreGenerationCheckerOutput
 
-class MultiplatformConfiguredChecker(val context: DokkaContext) : PreGenerationChecker {
+public class MultiplatformConfiguredChecker(
+    public val context: DokkaContext
+) : PreGenerationChecker {
 
     override fun invoke(): PreGenerationCheckerOutput {
         val isSinglePlatform = context.configuration.sourceSets.all { sourceSet ->
@@ -19,8 +21,8 @@ class MultiplatformConfiguredChecker(val context: DokkaContext) : PreGenerationC
         return PreGenerationCheckerOutput(isSinglePlatform, listOfNotNull(errorMessage.takeUnless { isSinglePlatform }))
     }
 
-    companion object {
-        const val errorMessage =
+    public companion object {
+        public const val errorMessage: String =
             "Dokka Javadoc plugin currently does not support generating documentation for multiplatform project. Please, adjust your configuration"
     }
 }

--- a/plugins/jekyll/jekyll-template-processing/src/main/kotlin/org/jetbrains/dokka/gfm/templateProcessing/JekyllTemplateProcessingPlugin.kt
+++ b/plugins/jekyll/jekyll-template-processing/src/main/kotlin/org/jetbrains/dokka/gfm/templateProcessing/JekyllTemplateProcessingPlugin.kt
@@ -8,12 +8,14 @@ import org.jetbrains.dokka.allModulesPage.AllModulesPagePlugin
 import org.jetbrains.dokka.allModulesPage.MultimoduleLocationProvider
 import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.base.resolvers.local.DokkaLocationProviderFactory
+import org.jetbrains.dokka.base.resolvers.local.LocationProviderFactory
 import org.jetbrains.dokka.jekyll.JekyllPlugin
 import org.jetbrains.dokka.plugability.DokkaPlugin
 import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
+import org.jetbrains.dokka.plugability.Extension
 import org.jetbrains.dokka.plugability.PluginApiPreviewAcknowledgement
 
-class JekyllTemplateProcessingPlugin : DokkaPlugin() {
+public class JekyllTemplateProcessingPlugin : DokkaPlugin() {
 
     private val allModulesPagePlugin by lazy { plugin<AllModulesPagePlugin>() }
 
@@ -22,14 +24,14 @@ class JekyllTemplateProcessingPlugin : DokkaPlugin() {
 
     private val dokkaBase by lazy { plugin<DokkaBase>() }
 
-    val jekyllLocationProvider by extending {
+    public val jekyllLocationProvider: Extension<LocationProviderFactory, *, *> by extending {
         dokkaBase.locationProviderFactory providing MultimoduleLocationProvider::Factory override listOf(
             jekyllPlugin.locationProvider,
             gfmTemplatingPlugin.gfmLocationProvider
         )
     }
 
-    val jekyllPartialLocationProvider by extending {
+    public val jekyllPartialLocationProvider: Extension<LocationProviderFactory, *, *> by extending {
         allModulesPagePlugin.partialLocationProviderFactory providing ::DokkaLocationProviderFactory override listOf(
             allModulesPagePlugin.baseLocationProviderFactory,
             gfmTemplatingPlugin.gfmPartialLocationProvider

--- a/plugins/jekyll/src/main/kotlin/JekyllPlugin.kt
+++ b/plugins/jekyll/src/main/kotlin/JekyllPlugin.kt
@@ -9,6 +9,7 @@ import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.base.renderers.PackageListCreator
 import org.jetbrains.dokka.base.renderers.RootCreator
 import org.jetbrains.dokka.base.resolvers.local.DokkaLocationProviderFactory
+import org.jetbrains.dokka.base.resolvers.local.LocationProviderFactory
 import org.jetbrains.dokka.base.resolvers.shared.RecognizedLinkFormat
 import org.jetbrains.dokka.gfm.GfmPlugin
 import org.jetbrains.dokka.gfm.renderer.BriefCommentPreprocessor
@@ -16,37 +17,38 @@ import org.jetbrains.dokka.gfm.renderer.CommonmarkRenderer
 import org.jetbrains.dokka.pages.ContentPage
 import org.jetbrains.dokka.plugability.*
 import org.jetbrains.dokka.renderers.PostAction
+import org.jetbrains.dokka.renderers.Renderer
 import org.jetbrains.dokka.transformers.pages.PageTransformer
 
-class JekyllPlugin : DokkaPlugin() {
+public class JekyllPlugin : DokkaPlugin() {
 
-    val jekyllPreprocessors by extensionPoint<PageTransformer>()
+    public val jekyllPreprocessors: ExtensionPoint<PageTransformer> by extensionPoint<PageTransformer>()
 
     private val dokkaBase by lazy { plugin<DokkaBase>() }
 
     private val gfmPlugin by lazy { plugin<GfmPlugin>() }
 
-    val renderer by extending {
+    public val renderer: Extension<Renderer, *, *> by extending {
         (CoreExtensions.renderer
                 providing { JekyllRenderer(it) }
                 override plugin<GfmPlugin>().renderer)
     }
 
-    val rootCreator by extending {
+    public val rootCreator: Extension<PageTransformer, *, *> by extending {
         jekyllPreprocessors with RootCreator
     }
 
-    val briefCommentPreprocessor by extending {
+    public val briefCommentPreprocessor: Extension<PageTransformer, *, *> by extending {
         jekyllPreprocessors with BriefCommentPreprocessor()
     }
 
-    val packageListCreator by extending {
+    public val packageListCreator: Extension<PageTransformer, *, *> by extending {
         jekyllPreprocessors providing {
             PackageListCreator(it, RecognizedLinkFormat.DokkaJekyll)
         } order { after(rootCreator) }
     }
 
-    val locationProvider by extending {
+    public val locationProvider: Extension<LocationProviderFactory, *, *> by extending {
         dokkaBase.locationProviderFactory providing ::DokkaLocationProviderFactory override listOf(gfmPlugin.locationProvider)
     }
 
@@ -66,11 +68,11 @@ class JekyllPlugin : DokkaPlugin() {
         PluginApiPreviewAcknowledgement
 }
 
-class JekyllRenderer(
+public class JekyllRenderer(
     context: DokkaContext
 ) : CommonmarkRenderer(context) {
 
-    override val preprocessors = context.plugin<JekyllPlugin>().query { jekyllPreprocessors }
+    override val preprocessors: List<PageTransformer> = context.plugin<JekyllPlugin>().query { jekyllPreprocessors }
 
     override fun buildPage(page: ContentPage, content: (StringBuilder, ContentPage) -> Unit): String {
         val builder = StringBuilder()

--- a/plugins/kotlin-as-java/src/main/kotlin/KotlinAsJavaPlugin.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/KotlinAsJavaPlugin.kt
@@ -6,33 +6,37 @@ package org.jetbrains.dokka.kotlinAsJava
 
 import org.jetbrains.dokka.CoreExtensions
 import org.jetbrains.dokka.base.DokkaBase
+import org.jetbrains.dokka.base.signatures.SignatureProvider
 import org.jetbrains.dokka.kotlinAsJava.signatures.JavaSignatureProvider
 import org.jetbrains.dokka.kotlinAsJava.transformers.JvmNameDocumentableTransformer
 import org.jetbrains.dokka.kotlinAsJava.transformers.KotlinAsJavaDocumentableTransformer
 import org.jetbrains.dokka.kotlinAsJava.translators.KotlinAsJavaDocumentableToPageTranslator
 import org.jetbrains.dokka.plugability.DokkaPlugin
 import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
+import org.jetbrains.dokka.plugability.Extension
 import org.jetbrains.dokka.plugability.PluginApiPreviewAcknowledgement
 import org.jetbrains.dokka.renderers.PostAction
+import org.jetbrains.dokka.transformers.documentation.DocumentableToPageTranslator
+import org.jetbrains.dokka.transformers.documentation.DocumentableTransformer
 
-class KotlinAsJavaPlugin : DokkaPlugin() {
-    val kotlinAsJavaDocumentableTransformer by extending {
+public class KotlinAsJavaPlugin : DokkaPlugin() {
+    public val kotlinAsJavaDocumentableTransformer: Extension<DocumentableTransformer, *, *> by extending {
         CoreExtensions.documentableTransformer with KotlinAsJavaDocumentableTransformer()
     }
 
-    val jvmNameTransformer by extending {
+    public val jvmNameTransformer: Extension<DocumentableTransformer, *, *> by extending {
         CoreExtensions.documentableTransformer with JvmNameDocumentableTransformer() order {
             after(kotlinAsJavaDocumentableTransformer)
         }
     }
 
-    val javaSignatureProvider by extending {
+    public val javaSignatureProvider: Extension<SignatureProvider, *, *> by extending {
         with(plugin<DokkaBase>()) {
             signatureProvider providing ::JavaSignatureProvider override kotlinSignatureProvider
         }
     }
 
-    val kotlinAsJavaDocumentableToPageTranslator by extending {
+    public val kotlinAsJavaDocumentableToPageTranslator: Extension<DocumentableToPageTranslator, *, *> by extending {
         CoreExtensions.documentableToPageTranslator providing ::KotlinAsJavaDocumentableToPageTranslator override
                 plugin<DokkaBase>().documentableToPageTranslator
     }

--- a/plugins/kotlin-as-java/src/main/kotlin/converters/KotlinToJavaConverter.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/converters/KotlinToJavaConverter.kt
@@ -17,7 +17,7 @@ import org.jetbrains.dokka.plugability.plugin
 import org.jetbrains.dokka.plugability.querySingle
 import org.jetbrains.dokka.analysis.kotlin.internal.InternalKotlinAnalysisPlugin
 
-val jvmNameProvider = JvmNameProvider()
+public val jvmNameProvider: JvmNameProvider = JvmNameProvider()
 internal const val OBJECT_INSTANCE_NAME = "INSTANCE"
 
 internal val DProperty.isConst: Boolean
@@ -37,7 +37,7 @@ private fun DProperty.hasModifier(modifier: ExtraModifiers.KotlinOnlyModifiers):
         ?.content
         ?.any { (_, modifiers) -> modifier in modifiers } == true
 
-class KotlinToJavaConverter(
+public class KotlinToJavaConverter(
     private val context: DokkaContext
 ) {
     private val kotlinToJavaMapper by lazy {

--- a/plugins/kotlin-as-java/src/main/kotlin/signatures/JavaSignatureProvider.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/signatures/JavaSignatureProvider.kt
@@ -22,12 +22,16 @@ import org.jetbrains.dokka.plugability.querySingle
 import org.jetbrains.dokka.utilities.DokkaLogger
 import kotlin.text.Typography.nbsp
 
-class JavaSignatureProvider internal constructor(ctcc: CommentsToContentConverter, logger: DokkaLogger) : SignatureProvider,
-    JvmSignatureUtils by JavaSignatureUtils {
-    constructor(context: DokkaContext) : this(
+public class JavaSignatureProvider internal constructor(
+    ctcc: CommentsToContentConverter,
+    logger: DokkaLogger
+) : SignatureProvider, JvmSignatureUtils by JavaSignatureUtils {
+
+    public constructor(context: DokkaContext) : this(
         context.plugin<DokkaBase>().querySingle { commentsToContentConverter },
         context.logger
     )
+
     private val contentBuilder = PageContentBuilder(ctcc, this, logger)
 
     private val ignoredVisibilities = setOf(JavaVisibility.Default)

--- a/plugins/kotlin-as-java/src/main/kotlin/signatures/JavaSignatureUtils.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/signatures/JavaSignatureUtils.kt
@@ -4,6 +4,7 @@
 
 package org.jetbrains.dokka.kotlinAsJava.signatures
 
+import org.jetbrains.dokka.DokkaConfiguration
 import org.jetbrains.dokka.base.signatures.All
 import org.jetbrains.dokka.base.signatures.JvmSignatureUtils
 import org.jetbrains.dokka.base.translators.documentables.PageContentBuilder
@@ -12,7 +13,7 @@ import org.jetbrains.dokka.model.*
 import org.jetbrains.dokka.model.AnnotationTarget
 import org.jetbrains.dokka.model.properties.WithExtraProperties
 
-object JavaSignatureUtils : JvmSignatureUtils {
+public object JavaSignatureUtils : JvmSignatureUtils {
 
     private val ignoredAnnotations = setOf(
         Annotations.Annotation(DRI("kotlin.jvm", "Transient"), emptyMap()),
@@ -26,15 +27,18 @@ object JavaSignatureUtils : JvmSignatureUtils {
     private val listBrackets = Pair('{', '}')
     private val classExtension = ".class"
 
-    override fun PageContentBuilder.DocumentableContentBuilder.annotationsBlock(d: AnnotationTarget) =
+    override fun PageContentBuilder.DocumentableContentBuilder.annotationsBlock(d: AnnotationTarget) {
         annotationsBlockWithIgnored(d, ignoredAnnotations, strategy, listBrackets, classExtension)
+    }
 
-    override fun PageContentBuilder.DocumentableContentBuilder.annotationsInline(d: AnnotationTarget) =
+    override fun PageContentBuilder.DocumentableContentBuilder.annotationsInline(d: AnnotationTarget) {
         annotationsInlineWithIgnored(d, ignoredAnnotations, strategy, listBrackets, classExtension)
+    }
 
-    override fun <T : Documentable> WithExtraProperties<T>.modifiers() =
-        extra[AdditionalModifiers]?.content?.entries?.associate {
+    override fun <T : Documentable> WithExtraProperties<T>.modifiers(): Map<DokkaConfiguration.DokkaSourceSet, Set<ExtraModifiers.JavaOnlyModifiers>> {
+        return extra[AdditionalModifiers]?.content?.entries?.associate {
             it.key to it.value.filterIsInstance<ExtraModifiers.JavaOnlyModifiers>().toSet()
         } ?: emptyMap()
+    }
 
 }

--- a/plugins/kotlin-as-java/src/main/kotlin/transformToJava.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/transformToJava.kt
@@ -16,26 +16,26 @@ private val JVM_NAME_DOCUMENTABLE_TRANSFORMER by lazy {
     JvmNameDocumentableTransformer()
 }
 
-fun DPackage.transformToJava(context: DokkaContext): DPackage {
+public fun DPackage.transformToJava(context: DokkaContext): DPackage {
     with(KotlinToJavaConverter(context)) {
         return JVM_NAME_DOCUMENTABLE_TRANSFORMER.transform(this@transformToJava.asJava(), context)
     }
 }
 
-fun DClasslike.transformToJava(context: DokkaContext): DClasslike {
+public fun DClasslike.transformToJava(context: DokkaContext): DClasslike {
     with(KotlinToJavaConverter(context)) {
         return JVM_NAME_DOCUMENTABLE_TRANSFORMER.transform(this@transformToJava.asJava(), context)
     }
 }
 
-fun DFunction.transformToJava(context: DokkaContext, containingClassName: String, isTopLevel: Boolean = false): List<DFunction> {
+public fun DFunction.transformToJava(context: DokkaContext, containingClassName: String, isTopLevel: Boolean = false): List<DFunction> {
     with(KotlinToJavaConverter(context)) {
         return this@transformToJava.asJava(containingClassName, isTopLevel)
             .map { JVM_NAME_DOCUMENTABLE_TRANSFORMER.transform(it, context) }
     }
 }
 
-fun DProperty.transformToJava(context: DokkaContext, isTopLevel: Boolean = false, relocateToClass: String? = null): DProperty {
+public fun DProperty.transformToJava(context: DokkaContext, isTopLevel: Boolean = false, relocateToClass: String? = null): DProperty {
     with(KotlinToJavaConverter(context)) {
         return JVM_NAME_DOCUMENTABLE_TRANSFORMER.transform(this@transformToJava.asJava(isTopLevel, relocateToClass), context)
     }

--- a/plugins/kotlin-as-java/src/main/kotlin/transformers/JvmNameDocumentableTransformer.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/transformers/JvmNameDocumentableTransformer.kt
@@ -9,7 +9,7 @@ import org.jetbrains.dokka.model.properties.PropertyContainer
 import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.transformers.documentation.DocumentableTransformer
 
-class JvmNameDocumentableTransformer : DocumentableTransformer {
+public class JvmNameDocumentableTransformer : DocumentableTransformer {
     private val jvmNameProvider = JvmNameProvider()
 
     override fun invoke(original: DModule, context: DokkaContext): DModule {

--- a/plugins/kotlin-as-java/src/main/kotlin/transformers/JvmNameProvider.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/transformers/JvmNameProvider.kt
@@ -10,26 +10,26 @@ import org.jetbrains.dokka.kotlinAsJava.jvmNameAsString
 import org.jetbrains.dokka.model.*
 import org.jetbrains.dokka.model.properties.WithExtraProperties
 
-data class Name(val fqName: String) {
-    val name = fqName.substringAfterLast(".")
+public data class Name(val fqName: String) {
+    val name: String = fqName.substringAfterLast(".")
 }
 
-class JvmNameProvider {
-    fun <T> nameFor(entry: T): String where T : Documentable, T : WithExtraProperties<T> =
+public class JvmNameProvider {
+    public fun <T> nameFor(entry: T): String where T : Documentable, T : WithExtraProperties<T> =
         entry.directlyAnnotatedJvmName()?.jvmNameAsString()
             ?: entry.name
             ?: throw IllegalStateException("Failed to provide a name for ${entry.javaClass.canonicalName}")
 
-    fun <T> nameForSyntheticClass(entry: T): Name where T : WithSources, T : WithExtraProperties<T>, T : Documentable {
+    public fun <T> nameForSyntheticClass(entry: T): Name where T : WithSources, T : WithExtraProperties<T>, T : Documentable {
         val name: String = (entry.fileLevelJvmName()?.params?.get("name") as? StringValue)?.value
             ?: (entry.sources.entries.first().value.path.split("/").last().split(".").first().capitalize() + "Kt")
         return Name("${entry.dri.packageName}.$name")
     }
 
-    fun nameForGetter(entry: DProperty): String? =
+    public fun nameForGetter(entry: DProperty): String? =
         entry.getter?.directlyAnnotatedJvmName()?.jvmNameAsString()
 
-    fun nameForSetter(entry: DProperty): String? =
+    public fun nameForSetter(entry: DProperty): String? =
         entry.setter?.directlyAnnotatedJvmName()?.jvmNameAsString()
 
     private fun List<Annotations.Annotation>.jvmNameAnnotation(): Annotations.Annotation? =

--- a/plugins/kotlin-as-java/src/main/kotlin/transformers/KotlinAsJavaDocumentableTransformer.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/transformers/KotlinAsJavaDocumentableTransformer.kt
@@ -9,7 +9,7 @@ import org.jetbrains.dokka.model.DModule
 import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.transformers.documentation.DocumentableTransformer
 
-class KotlinAsJavaDocumentableTransformer : DocumentableTransformer {
+public class KotlinAsJavaDocumentableTransformer : DocumentableTransformer {
     override fun invoke(original: DModule, context: DokkaContext): DModule =
         original.copy(packages = original.packages.map {
             with(KotlinToJavaConverter(context)) {

--- a/plugins/kotlin-as-java/src/main/kotlin/translators/KotlinAsJavaDocumentableToPageTranslator.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/translators/KotlinAsJavaDocumentableToPageTranslator.kt
@@ -13,7 +13,9 @@ import org.jetbrains.dokka.transformers.documentation.DocumentableToPageTranslat
 import org.jetbrains.dokka.utilities.DokkaLogger
 import org.jetbrains.dokka.analysis.kotlin.internal.InternalKotlinAnalysisPlugin
 
-class KotlinAsJavaDocumentableToPageTranslator(context: DokkaContext) : DocumentableToPageTranslator {
+public class KotlinAsJavaDocumentableToPageTranslator(
+    context: DokkaContext
+) : DocumentableToPageTranslator {
     private val configuration = configuration<DokkaBase, DokkaBaseConfiguration>(context)
     private val commentsToContentConverter = context.plugin<DokkaBase>().querySingle { commentsToContentConverter }
     private val signatureProvider = context.plugin<DokkaBase>().querySingle { signatureProvider }

--- a/plugins/kotlin-as-java/src/main/kotlin/translators/KotlinAsJavaPageCreator.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/translators/KotlinAsJavaPageCreator.kt
@@ -14,7 +14,7 @@ import org.jetbrains.dokka.pages.MemberPageNode
 import org.jetbrains.dokka.utilities.DokkaLogger
 import org.jetbrains.dokka.analysis.kotlin.internal.DocumentableSourceLanguageParser
 
-class KotlinAsJavaPageCreator(
+public class KotlinAsJavaPageCreator(
     configuration: DokkaBaseConfiguration?,
     commentsToContentConverter: CommentsToContentConverter,
     signatureProvider: SignatureProvider,

--- a/plugins/mathjax/src/main/kotlin/MathjaxPlugin.kt
+++ b/plugins/mathjax/src/main/kotlin/MathjaxPlugin.kt
@@ -16,15 +16,17 @@ import org.jetbrains.dokka.pages.RootPageNode
 import org.jetbrains.dokka.pages.WithDocumentables
 import org.jetbrains.dokka.plugability.DokkaPlugin
 import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
+import org.jetbrains.dokka.plugability.Extension
 import org.jetbrains.dokka.plugability.PluginApiPreviewAcknowledgement
 import org.jetbrains.dokka.transformers.pages.PageTransformer
 
-class MathjaxPlugin : DokkaPlugin() {
-    val transformer by extending {
+public class MathjaxPlugin : DokkaPlugin() {
+
+    public val transformer: Extension<PageTransformer, *, *> by extending {
         CoreExtensions.pageTransformer with MathjaxTransformer
     }
 
-    val mathjaxTagContentProvider by extending {
+    public val mathjaxTagContentProvider: Extension<CustomTagContentProvider, *, *> by extending {
         plugin<DokkaBase>().customTagContentProvider with MathjaxTagContentProvider order {
             before(plugin<DokkaBase>().sinceKotlinTagContentProvider)
         }
@@ -38,8 +40,9 @@ class MathjaxPlugin : DokkaPlugin() {
 private const val ANNOTATION = "usesMathJax"
 internal const val LIB_PATH = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js?config=TeX-AMS_SVG&latest"
 
-object MathjaxTransformer : PageTransformer {
-    override fun invoke(input: RootPageNode) = input.transformContentPagesTree {
+public object MathjaxTransformer : PageTransformer {
+
+    override fun invoke(input: RootPageNode): RootPageNode = input.transformContentPagesTree {
         it.modified(
             embeddedResources = it.embeddedResources + if (it.isNeedingMathjax) listOf(LIB_PATH) else emptyList()
         )
@@ -50,9 +53,10 @@ object MathjaxTransformer : PageTransformer {
             .flatMap { it.children }
             .any { (it as? CustomTagWrapper)?.name == ANNOTATION } }
 }
-object MathjaxTagContentProvider : CustomTagContentProvider {
 
-    override fun isApplicable(customTag: CustomTagWrapper) = customTag.name == ANNOTATION
+public object MathjaxTagContentProvider : CustomTagContentProvider {
+
+    override fun isApplicable(customTag: CustomTagWrapper): Boolean = customTag.name == ANNOTATION
 
     override fun DocumentableContentBuilder.contentForDescription(
         sourceSet: DokkaConfiguration.DokkaSourceSet,

--- a/plugins/templating/src/main/kotlin/templates/AddToNavigationCommandHandler.kt
+++ b/plugins/templating/src/main/kotlin/templates/AddToNavigationCommandHandler.kt
@@ -14,7 +14,9 @@ import java.io.File
 import java.nio.file.Files
 import java.util.concurrent.ConcurrentHashMap
 
-class AddToNavigationCommandHandler(val context: DokkaContext) : CommandHandler {
+public class AddToNavigationCommandHandler(
+    public val context: DokkaContext
+) : CommandHandler {
     private val navigationFragments = ConcurrentHashMap<String, Element>()
 
     override fun handleCommandAsTag(command: Command, body: Element, input: File, output: File) {
@@ -25,7 +27,7 @@ class AddToNavigationCommandHandler(val context: DokkaContext) : CommandHandler 
             ?.let { key -> navigationFragments[key.toString()] = body }
     }
 
-    override fun canHandle(command: Command) = command is AddToNavigationCommand
+    override fun canHandle(command: Command): Boolean = command is AddToNavigationCommand
 
     override fun finish(output: File) {
         if (navigationFragments.isNotEmpty()) {

--- a/plugins/templating/src/main/kotlin/templates/CommandHandler.kt
+++ b/plugins/templating/src/main/kotlin/templates/CommandHandler.kt
@@ -10,14 +10,16 @@ import org.jsoup.nodes.Node
 import java.io.File
 
 
-interface CommandHandler  {
+public interface CommandHandler  {
     @Deprecated("This was renamed to handleCommandAsTag", ReplaceWith("handleCommandAsTag(command, element, input, output)"))
-    fun handleCommand(element: Element, command: Command, input: File, output: File) { }
+    public fun handleCommand(element: Element, command: Command, input: File, output: File) { }
 
     @Suppress("DEPRECATION")
-    fun handleCommandAsTag(command: Command, body: Element, input: File, output: File) =
+    public fun handleCommandAsTag(command: Command, body: Element, input: File, output: File) {
         handleCommand(body, command, input, output)
-    fun handleCommandAsComment(command: Command, body: List<Node>, input: File, output: File) { }
-    fun canHandle(command: Command): Boolean
-    fun finish(output: File) {}
+    }
+    public fun handleCommandAsComment(command: Command, body: List<Node>, input: File, output: File) { }
+    public fun canHandle(command: Command): Boolean
+    public fun finish(output: File) {}
 }
+

--- a/plugins/templating/src/main/kotlin/templates/DirectiveBasedTemplateProcessing.kt
+++ b/plugins/templating/src/main/kotlin/templates/DirectiveBasedTemplateProcessing.kt
@@ -21,7 +21,7 @@ import org.jsoup.nodes.TextNode
 import java.io.File
 import java.nio.file.Files
 
-class DirectiveBasedHtmlTemplateProcessingStrategy(private val context: DokkaContext) : TemplateProcessingStrategy {
+public class DirectiveBasedHtmlTemplateProcessingStrategy(private val context: DokkaContext) : TemplateProcessingStrategy {
 
     private val directiveBasedCommandHandlers =
         context.plugin<TemplatingPlugin>().query { directiveBasedCommandHandlers }
@@ -45,11 +45,11 @@ class DirectiveBasedHtmlTemplateProcessingStrategy(private val context: DokkaCon
             true
         } else false
 
-    fun handleCommandAsTag(element: Element, command: Command, input: File, output: File) {
+    public fun handleCommandAsTag(element: Element, command: Command, input: File, output: File) {
         traverseHandlers(command) { handleCommandAsTag(command, element, input, output) }
     }
 
-    fun handleCommandAsComment(command: Command, body: List<Node>, input: File, output: File) {
+    public fun handleCommandAsComment(command: Command, body: List<Node>, input: File, output: File) {
         traverseHandlers(command) { handleCommandAsComment(command, body, input, output) }
     }
 

--- a/plugins/templating/src/main/kotlin/templates/FallbackTemplateProcessingStrategy.kt
+++ b/plugins/templating/src/main/kotlin/templates/FallbackTemplateProcessingStrategy.kt
@@ -7,7 +7,7 @@ package org.jetbrains.dokka.templates
 import org.jetbrains.dokka.DokkaConfiguration
 import java.io.File
 
-class FallbackTemplateProcessingStrategy : TemplateProcessingStrategy {
+public class FallbackTemplateProcessingStrategy : TemplateProcessingStrategy {
 
     override fun process(input: File, output: File, moduleContext: DokkaConfiguration.DokkaModuleDescription?): Boolean {
         if (input != output) input.copyTo(output, overwrite = true)

--- a/plugins/templating/src/main/kotlin/templates/JsonElementBasedTemplateProcessingStrategy.kt
+++ b/plugins/templating/src/main/kotlin/templates/JsonElementBasedTemplateProcessingStrategy.kt
@@ -14,13 +14,15 @@ import org.jetbrains.dokka.templates.TemplateProcessingStrategy
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 
-abstract class BaseJsonNavigationTemplateProcessingStrategy(val context: DokkaContext) : TemplateProcessingStrategy {
-    abstract val navigationFileNameWithoutExtension: String
-    abstract val path: String
+public abstract class BaseJsonNavigationTemplateProcessingStrategy(
+    public val context: DokkaContext
+) : TemplateProcessingStrategy {
+    public abstract val navigationFileNameWithoutExtension: String
+    public abstract val path: String
 
     private val fragments = ConcurrentHashMap<String, List<SearchRecord>>()
 
-    open fun canProcess(file: File): Boolean =
+    public open fun canProcess(file: File): Boolean =
         file.extension == "json" && file.nameWithoutExtension == navigationFileNameWithoutExtension
 
     override fun process(input: File, output: File, moduleContext: DokkaModuleDescription?): Boolean {
@@ -57,8 +59,9 @@ abstract class BaseJsonNavigationTemplateProcessingStrategy(val context: DokkaCo
 
 }
 
-class PagesSearchTemplateStrategy(val dokkaContext: DokkaContext) :
-    BaseJsonNavigationTemplateProcessingStrategy(dokkaContext) {
+public class PagesSearchTemplateStrategy(
+    public val dokkaContext: DokkaContext
+) : BaseJsonNavigationTemplateProcessingStrategy(dokkaContext) {
     override val navigationFileNameWithoutExtension: String = "pages"
     override val path: String = "scripts"
 }

--- a/plugins/templating/src/main/kotlin/templates/PackageListProcessingStrategy.kt
+++ b/plugins/templating/src/main/kotlin/templates/PackageListProcessingStrategy.kt
@@ -12,7 +12,9 @@ import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.templates.TemplateProcessingStrategy
 import java.io.File
 
-class PackageListProcessingStrategy(val context: DokkaContext) : TemplateProcessingStrategy {
+public class PackageListProcessingStrategy(
+    public val context: DokkaContext
+) : TemplateProcessingStrategy {
     private val fragments = mutableSetOf<PackageList>()
 
     private fun canProcess(file: File, moduleContext: DokkaModuleDescription?): Boolean =

--- a/plugins/templating/src/main/kotlin/templates/PathToRootSubstitutor.kt
+++ b/plugins/templating/src/main/kotlin/templates/PathToRootSubstitutor.kt
@@ -9,7 +9,9 @@ import org.jetbrains.dokka.base.templating.SubstitutionCommand
 import org.jetbrains.dokka.plugability.DokkaContext
 import java.io.File
 
-class PathToRootSubstitutor(private val dokkaContext: DokkaContext) : Substitutor {
+public class PathToRootSubstitutor(
+    private val dokkaContext: DokkaContext
+) : Substitutor {
 
     override fun trySubstitute(context: TemplatingContext<SubstitutionCommand>, match: MatchResult): String? =
         if (context.command is PathToRootSubstitutionCommand) {

--- a/plugins/templating/src/main/kotlin/templates/ProjectNameSubstitutor.kt
+++ b/plugins/templating/src/main/kotlin/templates/ProjectNameSubstitutor.kt
@@ -10,7 +10,9 @@ import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.templates.Substitutor
 import org.jetbrains.dokka.templates.TemplatingContext
 
-class ProjectNameSubstitutor(private val dokkaContext: DokkaContext) : Substitutor {
+public class ProjectNameSubstitutor(
+    private val dokkaContext: DokkaContext
+) : Substitutor {
 
     override fun trySubstitute(context: TemplatingContext<SubstitutionCommand>, match: MatchResult): String? =
         dokkaContext.configuration.moduleName.takeIf { context.command is ProjectNameSubstitutionCommand }

--- a/plugins/templating/src/main/kotlin/templates/ReplaceVersionCommandHandler.kt
+++ b/plugins/templating/src/main/kotlin/templates/ReplaceVersionCommandHandler.kt
@@ -12,7 +12,9 @@ import org.jsoup.nodes.Element
 import org.jsoup.nodes.TextNode
 import java.io.File
 
-class ReplaceVersionCommandHandler(private val context: DokkaContext) : CommandHandler {
+public class ReplaceVersionCommandHandler(
+    private val context: DokkaContext
+) : CommandHandler {
 
     override fun canHandle(command: Command): Boolean = command is ReplaceVersionsCommand
 

--- a/plugins/templating/src/main/kotlin/templates/SourcesetDependencyProcessingStrategy.kt
+++ b/plugins/templating/src/main/kotlin/templates/SourcesetDependencyProcessingStrategy.kt
@@ -15,7 +15,9 @@ import java.util.concurrent.ConcurrentHashMap
 
 private typealias Entry = Map<String, List<String>>
 
-class SourcesetDependencyProcessingStrategy(val context: DokkaContext) : TemplateProcessingStrategy {
+public class SourcesetDependencyProcessingStrategy(
+    public val context: DokkaContext
+) : TemplateProcessingStrategy {
     private val fileName = "sourceset_dependencies.js"
     private val fragments = ConcurrentHashMap<String, Entry>()
 

--- a/plugins/templating/src/main/kotlin/templates/SubstitutionCommandHandler.kt
+++ b/plugins/templating/src/main/kotlin/templates/SubstitutionCommandHandler.kt
@@ -15,7 +15,7 @@ import org.jsoup.nodes.Node
 import org.jsoup.nodes.TextNode
 import java.io.File
 
-class SubstitutionCommandHandler(context: DokkaContext) : CommandHandler {
+public class SubstitutionCommandHandler(context: DokkaContext) : CommandHandler {
 
     override fun handleCommandAsTag(command: Command, body: Element, input: File, output: File) {
         command as SubstitutionCommand

--- a/plugins/templating/src/main/kotlin/templates/Substitutor.kt
+++ b/plugins/templating/src/main/kotlin/templates/Substitutor.kt
@@ -6,6 +6,6 @@ package org.jetbrains.dokka.templates
 
 import org.jetbrains.dokka.base.templating.SubstitutionCommand
 
-fun interface Substitutor {
-    fun trySubstitute(context: TemplatingContext<SubstitutionCommand>, match: MatchResult): String?
+public fun interface Substitutor {
+    public fun trySubstitute(context: TemplatingContext<SubstitutionCommand>, match: MatchResult): String?
 }

--- a/plugins/templating/src/main/kotlin/templates/TemplateProcessor.kt
+++ b/plugins/templating/src/main/kotlin/templates/TemplateProcessor.kt
@@ -19,22 +19,22 @@ import org.jetbrains.dokka.plugability.querySingle
 import org.jsoup.nodes.Node
 import java.io.File
 
-interface TemplateProcessor
+public interface TemplateProcessor
 
-interface SubmoduleTemplateProcessor : TemplateProcessor {
-    fun process(modules: List<DokkaModuleDescription>): TemplatingResult
+public interface SubmoduleTemplateProcessor : TemplateProcessor {
+    public fun process(modules: List<DokkaModuleDescription>): TemplatingResult
 }
 
-interface MultiModuleTemplateProcessor : TemplateProcessor {
-    fun process(generatedPagesTree: RootPageNode)
+public interface MultiModuleTemplateProcessor : TemplateProcessor {
+    public fun process(generatedPagesTree: RootPageNode)
 }
 
-interface TemplateProcessingStrategy {
-    fun process(input: File, output: File, moduleContext: DokkaModuleDescription?): Boolean
-    fun finish(output: File) {}
+public interface TemplateProcessingStrategy {
+    public fun process(input: File, output: File, moduleContext: DokkaModuleDescription?): Boolean
+    public fun finish(output: File) {}
 }
 
-class DefaultSubmoduleTemplateProcessor(
+public class DefaultSubmoduleTemplateProcessor(
     private val context: DokkaContext,
 ) : SubmoduleTemplateProcessor {
 
@@ -44,14 +44,15 @@ class DefaultSubmoduleTemplateProcessor(
     private val configuredModulesPaths =
             context.configuration.modules.associate { it.sourceOutputDirectory.absolutePath to it.name }
 
-    override fun process(modules: List<DokkaModuleDescription>) =
-        runBlocking(Dispatchers.Default) {
+    override fun process(modules: List<DokkaModuleDescription>): TemplatingResult {
+        return runBlocking(Dispatchers.Default) {
             coroutineScope {
                 modules.fold(TemplatingResult()) { acc, module ->
                     acc + module.sourceOutputDirectory.visit(context.configuration.outputDir.resolve(module.relativePathToOutputDirectory), module)
                 }
             }
         }
+    }
 
     private suspend fun File.visit(target: File, module: DokkaModuleDescription, acc: TemplatingResult = TemplatingResult()): TemplatingResult =
         coroutineScope {
@@ -74,8 +75,8 @@ class DefaultSubmoduleTemplateProcessor(
         }
 }
 
-class DefaultMultiModuleTemplateProcessor(
-    val context: DokkaContext,
+public class DefaultMultiModuleTemplateProcessor(
+    public val context: DokkaContext,
 ) : MultiModuleTemplateProcessor {
     private val strategies: List<TemplateProcessingStrategy> =
         context.plugin<TemplatingPlugin>().query { templateProcessingStrategy }
@@ -89,13 +90,15 @@ class DefaultMultiModuleTemplateProcessor(
     }
 }
 
-data class TemplatingContext<out T : Command>(
+public data class TemplatingContext<out T : Command>(
     val input: File,
     val output: File,
     val body: List<Node>,
     val command: T,
 )
 
-data class TemplatingResult(val modules: List<String> = emptyList()) {
-    operator fun plus(rhs: TemplatingResult): TemplatingResult = TemplatingResult((modules + rhs.modules).distinct())
+public data class TemplatingResult(val modules: List<String> = emptyList()) {
+    public operator fun plus(rhs: TemplatingResult): TemplatingResult {
+        return TemplatingResult((modules + rhs.modules).distinct())
+    }
 }

--- a/plugins/templating/src/main/kotlin/templates/TemplatingPlugin.kt
+++ b/plugins/templating/src/main/kotlin/templates/TemplatingPlugin.kt
@@ -6,74 +6,71 @@ package org.jetbrains.dokka.templates
 
 import org.jetbrains.dokka.allModulesPage.templates.PackageListProcessingStrategy
 import org.jetbrains.dokka.allModulesPage.templates.PagesSearchTemplateStrategy
-import org.jetbrains.dokka.plugability.DokkaPlugin
-import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
-import org.jetbrains.dokka.plugability.PluginApiPreviewAcknowledgement
+import org.jetbrains.dokka.plugability.*
 import templates.ProjectNameSubstitutor
 import templates.ReplaceVersionCommandHandler
 import templates.SourcesetDependencyProcessingStrategy
 
 @Suppress("unused")
-class TemplatingPlugin : DokkaPlugin() {
+public class TemplatingPlugin : DokkaPlugin() {
 
-    val submoduleTemplateProcessor by extensionPoint<SubmoduleTemplateProcessor>()
-    val multimoduleTemplateProcessor by extensionPoint<MultiModuleTemplateProcessor>()
-    val templateProcessingStrategy by extensionPoint<TemplateProcessingStrategy>()
-    val directiveBasedCommandHandlers by extensionPoint<CommandHandler>()
+    public val submoduleTemplateProcessor: ExtensionPoint<SubmoduleTemplateProcessor> by extensionPoint()
+    public val multimoduleTemplateProcessor: ExtensionPoint<MultiModuleTemplateProcessor> by extensionPoint()
+    public val templateProcessingStrategy: ExtensionPoint<TemplateProcessingStrategy> by extensionPoint()
+    public val directiveBasedCommandHandlers: ExtensionPoint<CommandHandler> by extensionPoint()
+    public val substitutor: ExtensionPoint<Substitutor> by extensionPoint()
 
-    val substitutor by extensionPoint<Substitutor>()
-
-    val defaultSubmoduleTemplateProcessor by extending {
+    public val defaultSubmoduleTemplateProcessor: Extension<SubmoduleTemplateProcessor, *, *> by extending {
         submoduleTemplateProcessor providing ::DefaultSubmoduleTemplateProcessor
     }
 
-    val defaultMultiModuleTemplateProcessor by extending {
+    public val defaultMultiModuleTemplateProcessor: Extension<MultiModuleTemplateProcessor, *, *> by extending {
         multimoduleTemplateProcessor providing ::DefaultMultiModuleTemplateProcessor
     }
 
-    val directiveBasedHtmlTemplateProcessingStrategy by extending {
+    public val directiveBasedHtmlTemplateProcessingStrategy: Extension<TemplateProcessingStrategy, *, *> by extending {
         templateProcessingStrategy providing ::DirectiveBasedHtmlTemplateProcessingStrategy order {
             before(fallbackProcessingStrategy)
         }
     }
 
-    val sourcesetDependencyProcessingStrategy by extending {
+    public val sourcesetDependencyProcessingStrategy: Extension<TemplateProcessingStrategy, *, *> by extending {
         templateProcessingStrategy providing ::SourcesetDependencyProcessingStrategy order {
             before(fallbackProcessingStrategy)
         }
     }
 
-    val pagesSearchTemplateStrategy by extending {
+    public val pagesSearchTemplateStrategy: Extension<TemplateProcessingStrategy, *, *> by extending {
         templateProcessingStrategy providing ::PagesSearchTemplateStrategy order {
             before(fallbackProcessingStrategy)
         }
     }
 
-    val packageListProcessingStrategy by extending {
+    public val packageListProcessingStrategy: Extension<TemplateProcessingStrategy, *, *> by extending {
         templateProcessingStrategy providing ::PackageListProcessingStrategy order {
             before(fallbackProcessingStrategy)
         }
     }
 
-    val fallbackProcessingStrategy by extending {
+    public val fallbackProcessingStrategy: Extension<TemplateProcessingStrategy, *, *> by extending {
         templateProcessingStrategy with FallbackTemplateProcessingStrategy()
     }
 
-    val pathToRootSubstitutor by extending {
+    public val pathToRootSubstitutor: Extension<Substitutor, *, *> by extending {
         substitutor providing ::PathToRootSubstitutor
     }
 
-    val projectNameSubstitutor by extending {
+    public val projectNameSubstitutor: Extension<Substitutor, *, *> by extending {
         substitutor providing ::ProjectNameSubstitutor
     }
 
-    val addToNavigationCommandHandler by extending {
+    public val addToNavigationCommandHandler: Extension<CommandHandler, *, *> by extending {
         directiveBasedCommandHandlers providing ::AddToNavigationCommandHandler
     }
-    val substitutionCommandHandler by extending {
+    public val substitutionCommandHandler: Extension<CommandHandler, *, *> by extending {
         directiveBasedCommandHandlers providing ::SubstitutionCommandHandler
     }
-    val replaceVersionCommandHandler by extending {
+    public val replaceVersionCommandHandler: Extension<CommandHandler, *, *> by extending {
         directiveBasedCommandHandlers providing ::ReplaceVersionCommandHandler
     }
 

--- a/plugins/versioning/api/versioning.api
+++ b/plugins/versioning/api/versioning.api
@@ -114,7 +114,7 @@ public final class org/jetbrains/dokka/versioning/VersioningConfiguration$Compan
 	public final fun getDefaultOlderVersions ()Ljava/util/List;
 	public final fun getDefaultOlderVersionsDir ()Ljava/io/File;
 	public final fun getDefaultRenderVersionsNavigationOnAllPages ()Z
-	public final fun getDefaultVersion ()Ljava/lang/Void;
+	public final fun getDefaultVersion ()Ljava/lang/String;
 	public final fun getDefaultVersionsOrdering ()Ljava/util/List;
 }
 

--- a/plugins/versioning/src/main/kotlin/org/jetbrains/dokka/versioning/DefaultPreviousDocumentationCopyPostAction.kt
+++ b/plugins/versioning/src/main/kotlin/org/jetbrains/dokka/versioning/DefaultPreviousDocumentationCopyPostAction.kt
@@ -17,7 +17,9 @@ import org.jetbrains.dokka.templates.TemplateProcessingStrategy
 import org.jetbrains.dokka.templates.TemplatingPlugin
 import java.io.File
 
-class DefaultPreviousDocumentationCopyPostAction(private val context: DokkaContext) : PostAction {
+public class DefaultPreviousDocumentationCopyPostAction(
+    private val context: DokkaContext
+) : PostAction {
     private val versioningStorage by lazy { context.plugin<VersioningPlugin>().querySingle { versioningStorage } }
     private val processingStrategies: List<TemplateProcessingStrategy> =
         context.plugin<TemplatingPlugin>().query { templateProcessingStrategy }

--- a/plugins/versioning/src/main/kotlin/org/jetbrains/dokka/versioning/ReplaceVersionCommandConsumer.kt
+++ b/plugins/versioning/src/main/kotlin/org/jetbrains/dokka/versioning/ReplaceVersionCommandConsumer.kt
@@ -17,14 +17,14 @@ import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.plugability.plugin
 import org.jetbrains.dokka.plugability.querySingle
 
-class ReplaceVersionCommandConsumer(context: DokkaContext) : ImmediateHtmlCommandConsumer {
+public class ReplaceVersionCommandConsumer(context: DokkaContext) : ImmediateHtmlCommandConsumer {
 
     private val versionsNavigationCreator =
         context.plugin<VersioningPlugin>().querySingle { versionsNavigationCreator }
     private val versioningStorage =
         context.plugin<VersioningPlugin>().querySingle { versioningStorage }
 
-    override fun canProcess(command: Command) = command is ReplaceVersionsCommand
+    override fun canProcess(command: Command): Boolean = command is ReplaceVersionsCommand
 
     override fun <R> processCommand(
         command: Command,

--- a/plugins/versioning/src/main/kotlin/org/jetbrains/dokka/versioning/ReplaceVersionsCommand.kt
+++ b/plugins/versioning/src/main/kotlin/org/jetbrains/dokka/versioning/ReplaceVersionsCommand.kt
@@ -14,9 +14,9 @@ import org.jetbrains.dokka.templates.CommandHandler
 import org.jsoup.nodes.Element
 import java.io.File
 
-class ReplaceVersionCommandHandler(context: DokkaContext) : CommandHandler {
+public class ReplaceVersionCommandHandler(context: DokkaContext) : CommandHandler {
 
-    val versionsNavigationCreator by lazy {
+    public val versionsNavigationCreator: VersionsNavigationCreator by lazy {
         context.plugin<VersioningPlugin>().querySingle { versionsNavigationCreator }
     }
 

--- a/plugins/versioning/src/main/kotlin/org/jetbrains/dokka/versioning/VersioningConfiguration.kt
+++ b/plugins/versioning/src/main/kotlin/org/jetbrains/dokka/versioning/VersioningConfiguration.kt
@@ -8,7 +8,7 @@ import org.jetbrains.dokka.plugability.ConfigurableBlock
 import org.jetbrains.dokka.plugability.DokkaContext
 import java.io.File
 
-data class VersioningConfiguration(
+public data class VersioningConfiguration(
     var olderVersionsDir: File? = defaultOlderVersionsDir,
     var olderVersions: List<File>? = defaultOlderVersions,
     var versionsOrdering: List<String>? = defaultVersionsOrdering,
@@ -25,14 +25,14 @@ data class VersioningConfiguration(
         return olderVersionsDir?.listFiles()?.toList().orEmpty() + olderVersions.orEmpty()
     }
 
-    companion object {
-        val defaultOlderVersionsDir: File? = null
-        val defaultOlderVersions: List<File>? = null
-        val defaultVersionsOrdering: List<String>? = null
-        val defaultVersion = null
-        val defaultRenderVersionsNavigationOnAllPages = true
+    public companion object {
+        public val defaultOlderVersionsDir: File? = null
+        public val defaultOlderVersions: List<File>? = null
+        public val defaultVersionsOrdering: List<String>? = null
+        public val defaultVersion: String? = null
+        public val defaultRenderVersionsNavigationOnAllPages: Boolean = true
 
-        const val OLDER_VERSIONS_DIR = "older"
-        const val VERSIONS_FILE = "version.json"
+        public const val OLDER_VERSIONS_DIR: String = "older"
+        public const val VERSIONS_FILE: String = "version.json"
     }
 }

--- a/plugins/versioning/src/main/kotlin/org/jetbrains/dokka/versioning/VersioningPlugin.kt
+++ b/plugins/versioning/src/main/kotlin/org/jetbrains/dokka/versioning/VersioningPlugin.kt
@@ -6,53 +6,61 @@ package org.jetbrains.dokka.versioning
 
 import org.jetbrains.dokka.CoreExtensions.postActions
 import org.jetbrains.dokka.base.DokkaBase
-import org.jetbrains.dokka.plugability.DokkaPlugin
-import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
-import org.jetbrains.dokka.plugability.PluginApiPreviewAcknowledgement
-import org.jetbrains.dokka.plugability.configuration
+import org.jetbrains.dokka.base.templating.ImmediateHtmlCommandConsumer
+import org.jetbrains.dokka.plugability.*
+import org.jetbrains.dokka.renderers.PostAction
+import org.jetbrains.dokka.templates.CommandHandler
 import org.jetbrains.dokka.templates.TemplatingPlugin
+import org.jetbrains.dokka.transformers.pages.PageTransformer
 
-class VersioningPlugin : DokkaPlugin() {
+public class VersioningPlugin : DokkaPlugin() {
 
-    val versioningStorage by extensionPoint<VersioningStorage>()
-    val versionsNavigationCreator by extensionPoint<VersionsNavigationCreator>()
-    val versionsOrdering by extensionPoint<VersionsOrdering>()
+    public val versioningStorage: ExtensionPoint<VersioningStorage> by extensionPoint()
+    public val versionsNavigationCreator: ExtensionPoint<VersionsNavigationCreator> by extensionPoint()
+    public val versionsOrdering: ExtensionPoint<VersionsOrdering> by extensionPoint()
 
     private val dokkaBase by lazy { plugin<DokkaBase>() }
     private val templatingPlugin by lazy { plugin<TemplatingPlugin>() }
 
-    val defaultVersioningStorage by extending {
+    public val defaultVersioningStorage: Extension<VersioningStorage, *, *> by extending {
         versioningStorage providing ::DefaultVersioningStorage
     }
-    val defaultVersioningNavigationCreator by extending {
+
+    public val defaultVersioningNavigationCreator: Extension<VersionsNavigationCreator, *, *> by extending {
         versionsNavigationCreator providing ::HtmlVersionsNavigationCreator
     }
-    val replaceVersionCommandHandler by extending {
+
+    public val replaceVersionCommandHandler: Extension<CommandHandler, *, *> by extending {
         templatingPlugin.directiveBasedCommandHandlers providing ::ReplaceVersionCommandHandler override templatingPlugin.replaceVersionCommandHandler
     }
-    val resolveLinkConsumer by extending {
+
+    public val resolveLinkConsumer: Extension<ImmediateHtmlCommandConsumer, *, *> by extending {
         dokkaBase.immediateHtmlCommandConsumer providing ::ReplaceVersionCommandConsumer override dokkaBase.replaceVersionConsumer
     }
-    val cssStyleInstaller by extending {
+
+    public val cssStyleInstaller: Extension<PageTransformer, *, *> by extending {
         dokkaBase.htmlPreprocessors providing ::MultiModuleStylesInstaller order {
             after(dokkaBase.assetsInstaller)
             before(dokkaBase.customResourceInstaller)
         }
     }
-    val notFoundPageInstaller by extending {
+
+    public val notFoundPageInstaller: Extension<PageTransformer, *, *> by extending {
         dokkaBase.htmlPreprocessors providing ::NotFoundPageInstaller order {
             after(dokkaBase.assetsInstaller)
             before(dokkaBase.customResourceInstaller)
         } applyIf { !delayTemplateSubstitution }
     }
-    val versionsDefaultOrdering by extending {
+
+    public val versionsDefaultOrdering: Extension<VersionsOrdering, *, *> by extending {
         versionsOrdering providing { ctx ->
             configuration<VersioningPlugin, VersioningConfiguration>(ctx)?.versionsOrdering?.let {
                 ByConfigurationVersionOrdering(ctx)
             } ?: SemVerVersionOrdering()
         }
     }
-    val previousDocumentationCopyPostAction by extending {
+
+    public val previousDocumentationCopyPostAction: Extension<PostAction, *, *> by extending {
         postActions providing ::DefaultPreviousDocumentationCopyPostAction applyIf { !delayTemplateSubstitution }
     }
 

--- a/plugins/versioning/src/main/kotlin/org/jetbrains/dokka/versioning/VersioningStorage.kt
+++ b/plugins/versioning/src/main/kotlin/org/jetbrains/dokka/versioning/VersioningStorage.kt
@@ -11,18 +11,21 @@ import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.plugability.configuration
 import java.io.File
 
-data class VersionDirs(val src: File, val dst: File)
-data class CurrentVersion(val name: String, val dir: File)
+public data class VersionDirs(val src: File, val dst: File)
+public data class CurrentVersion(val name: String, val dir: File)
 
-interface VersioningStorage {
-    val previousVersions: Map<VersionId, VersionDirs>
-    val currentVersion: CurrentVersion
-    fun createVersionFile()
+public interface VersioningStorage {
+    public val previousVersions: Map<VersionId, VersionDirs>
+    public val currentVersion: CurrentVersion
+
+    public fun createVersionFile()
 }
 
-typealias VersionId = String
+public typealias VersionId = String
 
-class DefaultVersioningStorage(val context: DokkaContext) : VersioningStorage {
+public class DefaultVersioningStorage(
+    public val context: DokkaContext
+) : VersioningStorage {
 
     private val mapper = ObjectMapper()
     private val configuration = configuration<VersioningPlugin, VersioningConfiguration>(context)

--- a/plugins/versioning/src/main/kotlin/org/jetbrains/dokka/versioning/VersionsNavigationCreator.kt
+++ b/plugins/versioning/src/main/kotlin/org/jetbrains/dokka/versioning/VersionsNavigationCreator.kt
@@ -14,11 +14,13 @@ import org.jetbrains.dokka.plugability.querySingle
 import org.jetbrains.dokka.utilities.urlEncoded
 import java.io.File
 
-fun interface VersionsNavigationCreator {
-    operator fun invoke(output: File): String
+public fun interface VersionsNavigationCreator {
+    public operator fun invoke(output: File): String
 }
 
-class HtmlVersionsNavigationCreator(private val context: DokkaContext) : VersionsNavigationCreator {
+public class HtmlVersionsNavigationCreator(
+    private val context: DokkaContext
+) : VersionsNavigationCreator {
 
     private val versioningStorage by lazy { context.plugin<VersioningPlugin>().querySingle { versioningStorage } }
 

--- a/plugins/versioning/src/main/kotlin/org/jetbrains/dokka/versioning/VersionsOrdering.kt
+++ b/plugins/versioning/src/main/kotlin/org/jetbrains/dokka/versioning/VersionsOrdering.kt
@@ -8,17 +8,19 @@ import org.apache.maven.artifact.versioning.ComparableVersion
 import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.plugability.configuration
 
-fun interface VersionsOrdering {
-    fun order(records: List<VersionId>): List<VersionId>
+public fun interface VersionsOrdering {
+    public fun order(records: List<VersionId>): List<VersionId>
 }
 
-class ByConfigurationVersionOrdering(val dokkaContext: DokkaContext) : VersionsOrdering {
+public class ByConfigurationVersionOrdering(
+    public val dokkaContext: DokkaContext
+) : VersionsOrdering {
     override fun order(records: List<VersionId>): List<VersionId> =
         configuration<VersioningPlugin, VersioningConfiguration>(dokkaContext)?.versionsOrdering
             ?: throw IllegalStateException("Attempted to use a configuration ordering without providing configuration")
 }
 
-class SemVerVersionOrdering : VersionsOrdering {
+public class SemVerVersionOrdering : VersionsOrdering {
     override fun order(records: List<VersionId>): List<VersionId> =
         records.map { it to ComparableVersion(it) }.sortedByDescending { it.second }.map { it.first }
 }

--- a/plugins/versioning/src/main/kotlin/org/jetbrains/dokka/versioning/htmlPreprocessors.kt
+++ b/plugins/versioning/src/main/kotlin/org/jetbrains/dokka/versioning/htmlPreprocessors.kt
@@ -10,7 +10,9 @@ import org.jetbrains.dokka.pages.RootPageNode
 import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.transformers.pages.PageTransformer
 
-class MultiModuleStylesInstaller(private val dokkaContext: DokkaContext) : PageTransformer {
+public class MultiModuleStylesInstaller(
+    private val dokkaContext: DokkaContext
+) : PageTransformer {
     private val stylesPages = listOf(
         "styles/multimodule.css",
     )
@@ -26,7 +28,9 @@ class MultiModuleStylesInstaller(private val dokkaContext: DokkaContext) : PageT
         }
 }
 
-class NotFoundPageInstaller(private val dokkaContext: DokkaContext) : PageTransformer {
+public class NotFoundPageInstaller(
+    private val dokkaContext: DokkaContext
+) : PageTransformer {
     private val notFoundPage = listOf(
         "not-found-version.html",
     )

--- a/runners/cli/src/main/kotlin/org/jetbrains/dokka/CliArgumentTypes.kt
+++ b/runners/cli/src/main/kotlin/org/jetbrains/dokka/CliArgumentTypes.kt
@@ -11,20 +11,23 @@ import java.io.File
 import java.nio.file.Paths
 
 
-object ArgTypeFile : ArgType<File>(true) {
+public object ArgTypeFile : ArgType<File>(true) {
     override fun convert(value: kotlin.String, name: kotlin.String): File = Paths.get(value).toRealPath().toFile()
     override val description: kotlin.String
         get() = "{ String that represents a directory / file path }"
 }
 
-object ArgTypePlatform : ArgType<Platform>(true) {
+public object ArgTypePlatform : ArgType<Platform>(true) {
     override fun convert(value: kotlin.String, name: kotlin.String): Platform = Platform.fromString(value)
     override val description: kotlin.String
         get() = "{ String that represents a Kotlin platform. Possible values: jvm/js/native/common/android }"
 }
 
-object ArgTypeVisibility : ArgType<DokkaConfiguration.Visibility>(true) {
-    override fun convert(value: kotlin.String, name: kotlin.String) = DokkaConfiguration.Visibility.fromString(value)
+public object ArgTypeVisibility : ArgType<DokkaConfiguration.Visibility>(true) {
+    override fun convert(value: kotlin.String, name: kotlin.String): DokkaConfiguration.Visibility {
+        return DokkaConfiguration.Visibility.fromString(value)
+    }
+
     override val description: kotlin.String
         get() = "{ String that represents a visibility modifier. Possible values: ${getPossibleVisibilityValues()}"
 
@@ -32,7 +35,7 @@ object ArgTypeVisibility : ArgType<DokkaConfiguration.Visibility>(true) {
         DokkaConfiguration.Visibility.values().joinToString(separator = ", ")
 }
 
-object ArgTypePlugin : ArgType<DokkaConfiguration.PluginConfiguration>(true) {
+public object ArgTypePlugin : ArgType<DokkaConfiguration.PluginConfiguration>(true) {
     override fun convert(
         value: kotlin.String,
         name: kotlin.String
@@ -52,7 +55,7 @@ object ArgTypePlugin : ArgType<DokkaConfiguration.PluginConfiguration>(true) {
                 "Quotation marks (`\"`) inside json must be escaped. }"
 }
 
-object ArgTypeSourceLinkDefinition : ArgType<DokkaConfiguration.SourceLinkDefinition>(true) {
+public object ArgTypeSourceLinkDefinition : ArgType<DokkaConfiguration.SourceLinkDefinition>(true) {
     override fun convert(value: kotlin.String, name: kotlin.String): DokkaConfiguration.SourceLinkDefinition {
         return if (value.isNotEmpty() && value.contains("="))
             SourceLinkDefinitionImpl.parseSourceLinkDefinition(value)
@@ -68,7 +71,7 @@ object ArgTypeSourceLinkDefinition : ArgType<DokkaConfiguration.SourceLinkDefini
         get() = "{ String that represent source links. Format: {srcPath}={remotePath#lineSuffix} }"
 }
 
-data class ArgTypeArgument(val moduleName: CLIEntity<kotlin.String>) :
+public data class ArgTypeArgument(val moduleName: CLIEntity<kotlin.String>) :
     ArgType<DokkaConfiguration.DokkaSourceSet>(true) {
     override fun convert(value: kotlin.String, name: kotlin.String): DokkaConfiguration.DokkaSourceSet =
         (if (moduleName.valueOrigin != ArgParser.ValueOrigin.UNSET && moduleName.valueOrigin != ArgParser.ValueOrigin.UNDEFINED) {
@@ -84,7 +87,7 @@ data class ArgTypeArgument(val moduleName: CLIEntity<kotlin.String>) :
 }
 
 // Workaround for printing nested parsers help
-data class ArgTypeHelpSourceSet(val moduleName: CLIEntity<kotlin.String>) : ArgType<Any>(false) {
+public data class ArgTypeHelpSourceSet(val moduleName: CLIEntity<kotlin.String>) : ArgType<Any>(false) {
     override fun convert(value: kotlin.String, name: kotlin.String): Any = Any().also {
         parseSourceSet(moduleName.value, arrayOf("-h"))
     }

--- a/runners/cli/src/main/kotlin/org/jetbrains/dokka/GlobalArguments.kt
+++ b/runners/cli/src/main/kotlin/org/jetbrains/dokka/GlobalArguments.kt
@@ -11,11 +11,11 @@ import org.jetbrains.dokka.utilities.LoggingLevel
 import org.jetbrains.dokka.utilities.cast
 import java.io.File
 
-class GlobalArguments(args: Array<String>) : DokkaConfiguration {
+public class GlobalArguments(args: Array<String>) : DokkaConfiguration {
 
-    val parser = ArgParser("dokka-cli", prefixStyle = ArgParser.OptionPrefixStyle.JVM)
+    public val parser: ArgParser = ArgParser("dokka-cli", prefixStyle = ArgParser.OptionPrefixStyle.JVM)
 
-    val json: String? by parser.argument(ArgType.String, description = "JSON configuration file path").optional()
+    public val json: String? by parser.argument(ArgType.String, description = "JSON configuration file path").optional()
 
     private val _moduleName = parser.option(
         ArgType.String,
@@ -25,50 +25,50 @@ class GlobalArguments(args: Array<String>) : DokkaConfiguration {
 
     override val moduleName: String by _moduleName
 
-    override val moduleVersion by parser.option(
+    override val moduleVersion: String? by parser.option(
         ArgType.String,
         description = "Documented version",
         fullName = "moduleVersion"
     )
 
-    override val outputDir by parser.option(ArgTypeFile, description = "Output directory path, ./dokka by default")
+    override val outputDir: File by parser.option(ArgTypeFile, description = "Output directory path, ./dokka by default")
         .default(DokkaDefaults.outputDir)
 
-    override val cacheRoot = null
+    override val cacheRoot: File? = null
 
-    override val sourceSets by parser.option(
+    override val sourceSets: List<DokkaConfiguration.DokkaSourceSet> by parser.option(
         ArgTypeArgument(_moduleName),
         description = "Configuration for a Dokka source set. Contains nested configuration.",
         fullName = "sourceSet"
     ).multiple()
 
-    override val pluginsConfiguration by parser.option(
+    override val pluginsConfiguration: List<DokkaConfiguration.PluginConfiguration> by parser.option(
         ArgTypePlugin,
         description = "Configuration for Dokka plugins. Accepts multiple values separated by `^^`."
     ).delimiter("^^")
 
-    override val pluginsClasspath by parser.option(
+    override val pluginsClasspath: List<File> by parser.option(
         ArgTypeFile,
         fullName = "pluginsClasspath",
         description = "List of jars with Dokka plugins and their dependencies. Accepts multiple paths separated by semicolons"
     ).delimiter(";")
 
-    override val offlineMode by parser.option(
+    override val offlineMode: Boolean by parser.option(
         ArgType.Boolean,
         description = "Whether to resolve remote files/links over network"
     ).default(DokkaDefaults.offlineMode)
 
-    override val failOnWarning by parser.option(
+    override val failOnWarning: Boolean by parser.option(
         ArgType.Boolean,
         description = "Whether to fail documentation generation if Dokka has emitted a warning or an error"
     ).default(DokkaDefaults.failOnWarning)
 
-    override val delayTemplateSubstitution by parser.option(
+    override val delayTemplateSubstitution: Boolean by parser.option(
         ArgType.Boolean,
         description = "Delay substitution of some elements. Used in incremental builds of multimodule projects"
     ).default(DokkaDefaults.delayTemplateSubstitution)
 
-    val noSuppressObviousFunctions: Boolean by parser.option(
+    public val noSuppressObviousFunctions: Boolean by parser.option(
         ArgType.Boolean,
         description = "Whether to suppress obvious functions such as inherited from `kotlin.Any` and `java.lang.Object`"
     ).default(!DokkaDefaults.suppressObviousFunctions)
@@ -91,31 +91,31 @@ class GlobalArguments(args: Array<String>) : DokkaConfiguration {
 
     override val finalizeCoroutines: Boolean = true
 
-    val globalPackageOptions by parser.option(
+    public val globalPackageOptions: List<String> by parser.option(
         ArgType.String,
         description = "Global list of package configurations in format " +
                 "\"matchingRegexp,-deprecated,-privateApi,+warnUndocumented,+suppress;...\". " +
                 "Accepts multiple values separated by semicolons. "
     ).delimiter(";")
 
-    val globalLinks by parser.option(
+    public val globalLinks: List<String> by parser.option(
         ArgType.String,
         description = "Global external documentation links in format {url}^{packageListUrl}. " +
                 "Accepts multiple values separated by `^^`"
     ).delimiter("^^")
 
-    val globalSrcLink by parser.option(
+    public val globalSrcLink: List<String> by parser.option(
         ArgType.String,
         description = "Global mapping between a source directory and a Web service for browsing the code. " +
                 "Accepts multiple paths separated by semicolons"
     ).delimiter(";")
 
-    val helpSourceSet by parser.option(
+    public val helpSourceSet: Any? by parser.option(
         ArgTypeHelpSourceSet(_moduleName),
         description = "Prints help for nested -sourceSet configuration"
     )
 
-    val loggingLevel by parser.option(
+    public val loggingLevel: LoggingLevel by parser.option(
         ArgType.Choice(toVariant = {
             when (it.toUpperCase().trim()) {
                 "DEBUG", "" -> LoggingLevel.DEBUG
@@ -134,7 +134,7 @@ class GlobalArguments(args: Array<String>) : DokkaConfiguration {
 
     override val modules: List<DokkaConfiguration.DokkaModuleDescription> = emptyList()
 
-    val logger: DokkaLogger by lazy {
+    public val logger: DokkaLogger by lazy {
         DokkaConsoleLogger(loggingLevel)
     }
 

--- a/runners/cli/src/main/kotlin/org/jetbrains/dokka/LinkMapper.kt
+++ b/runners/cli/src/main/kotlin/org/jetbrains/dokka/LinkMapper.kt
@@ -9,7 +9,7 @@ import java.net.MalformedURLException
 import java.net.URL
 
 @OptIn(ExperimentalStdlibApi::class) // for buildList
-fun defaultLinks(config: DokkaConfiguration.DokkaSourceSet): MutableList<DokkaConfiguration.ExternalDocumentationLink> =
+public fun defaultLinks(config: DokkaConfiguration.DokkaSourceSet): MutableList<DokkaConfiguration.ExternalDocumentationLink> =
     buildList<DokkaConfiguration.ExternalDocumentationLink> {
         if (!config.noJdkLink) {
             add(DokkaConfiguration.ExternalDocumentationLink.jdk(config.jdkVersion))
@@ -21,7 +21,7 @@ fun defaultLinks(config: DokkaConfiguration.DokkaSourceSet): MutableList<DokkaCo
     }.toMutableList()
 
 
-fun parseLinks(links: List<String>): List<DokkaConfiguration.ExternalDocumentationLink> {
+public fun parseLinks(links: List<String>): List<DokkaConfiguration.ExternalDocumentationLink> {
     val (parsedLinks, parsedOfflineLinks) = links
         .map { it.split("^").map { it.trim() }.filter { it.isNotBlank() } }
         .filter { it.isNotEmpty() }

--- a/runners/cli/src/main/kotlin/org/jetbrains/dokka/main.kt
+++ b/runners/cli/src/main/kotlin/org/jetbrains/dokka/main.kt
@@ -8,13 +8,13 @@ import org.jetbrains.dokka.DokkaConfiguration.ExternalDocumentationLink
 import org.jetbrains.dokka.utilities.*
 import java.nio.file.Paths
 
-fun main(args: Array<String>) {
+public fun main(args: Array<String>) {
     val globalArguments = GlobalArguments(args)
     val configuration = initializeConfiguration(globalArguments)
     DokkaGenerator(configuration, globalArguments.logger).generate()
 }
 
-fun initializeConfiguration(globalArguments: GlobalArguments): DokkaConfiguration {
+public fun initializeConfiguration(globalArguments: GlobalArguments): DokkaConfiguration {
     return if (globalArguments.json != null) {
         val jsonContent = Paths.get(checkNotNull(globalArguments.json)).toFile().readText()
         val globals = GlobalDokkaConfiguration(jsonContent)

--- a/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
+++ b/runners/maven-plugin/src/main/kotlin/DokkaMojo.kt
@@ -28,7 +28,9 @@ import org.jetbrains.dokka.DokkaConfiguration.ExternalDocumentationLink
 import java.io.File
 import java.net.URL
 
-abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependency>) : AbstractMojo() {
+public abstract class AbstractDokkaMojo(
+    private val defaultDokkaPlugins: List<Dependency>
+) : AbstractMojo() {
 
     @Parameter(defaultValue = "\${project}", readonly = true, required = true)
     protected var mavenProject: MavenProject? = null
@@ -47,10 +49,10 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
     private var resolutionErrorHandler: ResolutionErrorHandler? = null
 
     @Parameter(defaultValue = "JVM")
-    var displayName: String = "JVM"
+    public var displayName: String = "JVM"
 
     @Parameter
-    var sourceSetName: String = "JVM"
+    public var sourceSetName: String = "JVM"
 
     /**
      * Source code roots to be analyzed and documented.
@@ -59,14 +61,14 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
      * Default is `{project.compileSourceRoots}`.
      */
     @Parameter(required = true, defaultValue = "\${project.compileSourceRoots}")
-    var sourceDirectories: List<String> = emptyList()
+    public var sourceDirectories: List<String> = emptyList()
 
     /**
      * List of directories or files that contain sample functions which are referenced via
      * [@sample](https://kotlinlang.org/docs/kotlin-doc.html#sample-identifier) KDoc tag.
      */
     @Parameter
-    var samples: List<String> = emptyList()
+    public var samples: List<String> = emptyList()
 
     /**
      * List of Markdown files that contain
@@ -95,7 +97,7 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
      * ```
      */
     @Parameter
-    var includes: List<String> = emptyList()
+    public var includes: List<String> = emptyList()
 
     /**
      * Classpath for analysis and interactive samples.
@@ -106,14 +108,14 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
      * Default is `{project.compileClasspathElements}`.
      */
     @Parameter(required = true, defaultValue = "\${project.compileClasspathElements}")
-    var classpath: List<String> = emptyList()
+    public var classpath: List<String> = emptyList()
 
     /**
      * Specifies the location of the project source code on the Web. If provided, Dokka generates
      * "source" links for each declaration. See [SourceLinkMapItem] for more details.
      */
     @Parameter
-    var sourceLinks: List<SourceLinkMapItem> = emptyList()
+    public var sourceLinks: List<SourceLinkMapItem> = emptyList()
 
     /**
      * Display name used to refer to the project/module. Used for ToC, navigation, logging, etc.
@@ -121,7 +123,7 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
      * Default is `{project.artifactId}`.
      */
     @Parameter(required = true, defaultValue = "\${project.artifactId}")
-    var moduleName: String = ""
+    public var moduleName: String = ""
 
     /**
      * Whether to skip documentation generation.
@@ -129,7 +131,7 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
      * Default is `false`.
      */
     @Parameter(required = false, defaultValue = "false")
-    var skip: Boolean = false
+    public var skip: Boolean = false
 
     /**
      * JDK version to use when generating external documentation links for Java types.
@@ -141,7 +143,7 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
      * Default is JDK 8.
      */
     @Parameter(required = false, defaultValue = "${DokkaDefaults.jdkVersion}")
-    var jdkVersion: Int = DokkaDefaults.jdkVersion
+    public var jdkVersion: Int = DokkaDefaults.jdkVersion
 
     /**
      * Whether to document declarations annotated with [Deprecated].
@@ -151,7 +153,7 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
      * Default is `false`.
      */
     @Parameter
-    var skipDeprecated: Boolean = DokkaDefaults.skipDeprecated
+    public var skipDeprecated: Boolean = DokkaDefaults.skipDeprecated
 
     /**
      * Whether to skip packages that contain no visible declarations after
@@ -163,7 +165,7 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
      * Default is `true`.
      */
     @Parameter
-    var skipEmptyPackages: Boolean = DokkaDefaults.skipEmptyPackages
+    public var skipEmptyPackages: Boolean = DokkaDefaults.skipEmptyPackages
 
     /**
      * Whether to emit warnings about visible undocumented declarations, that is declarations without KDocs
@@ -176,7 +178,7 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
      * Default is `false`.
      */
     @Parameter
-    var reportUndocumented: Boolean = DokkaDefaults.reportUndocumented
+    public var reportUndocumented: Boolean = DokkaDefaults.reportUndocumented
 
     /**
      * Allows to customize documentation generation options on a per-package basis.
@@ -184,7 +186,7 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
      * @see PackageOptions for details
      */
     @Parameter
-    var perPackageOptions: List<PackageOptions> = emptyList()
+    public var perPackageOptions: List<PackageOptions> = emptyList()
 
     /**
      * Allows linking to Dokka/Javadoc documentation of the project's dependencies.
@@ -192,7 +194,7 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
      * @see ExternalDocumentationLinkBuilder for details
      */
     @Parameter
-    var externalDocumentationLinks: List<ExternalDocumentationLinkBuilder> = emptyList()
+    public var externalDocumentationLinks: List<ExternalDocumentationLinkBuilder> = emptyList()
 
     /**
      * Whether to generate external documentation links that lead to API reference
@@ -201,7 +203,7 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
      * Default is `false`, meaning links will be generated.
      */
     @Parameter(defaultValue = "${DokkaDefaults.noStdlibLink}")
-    var noStdlibLink: Boolean = DokkaDefaults.noStdlibLink
+    public var noStdlibLink: Boolean = DokkaDefaults.noStdlibLink
 
     /**
      * Whether to generate external documentation links to JDK's Javadocs
@@ -212,7 +214,7 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
      * Default is `false`, meaning links will be generated.
      */
     @Parameter(defaultValue = "${DokkaDefaults.noJdkLink}")
-    var noJdkLink: Boolean = DokkaDefaults.noJdkLink
+    public var noJdkLink: Boolean = DokkaDefaults.noJdkLink
 
     /**
      * Whether to resolve remote files/links over network.
@@ -230,7 +232,7 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
      * Default is `false`.
      */
     @Parameter(defaultValue = "${DokkaDefaults.offlineMode}")
-    var offlineMode: Boolean = DokkaDefaults.offlineMode
+    public var offlineMode: Boolean = DokkaDefaults.offlineMode
 
     /**
      * [Kotlin language version](https://kotlinlang.org/docs/compatibility-modes.html)
@@ -240,7 +242,7 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
      * By default, the latest language version available to Dokka's embedded compiler will be used.
      */
     @Parameter
-    var languageVersion: String? = null
+    public var languageVersion: String? = null
 
     /**
      * [Kotlin API version](https://kotlinlang.org/docs/compatibility-modes.html)
@@ -250,14 +252,14 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
      * By default, it will be deduced from [languageVersion].
      */
     @Parameter
-    var apiVersion: String? = null
+    public var apiVersion: String? = null
 
     /**
      * Directories or individual files that should be suppressed, meaning declarations from them
      * will be not documented.
      */
     @Parameter
-    var suppressedFiles: List<String> = emptyList()
+    public var suppressedFiles: List<String> = emptyList()
 
     /**
      * Set of visibility modifiers that should be documented.
@@ -270,7 +272,7 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
      * Default is [DokkaConfiguration.Visibility.PUBLIC].
      */
     @Parameter(property = "visibility")
-    var documentedVisibilities: Set<DokkaConfiguration.Visibility> = DokkaDefaults.documentedVisibilities
+    public var documentedVisibilities: Set<DokkaConfiguration.Visibility> = DokkaDefaults.documentedVisibilities
         // hack to set the default value for lists, didn't find any other safe way
         // maven seems to overwrite Kotlin's default initialization value, so it doesn't matter what you put there
         get() = field.ifEmpty { DokkaDefaults.documentedVisibilities }
@@ -284,7 +286,7 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
      * Default is `false`.
      */
     @Parameter
-    var failOnWarning: Boolean = DokkaDefaults.failOnWarning
+    public var failOnWarning: Boolean = DokkaDefaults.failOnWarning
 
     /**
      * Whether to suppress obvious functions.
@@ -298,7 +300,7 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
      * Default is `true`
      */
     @Parameter(defaultValue = "${DokkaDefaults.suppressObviousFunctions}")
-    var suppressObviousFunctions: Boolean = DokkaDefaults.suppressObviousFunctions
+    public var suppressObviousFunctions: Boolean = DokkaDefaults.suppressObviousFunctions
 
     /**
      * Whether to suppress inherited members that aren't explicitly overridden in a given class.
@@ -310,7 +312,7 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
      * Default is `false`.
      */
     @Parameter(defaultValue = "${DokkaDefaults.suppressInheritedMembers}")
-    var suppressInheritedMembers: Boolean = DokkaDefaults.suppressInheritedMembers
+    public var suppressInheritedMembers: Boolean = DokkaDefaults.suppressInheritedMembers
 
     /**
      * Dokka plugins to be using during documentation generation.
@@ -328,20 +330,20 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
      * ```
      */
     @Parameter
-    var dokkaPlugins: List<Dependency> = emptyList()
+    public var dokkaPlugins: List<Dependency> = emptyList()
         get() = field + defaultDokkaPlugins
 
     @Parameter
-    var cacheRoot: String? = null
+    public var cacheRoot: String? = null
 
     @Parameter
-    var platform: String = ""
+    public var platform: String = ""
 
     /**
      * Deprecated. Use [documentedVisibilities] instead.
      */
     @Parameter
-    var includeNonPublic: Boolean = DokkaDefaults.includeNonPublic
+    public var includeNonPublic: Boolean = DokkaDefaults.includeNonPublic
 
     protected abstract fun getOutDir(): String
 
@@ -493,7 +495,7 @@ abstract class AbstractDokkaMojo(private val defaultDokkaPlugins: List<Dependenc
     requiresDependencyResolution = ResolutionScope.COMPILE,
     requiresProject = true
 )
-class DokkaMojo : AbstractDokkaMojo(emptyList()) {
+public class DokkaMojo : AbstractDokkaMojo(emptyList()) {
 
     /**
      * Directory to which documentation will be generated.
@@ -501,9 +503,9 @@ class DokkaMojo : AbstractDokkaMojo(emptyList()) {
      * Default is `{project.basedir}/target/dokka`.
      */
     @Parameter(required = true, defaultValue = "\${project.basedir}/target/dokka")
-    var outputDir: String = ""
+    public var outputDir: String = ""
 
-    override fun getOutDir() = outputDir
+    override fun getOutDir(): String = outputDir
 }
 
 @Mojo(
@@ -513,7 +515,7 @@ class DokkaMojo : AbstractDokkaMojo(emptyList()) {
     requiresDependencyResolution = ResolutionScope.COMPILE,
     requiresProject = true
 )
-class DokkaJavadocMojo : AbstractDokkaMojo(listOf(javadocDependency)) {
+public class DokkaJavadocMojo : AbstractDokkaMojo(listOf(javadocDependency)) {
 
     /**
      * Directory to which documentation will be generated.
@@ -521,9 +523,9 @@ class DokkaJavadocMojo : AbstractDokkaMojo(listOf(javadocDependency)) {
      * Default is `{project.basedir}/target/dokkaJavadoc`.
      */
     @Parameter(required = true, defaultValue = "\${project.basedir}/target/dokkaJavadoc")
-    var outputDir: String = ""
+    public var outputDir: String = ""
 
-    override fun getOutDir() = outputDir
+    override fun getOutDir(): String = outputDir
 }
 
 @Mojo(
@@ -533,7 +535,7 @@ class DokkaJavadocMojo : AbstractDokkaMojo(listOf(javadocDependency)) {
     requiresDependencyResolution = ResolutionScope.COMPILE,
     requiresProject = true
 )
-class DokkaJavadocJarMojo : AbstractDokkaMojo(listOf(javadocDependency)) {
+public class DokkaJavadocJarMojo : AbstractDokkaMojo(listOf(javadocDependency)) {
 
     /**
      * Directory to which documentation jar will be generated.
@@ -541,7 +543,7 @@ class DokkaJavadocJarMojo : AbstractDokkaMojo(listOf(javadocDependency)) {
      * Default is `{project.basedir}/target/dokkaJavadocJar`.
      */
     @Parameter(required = true, defaultValue = "\${project.basedir}/target/dokkaJavadocJar")
-    var outputDir: String = ""
+    public var outputDir: String = ""
 
     /**
      * Specifies the directory where the generated jar file will be put.
@@ -578,7 +580,7 @@ class DokkaJavadocJarMojo : AbstractDokkaMojo(listOf(javadocDependency)) {
     @Component(role = Archiver::class, hint = "jar")
     private var jarArchiver: JarArchiver? = null
 
-    override fun getOutDir() = outputDir
+    override fun getOutDir(): String = outputDir
 
     override fun execute() {
         super.execute()

--- a/runners/maven-plugin/src/main/kotlin/ExternalDocumentationLinkBuilder.kt
+++ b/runners/maven-plugin/src/main/kotlin/ExternalDocumentationLinkBuilder.kt
@@ -6,6 +6,7 @@ package org.jetbrains.dokka.maven
 
 import org.apache.maven.plugins.annotations.Parameter
 import org.jetbrains.dokka.ExternalDocumentationLink
+import org.jetbrains.dokka.ExternalDocumentationLinkImpl
 import java.net.URL
 
 /**
@@ -30,7 +31,7 @@ import java.net.URL
  * </externalDocumentationLinks>
  * ```
  */
-class ExternalDocumentationLinkBuilder {
+public class ExternalDocumentationLinkBuilder {
 
     /**
      * Root URL of documentation to link with. **Must** contain a trailing slash.
@@ -48,7 +49,7 @@ class ExternalDocumentationLinkBuilder {
      * ```
      */
     @Parameter(name = "url", required = true)
-    var url: URL? = null
+    public var url: URL? = null
 
     /**
      * Specifies the exact location of a `package-list` instead of relying on Dokka
@@ -61,7 +62,7 @@ class ExternalDocumentationLinkBuilder {
      * ```
      */
     @Parameter(name = "packageListUrl", required = true)
-    var packageListUrl: URL? = null
+    public var packageListUrl: URL? = null
 
-    fun build() = ExternalDocumentationLink(url, packageListUrl)
+    public fun build(): ExternalDocumentationLinkImpl = ExternalDocumentationLink(url, packageListUrl)
 }

--- a/runners/maven-plugin/src/main/kotlin/MavenDokkaLogger.kt
+++ b/runners/maven-plugin/src/main/kotlin/MavenDokkaLogger.kt
@@ -8,7 +8,9 @@ import org.apache.maven.plugin.logging.Log
 import org.jetbrains.dokka.utilities.DokkaLogger
 import java.util.concurrent.atomic.AtomicInteger
 
-class MavenDokkaLogger(val log: Log) : DokkaLogger {
+public class MavenDokkaLogger(
+    public val log: Log
+) : DokkaLogger {
     private val warningsCounter = AtomicInteger()
     private val errorsCounter = AtomicInteger()
 
@@ -20,9 +22,23 @@ class MavenDokkaLogger(val log: Log) : DokkaLogger {
         get() = errorsCounter.get()
         set(value) = errorsCounter.set(value)
 
-    override fun debug(message: String) = log.debug(message)
-    override fun info(message: String) = log.info(message)
-    override fun progress(message: String) = log.info(message)
-    override fun warn(message: String) = log.warn(message).also { warningsCounter.incrementAndGet() }
-    override fun error(message: String) = log.error(message).also { errorsCounter.incrementAndGet() }
+    override fun debug(message: String) {
+        log.debug(message)
+    }
+
+    override fun info(message: String) {
+        log.info(message)
+    }
+
+    override fun progress(message: String) {
+        log.info(message)
+    }
+
+    override fun warn(message: String) {
+        this.log.warn(message).also { warningsCounter.incrementAndGet() }
+    }
+
+    override fun error(message: String) {
+        log.error(message).also { errorsCounter.incrementAndGet() }
+    }
 }

--- a/runners/maven-plugin/src/main/kotlin/PackageOptions.kt
+++ b/runners/maven-plugin/src/main/kotlin/PackageOptions.kt
@@ -31,7 +31,7 @@ import org.jetbrains.dokka.DokkaDefaults
  * </configuration>
  * ```
  */
-class PackageOptions : DokkaConfiguration.PackageOptions {
+public class PackageOptions : DokkaConfiguration.PackageOptions {
 
     /**
      * Regular expression that is used to match the package.

--- a/runners/maven-plugin/src/main/kotlin/SourceLinkMapItem.kt
+++ b/runners/maven-plugin/src/main/kotlin/SourceLinkMapItem.kt
@@ -23,7 +23,7 @@ import org.apache.maven.plugins.annotations.Parameter
  * </sourceLinks>
  * ```
  */
-class SourceLinkMapItem {
+public class SourceLinkMapItem {
 
     /**
      * Path to the local source directory. The path must be relative to the root of current project.
@@ -35,7 +35,7 @@ class SourceLinkMapItem {
      * ```
      */
     @Parameter(name = "path", required = true)
-    var path: String = ""
+    public var path: String = ""
 
     /**
      * URL of source code hosting service that can be accessed by documentation readers,
@@ -49,7 +49,7 @@ class SourceLinkMapItem {
      * ```
      */
     @Parameter(name = "url", required = true)
-    var url: String = ""
+    public var url: String = ""
 
     /**
      * Suffix used to append source code line number to the URL. This will help readers navigate
@@ -65,5 +65,5 @@ class SourceLinkMapItem {
      * - Bitbucket: `#lines-`
      */
     @Parameter(name = "lineSuffix")
-    var lineSuffix: String? = null
+    public var lineSuffix: String? = null
 }

--- a/subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/JavaAnalysisPlugin.kt
+++ b/subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/JavaAnalysisPlugin.kt
@@ -26,48 +26,48 @@ import java.io.File
 
 
 @InternalDokkaApi
-interface ProjectProvider {
-    fun getProject(sourceSet: DokkaSourceSet, context: DokkaContext): Project
+public interface ProjectProvider {
+    public fun getProject(sourceSet: DokkaSourceSet, context: DokkaContext): Project
 }
 
 @InternalDokkaApi
-interface SourceRootsExtractor {
-    fun extract(sourceSet: DokkaSourceSet, context: DokkaContext): List<File>
+public interface SourceRootsExtractor {
+    public fun extract(sourceSet: DokkaSourceSet, context: DokkaContext): List<File>
 }
 
 @InternalDokkaApi
-interface BreakingAbstractionKotlinLightMethodChecker {
+public interface BreakingAbstractionKotlinLightMethodChecker {
     // TODO [beresnev] not even sure it's needed, but left for compatibility and to preserve behaviour
-    fun isLightAnnotation(annotation: PsiAnnotation): Boolean
-    fun isLightAnnotationAttribute(attribute: JvmAnnotationAttribute): Boolean
+    public fun isLightAnnotation(annotation: PsiAnnotation): Boolean
+    public fun isLightAnnotationAttribute(attribute: JvmAnnotationAttribute): Boolean
 }
 
 @InternalDokkaApi
-class JavaAnalysisPlugin : DokkaPlugin() {
+public class JavaAnalysisPlugin : DokkaPlugin() {
 
     // single
-    val projectProvider by extensionPoint<ProjectProvider>()
+    public val projectProvider: ExtensionPoint<ProjectProvider> by extensionPoint()
 
     // single
-    val sourceRootsExtractor by extensionPoint<SourceRootsExtractor>()
+    public val sourceRootsExtractor: ExtensionPoint<SourceRootsExtractor> by extensionPoint()
 
     // multiple
-    val docCommentCreators by extensionPoint<DocCommentCreator>()
+    public val docCommentCreators: ExtensionPoint<DocCommentCreator> by extensionPoint()
 
     // multiple
-    val docCommentParsers by extensionPoint<DocCommentParser>()
+    public val docCommentParsers: ExtensionPoint<DocCommentParser> by extensionPoint()
 
     // none or more
-    val inheritDocTagContentProviders by extensionPoint<InheritDocTagContentProvider>()
+    public val inheritDocTagContentProviders: ExtensionPoint<InheritDocTagContentProvider> by extensionPoint()
 
     // TODO [beresnev] figure out a better way depending on what it's used for
-    val kotlinLightMethodChecker by extensionPoint<BreakingAbstractionKotlinLightMethodChecker>()
+    public val kotlinLightMethodChecker: ExtensionPoint<BreakingAbstractionKotlinLightMethodChecker> by extensionPoint()
 
     private val docCommentFactory by lazy {
         DocCommentFactory(query { docCommentCreators }.reversed())
     }
 
-    val docCommentFinder by lazy {
+    public val docCommentFinder: DocCommentFinder by lazy {
         DocCommentFinder(logger, docCommentFactory)
     }
 

--- a/subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/JavadocTag.kt
+++ b/subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/JavadocTag.kt
@@ -8,45 +8,47 @@ import com.intellij.psi.PsiMethod
 import org.jetbrains.dokka.InternalDokkaApi
 
 @InternalDokkaApi
-sealed class JavadocTag(val name: String)
+public sealed class JavadocTag(
+    public val name: String
+)
 
-object AuthorJavadocTag : JavadocTag("author")
-object DeprecatedJavadocTag : JavadocTag("deprecated")
-object DescriptionJavadocTag : JavadocTag("description")
-object ReturnJavadocTag : JavadocTag("return")
-object SinceJavadocTag : JavadocTag("since")
+public object AuthorJavadocTag : JavadocTag("author")
+public object DeprecatedJavadocTag : JavadocTag("deprecated")
+public object DescriptionJavadocTag : JavadocTag("description")
+public object ReturnJavadocTag : JavadocTag("return")
+public object SinceJavadocTag : JavadocTag("since")
 
-class ParamJavadocTag(
-    val method: PsiMethod,
-    val paramName: String,
-    val paramIndex: Int
+public class ParamJavadocTag(
+    public val method: PsiMethod,
+    public val paramName: String,
+    public val paramIndex: Int
 ) : JavadocTag(name) {
-    companion object {
-        const val name: String = "param"
+    public companion object {
+        public const val name: String = "param"
     }
 }
 
-class SeeJavadocTag(
-    val qualifiedReference: String
+public class SeeJavadocTag(
+    public val qualifiedReference: String
 ) : JavadocTag(name) {
-    companion object {
-        const val name: String = "see"
+    public companion object {
+        public const val name: String = "see"
     }
 }
 
-sealed class ThrowingExceptionJavadocTag(
+public sealed class ThrowingExceptionJavadocTag(
     name: String,
-    val exceptionQualifiedName: String?
+    public val exceptionQualifiedName: String?
 ) : JavadocTag(name)
 
-class ThrowsJavadocTag(exceptionQualifiedName: String?) : ThrowingExceptionJavadocTag(name, exceptionQualifiedName) {
-    companion object {
-        const val name: String = "throws"
+public class ThrowsJavadocTag(exceptionQualifiedName: String?) : ThrowingExceptionJavadocTag(name, exceptionQualifiedName) {
+    public companion object {
+        public const val name: String = "throws"
     }
 }
 
-class ExceptionJavadocTag(exceptionQualifiedName: String?) : ThrowingExceptionJavadocTag(name, exceptionQualifiedName) {
-    companion object {
-        const val name: String = "exception"
+public class ExceptionJavadocTag(exceptionQualifiedName: String?) : ThrowingExceptionJavadocTag(name, exceptionQualifiedName) {
+    public companion object {
+        public const val name: String = "exception"
     }
 }

--- a/subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/doccomment/DocComment.kt
+++ b/subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/doccomment/DocComment.kt
@@ -11,8 +11,8 @@ import org.jetbrains.dokka.analysis.java.JavadocTag
  * MUST override equals and hashcode
  */
 @InternalDokkaApi
-interface DocComment {
-    fun hasTag(tag: JavadocTag): Boolean
+public interface DocComment {
+    public fun hasTag(tag: JavadocTag): Boolean
 
-    fun resolveTag(tag: JavadocTag): List<DocumentationContent>
+    public fun resolveTag(tag: JavadocTag): List<DocumentationContent>
 }

--- a/subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/doccomment/DocCommentCreator.kt
+++ b/subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/doccomment/DocCommentCreator.kt
@@ -8,6 +8,6 @@ import com.intellij.psi.PsiNamedElement
 import org.jetbrains.dokka.InternalDokkaApi
 
 @InternalDokkaApi
-interface DocCommentCreator {
-    fun create(element: PsiNamedElement): DocComment?
+public interface DocCommentCreator {
+    public fun create(element: PsiNamedElement): DocComment?
 }

--- a/subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/doccomment/DocCommentFactory.kt
+++ b/subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/doccomment/DocCommentFactory.kt
@@ -8,10 +8,10 @@ import com.intellij.psi.PsiNamedElement
 import org.jetbrains.dokka.InternalDokkaApi
 
 @InternalDokkaApi
-class DocCommentFactory(
+public class DocCommentFactory(
     private val docCommentCreators: List<DocCommentCreator>
 ) {
-    fun fromElement(element: PsiNamedElement): DocComment? {
+    public fun fromElement(element: PsiNamedElement): DocComment? {
         docCommentCreators.forEach { creator ->
             val comment = creator.create(element)
             if (comment != null) {

--- a/subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/doccomment/DocCommentFinder.kt
+++ b/subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/doccomment/DocCommentFinder.kt
@@ -14,11 +14,11 @@ import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.utilities.DokkaLogger
 
 @InternalDokkaApi
-class DocCommentFinder(
+public class DocCommentFinder(
     private val logger: DokkaLogger,
     private val docCommentFactory: DocCommentFactory,
 ) {
-    fun findClosestToElement(element: PsiNamedElement): DocComment? {
+    public fun findClosestToElement(element: PsiNamedElement): DocComment? {
         val docComment = docCommentFactory.fromElement(element)
         if (docComment != null) {
             return docComment

--- a/subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/doccomment/DocumentationContent.kt
+++ b/subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/doccomment/DocumentationContent.kt
@@ -8,8 +8,8 @@ import org.jetbrains.dokka.InternalDokkaApi
 import org.jetbrains.dokka.analysis.java.JavadocTag
 
 @InternalDokkaApi
-interface DocumentationContent {
-    val tag: JavadocTag
+public interface DocumentationContent {
+    public val tag: JavadocTag
 
-    fun resolveSiblings(): List<DocumentationContent>
+    public fun resolveSiblings(): List<DocumentationContent>
 }

--- a/subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/parsers/DocCommentParser.kt
+++ b/subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/parsers/DocCommentParser.kt
@@ -10,7 +10,7 @@ import org.jetbrains.dokka.analysis.java.doccomment.DocComment
 import org.jetbrains.dokka.model.doc.DocumentationNode
 
 @InternalDokkaApi
-interface DocCommentParser {
-    fun canParse(docComment: DocComment): Boolean
-    fun parse(docComment: DocComment, context: PsiNamedElement): DocumentationNode
+public interface DocCommentParser {
+    public fun canParse(docComment: DocComment): Boolean
+    public fun parse(docComment: DocComment, context: PsiNamedElement): DocumentationNode
 }

--- a/subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/parsers/JavadocParser.kt
+++ b/subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/parsers/JavadocParser.kt
@@ -14,7 +14,7 @@ internal fun interface JavaDocumentationParser {
 }
 
 @InternalDokkaApi
-class JavadocParser(
+public class JavadocParser(
     private val docCommentParsers: List<DocCommentParser>,
     private val docCommentFinder: DocCommentFinder
 ) : JavaDocumentationParser {

--- a/subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/parsers/doctag/DocTagParserContext.kt
+++ b/subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/parsers/doctag/DocTagParserContext.kt
@@ -10,7 +10,7 @@ import org.jetbrains.dokka.model.doc.DocumentationNode
 import java.util.*
 
 @InternalDokkaApi
-class DocTagParserContext {
+public class DocTagParserContext {
     /**
      * exists for resolving `@link element` links, where the referenced
      * PSI element is mapped as DRI
@@ -30,7 +30,7 @@ class DocTagParserContext {
     /**
      * @return key of the stored DRI
      */
-    fun store(dri: DRI): String {
+    public fun store(dri: DRI): String {
         val id = dri.toString()
         driMap[id] = dri
         return id
@@ -39,13 +39,13 @@ class DocTagParserContext {
     /**
      * @return key of the stored documentation node
      */
-    fun store(documentationNode: DocumentationNode): String {
+    public fun store(documentationNode: DocumentationNode): String {
         val id = UUID.randomUUID().toString()
         inheritDocSections[id] = documentationNode
         return id
     }
 
-    fun getDri(id: String): DRI? = driMap[id]
+    public fun getDri(id: String): DRI? = driMap[id]
 
-    fun getDocumentationNode(id: String): DocumentationNode? = inheritDocSections[id]
+    public fun getDocumentationNode(id: String): DocumentationNode? = inheritDocSections[id]
 }

--- a/subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/parsers/doctag/InheritDocTagContentProvider.kt
+++ b/subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/parsers/doctag/InheritDocTagContentProvider.kt
@@ -8,7 +8,7 @@ import org.jetbrains.dokka.InternalDokkaApi
 import org.jetbrains.dokka.analysis.java.doccomment.DocumentationContent
 
 @InternalDokkaApi
-interface InheritDocTagContentProvider {
-    fun canConvert(content: DocumentationContent): Boolean
-    fun convertToHtml(content: DocumentationContent, docTagParserContext: DocTagParserContext): String
+public interface InheritDocTagContentProvider {
+    public fun canConvert(content: DocumentationContent): Boolean
+    public fun convertToHtml(content: DocumentationContent, docTagParserContext: DocTagParserContext): String
 }

--- a/subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/util/PsiUtil.kt
+++ b/subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/util/PsiUtil.kt
@@ -17,7 +17,7 @@ internal val PsiElement.parentsWithSelf: Sequence<PsiElement>
     get() = generateSequence(this) { if (it is PsiFile) null else it.parent }
 
 @InternalDokkaApi
-fun DRI.Companion.from(psi: PsiElement) = psi.parentsWithSelf.run {
+public fun DRI.Companion.from(psi: PsiElement): DRI = psi.parentsWithSelf.run {
     val psiMethod = firstIsInstanceOrNull<PsiMethod>()
     val psiField = firstIsInstanceOrNull<PsiField>()
     val classes = filterIsInstance<PsiClass>().filterNot { it is PsiTypeParameter }
@@ -92,8 +92,10 @@ internal fun PsiElement.getNextSiblingIgnoringWhitespace(withItself: Boolean = f
 }
 
 @InternalDokkaApi
-class PsiDocumentableSource(val psi: PsiNamedElement) : DocumentableSource {
-    override val path = psi.containingFile.virtualFile.path
+public class PsiDocumentableSource(
+    public val psi: PsiNamedElement
+) : DocumentableSource {
+    override val path: String = psi.containingFile.virtualFile.path
 
     override fun computeLineNumber(): Int? {
         val range = psi.getChildOfType<PsiIdentifier>()?.textRange ?: psi.textRange
@@ -103,7 +105,7 @@ class PsiDocumentableSource(val psi: PsiNamedElement) : DocumentableSource {
     }
 }
 
-inline fun <reified T : PsiElement> PsiElement.getChildOfType(): T? {
+public inline fun <reified T : PsiElement> PsiElement.getChildOfType(): T? {
     return PsiTreeUtil.getChildOfType(this, T::class.java)
 }
 

--- a/subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/KotlinAnalysisPlugin.kt
+++ b/subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/KotlinAnalysisPlugin.kt
@@ -8,7 +8,7 @@ import org.jetbrains.dokka.plugability.DokkaPlugin
 import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
 import org.jetbrains.dokka.plugability.PluginApiPreviewAcknowledgement
 
-class KotlinAnalysisPlugin : DokkaPlugin() {
+public class KotlinAnalysisPlugin : DokkaPlugin() {
 
     /*
      * This is where stable public API will go.

--- a/subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/internal/DocumentableSourceLanguageParser.kt
+++ b/subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/internal/DocumentableSourceLanguageParser.kt
@@ -10,11 +10,11 @@ import org.jetbrains.dokka.model.Documentable
 import org.jetbrains.dokka.model.WithSources
 
 @InternalDokkaApi
-enum class DocumentableLanguage {
+public enum class DocumentableLanguage {
     JAVA, KOTLIN
 }
 
 @InternalDokkaApi
-interface DocumentableSourceLanguageParser {
-    fun getLanguage(documentable: Documentable, sourceSet: DokkaConfiguration.DokkaSourceSet): DocumentableLanguage?
+public interface DocumentableSourceLanguageParser {
+    public fun getLanguage(documentable: Documentable, sourceSet: DokkaConfiguration.DokkaSourceSet): DocumentableLanguage?
 }

--- a/subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/internal/ExternalDocumentablesProvider.kt
+++ b/subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/internal/ExternalDocumentablesProvider.kt
@@ -17,12 +17,12 @@ import org.jetbrains.dokka.model.DClasslike
  * of classes defined in project).
  */
 @InternalDokkaApi
-fun interface ExternalDocumentablesProvider {
+public fun interface ExternalDocumentablesProvider {
 
     /**
      * Returns [DClasslike] matching provided [DRI] in specified source set.
      *
      * Result is null if compiler haven't generated matching class descriptor.
      */
-    fun findClasslike(dri: DRI, sourceSet: DokkaConfiguration.DokkaSourceSet): DClasslike?
+    public fun findClasslike(dri: DRI, sourceSet: DokkaConfiguration.DokkaSourceSet): DClasslike?
 }

--- a/subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/internal/FullClassHierarchyBuilder.kt
+++ b/subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/internal/FullClassHierarchyBuilder.kt
@@ -10,12 +10,12 @@ import org.jetbrains.dokka.model.DModule
 import org.jetbrains.dokka.model.SourceSetDependent
 
 @InternalDokkaApi
-typealias Supertypes = List<DRI>
+public typealias Supertypes = List<DRI>
 
 @InternalDokkaApi
-typealias ClassHierarchy = SourceSetDependent<Map<DRI, Supertypes>>
+public typealias ClassHierarchy = SourceSetDependent<Map<DRI, Supertypes>>
 
 @InternalDokkaApi
-interface FullClassHierarchyBuilder {
-    suspend fun build(module: DModule): ClassHierarchy
+public interface FullClassHierarchyBuilder {
+    public suspend fun build(module: DModule): ClassHierarchy
 }

--- a/subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/internal/InheritanceBuilder.kt
+++ b/subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/internal/InheritanceBuilder.kt
@@ -9,12 +9,12 @@ import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.model.Documentable
 
 @InternalDokkaApi
-interface InheritanceBuilder {
-    fun build(documentables: Map<DRI, Documentable>): List<InheritanceNode>
+public interface InheritanceBuilder {
+    public fun build(documentables: Map<DRI, Documentable>): List<InheritanceNode>
 }
 
 @InternalDokkaApi
-data class InheritanceNode(
+public data class InheritanceNode(
     val dri: DRI,
     val children: List<InheritanceNode> = emptyList(),
     val interfaces: List<DRI> = emptyList(),

--- a/subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/internal/InternalKotlinAnalysisPlugin.kt
+++ b/subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/internal/InternalKotlinAnalysisPlugin.kt
@@ -7,6 +7,7 @@ package org.jetbrains.dokka.analysis.kotlin.internal
 import org.jetbrains.dokka.InternalDokkaApi
 import org.jetbrains.dokka.plugability.DokkaPlugin
 import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
+import org.jetbrains.dokka.plugability.ExtensionPoint
 import org.jetbrains.dokka.plugability.PluginApiPreviewAcknowledgement
 
 /**
@@ -14,23 +15,23 @@ import org.jetbrains.dokka.plugability.PluginApiPreviewAcknowledgement
  * external plugins. If you need any of the given API stabilized, please create an issue describing your use case.
  */
 @InternalDokkaApi
-class InternalKotlinAnalysisPlugin : DokkaPlugin() {
+public class InternalKotlinAnalysisPlugin : DokkaPlugin() {
 
-    val fullClassHierarchyBuilder by extensionPoint<FullClassHierarchyBuilder>()
+    public val fullClassHierarchyBuilder: ExtensionPoint<FullClassHierarchyBuilder> by extensionPoint()
 
-    val syntheticDocumentableDetector by extensionPoint<SyntheticDocumentableDetector>()
+    public val syntheticDocumentableDetector: ExtensionPoint<SyntheticDocumentableDetector> by extensionPoint()
 
-    val moduleAndPackageDocumentationReader by extensionPoint<ModuleAndPackageDocumentationReader>()
+    public val moduleAndPackageDocumentationReader: ExtensionPoint<ModuleAndPackageDocumentationReader> by extensionPoint()
 
-    val kotlinToJavaService by extensionPoint<KotlinToJavaService>()
+    public val kotlinToJavaService: ExtensionPoint<KotlinToJavaService> by extensionPoint()
 
-    val inheritanceBuilder by extensionPoint<InheritanceBuilder>()
+    public val inheritanceBuilder: ExtensionPoint<InheritanceBuilder> by extensionPoint()
 
-    val externalDocumentablesProvider by extensionPoint<ExternalDocumentablesProvider>()
+    public val externalDocumentablesProvider: ExtensionPoint<ExternalDocumentablesProvider> by extensionPoint()
 
-    val documentableSourceLanguageParser by extensionPoint<DocumentableSourceLanguageParser>()
+    public val documentableSourceLanguageParser: ExtensionPoint<DocumentableSourceLanguageParser> by extensionPoint()
 
-    val sampleProviderFactory by extensionPoint<SampleProviderFactory>()
+    public val sampleProviderFactory: ExtensionPoint<SampleProviderFactory> by extensionPoint()
 
     @OptIn(DokkaPluginApiPreview::class)
     override fun pluginApiPreviewAcknowledgement(): PluginApiPreviewAcknowledgement = PluginApiPreviewAcknowledgement

--- a/subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/internal/KotlinToJavaService.kt
+++ b/subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/internal/KotlinToJavaService.kt
@@ -8,6 +8,6 @@ import org.jetbrains.dokka.InternalDokkaApi
 import org.jetbrains.dokka.links.DRI
 
 @InternalDokkaApi
-interface KotlinToJavaService {
-    fun findAsJava(kotlinDri: DRI): DRI?
+public interface KotlinToJavaService {
+    public fun findAsJava(kotlinDri: DRI): DRI?
 }

--- a/subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/internal/ModuleAndPackageDocumentationReader.kt
+++ b/subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/internal/ModuleAndPackageDocumentationReader.kt
@@ -12,8 +12,8 @@ import org.jetbrains.dokka.model.SourceSetDependent
 import org.jetbrains.dokka.model.doc.DocumentationNode
 
 @InternalDokkaApi
-interface ModuleAndPackageDocumentationReader {
-    fun read(module: DModule): SourceSetDependent<DocumentationNode>
-    fun read(pkg: DPackage): SourceSetDependent<DocumentationNode>
-    fun read(module: DokkaConfiguration.DokkaModuleDescription): DocumentationNode?
+public interface ModuleAndPackageDocumentationReader {
+    public fun read(module: DModule): SourceSetDependent<DocumentationNode>
+    public fun read(pkg: DPackage): SourceSetDependent<DocumentationNode>
+    public fun read(module: DokkaConfiguration.DokkaModuleDescription): DocumentationNode?
 }

--- a/subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/internal/SampleProvider.kt
+++ b/subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/internal/SampleProvider.kt
@@ -8,13 +8,13 @@ import org.jetbrains.dokka.DokkaConfiguration
 import org.jetbrains.dokka.InternalDokkaApi
 
 @InternalDokkaApi
-interface SampleProviderFactory {
+public interface SampleProviderFactory {
     /**
      * [SampleProvider] is a short-lived closeable instance.
      * It assumes that [SampleProvider] scope of use is not big.
      * Otherwise, it can lead to high memory consumption / leaks during Dokka running.
      */
-    fun build(): SampleProvider
+    public fun build(): SampleProvider
 }
 
 /**
@@ -23,12 +23,14 @@ interface SampleProviderFactory {
  * In general case, it creates a separate project to analysis samples directories.
  */
 @InternalDokkaApi
-interface SampleProvider: AutoCloseable {
-    class SampleSnippet(val imports: String, val body:String)
-
+public interface SampleProvider: AutoCloseable {
+    public class SampleSnippet(
+        public val imports: String,
+        public val body: String
+    )
 
     /**
      * @return [SampleSnippet] or null if it has not found by [fqLink]
      */
-    fun getSample(sourceSet: DokkaConfiguration.DokkaSourceSet, fqLink: String): SampleSnippet?
+    public fun getSample(sourceSet: DokkaConfiguration.DokkaSourceSet, fqLink: String): SampleSnippet?
 }

--- a/subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/internal/SyntheticDocumentableDetector.kt
+++ b/subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/internal/SyntheticDocumentableDetector.kt
@@ -10,6 +10,6 @@ import org.jetbrains.dokka.model.Documentable
 
 // TODO [beresnev] isSynthetic could be a property of Documentable
 @InternalDokkaApi
-interface SyntheticDocumentableDetector {
-    fun isSynthetic(documentable: Documentable, sourceSet: DokkaConfiguration.DokkaSourceSet): Boolean
+public interface SyntheticDocumentableDetector {
+    public fun isSynthetic(documentable: Documentable, sourceSet: DokkaConfiguration.DokkaSourceSet): Boolean
 }

--- a/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/AnalysisContextCreator.kt
+++ b/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/AnalysisContextCreator.kt
@@ -13,8 +13,8 @@ import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 
 @InternalDokkaApi
-interface AnalysisContextCreator {
-    fun create(
+public interface AnalysisContextCreator {
+    public fun create(
         project: MockProject,
         moduleDescriptor: ModuleDescriptor,
         moduleResolver: ResolverForModule,

--- a/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/CompilerDescriptorAnalysisPlugin.kt
+++ b/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/CompilerDescriptorAnalysisPlugin.kt
@@ -20,26 +20,34 @@ import org.jetbrains.dokka.analysis.kotlin.descriptors.compiler.translator.Defau
 import org.jetbrains.dokka.analysis.kotlin.descriptors.compiler.translator.DefaultExternalDocumentablesProvider
 import org.jetbrains.dokka.renderers.PostAction
 import org.jetbrains.dokka.analysis.kotlin.internal.InternalKotlinAnalysisPlugin
+import org.jetbrains.dokka.analysis.kotlin.internal.SampleProviderFactory
 import org.jetbrains.dokka.plugability.*
 import org.jetbrains.kotlin.asJava.elements.KtLightAbstractAnnotation
 
 @Suppress("unused")
 @InternalDokkaApi
-class CompilerDescriptorAnalysisPlugin : DokkaPlugin() {
+public class CompilerDescriptorAnalysisPlugin : DokkaPlugin() {
 
-    val kdocFinder by extensionPoint<KDocFinder>()
+    @InternalDokkaApi
+    public val kdocFinder: ExtensionPoint<KDocFinder> by extensionPoint()
 
-    val descriptorFinder by extensionPoint<DescriptorFinder>()
+    @InternalDokkaApi
+    public val descriptorFinder: ExtensionPoint<DescriptorFinder> by extensionPoint()
 
-    val klibService by extensionPoint<KLibService>()
+    @InternalDokkaApi
+    public val klibService: ExtensionPoint<KLibService> by extensionPoint()
 
-    val compilerExtensionPointProvider by extensionPoint<CompilerExtensionPointProvider>()
+    @InternalDokkaApi
+    public val compilerExtensionPointProvider: ExtensionPoint<CompilerExtensionPointProvider> by extensionPoint()
 
-    val mockApplicationHack by extensionPoint<MockApplicationHack>()
+    @InternalDokkaApi
+    public val mockApplicationHack: ExtensionPoint<MockApplicationHack> by extensionPoint()
 
-    val analysisContextCreator by extensionPoint<AnalysisContextCreator>()
+    @InternalDokkaApi
+    public val analysisContextCreator: ExtensionPoint<AnalysisContextCreator> by extensionPoint()
 
-    val kotlinAnalysis by extensionPoint<KotlinAnalysis>()
+    @InternalDokkaApi
+    public val kotlinAnalysis: ExtensionPoint<KotlinAnalysis> by extensionPoint()
 
     internal val documentableAnalyzerImpl by extending {
         plugin<InternalKotlinAnalysisPlugin>().documentableSourceLanguageParser providing { CompilerDocumentableSourceLanguageParser() }
@@ -72,7 +80,7 @@ class CompilerDescriptorAnalysisPlugin : DokkaPlugin() {
      * So it should have a possibility to override this extension
      */
     @InternalDokkaApi
-    val kotlinSampleProviderFactory by extending {
+    public val kotlinSampleProviderFactory: Extension<SampleProviderFactory, *, *> by extending {
         plugin<InternalKotlinAnalysisPlugin>().sampleProviderFactory providing ::KotlinSampleProviderFactory
     }
 

--- a/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/CompilerExtensionPointProvider.kt
+++ b/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/CompilerExtensionPointProvider.kt
@@ -8,11 +8,11 @@ import org.jetbrains.dokka.InternalDokkaApi
 import org.jetbrains.kotlin.extensions.ApplicationExtensionDescriptor
 
 @InternalDokkaApi
-interface CompilerExtensionPointProvider {
-    fun get(): List<CompilerExtensionPoint>
+public interface CompilerExtensionPointProvider {
+    public fun get(): List<CompilerExtensionPoint>
 
-    class CompilerExtensionPoint(
-        val extensionDescriptor: ApplicationExtensionDescriptor<Any>,
-        val extensions: List<Any>
+    public class CompilerExtensionPoint(
+        public val extensionDescriptor: ApplicationExtensionDescriptor<Any>,
+        public val extensions: List<Any>
     )
 }

--- a/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/DescriptorFinder.kt
+++ b/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/DescriptorFinder.kt
@@ -9,6 +9,6 @@ import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.psi.KtDeclaration
 
 @InternalDokkaApi
-interface DescriptorFinder {
-    fun KtDeclaration.findDescriptor(): DeclarationDescriptor?
+public interface DescriptorFinder {
+    public fun KtDeclaration.findDescriptor(): DeclarationDescriptor?
 }

--- a/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/KDocFinder.kt
+++ b/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/KDocFinder.kt
@@ -14,10 +14,10 @@ import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.resolve.DescriptorToSourceUtils
 
 @InternalDokkaApi
-interface KDocFinder {
-    fun KtElement.findKDoc(): KDocTag?
+public interface KDocFinder {
+    public fun KtElement.findKDoc(): KDocTag?
 
-    fun DeclarationDescriptor.find(
+    public fun DeclarationDescriptor.find(
         descriptorToPsi: (DeclarationDescriptorWithSource) -> PsiElement? = {
             DescriptorToSourceUtils.descriptorToDeclaration(
                 it
@@ -25,7 +25,7 @@ interface KDocFinder {
         }
     ): KDocTag?
 
-    fun resolveKDocLink(
+    public fun resolveKDocLink(
         fromDescriptor: DeclarationDescriptor,
         qualifiedName: String,
         sourceSet: DokkaConfiguration.DokkaSourceSet,

--- a/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/KLibService.kt
+++ b/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/KLibService.kt
@@ -14,8 +14,8 @@ import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.storage.StorageManager
 
 @InternalDokkaApi
-interface KLibService {
-    fun KotlinLibrary.createPackageFragmentProvider(
+public interface KLibService {
+    public fun KotlinLibrary.createPackageFragmentProvider(
         storageManager: StorageManager,
         metadataModuleDescriptorFactory: KlibMetadataModuleDescriptorFactory,
         languageVersionSettings: LanguageVersionSettings,
@@ -23,5 +23,5 @@ interface KLibService {
         lookupTracker: LookupTracker
     ): PackageFragmentProvider?
 
-    fun isAnalysisCompatible(kotlinLibrary: KotlinLibrary): Boolean
+    public fun isAnalysisCompatible(kotlinLibrary: KotlinLibrary): Boolean
 }

--- a/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/MockApplicationHack.kt
+++ b/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/MockApplicationHack.kt
@@ -8,6 +8,6 @@ import com.intellij.mock.MockApplication
 import org.jetbrains.dokka.InternalDokkaApi
 
 @InternalDokkaApi
-interface MockApplicationHack { // ¯\_(ツ)_/¯
-    fun hack(mockApplication: MockApplication)
+public interface MockApplicationHack { // ¯\_(ツ)_/¯
+    public fun hack(mockApplication: MockApplication)
 }

--- a/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/AnalysisContext.kt
+++ b/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/AnalysisContext.kt
@@ -6,6 +6,7 @@ package org.jetbrains.dokka.analysis.kotlin.descriptors.compiler.configuration
 
 import com.intellij.openapi.project.Project
 import org.jetbrains.dokka.DokkaConfiguration
+import org.jetbrains.dokka.InternalDokkaApi
 import org.jetbrains.dokka.Platform
 import org.jetbrains.dokka.analysis.kotlin.descriptors.compiler.AnalysisContextCreator
 import org.jetbrains.dokka.analysis.kotlin.descriptors.compiler.CompilerDescriptorAnalysisPlugin
@@ -92,9 +93,10 @@ internal class DokkaMessageCollector(private val logger: DokkaLogger) : MessageC
     override fun hasErrors() = seenErrors
 }
 
-interface AnalysisContext : Closeable {
-    val environment: KotlinCoreEnvironment
-    val resolveSession: ResolveSession
-    val moduleDescriptor: ModuleDescriptor
-    val project: Project
+@InternalDokkaApi
+public interface AnalysisContext : Closeable {
+    public val environment: KotlinCoreEnvironment
+    public val resolveSession: ResolveSession
+    public val moduleDescriptor: ModuleDescriptor
+    public val project: Project
 }

--- a/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/AnalysisEnvironment.kt
+++ b/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/AnalysisEnvironment.kt
@@ -90,7 +90,7 @@ internal const val JAR_SEPARATOR = "!/"
  * $body: optional and can be used to configure environment without creating local variable
  */
 @InternalDokkaApi
-class AnalysisEnvironment(
+public class AnalysisEnvironment(
     private val messageCollector: MessageCollector,
     internal val analysisPlatform: Platform,
     private val mockApplicationHack: MockApplicationHack,

--- a/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/KotlinAnalysis.kt
+++ b/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/KotlinAnalysis.kt
@@ -59,15 +59,15 @@ internal fun SamplesKotlinAnalysis(
     return EnvironmentKotlinAnalysis(environments, projectKotlinAnalysis)
 }
 @DokkaPluginApiPreview
-data class DokkaAnalysisConfiguration(
+public data class DokkaAnalysisConfiguration(
     /**
      * Only for common platform ignore BuiltIns for StdLib since it can cause a conflict
      * between BuiltIns from a compiler and ones from source code.
      */
     val ignoreCommonBuiltIns: Boolean = DEFAULT_IGNORE_COMMON_BUILT_INS
 ): ConfigurableBlock {
-    companion object {
-        const val DEFAULT_IGNORE_COMMON_BUILT_INS = false
+    public companion object {
+        public const val DEFAULT_IGNORE_COMMON_BUILT_INS: Boolean = false
     }
 }
 
@@ -75,11 +75,11 @@ data class DokkaAnalysisConfiguration(
  * First child delegation. It does not close [parent].
  */
 @InternalDokkaApi
-abstract class KotlinAnalysis(
+public abstract class KotlinAnalysis(
     private val parent: KotlinAnalysis? = null
 ) : Closeable {
 
-    operator fun get(key: DokkaSourceSet): AnalysisContext {
+    public operator fun get(key: DokkaSourceSet): AnalysisContext {
         return get(key.sourceSetID)
     }
 

--- a/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/impl/KotlinSampleProvider.kt
+++ b/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/impl/KotlinSampleProvider.kt
@@ -24,7 +24,9 @@ import org.jetbrains.kotlin.psi.KtDeclarationWithBody
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.lazy.ResolveSession
 
-class KotlinSampleProviderFactory(val context: DokkaContext): SampleProviderFactory {
+public class KotlinSampleProviderFactory(
+    public val context: DokkaContext
+): SampleProviderFactory {
     override fun build(): SampleProvider {
         return KotlinSampleProvider(context)
     }
@@ -35,7 +37,9 @@ class KotlinSampleProviderFactory(val context: DokkaContext): SampleProviderFact
  * with [processBody] and [processImports]
  */
 @InternalDokkaApi
-open class KotlinSampleProvider(val context: DokkaContext): SampleProvider {
+public open class KotlinSampleProvider(
+    public val context: DokkaContext
+): SampleProvider {
     private val kDocFinder: KDocFinder = context.plugin<CompilerDescriptorAnalysisPlugin>().querySingle { kdocFinder }
     private val analysis = lazy {
         /**

--- a/subprojects/analysis-kotlin-descriptors/ide/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/ide/CoreKotlinCacheService.kt
+++ b/subprojects/analysis-kotlin-descriptors/ide/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/ide/CoreKotlinCacheService.kt
@@ -25,7 +25,7 @@ internal class CoreKotlinCacheService(private val resolutionFacade: DokkaResolut
 
     override fun getResolutionFacadeByFile(
         file: PsiFile,
-        platform: org.jetbrains.kotlin.platform.TargetPlatform
+        platform: TargetPlatform
     ): ResolutionFacade {
         return resolutionFacade
     }
@@ -39,7 +39,7 @@ internal class CoreKotlinCacheService(private val resolutionFacade: DokkaResolut
 
     override fun getResolutionFacadeByModuleInfo(
         moduleInfo: ModuleInfo,
-        platform: org.jetbrains.kotlin.platform.TargetPlatform
+        platform: TargetPlatform
     ): ResolutionFacade {
         return resolutionFacade
     }

--- a/subprojects/analysis-kotlin-descriptors/ide/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/ide/IdeDescriptorAnalysisPlugin.kt
+++ b/subprojects/analysis-kotlin-descriptors/ide/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/ide/IdeDescriptorAnalysisPlugin.kt
@@ -11,7 +11,7 @@ import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
 import org.jetbrains.dokka.plugability.PluginApiPreviewAcknowledgement
 
 @InternalDokkaApi
-class IdeDescriptorAnalysisPlugin : DokkaPlugin() {
+public class IdeDescriptorAnalysisPlugin : DokkaPlugin() {
 
     internal val ideKdocFinder by extending {
         plugin<CompilerDescriptorAnalysisPlugin>().kdocFinder providing ::IdePluginKDocFinder

--- a/subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/services/KotlinSampleProvider.kt
+++ b/subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/services/KotlinSampleProvider.kt
@@ -21,7 +21,9 @@ import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtDeclarationWithBody
 import org.jetbrains.kotlin.psi.KtFile
 
-class KotlinSampleProviderFactory(val context: DokkaContext): SampleProviderFactory {
+public class KotlinSampleProviderFactory(
+    public val context: DokkaContext
+): SampleProviderFactory {
     override fun build(): SampleProvider {
         return KotlinSampleProvider(context)
     }
@@ -32,7 +34,9 @@ class KotlinSampleProviderFactory(val context: DokkaContext): SampleProviderFact
  * with [processBody] and [processImports]
  */
 @InternalDokkaApi
-open class KotlinSampleProvider(val context: DokkaContext): SampleProvider {
+public open class KotlinSampleProvider(
+    public val context: DokkaContext
+): SampleProvider {
     private val kotlinAnalysis = SamplesKotlinAnalysis(
         sourceSets = context.configuration.sourceSets,
         context = context,

--- a/subprojects/analysis-markdown-jb/src/main/kotlin/org/jetbrains/dokka/analysis/markdown/jb/MarkdownApi.kt
+++ b/subprojects/analysis-markdown-jb/src/main/kotlin/org/jetbrains/dokka/analysis/markdown/jb/MarkdownApi.kt
@@ -9,4 +9,4 @@ import org.jetbrains.dokka.InternalDokkaApi
 
 // TODO [beresnev] move/rename if it's only used for CustomDocTag. for now left as is for compatibility
 @InternalDokkaApi
-val MARKDOWN_ELEMENT_FILE_NAME = MarkdownElementTypes.MARKDOWN_FILE.name
+public val MARKDOWN_ELEMENT_FILE_NAME: String = MarkdownElementTypes.MARKDOWN_FILE.name

--- a/subprojects/analysis-markdown-jb/src/main/kotlin/org/jetbrains/dokka/analysis/markdown/jb/MarkdownParser.kt
+++ b/subprojects/analysis-markdown-jb/src/main/kotlin/org/jetbrains/dokka/analysis/markdown/jb/MarkdownParser.kt
@@ -24,7 +24,7 @@ import java.net.URL
 import org.intellij.markdown.parser.MarkdownParser as IntellijMarkdownParser
 
 @InternalDokkaApi
-open class MarkdownParser(
+public open class MarkdownParser(
     private val externalDri: (String) -> DRI?,
     private val kdocLocation: String?,
 ) : Parser() {
@@ -45,7 +45,7 @@ open class MarkdownParser(
         return CustomDocTag(children = parsed, params = emptyMap(), name = "")
     }
 
-    override fun preparse(text: String) = text.replace("\r\n", "\n").replace("\r", "\n")
+    override fun preparse(text: String): String = text.replace("\r\n", "\n").replace("\r", "\n")
 
     override fun parseTagWithBody(tagName: String, content: String): TagWrapper =
         when (tagName) {
@@ -501,8 +501,8 @@ open class MarkdownParser(
         )
 
 
-    companion object {
-        fun DRI.fqDeclarationName(): String? {
+    public companion object {
+        public fun DRI.fqDeclarationName(): String? {
             if (this.target !is PointingToDeclaration) {
                 return null
             }

--- a/subprojects/analysis-markdown-jb/src/main/kotlin/org/jetbrains/dokka/analysis/markdown/jb/ParseUtils.kt
+++ b/subprojects/analysis-markdown-jb/src/main/kotlin/org/jetbrains/dokka/analysis/markdown/jb/ParseUtils.kt
@@ -13,7 +13,7 @@ import org.jsoup.internal.StringUtil
 import org.jsoup.nodes.Entities
 
 @InternalDokkaApi
-fun String.parseHtmlEncodedWithNormalisedSpaces(
+public fun String.parseHtmlEncodedWithNormalisedSpaces(
     renderWhiteCharactersAsSpaces: Boolean
 ): List<DocTag> {
     val accum = StringBuilder()

--- a/subprojects/analysis-markdown-jb/src/main/kotlin/org/jetbrains/dokka/analysis/markdown/jb/Parser.kt
+++ b/subprojects/analysis-markdown-jb/src/main/kotlin/org/jetbrains/dokka/analysis/markdown/jb/Parser.kt
@@ -8,13 +8,13 @@ import org.jetbrains.dokka.InternalDokkaApi
 import org.jetbrains.dokka.model.doc.*
 
 @InternalDokkaApi
-abstract class Parser {
+public abstract class Parser {
 
-    abstract fun parseStringToDocNode(extractedString: String): DocTag
+    public abstract fun parseStringToDocNode(extractedString: String): DocTag
 
     protected abstract fun preparse(text: String): String
 
-    open fun parse(text: String): DocumentationNode =
+    public open fun parse(text: String): DocumentationNode =
         DocumentationNode(extractTagsToListOfPairs(preparse(text)).map { (tag, content) -> parseTagWithBody(tag, content) })
 
     protected open fun parseTagWithBody(tagName: String, content: String): TagWrapper =


### PR DESCRIPTION
Depends on #3138, will rebase onto master once it gets merged.

This PR enables explicit API mode, which adds compiler checks for explicit visibility modifiers and return types.

You can see by the changes in the `.api` files that I changed some of the return types - I believe they were inferred incorrectly, as in most cases the supertype was deduced instead of the interface / base type. Other than that, I think everything should be fine in terms of backward compatibility.

Additionally, because visibility modifiers and return types made the lines longer, I did some small reformatting along the way, mostly adding line breaks or converting functions to block bodies.