### PR TITLE
Fix overflow of long names in HTML

### DIFF
--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/renderers/html/HtmlRenderer.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/renderers/html/HtmlRenderer.kt
@@ -899,8 +899,7 @@ public open class HtmlRenderer(
                     buildText(textNode, unappliedStyles - styleToApply)
                 }
             }
-            textNode.hasStyle(ContentStyle.RowTitle) || textNode.hasStyle(TextStyle.Cover) ||
-                    textNode.hasStyle(TextStyle.Monospace) ->
+            textNode.hasStyle(ContentStyle.RowTitle) || textNode.hasStyle(TextStyle.Cover) ->
                 buildBreakableText(textNode.text)
             else -> text(textNode.text)
         }

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/renderers/html/HtmlRenderer.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/renderers/html/HtmlRenderer.kt
@@ -899,7 +899,8 @@ public open class HtmlRenderer(
                     buildText(textNode, unappliedStyles - styleToApply)
                 }
             }
-            textNode.hasStyle(ContentStyle.RowTitle) || textNode.hasStyle(TextStyle.Cover) ->
+            textNode.hasStyle(ContentStyle.RowTitle) || textNode.hasStyle(TextStyle.Cover) ||
+                    textNode.hasStyle(TextStyle.Monospace) ->
                 buildBreakableText(textNode.text)
             else -> text(textNode.text)
         }

--- a/dokka-subprojects/plugin-base/src/main/resources/dokka/styles/style.css
+++ b/dokka-subprojects/plugin-base/src/main/resources/dokka/styles/style.css
@@ -247,6 +247,7 @@ td:first-child {
     display: flex;
     flex-direction: column;
     height: 100%;
+    word-break: break-word;
 }
 
 /* --- Navigation styles --- */


### PR DESCRIPTION
This PR aims to fix the issue that long names sometimes overflow in the generated HTML pages.

The CSS property word-break: break-word is added to the root style to prevent any general overflows.
`ContentText` nodes with the `Monospace` style are made breakable since long names can occur in code blocks as well.

Resolves #3241.