### PR TITLE
[K2] Reorganize project model for MPP

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ kotlinx-bcv = "0.13.2"
 
 ## Analysis
 kotlin-compiler = "1.9.10"
-kotlin-compiler-k2 = "1.9.30-dev-3330"
+kotlin-compiler-k2 = "2.0.0-dev-5387"
 
 # MUST match the version of the intellij platform used in the kotlin compiler,
 # otherwise this will lead to different versions of psi API and implementations

--- a/plugins/base/src/test/kotlin/content/annotations/SinceKotlinTest.kt
+++ b/plugins/base/src/test/kotlin/content/annotations/SinceKotlinTest.kt
@@ -14,10 +14,7 @@ import org.jetbrains.dokka.model.doc.CustomTagWrapper
 import org.jetbrains.dokka.model.doc.Text
 import org.jetbrains.dokka.pages.ContentPage
 import signatures.AbstractRenderingTest
-import utils.ParamAttributes
-import utils.TestOutputWriterPlugin
-import utils.assertNotNull
-import utils.bareSignature
+import utils.*
 import kotlin.test.*
 
 
@@ -125,30 +122,54 @@ class SinceKotlinTest : AbstractRenderingTest() {
         val configuration =   dokkaConfiguration {
             sourceSets {
                 sourceSet {
-                    sourceRoots = listOf("src/")
+                    sourceRoots = listOf("src/jvm/")
                     analysisPlatform = "jvm"
                 }
                 sourceSet {
-                    sourceRoots = listOf("src/")
+                    sourceRoots = listOf("src/native/")
                     analysisPlatform = "native"
                 }
                 sourceSet {
-                    sourceRoots = listOf("src/")
+                    sourceRoots = listOf("src/common/")
                     analysisPlatform = "common"
                 }
                 sourceSet {
-                    sourceRoots = listOf("src/")
+                    sourceRoots = listOf("src/js/")
                     analysisPlatform = "js"
                 }
                 sourceSet {
-                    sourceRoots = listOf("src/")
+                    sourceRoots = listOf("src/wasm/")
                     analysisPlatform = "wasm"
                 }
             }
         }
         testInline(
             """
-            |/src/main/kotlin/test/source.kt
+            |/src/jvm/kotlin/test/source.kt
+            |package test
+            |
+            |fun ring(abc: String): String {
+            |    return "My precious " + abc
+            |}
+            |/src/native/kotlin/test/source.kt
+            |package test
+            |
+            |fun ring(abc: String): String {
+            |    return "My precious " + abc
+            |}
+            |/src/common/kotlin/test/source.kt
+            |package test
+            |
+            |fun ring(abc: String): String {
+            |    return "My precious " + abc
+            |}
+            |/src/js/kotlin/test/source.kt
+            |package test
+            |
+            |fun ring(abc: String): String {
+            |    return "My precious " + abc
+            |}
+            |/src/wasm/kotlin/test/source.kt
             |package test
             |
             |fun ring(abc: String): String {
@@ -181,37 +202,70 @@ class SinceKotlinTest : AbstractRenderingTest() {
     }
 
     @Test
+    @OnlyDescriptorsMPP("SinceKotlin is unresolved in platform source sets")
     fun `mpp fun with SinceKotlin annotation`() {
         val configuration =   dokkaConfiguration {
             sourceSets {
                 sourceSet {
-                    sourceRoots = listOf("src/")
+                    sourceRoots = listOf("src/jvm/")
                     classpath = listOfNotNull(jvmStdlibPath)
                     analysisPlatform = "jvm"
                 }
                 sourceSet {
-                    sourceRoots = listOf("src/")
+                    sourceRoots = listOf("src/native/")
                     analysisPlatform = "native"
                 }
                 sourceSet {
-                    sourceRoots = listOf("src/")
+                    sourceRoots = listOf("src/common/")
                     classpath = listOfNotNull(commonStdlibPath)
                     analysisPlatform = "common"
                 }
                 sourceSet {
-                    sourceRoots = listOf("src/")
+                    sourceRoots = listOf("src/js/")
                     classpath = listOfNotNull(jsStdlibPath)
                     analysisPlatform = "js"
                 }
                 sourceSet {
-                    sourceRoots = listOf("src/")
+                    sourceRoots = listOf("src/wasm/")
                     analysisPlatform = "wasm"
                 }
             }
         }
         testInline(
             """
-            |/src/main/kotlin/test/source.kt
+            |/src/jvm/kotlin/test/source.kt
+            |package test
+            |
+            |/** dssdd */
+            |@SinceKotlin("1.3")
+            |fun ring(abc: String): String {
+            |    return "My precious " + abc
+            |}            
+            |/src/native/kotlin/test/source.kt
+            |package test
+            |
+            |/** dssdd */
+            |@SinceKotlin("1.3")
+            |fun ring(abc: String): String {
+            |    return "My precious " + abc
+            |}
+            |/src/common/kotlin/test/source.kt
+            |package test
+            |
+            |/** dssdd */
+            |@SinceKotlin("1.3")
+            |fun ring(abc: String): String {
+            |    return "My precious " + abc
+            |}            
+            |/src/js/kotlin/test/source.kt
+            |package test
+            |
+            |/** dssdd */
+            |@SinceKotlin("1.3")
+            |fun ring(abc: String): String {
+            |    return "My precious " + abc
+            |}            
+            |/src/wasm/kotlin/test/source.kt
             |package test
             |
             |/** dssdd */
@@ -226,7 +280,7 @@ class SinceKotlinTest : AbstractRenderingTest() {
                     .children.filter { it.name == "ring" && it is DFunction } as List<DFunction>
                 with(funcs) {
                     val sinceKotlin = mapOf(
-                        Platform.common to SinceKotlinVersion("1.3"),
+                       // Platform.common to SinceKotlinVersion("1.3"),
                         Platform.jvm to SinceKotlinVersion("1.3"),
                         Platform.js to SinceKotlinVersion("1.3"),
                         Platform.native to SinceKotlinVersion("1.3"),
@@ -238,7 +292,7 @@ class SinceKotlinTest : AbstractRenderingTest() {
                             find { it.sourceSets.first().analysisPlatform == i.key }?.documentation?.values?.first()
                                 ?.dfs { it is CustomTagWrapper && it.name == "Since Kotlin" }
                                 .assertNotNull("SinceKotlin[${i.key}]")
-                        assertEquals((tag.children.first() as Text).body, i.value.toString())
+                        assertEquals(i.value.toString(), (tag.children.first() as Text).body , "Platform ${i.key}")
                     }
                 }
             }

--- a/plugins/base/src/test/kotlin/content/annotations/SinceKotlinTest.kt
+++ b/plugins/base/src/test/kotlin/content/annotations/SinceKotlinTest.kt
@@ -202,7 +202,6 @@ class SinceKotlinTest : AbstractRenderingTest() {
     }
 
     @Test
-    @OnlyDescriptorsMPP("SinceKotlin is unresolved in platform source sets")
     fun `mpp fun with SinceKotlin annotation`() {
         val configuration =   dokkaConfiguration {
             sourceSets {

--- a/plugins/base/src/test/kotlin/content/annotations/SinceKotlinTest.kt
+++ b/plugins/base/src/test/kotlin/content/annotations/SinceKotlinTest.kt
@@ -128,18 +128,22 @@ class SinceKotlinTest : AbstractRenderingTest() {
                 sourceSet {
                     sourceRoots = listOf("src/native/")
                     analysisPlatform = "native"
+                    name = "native"
                 }
                 sourceSet {
                     sourceRoots = listOf("src/common/")
                     analysisPlatform = "common"
+                    name = "common"
                 }
                 sourceSet {
                     sourceRoots = listOf("src/js/")
                     analysisPlatform = "js"
+                    name = "js"
                 }
                 sourceSet {
                     sourceRoots = listOf("src/wasm/")
                     analysisPlatform = "wasm"
+                    name = "wasm"
                 }
             }
         }
@@ -213,20 +217,24 @@ class SinceKotlinTest : AbstractRenderingTest() {
                 sourceSet {
                     sourceRoots = listOf("src/native/")
                     analysisPlatform = "native"
+                    name = "native"
                 }
                 sourceSet {
                     sourceRoots = listOf("src/common/")
                     classpath = listOfNotNull(commonStdlibPath)
                     analysisPlatform = "common"
+                    name = "common"
                 }
                 sourceSet {
                     sourceRoots = listOf("src/js/")
                     classpath = listOfNotNull(jsStdlibPath)
                     analysisPlatform = "js"
+                    name = "js"
                 }
                 sourceSet {
                     sourceRoots = listOf("src/wasm/")
                     analysisPlatform = "wasm"
+                    name = "wasm"
                 }
             }
         }
@@ -279,7 +287,7 @@ class SinceKotlinTest : AbstractRenderingTest() {
                     .children.filter { it.name == "ring" && it is DFunction } as List<DFunction>
                 with(funcs) {
                     val sinceKotlin = mapOf(
-                       // Platform.common to SinceKotlinVersion("1.3"),
+                        Platform.common to SinceKotlinVersion("1.3"),
                         Platform.jvm to SinceKotlinVersion("1.3"),
                         Platform.js to SinceKotlinVersion("1.3"),
                         Platform.native to SinceKotlinVersion("1.3"),

--- a/plugins/base/src/test/kotlin/content/exceptions/ContentForExceptions.kt
+++ b/plugins/base/src/test/kotlin/content/exceptions/ContentForExceptions.kt
@@ -339,7 +339,6 @@ class ContentForExceptions : BaseAbstractTest() {
         }
     }
 
-    @OnlyDescriptorsMPP("Return type for native `function` should be null rather than kotlin/Unit")
     @Test
     fun `throws in merged functions`() {
         testInline(

--- a/plugins/base/src/test/kotlin/content/seealso/ContentForSeeAlsoTest.kt
+++ b/plugins/base/src/test/kotlin/content/seealso/ContentForSeeAlsoTest.kt
@@ -759,7 +759,6 @@ class ContentForSeeAlsoTest : BaseAbstractTest() {
         }
     }
 
-    @OnlyDescriptorsMPP
     @Test
     fun `multiplatform class with seealso in few platforms`() {
         testInline(

--- a/plugins/base/src/test/kotlin/linkableContent/LinkableContentTest.kt
+++ b/plugins/base/src/test/kotlin/linkableContent/LinkableContentTest.kt
@@ -20,12 +20,11 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
-import utils.OnlyDescriptors
 import utils.OnlyDescriptorsMPP
 
 class LinkableContentTest : BaseAbstractTest() {
 
-    @OnlyDescriptorsMPP
+    @OnlyDescriptorsMPP("#3238")
     @Test
     fun `Include module and package documentation`() {
 
@@ -151,7 +150,7 @@ class LinkableContentTest : BaseAbstractTest() {
         }
     }
 
-    @OnlyDescriptorsMPP
+    @OnlyDescriptorsMPP("#3238")
     @Test
     fun `Samples multiplatform documentation`() {
 

--- a/plugins/base/src/test/kotlin/linkableContent/LinkableContentTest.kt
+++ b/plugins/base/src/test/kotlin/linkableContent/LinkableContentTest.kt
@@ -286,7 +286,7 @@ class LinkableContentTest : BaseAbstractTest() {
             sourceSets {
                 sourceSet {
                     analysisPlatform = "js"
-                    sourceRoots = listOf("jsMain", "commonMain", "jvmAndJsSecondCommonMain").map {
+                    sourceRoots = listOf("jsMain").map {
                         Paths.get("$testDataDir/$it/kotlin").toString()
                     }
                     name = "js"
@@ -294,7 +294,7 @@ class LinkableContentTest : BaseAbstractTest() {
                 }
                 sourceSet {
                     analysisPlatform = "jvm"
-                    sourceRoots = listOf("jvmMain", "commonMain", "jvmAndJsSecondCommonMain").map {
+                    sourceRoots = listOf("jvmMain").map {
                         Paths.get("$testDataDir/$it/kotlin").toString()
                     }
                     name = "jvm"

--- a/plugins/base/src/test/kotlin/model/InheritorsTest.kt
+++ b/plugins/base/src/test/kotlin/model/InheritorsTest.kt
@@ -60,15 +60,22 @@ class InheritorsTest : AbstractModelTest("/src/main/kotlin/inheritors/Test.kt", 
     fun multiplatform() {
         val configuration = dokkaConfiguration {
             sourceSets {
+                val commonSourceSet = sourceSet {
+                    name = "common"
+                    sourceRoots = listOf("common/src/")
+                    analysisPlatform = "common"
+                }
                 sourceSet {
                     name = "jvm"
-                    sourceRoots = listOf("common/src/", "jvm/src/")
+                    sourceRoots = listOf("jvm/src/")
                     analysisPlatform = "jvm"
+                    dependentSourceSets =  setOf(commonSourceSet.value.sourceSetID)
                 }
                 sourceSet {
                     name = "js"
-                    sourceRoots = listOf("common/src/", "js/src/")
+                    sourceRoots = listOf("js/src/")
                     analysisPlatform = "js"
+                    dependentSourceSets =  setOf(commonSourceSet.value.sourceSetID)
                 }
             }
         }

--- a/plugins/base/src/test/kotlin/signatures/DivergentSignatureTest.kt
+++ b/plugins/base/src/test/kotlin/signatures/DivergentSignatureTest.kt
@@ -7,10 +7,8 @@ package signatures
 import utils.TestOutputWriterPlugin
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import utils.OnlyDescriptors
-import utils.OnlyDescriptorsMPP
 
-@OnlyDescriptorsMPP
+
 class DivergentSignatureTest : AbstractRenderingTest() {
 
     @Test

--- a/plugins/base/src/test/kotlin/signatures/SignatureTest.kt
+++ b/plugins/base/src/test/kotlin/signatures/SignatureTest.kt
@@ -555,7 +555,6 @@ class SignatureTest : BaseAbstractTest() {
             }
         }
     }
-    @OnlyDescriptorsMPP
     @Test
     fun `actual typealias should have generic parameters and fully qualified name of the expansion type`() {
         val writerPlugin = TestOutputWriterPlugin()

--- a/plugins/base/src/test/kotlin/signatures/SignatureTest.kt
+++ b/plugins/base/src/test/kotlin/signatures/SignatureTest.kt
@@ -589,7 +589,6 @@ class SignatureTest : BaseAbstractTest() {
         }
     }
 
-    @OnlyDescriptorsMPP
     @Test
     fun `type with an actual typealias`() {
         val writerPlugin = TestOutputWriterPlugin()

--- a/plugins/base/src/test/kotlin/transformers/ModuleAndPackageDocumentationTransformerFunctionalTest.kt
+++ b/plugins/base/src/test/kotlin/transformers/ModuleAndPackageDocumentationTransformerFunctionalTest.kt
@@ -15,7 +15,7 @@ import kotlin.test.assertEquals
 
 class ModuleAndPackageDocumentationTransformerFunctionalTest : BaseAbstractTest() {
 
-    @OnlyDescriptorsMPP
+    @OnlyDescriptorsMPP("#3238")
     @Test
     fun `multiplatform project`(@TempDir tempDir: Path) {
         val include = tempDir.resolve("include.md").toFile()

--- a/plugins/base/src/test/kotlin/transformers/SourceLinkTransformerTest.kt
+++ b/plugins/base/src/test/kotlin/transformers/SourceLinkTransformerTest.kt
@@ -9,7 +9,6 @@ import org.jetbrains.dokka.SourceLinkDefinitionImpl
 import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
 import org.jsoup.nodes.Element
 import signatures.renderedContent
-import utils.OnlyDescriptorsMPP
 import utils.TestOutputWriterPlugin
 import java.net.URL
 import kotlin.test.Test
@@ -71,7 +70,6 @@ class SourceLinkTransformerTest : BaseAbstractTest() {
         }
     }
 
-    @OnlyDescriptorsMPP
     @Test
     fun `source link should be for actual typealias`() {
         val mppConfiguration = dokkaConfiguration {

--- a/subprojects/analysis-kotlin-symbols/build.gradle.kts
+++ b/subprojects/analysis-kotlin-symbols/build.gradle.kts
@@ -72,6 +72,9 @@ dependencies {
             isTransitive = false // see KTIJ-19820
         }
     }
+    // copy-pasted from Analysis API https://github.com/JetBrains/kotlin/blob/a10042f9099e20a656dec3ecf1665eea340a3633/analysis/low-level-api-fir/build.gradle.kts#L37
+    runtimeOnly("com.github.ben-manes.caffeine:caffeine:2.9.3")
+
     runtimeOnly(libs.kotlinx.collections.immutable)
     implementation(libs.kotlin.compiler.k2) {
         isTransitive = false
@@ -79,6 +82,7 @@ dependencies {
 
     // TODO [beresnev] get rid of it
     compileOnly(libs.kotlinx.coroutines.core)
+
 }
 
 tasks {

--- a/subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/kdoc/java/KotlinDocCommentParser.kt
+++ b/subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/kdoc/java/KotlinDocCommentParser.kt
@@ -39,7 +39,7 @@ internal class KotlinDocCommentParser(
         }
         val kotlinAnalysis = context.plugin<SymbolsAnalysisPlugin>().querySingle { kotlinAnalysis }
         val elementName = element.resolveDocContext.ktElement.name
-        return analyze(kotlinAnalysis[sourceSet].mainModule) {
+        return analyze(kotlinAnalysis.getModule(sourceSet)) {
             parseFromKDocTag(
                 kDocTag = element.comment,
                 externalDri = { link -> resolveKDocLink(link).ifUnresolved { context.logger.logUnresolvedLink(link.getLinkText(), elementName) } },

--- a/subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/kdoc/moduledocs/ModuleAndPackageDocumentationParsingContext.kt
+++ b/subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/kdoc/moduledocs/ModuleAndPackageDocumentationParsingContext.kt
@@ -36,8 +36,8 @@ internal fun ModuleAndPackageDocumentationParsingContext(
     if (kotlinAnalysis == null || sourceSet == null) {
         MarkdownParser(externalDri = { null }, sourceLocation)
     } else {
-        val analysisContext = kotlinAnalysis[sourceSet]
-        val contextPsi = analyze(analysisContext.mainModule) {
+        val sourceModule = kotlinAnalysis.getModule(sourceSet)
+        val contextPsi = analyze(sourceModule) {
             val contextSymbol = when (fragment.classifier) {
                 Module -> ROOT_PACKAGE_SYMBOL
                 Package -> getPackageSymbolIfPackageExists(FqName(fragment.name))
@@ -46,7 +46,7 @@ internal fun ModuleAndPackageDocumentationParsingContext(
         }
         MarkdownParser(
             externalDri = { link ->
-                analyze(analysisContext.mainModule) {
+                analyze(sourceModule) {
                     resolveKDocTextLink(
                         link,
                         contextPsi

--- a/subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/kdoc/moduledocs/ModuleAndPackageDocumentationReader.kt
+++ b/subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/kdoc/moduledocs/ModuleAndPackageDocumentationReader.kt
@@ -38,7 +38,7 @@ private class ContextModuleAndPackageDocumentationReader(
     ): SourceSetDependent<DocumentationNode> {
         return sourceSets.associateWithNotNull { sourceSet ->
             val fragments = documentationFragments[sourceSet].orEmpty().filter(predicate)
-            kotlinAnalysis[sourceSet] // test: to throw exception for unknown sourceSet
+            kotlinAnalysis.getModule(sourceSet)// test: to throw exception for unknown sourceSet
             val documentations = fragments.map { fragment ->
                 parseModuleAndPackageDocumentation(
                     context = ModuleAndPackageDocumentationParsingContext(context.logger, kotlinAnalysis, sourceSet),

--- a/subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/AnalysisContext.kt
+++ b/subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/AnalysisContext.kt
@@ -40,6 +40,9 @@ internal class KotlinAnalysis(
     fun getModule(sourceSet: DokkaConfiguration.DokkaSourceSet) =
         sourceModules[sourceSet] ?: error("Missing a source module for sourceSet ${sourceSet.displayName} with id ${sourceSet.sourceSetID}")
 
+    fun getModuleOrNull(sourceSet: DokkaConfiguration.DokkaSourceSet) =
+        sourceModules[sourceSet]
+
     val modulesWithFiles
         get() = analysisSession.modulesWithFiles
 

--- a/subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/AnalysisContext.kt
+++ b/subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/AnalysisContext.kt
@@ -5,137 +5,43 @@
 package org.jetbrains.dokka.analysis.kotlin.symbols.plugin
 
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import org.jetbrains.dokka.DokkaConfiguration
-import org.jetbrains.dokka.DokkaSourceSetID
 import org.jetbrains.dokka.model.SourceSetDependent
 import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.kotlin.analysis.api.standalone.StandaloneAnalysisAPISession
 import org.jetbrains.kotlin.analysis.project.structure.KtSourceModule
 import java.io.Closeable
-import java.io.File
 
-@Suppress("FunctionName", "UNUSED_PARAMETER")
 internal fun SamplesKotlinAnalysis(
     sourceSets: List<DokkaConfiguration.DokkaSourceSet>,
     context: DokkaContext,
-    projectKotlinAnalysis: KotlinAnalysis
-): KotlinAnalysis {
-    val environments = sourceSets
-        .filter { it.samples.isNotEmpty() }
-        .associateWith { sourceSet ->
-            createAnalysisContext(
-                classpath = sourceSet.classpath,
-                sourceRoots = sourceSet.samples,
-                sourceSet = sourceSet
-            )
-        }
-
-    return EnvironmentKotlinAnalysis(environments, projectKotlinAnalysis)
-}
+): KotlinAnalysis = createAnalysisSession(
+    sourceSets = sourceSets,
+    logger = context.logger,
+    isSampleProject = true
+)
 
 internal fun ProjectKotlinAnalysis(
     sourceSets: List<DokkaConfiguration.DokkaSourceSet>,
     context: DokkaContext,
-): KotlinAnalysis {
-    val environments = sourceSets.associateWith { sourceSet ->
-        createAnalysisContext(
-            context = context,
-            sourceSets = sourceSets,
-            sourceSet = sourceSet
-        )
-    }
-    return EnvironmentKotlinAnalysis(environments)
-}
+): KotlinAnalysis = createAnalysisSession(
+    sourceSets = sourceSets,
+    logger = context.logger
+)
 
-
-@Suppress("UNUSED_PARAMETER")
-internal fun createAnalysisContext(
-    context: DokkaContext,
-    sourceSets: List<DokkaConfiguration.DokkaSourceSet>,
-    sourceSet: DokkaConfiguration.DokkaSourceSet
-): AnalysisContext {
-    val parentSourceSets = sourceSets.filter { it.sourceSetID in sourceSet.dependentSourceSets }
-    val classpath = sourceSet.classpath + parentSourceSets.flatMap { it.classpath }
-    val sources = sourceSet.sourceRoots + parentSourceSets.flatMap { it.sourceRoots }
-
-    return createAnalysisContext(classpath, sources, sourceSet)
-}
-
-internal fun createAnalysisContext(
-    classpath: List<File>,
-    sourceRoots: Set<File>,
-    sourceSet: DokkaConfiguration.DokkaSourceSet
-): AnalysisContext {
-    val applicationDisposable: Disposable = Disposer.newDisposable("StandaloneAnalysisAPISession.application")
-    val projectDisposable: Disposable = Disposer.newDisposable("StandaloneAnalysisAPISession.project")
-
-    val analysis= createAnalysisSession(
-        classpath = classpath,
-        sourceRoots = sourceRoots,
-        analysisPlatform = sourceSet.analysisPlatform,
-        languageVersion = sourceSet.languageVersion,
-        apiVersion = sourceSet.apiVersion,
-        applicationDisposable = applicationDisposable,
-        projectDisposable = projectDisposable
-    )
-    return AnalysisContextImpl(
-        mainModule = analysis.second,
-        analysisSession = analysis.first,
-        applicationDisposable = applicationDisposable,
-        projectDisposable = projectDisposable
-    )
-}
-
-
-/**
- * First child delegation. It does not close [parent].
- */
-internal abstract class KotlinAnalysis(
-    private val parent: KotlinAnalysis? = null
-) : Closeable {
-
-    operator fun get(key: DokkaConfiguration.DokkaSourceSet): AnalysisContext {
-        return get(key.sourceSetID)
-    }
-
-    internal operator fun get(key: DokkaSourceSetID): AnalysisContext {
-        return find(key)
-            ?: parent?.get(key)
-            ?: throw IllegalStateException("Missing EnvironmentAndFacade for sourceSet $key")
-    }
-
-    internal abstract fun find(sourceSetID: DokkaSourceSetID): AnalysisContext?
-}
-
-internal open class EnvironmentKotlinAnalysis(
-    private val environments: SourceSetDependent<AnalysisContext>,
-    parent: KotlinAnalysis? = null,
-) : KotlinAnalysis(parent = parent) {
-
-    override fun find(sourceSetID: DokkaSourceSetID): AnalysisContext? =
-        environments.entries.firstOrNull { (sourceSet, _) -> sourceSet.sourceSetID == sourceSetID }?.value
-
-    override fun close() {
-        environments.values.forEach(AnalysisContext::close)
-    }
-}
-
-internal interface AnalysisContext: Closeable {
-    val project: Project
-    val mainModule: KtSourceModule
-    val analysisSession: StandaloneAnalysisAPISession
-}
-
-private class AnalysisContextImpl(
-    override val mainModule: KtSourceModule,
-    override val analysisSession: StandaloneAnalysisAPISession,
+internal class KotlinAnalysis(
+    private val sourceModules: SourceSetDependent<KtSourceModule>,
+    private val analysisSession: StandaloneAnalysisAPISession,
     private val applicationDisposable: Disposable,
     private val projectDisposable: Disposable
-) : AnalysisContext {
-    override val project: Project
-        get() = analysisSession.project
+) : Closeable {
+
+    fun getModule(sourceSet: DokkaConfiguration.DokkaSourceSet) =
+        sourceModules[sourceSet] ?: error("Missing a source module for sourceSet ${sourceSet.displayName} with id ${sourceSet.sourceSetID}")
+
+    val modulesWithFiles
+        get() = analysisSession.modulesWithFiles
 
     override fun close() {
         Disposer.dispose(applicationDisposable)

--- a/subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/services/KotlinAnalysisProjectProvider.kt
+++ b/subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/services/KotlinAnalysisProjectProvider.kt
@@ -15,6 +15,6 @@ import org.jetbrains.dokka.plugability.querySingle
 internal class KotlinAnalysisProjectProvider : ProjectProvider {
     override fun getProject(sourceSet: DokkaConfiguration.DokkaSourceSet, context: DokkaContext): Project {
         val kotlinAnalysis = context.plugin<SymbolsAnalysisPlugin>().querySingle { kotlinAnalysis }
-        return kotlinAnalysis[sourceSet].project
+        return kotlinAnalysis.getModule(sourceSet).project
     }
 }

--- a/subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/services/KotlinSampleProvider.kt
+++ b/subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/services/KotlinSampleProvider.kt
@@ -73,10 +73,10 @@ public open class KotlinSampleProvider(
      * @return [SampleProvider.SampleSnippet] or null if it has not found by [fqLink]
      */
     override fun getSample(sourceSet: DokkaConfiguration.DokkaSourceSet, fqLink: String): SampleProvider.SampleSnippet? {
-        return getSampleFromModule(kotlinAnalysisOfRegularSources.getModule(sourceSet), fqLink) ?: getSampleFromModule(
-            kotlinAnalysisOfRegularSources.getModule(sourceSet),
-            fqLink
-        )
+        return kotlinAnalysisOfSamples.getModuleOrNull(sourceSet)?.let { getSampleFromModule(it, fqLink) }
+            ?: getSampleFromModule(
+                kotlinAnalysisOfRegularSources.getModule(sourceSet), fqLink
+            )
     }
     private fun getSampleFromModule(module: KtSourceModule, fqLink: String): SampleProvider.SampleSnippet? {
         val psiElement = analyze(module) {

--- a/subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/services/SymbolExternalDocumentablesProvider.kt
+++ b/subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/services/SymbolExternalDocumentablesProvider.kt
@@ -24,10 +24,9 @@ internal class SymbolExternalDocumentablesProvider(val context: DokkaContext) : 
     override fun findClasslike(dri: DRI, sourceSet: DokkaSourceSet): DClasslike? {
         val classId = getClassIdFromDRI(dri)
 
-        val analysisContext = kotlinAnalysis[sourceSet]
-        return analyze(analysisContext.mainModule) {
+        return analyze(kotlinAnalysis.getModule(sourceSet)) {
             val symbol = getClassOrObjectSymbolByClassId(classId) as? KtNamedClassOrObjectSymbol?: return@analyze null
-            val translator = DokkaSymbolVisitor(sourceSet, sourceSet.displayName, analysisContext, logger = context.logger)
+            val translator = DokkaSymbolVisitor(sourceSet, sourceSet.displayName, kotlinAnalysis, logger = context.logger)
 
             val parentDRI = symbol.getContainingSymbol()?.let { getDRIFromSymbol(it) } ?: /* top level */ DRI(dri.packageName)
             with(translator) {

--- a/subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/services/SymbolFullClassHierarchyBuilder.kt
+++ b/subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/services/SymbolFullClassHierarchyBuilder.kt
@@ -79,7 +79,7 @@ internal class SymbolFullClassHierarchyBuilder(val context: DokkaContext) : Full
             documentable.sources.forEach { (sourceSet, source) ->
                 if (source is KtPsiDocumentableSource) {
                     (source.psi as? KtClassOrObject)?.let { psi ->
-                        analyze(kotlinAnalysis[sourceSet].mainModule) {
+                        analyze(kotlinAnalysis.getModule(sourceSet)) {
                             val type = psi.getNamedClassOrObjectSymbol()?.buildSelfClassType() ?: return@analyze
                             hierarchy[sourceSet]?.let { collectSupertypesFromKtType(documentable.dri to type, it) }
                         }

--- a/subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/DRIFactory.kt
+++ b/subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/DRIFactory.kt
@@ -103,7 +103,7 @@ internal fun KtAnalysisSession.getDRIFromSymbol(symbol: KtSymbol): DRI =
         is KtFunctionLikeSymbol -> getDRIFromFunctionLike(symbol)
         is KtClassLikeSymbol -> getDRIFromClassLike(symbol)
         is KtPackageSymbol -> getDRIFromPackage(symbol)
-        else -> throw IllegalStateException("Unknown symbol while creating DRI ")
+        else -> throw IllegalStateException("Unknown symbol while creating DRI $symbol")
     }
 
 private fun KtAnalysisSession.getDRIFromNonCallablePossibleLocalSymbol(symbol: KtSymbol): DRI {


### PR DESCRIPTION
We map [Dokka's source set ](https://kotlinlang.org/docs/dokka-gradle.html#source-set-configuration) directly to [a source module ](https://github.com/JetBrains/kotlin/blob/500de9f9bba5baad7e0f2c9260c298bb21cd5de7/analysis/project-structure/src/org/jetbrains/kotlin/analysis/project/structure/KtModule.kt#L25C27-L25C27) of Analysis API inside one [Analysis Standalone session](https://github.com/JetBrains/kotlin/blob/141333bdcd22c9d257d88dbce50fa8499206a0f8/analysis/analysis-api-standalone/src/org/jetbrains/kotlin/analysis/api/standalone/StandaloneAnalysisAPISession.kt#L18).

Analysis API session is created in `src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/KotlinAnalysis.kt` (see  `fun createAnalysisSession`)

Before the PR, one Dokka's source set corresponded to one Standalone API session with one source module that has source roots from dependent source sets.

The PR allows the enabling of some tests annotated with `OnlyDescriptorsMPP`.  
Also, tests with `OnlyDescriptorsMPP` that have unresolved common symbols are fixed by the new version of Analysis API.
