### PR TITLE
Register Kotlin stdlib classpath in every unit test and mute some tests for K2

### DIFF
--- a/plugins/base/src/test/kotlin/content/HighlightingTest.kt
+++ b/plugins/base/src/test/kotlin/content/HighlightingTest.kt
@@ -15,7 +15,7 @@ class HighlightingTest : BaseAbstractTest() {
         sourceSets {
             sourceSet {
                 sourceRoots = listOf("src/")
-                classpath = listOf(commonStdlibPath!!)
+                classpath = listOf(commonStdlibPath!!, jvmStdlibPath!!)
                 externalDocumentationLinks = listOf(stdlibExternalDocumentationLink)
             }
         }

--- a/plugins/base/src/test/kotlin/content/annotations/KotlinDeprecatedTest.kt
+++ b/plugins/base/src/test/kotlin/content/annotations/KotlinDeprecatedTest.kt
@@ -27,6 +27,7 @@ class KotlinDeprecatedTest : BaseAbstractTest() {
         sourceSets {
             sourceSet {
                 sourceRoots = listOf("src/")
+                classpath = listOfNotNull(jvmStdlibPath)
                 analysisPlatform = "jvm"
             }
         }

--- a/plugins/base/src/test/kotlin/content/annotations/SinceKotlinTest.kt
+++ b/plugins/base/src/test/kotlin/content/annotations/SinceKotlinTest.kt
@@ -27,6 +27,7 @@ class SinceKotlinTest : AbstractRenderingTest() {
         sourceSets {
             sourceSet {
                 sourceRoots = listOf("src/")
+                classpath = listOfNotNull(jvmStdlibPath)
                 analysisPlatform = "jvm"
             }
         }
@@ -185,6 +186,7 @@ class SinceKotlinTest : AbstractRenderingTest() {
             sourceSets {
                 sourceSet {
                     sourceRoots = listOf("src/")
+                    classpath = listOfNotNull(jvmStdlibPath)
                     analysisPlatform = "jvm"
                 }
                 sourceSet {
@@ -193,10 +195,12 @@ class SinceKotlinTest : AbstractRenderingTest() {
                 }
                 sourceSet {
                     sourceRoots = listOf("src/")
+                    classpath = listOfNotNull(commonStdlibPath)
                     analysisPlatform = "common"
                 }
                 sourceSet {
                     sourceRoots = listOf("src/")
+                    classpath = listOfNotNull(jsStdlibPath)
                     analysisPlatform = "js"
                 }
                 sourceSet {

--- a/plugins/base/src/test/kotlin/content/exceptions/ContentForExceptions.kt
+++ b/plugins/base/src/test/kotlin/content/exceptions/ContentForExceptions.kt
@@ -10,10 +10,7 @@ import org.jetbrains.dokka.PluginConfigurationImpl
 import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
 import org.jetbrains.dokka.model.DisplaySourceSet
-import utils.ParamAttributes
-import utils.bareSignature
-import utils.findTestType
-import utils.OnlyDescriptors
+import utils.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -22,6 +19,7 @@ class ContentForExceptions : BaseAbstractTest() {
         sourceSets {
             sourceSet {
                 sourceRoots = listOf("src/")
+                classpath = listOfNotNull(jvmStdlibPath)
                 analysisPlatform = "jvm"
             }
         }
@@ -35,6 +33,7 @@ class ContentForExceptions : BaseAbstractTest() {
                 displayName = "common"
                 analysisPlatform = "common"
                 sourceRoots = listOf("src/commonMain/kotlin/pageMerger/Test.kt")
+                classpath = listOfNotNull(commonStdlibPath)
             }
             sourceSet {
                 name = "jvm"
@@ -42,6 +41,7 @@ class ContentForExceptions : BaseAbstractTest() {
                 analysisPlatform = "jvm"
                 dependentSourceSets = setOf(common.value.sourceSetID)
                 sourceRoots = listOf("src/jvmMain/kotlin/pageMerger/Test.kt")
+                classpath = listOfNotNull(jvmStdlibPath)
             }
             sourceSet {
                 name = "linuxX64"
@@ -339,6 +339,7 @@ class ContentForExceptions : BaseAbstractTest() {
         }
     }
 
+    @OnlyDescriptorsMPP("Return type for native `function` should be null rather than kotlin/Unit")
     @Test
     fun `throws in merged functions`() {
         testInline(

--- a/plugins/base/src/test/kotlin/content/params/ContentForParamsTest.kt
+++ b/plugins/base/src/test/kotlin/content/params/ContentForParamsTest.kt
@@ -23,6 +23,7 @@ class ContentForParamsTest : BaseAbstractTest() {
         sourceSets {
             sourceSet {
                 sourceRoots = listOf("src/")
+                classpath = listOfNotNull(jvmStdlibPath)
                 analysisPlatform = "jvm"
             }
         }
@@ -531,7 +532,7 @@ class ContentForParamsTest : BaseAbstractTest() {
                                             link {
                                                 check {
                                                     assertEquals(
-                                                        "java.lang/RuntimeException///PointingToDeclaration/",
+                                                        "kotlin/RuntimeException///PointingToDeclaration/",
                                                         (this as ContentDRILink).address.toString()
                                                     )
                                                 }

--- a/plugins/base/src/test/kotlin/content/seealso/ContentForSeeAlsoTest.kt
+++ b/plugins/base/src/test/kotlin/content/seealso/ContentForSeeAlsoTest.kt
@@ -17,6 +17,7 @@ class ContentForSeeAlsoTest : BaseAbstractTest() {
         sourceSets {
             sourceSet {
                 sourceRoots = listOf("src/")
+                classpath = listOfNotNull(jvmStdlibPath)
                 analysisPlatform = "jvm"
             }
         }
@@ -217,6 +218,7 @@ class ContentForSeeAlsoTest : BaseAbstractTest() {
         }
     }
 
+    @OnlyDescriptors("issue #3179")
     @Test
     fun `undocumented seealso with reference to property for class`() {
         testInline(
@@ -310,6 +312,7 @@ class ContentForSeeAlsoTest : BaseAbstractTest() {
         }
     }
 
+    @OnlyDescriptors("issue #3179")
     @Test
     fun `documented seealso with reference to property for class`() {
         testInline(

--- a/plugins/base/src/test/kotlin/content/typealiases/TypealiasTest.kt
+++ b/plugins/base/src/test/kotlin/content/typealiases/TypealiasTest.kt
@@ -18,7 +18,7 @@ class TypealiasTest : BaseAbstractTest() {
         sourceSets {
             sourceSet {
                 sourceRoots = listOf("src/")
-                classpath = listOf(commonStdlibPath!!)
+                classpath = listOf(commonStdlibPath!!, jvmStdlibPath!!)
                 externalDocumentationLinks = listOf(stdlibExternalDocumentationLink)
             }
         }

--- a/plugins/base/src/test/kotlin/enums/KotlinEnumsTest.kt
+++ b/plugins/base/src/test/kotlin/enums/KotlinEnumsTest.kt
@@ -292,6 +292,7 @@ class KotlinEnumsTest : BaseAbstractTest() {
             sourceSets {
                 sourceSet {
                     sourceRoots = listOf("src/")
+                    classpath = listOfNotNull(jvmStdlibPath)
                 }
             }
         }

--- a/plugins/base/src/test/kotlin/filter/DeprecationFilterTest.kt
+++ b/plugins/base/src/test/kotlin/filter/DeprecationFilterTest.kt
@@ -18,6 +18,7 @@ class DeprecationFilterTest : BaseAbstractTest() {
             sourceSets {
                 sourceSet {
                     sourceRoots = listOf("src/main/kotlin/basic/Test.kt")
+                    classpath = listOfNotNull(jvmStdlibPath)
                     skipDeprecated = false
                     perPackageOptions = mutableListOf(
                         PackageOptionsImpl(

--- a/plugins/base/src/test/kotlin/filter/VisibilityFilterTest.kt
+++ b/plugins/base/src/test/kotlin/filter/VisibilityFilterTest.kt
@@ -691,6 +691,7 @@ class VisibilityFilterTest : BaseAbstractTest() {
                 sourceSet {
                     includeNonPublic = true
                     sourceRoots = listOf("src/main/kotlin/basic/Test.kt")
+                    classpath = listOfNotNull(jvmStdlibPath)
                 }
             }
         }

--- a/plugins/base/src/test/kotlin/signatures/FunctionalTypeConstructorsSignatureTest.kt
+++ b/plugins/base/src/test/kotlin/signatures/FunctionalTypeConstructorsSignatureTest.kt
@@ -20,7 +20,7 @@ class FunctionalTypeConstructorsSignatureTest : BaseAbstractTest() {
         sourceSets {
             sourceSet {
                 sourceRoots = listOf("src/")
-                classpath = listOf(commonStdlibPath!!)
+                classpath = listOf(commonStdlibPath!!, jvmStdlibPath!!)
                 externalDocumentationLinks = listOf(
                     stdlibExternalDocumentationLink,
                     DokkaConfiguration.ExternalDocumentationLink.Companion.jdk(8)


### PR DESCRIPTION
 Due to the recent changes in how Analysis API handles builtins, the update to the fresh version of Analysis API requires registering Kotlin stdlib in every testsuite.

Also, it mutes some unit tests for K2 since the new Analysis API broke them.