### PR TITLE
Fix docs link for OkHttp

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Some libraries that use Dokka for their API reference documentation:
 * [Bitmovin](https://cdn.bitmovin.com/player/android/3/docs/index.html)
 * [Hexagon](https://hexagonkt.com/api/index.html)
 * [Ktor](https://api.ktor.io/)
-* [OkHttp](https://square.github.io/okhttp/4.x/okhttp/okhttp3/) (Markdown)
+* [OkHttp](https://square.github.io/okhttp/5.x/okhttp/okhttp3/)
 * [Gradle](https://docs.gradle.org/current/kotlin-dsl/index.html)
 
 You can run Dokka using [Gradle](https://kotlinlang.org/docs/dokka-gradle.html), 


### PR DESCRIPTION
The documentation for OkHttp has been moved to https://square.github.io/okhttp/5.x/okhttp/okhttp3/

As per https://github.com/square/okhttp/commit/05718b4d87b591820a178b3fb6a4325c83c55d7a, they are currently using HTML for docs and not markdown