### PR TITLE
Update org.jetbrains.markdown from 0.3.1 to 0.5.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ korlibs-template = "4.0.10"
 kotlinx-html = "0.9.1"
 
 ## Markdown
-jetbrains-markdown = "0.3.1"
+jetbrains-markdown = "0.5.2"
 
 ## JSON
 jackson = "2.12.7" # jackson 2.13.X does not support kotlin language version 1.4, check before updating

--- a/plugins/base/src/test/kotlin/markdown/ParserTest.kt
+++ b/plugins/base/src/test/kotlin/markdown/ParserTest.kt
@@ -1573,7 +1573,23 @@ class ParserTest : KDocTest() {
             P(listOf(Text(" sdsdsds sdd"))),
             P(listOf(Text(" eweww  ")))
         )
-        print(expectedDocumentationNode)
+        assertEquals(actualDocumentationNode, expectedDocumentationNode)
+    }
+
+    @Test // exists due to #3231
+    fun `should ignore the first whitespace in header in-between the hash symbol and header text`() {
+        val markdown = """
+        | #   first header
+        | ##     second header
+        | ###                third header
+        | 
+        """.trimMargin()
+        val actualDocumentationNode = parseMarkdownToDocNode(markdown).children
+        val expectedDocumentationNode = listOf(
+            H1(listOf(Text("first header"))),
+            H2(listOf(Text("second header"))),
+            H3(listOf(Text("third header"))),
+        )
         assertEquals(actualDocumentationNode, expectedDocumentationNode)
     }
 }

--- a/plugins/base/src/test/kotlin/markdown/ParserTest.kt
+++ b/plugins/base/src/test/kotlin/markdown/ParserTest.kt
@@ -1577,18 +1577,55 @@ class ParserTest : KDocTest() {
     }
 
     @Test // exists due to #3231
-    fun `should ignore the first whitespace in header in-between the hash symbol and header text`() {
+    fun `should ignore the leading whitespace in header in-between the hash symbol and header text`() {
         val markdown = """
         | #   first header
         | ##     second header
         | ###                third header
-        | 
         """.trimMargin()
         val actualDocumentationNode = parseMarkdownToDocNode(markdown).children
         val expectedDocumentationNode = listOf(
             H1(listOf(Text("first header"))),
             H2(listOf(Text("second header"))),
             H3(listOf(Text("third header"))),
+        )
+        assertEquals(actualDocumentationNode, expectedDocumentationNode)
+    }
+
+    @Test // exists due to #3231
+    fun `should ignore trailing whitespace in header`() {
+        val markdown = """
+        | # first header     
+        | ## second header        
+        | ### third header                                          
+        """.trimMargin()
+        val actualDocumentationNode = parseMarkdownToDocNode(markdown).children
+        val expectedDocumentationNode = listOf(
+            H1(listOf(Text("first header"))),
+            H2(listOf(Text("second header"))),
+            H3(listOf(Text("third header"))),
+        )
+        assertEquals(actualDocumentationNode, expectedDocumentationNode)
+    }
+
+    @Test // exists due to #3231
+    fun `should ignore leading and trailing whitespace in header, but not whitespace in the middle`() {
+        val markdown = """
+        | #          first header     
+        | ##     second ~~header~~   in a **long** sentence ending     with whitespaces   
+        | ###                third      header        
+        """.trimMargin()
+        val actualDocumentationNode = parseMarkdownToDocNode(markdown).children
+        val expectedDocumentationNode = listOf(
+            H1(listOf(Text("first header"))),
+            H2(listOf(
+                Text("second "),
+                Strikethrough(listOf(Text("header"))),
+                Text("   in a "),
+                B(listOf(Text("long"))),
+                Text(" sentence ending     with whitespaces")
+            )),
+            H3(listOf(Text("third      header"))),
         )
         assertEquals(actualDocumentationNode, expectedDocumentationNode)
     }

--- a/subprojects/analysis-markdown-jb/src/main/kotlin/org/jetbrains/dokka/analysis/markdown/jb/MarkdownParser.kt
+++ b/subprojects/analysis-markdown-jb/src/main/kotlin/org/jetbrains/dokka/analysis/markdown/jb/MarkdownParser.kt
@@ -90,6 +90,8 @@ public open class MarkdownParser(
         // in-between the `#` symbol and the text (like `# header`), it will be present here too.
         // However, we don't need the first space between the `#` symbol and the text,
         // so we just skip it (otherwise the header text will be parsed as `<whitespace>header` instead of `header`).
+        // If there's more space between `#` and text, like `#     header`, it will still be a single WHITE_SPACE
+        // element, but it will be wider, so the solution below should still hold.
         val textStartsWithWhitespace = node.children.firstOrNull()?.type == MarkdownTokenTypes.WHITE_SPACE
         val children = if (textStartsWithWhitespace) node.children.subList(1, node.children.size) else node.children
 


### PR DESCRIPTION
I've checked some trivial cases, and we have some test coverage (direct and indirect), so it should be relatively safe

I'll try to find the team who oversees this library and ask them if there were any significant changes or cases worth checking just in case.