### PR TITLE
Add the native stdlib and platform libraries from K/N distribution

### DIFF
--- a/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/kotlin/kotlinClasspathUtils.kt
+++ b/runners/gradle-plugin/src/main/kotlin/org/jetbrains/dokka/gradle/kotlin/kotlinClasspathUtils.kt
@@ -7,6 +7,13 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import org.jetbrains.kotlin.gradle.plugin.mpp.AbstractKotlinNativeCompilation
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompileTool
+import org.jetbrains.kotlin.gradle.utils.NativeCompilerDownloader
+import org.jetbrains.kotlin.konan.library.KONAN_DISTRIBUTION_COMMON_LIBS_DIR
+import org.jetbrains.kotlin.konan.library.KONAN_DISTRIBUTION_KLIB_DIR
+import org.jetbrains.kotlin.konan.library.KONAN_DISTRIBUTION_PLATFORM_LIBS_DIR
+import org.jetbrains.kotlin.konan.library.KONAN_STDLIB_NAME
+import org.jetbrains.kotlin.konan.target.KonanTarget
+import java.io.File
 
 internal fun Project.classpathOf(sourceSet: KotlinSourceSet): FileCollection {
     val compilations = compilationsOf(sourceSet)
@@ -79,7 +86,7 @@ private fun KotlinCompilation.getKotlinCompileTask(kgpVersion: KotlinGradlePlugi
 private fun KotlinCompilation.platformDependencyFiles(project: Project): FileCollection {
     val excludePlatformDependencyFiles = project.classpathProperty("excludePlatformDependencyFiles", default = false)
 
-    if (excludePlatformDependencyFiles) return project.files()
+    if (excludePlatformDependencyFiles) return getPlatfromDependenciesFromKonanDistribution(project)
     return (this as? AbstractKotlinNativeCompilation)
         ?.target?.project?.configurations
         ?.findByName(@Suppress("DEPRECATION") this.defaultSourceSet.implementationMetadataConfigurationName) // KT-58640
@@ -88,3 +95,37 @@ private fun KotlinCompilation.platformDependencyFiles(project: Project): FileCol
 
 private fun Project.classpathProperty(name: String, default: Boolean): Boolean =
     (findProperty("org.jetbrains.dokka.classpath.$name") as? String)?.toBoolean() ?: default
+
+// -------- The hack for platform dependencies from compiler ------------------
+// adapted from https://github.com/jetbrains/kotlin/blob/b6a215d681695a2fe0cc798308966c5675de447f/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/KotlinNativePlatformDependencies.kt#L39
+
+private fun KotlinCompilation.getPlatfromDependenciesFromKonanDistribution(project: Project): FileCollection {
+    return if (this is AbstractKotlinNativeCompilation)
+        project.files(project.getStdLibFromKonanDistribution()) + project.files(project.getPlatformLibsFromKonanDistribution(this.konanTarget))
+    else
+        project.files()
+}
+
+private fun Project.nativeHome(): String? =
+    this.findProperty("org.jetbrains.kotlin.native.home") as? String
+
+// copy-pasted from https://github.com/jetbrains/kotlin/blob/c9aeadd31f763646237faffab38a57923c520fa1/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/nativeToolRunners.kt#L29
+private fun Project.konanHome(): String {
+    return nativeHome()?.let { file(it).absolutePath }
+        ?: NativeCompilerDownloader(project).compilerDirectory.absolutePath
+}
+
+private fun Project.getStdLibFromKonanDistribution(): File {
+    val root = file(this.konanHome())
+    val konanCommonLibraries = root.resolve(KONAN_DISTRIBUTION_KLIB_DIR).resolve(KONAN_DISTRIBUTION_COMMON_LIBS_DIR)
+    val stdlib = konanCommonLibraries.resolve(KONAN_STDLIB_NAME)
+    return stdlib
+}
+//copy-pasted from https://github.com/jetbrains/kotlin/blob/05a6d89151e6a7230faf733e51161b5f07ae10a7/native/commonizer/src/org/jetbrains/kotlin/commonizer/repository/KonanDistributionRepository.kt#L20
+// https://github.com/jetbrains/kotlin/blob/b6a215d681695a2fe0cc798308966c5675de447f/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/KotlinNativePlatformDependencies.kt#L83
+private fun Project.getPlatformLibsFromKonanDistribution(target: KonanTarget): Array<out File>? {
+    val root = file(this.konanHome())
+    val platformLibsDir = root.resolve(KONAN_DISTRIBUTION_KLIB_DIR).resolve(KONAN_DISTRIBUTION_PLATFORM_LIBS_DIR)
+    val libs = platformLibsDir.resolve(target.name).takeIf { it.isDirectory }?.listFiles()
+    return libs
+}


### PR DESCRIPTION
This current hack is temporary under the property `org.jetbrains.dokka.classpath.excludePlatformDependencyFiles=true`. 
Some stable API is needed from KGP.

Dokka reuses a compiler frontend. From this point of view, Dokka needs the same classpath as the compiler. Dokka extracts the classpath from `Compilation`s in KGP plugin.
 
KGP's pipeline:   `Compilation` --> `KotlinTool`  (Compile task) --> run a compiler process with CLI arguments.
For classpath, KGP transforms `KotlinTool.libraries` (or `compilation.compileDependencyFiles`) to `-library` CLI argument. (see, e.g. for Native - [here](https://github.com/jetbrains/kotlin/blob/40d29d13bf06af4f9b6bf5e2cdff67844d93c104/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/KotlinNativeTasks.kt#L535)). The compiler arguments can be printed if `--info` flag is used in Gradle.

Dokka already uses `KotlinTool.libraries` that KGP passes to the compiler. But the Kotlin/Native compiler (aka Konan) knows about some platform dependencies (e.g. native stdlib, [platform libraries](https://kotlinlang.org/docs/native-platform-libs.html): posix, iconv, gles...) , but Dokka does not. 
They are a part of the Native compiler distribution, see [this readme](https://github.com/JetBrains/kotlin/tree/master/kotlin-native#kotlinnative) and `~/.konan/klib`, and `KotlinTool.libraries` does not contain them. By the way, e.g. a platform library of Apple SDK is unavaible on non-apple computers.

In order to get it, Dokka uses `platformDependencies` in Gradle Runner. _(TBH, I haven't researched what else in `platformDependencies`)_

For KGP 1.9.0 `platformDependencies` starts leading to issues (e.g., implicit dependencies).

The hack comes from the [setupKotlinNativePlatformDependencies](https://github.com/vmishenev/kotlin/blob/b6a215d681695a2fe0cc798308966c5675de447f/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/KotlinNativePlatformDependencies.kt#L39) function.

[Here](https://github.com/vmishenev/kotlin/blob/b6a215d681695a2fe0cc798308966c5675de447f/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/KotlinNativePlatformDependencies.kt#L92)  it adds these dependencies only into Dokka's  `platformDependencies` (aka `implementationMetadataConfigurationName` configuration) and metadata compilation.