### PR TITLE
Fix overflow of long underscore separated names in HTML

### DIFF
--- a/dokka-subprojects/plugin-base/api/plugin-base.api
+++ b/dokka-subprojects/plugin-base/api/plugin-base.api
@@ -305,7 +305,7 @@ public abstract interface class org/jetbrains/dokka/base/renderers/html/HtmlCode
 }
 
 public final class org/jetbrains/dokka/base/renderers/html/HtmlFormatingUtilsKt {
-	public static final fun buildBreakableDotSeparatedHtml (Lkotlinx/html/FlowContent;Ljava/lang/String;)V
+	public static final fun buildBreakableCharSeparatedHtml (Lkotlinx/html/FlowContent;Ljava/lang/String;C)V
 	public static final fun buildBreakableText (Lkotlinx/html/FlowContent;Ljava/lang/String;)V
 	public static final fun buildTextBreakableAfterCapitalLetters (Lkotlinx/html/FlowContent;Ljava/lang/String;Z)V
 	public static synthetic fun buildTextBreakableAfterCapitalLetters$default (Lkotlinx/html/FlowContent;Ljava/lang/String;ZILjava/lang/Object;)V

--- a/dokka-subprojects/plugin-base/api/plugin-base.api
+++ b/dokka-subprojects/plugin-base/api/plugin-base.api
@@ -306,6 +306,7 @@ public abstract interface class org/jetbrains/dokka/base/renderers/html/HtmlCode
 
 public final class org/jetbrains/dokka/base/renderers/html/HtmlFormatingUtilsKt {
 	public static final fun buildBreakableCharSeparatedHtml (Lkotlinx/html/FlowContent;Ljava/lang/String;C)V
+	public static final fun buildBreakableDotSeparatedHtml (Lkotlinx/html/FlowContent;Ljava/lang/String;)V
 	public static final fun buildBreakableText (Lkotlinx/html/FlowContent;Ljava/lang/String;)V
 	public static final fun buildTextBreakableAfterCapitalLetters (Lkotlinx/html/FlowContent;Ljava/lang/String;Z)V
 	public static synthetic fun buildTextBreakableAfterCapitalLetters$default (Lkotlinx/html/FlowContent;Ljava/lang/String;ZILjava/lang/Object;)V

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/renderers/html/htmlFormatingUtils.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/renderers/html/htmlFormatingUtils.kt
@@ -24,7 +24,18 @@ public fun FlowContent.buildTextBreakableAfterCapitalLetters(name: String, hasLa
 }
 
 /**
- * Makes [name] breakable after each occurrence of [breakableChar].
+ * Makes [name] breakable by inserting `<wbr>` element after each occurrence of `.`.
+ */
+@Deprecated(
+    "`buildBreakableCharSeparatedHtml` should be used instead with `.` as `breakableChar`",
+    ReplaceWith("buildBreakableCharSeparatedHtml(name, '.')")
+)
+public fun FlowContent.buildBreakableDotSeparatedHtml(name: String) {
+    buildBreakableCharSeparatedHtml(name, '.')
+}
+
+/**
+ * Makes [name] breakable by inserting `<wbr>` element after each occurrence of [breakableChar].
  */
 public fun FlowContent.buildBreakableCharSeparatedHtml(name: String, breakableChar: Char) {
     val phrases = name.split(breakableChar)

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/renderers/html/htmlFormatingUtils.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/renderers/html/htmlFormatingUtils.kt
@@ -23,14 +23,17 @@ public fun FlowContent.buildTextBreakableAfterCapitalLetters(name: String, hasLa
     }
 }
 
-public fun FlowContent.buildBreakableDotSeparatedHtml(name: String) {
-    val phrases = name.split(".")
+/**
+ * Makes [name] breakable after each occurrence of [breakableChar].
+ */
+public fun FlowContent.buildBreakableCharSeparatedHtml(name: String, breakableChar: Char) {
+    val phrases = name.split(breakableChar)
     phrases.forEachIndexed { i, e ->
-        val elementWithOptionalDot = e.takeIf { i == phrases.lastIndex } ?: "$e."
+        val elementWithOptionalChar = e.takeIf { i == phrases.lastIndex } ?: "$e$breakableChar"
         if (e.length > 10) {
-            buildTextBreakableAfterCapitalLetters(elementWithOptionalDot, hasLastElement = i == phrases.lastIndex)
+            buildTextBreakableAfterCapitalLetters(elementWithOptionalChar, hasLastElement = i == phrases.lastIndex)
         } else {
-            buildBreakableHtmlElement(elementWithOptionalDot, i == phrases.lastIndex)
+            buildBreakableHtmlElement(elementWithOptionalChar, i == phrases.lastIndex)
         }
     }
 }
@@ -62,6 +65,7 @@ private fun FlowContent.buildBreakableHtmlElement(element: String, last: Boolean
 }
 
 public fun FlowContent.buildBreakableText(name: String) {
-    if (name.contains(".")) buildBreakableDotSeparatedHtml(name)
+    if (name.contains(".")) buildBreakableCharSeparatedHtml(name, '.')
+    else if (name.contains("_")) buildBreakableCharSeparatedHtml(name, '_')
     else buildTextBreakableAfterCapitalLetters(name, hasLastElement = true)
 }

--- a/dokka-subprojects/plugin-base/src/test/kotlin/renderers/html/FormattingUtilsTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/renderers/html/FormattingUtilsTest.kt
@@ -83,4 +83,22 @@ class FormattingUtilsTest {
 
         assertEquals(expectedHtml.trim(), html.trim())
     }
+
+    @Test
+    fun `should build breakable text for underscore separated notation`(){
+        val testedText = "THIS_IS_UNDERSCORE_SEPARATED"
+        val expectedHtml = """
+            <html>
+              <body><span>THIS_</span><wbr></wbr><span>IS_</span><wbr></wbr><span>UNDERSCORE_</span><wbr></wbr><span>SEPARATED</span></body>
+            </html>
+        """.trimIndent()
+
+        val html = createHTML(prettyPrint = true).html {
+            body {
+                buildBreakableText(testedText)
+            }
+        }
+
+        assertEquals(expectedHtml.trim(), html.trim())
+    }
 }


### PR DESCRIPTION
This PR makes underscore separated names breakable after each underscore similar to how names separated by dots are rendered.

Resolves #3093.