### PR TITLE
Opt-in `ExperimentalCoroutinesApi` for `newSingleThreadContext`

### DIFF
--- a/plugins/base/src/main/kotlin/generation/SingleModuleGeneration.kt
+++ b/plugins/base/src/main/kotlin/generation/SingleModuleGeneration.kt
@@ -4,10 +4,7 @@
 
 package org.jetbrains.dokka.base.generation
 
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.newSingleThreadContext
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.*
 import org.jetbrains.dokka.CoreExtensions
 import org.jetbrains.dokka.DokkaConfiguration
 import org.jetbrains.dokka.DokkaException
@@ -66,7 +63,7 @@ public class SingleModuleGeneration(private val context: DokkaContext) : Generat
     /**
      * Implementation note: it runs in a separated single thread due to existing support of coroutines (see #2936)
      */
-    @OptIn(DelicateCoroutinesApi::class)
+    @OptIn(DelicateCoroutinesApi::class, ExperimentalCoroutinesApi::class)
     public fun createDocumentationModels(): List<DModule> = newSingleThreadContext("Generating documentable model").use { coroutineContext -> // see https://github.com/Kotlin/dokka/issues/3151
         runBlocking(coroutineContext) {
             context.configuration.sourceSets.parallelMap { sourceSet -> translateSources(sourceSet, context) }.flatten()

--- a/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/translator/DefaultDescriptorToDocumentableTranslator.kt
+++ b/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/translator/DefaultDescriptorToDocumentableTranslator.kt
@@ -124,7 +124,7 @@ internal class DefaultDescriptorToDocumentableTranslator(
     /**
      * Implementation note: it runs in a separated single thread due to existing support of coroutines (see #2936)
      */
-    @OptIn(DelicateCoroutinesApi::class)
+    @OptIn(DelicateCoroutinesApi::class, ExperimentalCoroutinesApi::class)
     override fun translateClassDescriptor(descriptor: ClassDescriptor, sourceSet: DokkaSourceSet): DClasslike {
         val driInfo = DRI.from(descriptor.parents.first()).withEmptyInfo()
 


### PR DESCRIPTION
It was marked experimental in a new version of coroutines https://github.com/Kotlin/kotlinx.coroutines/commit/042720589c6f438f77d84254bd2dceb569f0184, after 5a6fab535b68916a28d922d5d7a294fa432b7d6b