### PR TITLE
[K2] Avoid calling `analyze` on built-ins psi

### DIFF
--- a/subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/SymbolsAnalysisPlugin.kt
+++ b/subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/SymbolsAnalysisPlugin.kt
@@ -93,7 +93,7 @@ public class SymbolsAnalysisPlugin : DokkaPlugin() {
         plugin<InternalKotlinAnalysisPlugin>().documentableSourceLanguageParser providing { KotlinDocumentableSourceLanguageParser() }
     }
     internal val symbolFullClassHierarchyBuilder by extending {
-        plugin<InternalKotlinAnalysisPlugin>().fullClassHierarchyBuilder providing { SymbolFullClassHierarchyBuilder() }
+        plugin<InternalKotlinAnalysisPlugin>().fullClassHierarchyBuilder providing ::SymbolFullClassHierarchyBuilder
     }
 
     internal val symbolSyntheticDocumentableDetector by extending {


### PR DESCRIPTION
Otherwise, `Caused by: org.jetbrains.kotlin.utils.exceptions.KotlinIllegalArgumentExceptionWithAttachments: Unexpected class org.jetbrains.kotlin.analysis.project.structure.KtBuiltinsModule
                          	at org.jetbrains.kotlin.analysis.low.level.api.fir.util.ExceptionUtilsKt.errorWithFirSpecificEntries(exceptionUtils.kt:50)`