### PR TITLE
Allow manual deployment of the developer guides

### DIFF
--- a/.github/workflows/gh-pages-deploy-dev-docs.yml
+++ b/.github/workflows/gh-pages-deploy-dev-docs.yml
@@ -1,6 +1,7 @@
 name: Deploy developer docs to GitHub Pages
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master


### PR DESCRIPTION
The `dokka_version` property was set to `1.9.0-SNAPSHOT` in the release branch when I published the release on GitHub, so it published the developer guides under [kotlin.github.io/dokka/1.9.0-SNAPSHOT](https://kotlin.github.io/dokka/1.9.0-SNAPSHOT/).

I've [fixed the version](https://github.com/Kotlin/dokka/commit/83eaebecf088939a36be6591c9e1ee9c5eba8876), but there's no way to redeploy the docs.

Adding `workflow_dispatch` allows one to manually trigger a workflow on a branch, which will allow me to publish the developer guides under the correct version