### PR TITLE
Update Kotlin compiler and KGP to 1.9.20-RC2

### DIFF
--- a/core/test-api/src/main/kotlin/testApi/testRunner/TestRunner.kt
+++ b/core/test-api/src/main/kotlin/testApi/testRunner/TestRunner.kt
@@ -191,12 +191,11 @@ public abstract class AbstractTest<M : TestMethods, T : TestBuilder<M>, D : Dokk
             ?.replaceAfter(".jar", "")
     }
 
-    protected val commonStdlibPath: String? by lazy {
-        // TODO: feels hacky, find a better way to do it
-        ClassLoader.getSystemResource("kotlin/UInt.kotlin_metadata")
-            ?.file
-            ?.replace("file:", "")
-            ?.replaceAfter(".jar", "")
+    protected val commonStdlibPath: String?  by lazy {
+        // `kotlin-stdlib-common` is legacy
+        // we can use any platform dependency
+        // since common code should be resolved with all platform
+        jvmStdlibPath
     }
 
     protected val stdlibExternalDocumentationLink: ExternalDocumentationLinkImpl = ExternalDocumentationLinkImpl(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ kotlinx-collections-immutable = "0.3.6"
 kotlinx-bcv = "0.13.2"
 
 ## Analysis
-kotlin-compiler = "1.9.10"
+kotlin-compiler = "1.9.20-RC2"
 kotlin-compiler-k2 = "2.0.0-dev-5387"
 
 # MUST match the version of the intellij platform used in the kotlin compiler,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 
-gradlePlugin-kotlin = "1.9.10"
+gradlePlugin-kotlin = "1.9.20-RC2"
 # See: https://kotlinlang.org/docs/gradle-configure-project.html#apply-the-plugin
 gradlePlugin-android = "4.2.2"
 gradlePlugin-dokka = "1.9.10"

--- a/integration-tests/gradle/projects/it-multiplatform-0/build.gradle.kts
+++ b/integration-tests/gradle/projects/it-multiplatform-0/build.gradle.kts
@@ -16,7 +16,7 @@ kotlin {
     jvm()
     linuxX64("linux")
     macosX64("macos")
-    js(BOTH)
+    js(IR) // Starting with Kotlin 1.9.0, using compiler types LEGACY or BOTH leads to an error.
     //TODO Add wasm when kx.coroutines will be supported and published into the main repo
     sourceSets {
         val commonMain by sourceSets.getting

--- a/integration-tests/gradle/projects/it-multiplatform-0/gradle.properties
+++ b/integration-tests/gradle/projects/it-multiplatform-0/gradle.properties
@@ -3,7 +3,3 @@
 #
 
 dokka_it_kotlin_version=1.9.10
-#these flags are enabled by default since 1.6.20.
-#remove when this test is executed with Kotlin >= 1.6.20
-kotlin.mpp.enableGranularSourceSetsMetadata=true
-kotlin.native.enableDependencyPropagation=false

--- a/integration-tests/gradle/projects/it-wasm-basic/build.gradle.kts
+++ b/integration-tests/gradle/projects/it-wasm-basic/build.gradle.kts
@@ -20,7 +20,7 @@ repositories {
 kotlin {
     wasm()
     sourceSets {
-        val wasmJsMain by getting {
+        val wasmMain by getting {
             dependencies {
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4-wasm1")
                 implementation("org.jetbrains.kotlinx:atomicfu-wasm:0.18.5-wasm1")

--- a/integration-tests/gradle/projects/it-wasm-basic/build.gradle.kts
+++ b/integration-tests/gradle/projects/it-wasm-basic/build.gradle.kts
@@ -20,7 +20,7 @@ repositories {
 kotlin {
     wasm()
     sourceSets {
-        val wasmMain by getting {
+        val wasmJsMain by getting {
             dependencies {
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4-wasm1")
                 implementation("org.jetbrains.kotlinx:atomicfu-wasm:0.18.5-wasm1")

--- a/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/Multiplatform0GradleIntegrationTest.kt
+++ b/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/Multiplatform0GradleIntegrationTest.kt
@@ -27,7 +27,19 @@ class Multiplatform0GradleIntegrationTest : AbstractGradleIntegrationTest() {
     @ParameterizedTest(name = "{0}")
     @ArgumentsSource(AllSupportedTestedVersionsArgumentsProvider::class)
     fun execute(buildVersions: BuildVersions) {
-        val result = createGradleRunner(buildVersions, "dokkaHtml", "-i", "-s").buildRelaxed()
+        // `enableGranularSourceSetsMetadata` and  `enableDependencyPropagation` flags are enabled by default since 1.6.20.
+        // remove when this test is executed with Kotlin >= 1.6.20
+        val result = if (buildVersions.kotlinVersion < "1.6.20")
+            createGradleRunner(
+                buildVersions,
+                "dokkaHtml",
+                "-i",
+                "-s",
+                "-Pkotlin.mpp.enableGranularSourceSetsMetadata=true",
+                "-Pkotlin.native.enableDependencyPropagation=false"
+            ).buildRelaxed()
+        else
+            createGradleRunner(buildVersions, "dokkaHtml", "-i", "-s").buildRelaxed()
 
         assertEquals(TaskOutcome.SUCCESS, assertNotNull(result.task(":dokkaHtml")).outcome)
 

--- a/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/TestedVersions.kt
+++ b/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/TestedVersions.kt
@@ -14,7 +14,7 @@ internal open class AllSupportedTestedVersionsArgumentsProvider : TestedVersions
 
 internal object TestedVersions {
 
-    val LATEST = BuildVersions("7.6.2", "1.9.20-RC")
+    val LATEST = BuildVersions("7.6.2", "1.9.20-RC2")
 
     /**
      * All supported Gradle/Kotlin versions, including [LATEST]
@@ -61,6 +61,7 @@ internal object TestedVersions {
         "1.8.20" to "18.2.0-pre.546",
         "1.9.0" to "18.2.0-pre.597",
         "1.9.10" to "18.2.0-pre.597",
+        "1.9.20-RC2" to "18.2.0-pre.635",
     )
 }
 

--- a/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/TestedVersions.kt
+++ b/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/TestedVersions.kt
@@ -14,7 +14,7 @@ internal open class AllSupportedTestedVersionsArgumentsProvider : TestedVersions
 
 internal object TestedVersions {
 
-    val LATEST = BuildVersions("7.6.2", "1.9.10")
+    val LATEST = BuildVersions("7.6.2", "1.9.20-RC")
 
     /**
      * All supported Gradle/Kotlin versions, including [LATEST]
@@ -24,7 +24,7 @@ internal object TestedVersions {
     val ALL_SUPPORTED =
         BuildVersions.permutations(
             gradleVersions = listOf("7.6.2"),
-            kotlinVersions = listOf("1.9.0", "1.8.20", "1.7.20", "1.6.21", "1.5.31"),
+            kotlinVersions = listOf("1.9.10", "1.8.20", "1.7.20", "1.6.21", "1.5.31"),
         ) + BuildVersions.permutations(
             gradleVersions = listOf(*ifExhaustive("7.0", "6.1.1")),
             kotlinVersions = listOf(*ifExhaustive( "1.8.0", "1.7.0", "1.6.0", "1.5.0"))

--- a/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/WasmGradleIntegrationTest.kt
+++ b/integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/WasmGradleIntegrationTest.kt
@@ -20,7 +20,8 @@ internal class WasmTestedVersionsArgumentsProvider : AllSupportedTestedVersionsA
     override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> {
         return super.provideArguments(context).filter {
             val buildVersions = it.get().single() as BuildVersions
-            buildVersions.kotlinVersion >= "1.8.20" // 1.8.20 is the first public version that can be tested with wasm
+            buildVersions.kotlinVersion >= "1.8.20"  && // 1.8.20 is the first public version that can be tested with wasm
+            buildVersions.kotlinVersion <= "1.9.10"// in 1.9.20 wasm target was split into `wasm-js` and `wasm-wasi`
         }
     }
 }

--- a/integration-tests/maven/projects/it-maven/pom.xml
+++ b/integration-tests/maven/projects/it-maven/pom.xml
@@ -11,7 +11,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <kotlin.version>1.9.10</kotlin.version>
+        <kotlin.version>1.9.20-RC</kotlin.version>
     </properties>
     <build>
         <plugins>

--- a/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/resolve/DokkaJsResolverForModuleFactory.kt
+++ b/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/resolve/DokkaJsResolverForModuleFactory.kt
@@ -44,7 +44,6 @@ internal class DokkaJsResolverForModuleFactory(
             metadataFactories.DefaultDescriptorFactory,
             metadataFactories.DefaultPackageFragmentsFactory,
             metadataFactories.flexibleTypeDeserializer,
-            metadataFactories.platformDependentTypeTransformer
         )
     }
 

--- a/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/resolve/DokkaKlibMetadataCommonDependencyContainer.kt
+++ b/subprojects/analysis-kotlin-descriptors/compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/resolve/DokkaKlibMetadataCommonDependencyContainer.kt
@@ -16,7 +16,6 @@ import org.jetbrains.kotlin.library.metadata.DeserializedKlibModuleOrigin
 import org.jetbrains.kotlin.incremental.components.LookupTracker
 import org.jetbrains.kotlin.library.metadata.KlibMetadataFactories
 import org.jetbrains.kotlin.library.KotlinLibrary
-import org.jetbrains.kotlin.library.metadata.NativeTypeTransformer
 import org.jetbrains.kotlin.library.metadata.NullFlexibleTypeDeserializer
 import org.jetbrains.kotlin.library.metadata.parseModuleHeader
 import org.jetbrains.kotlin.name.Name
@@ -107,8 +106,7 @@ internal class DokkaKlibMetadataCommonDependencyContainer(
         KlibMetadataModuleDescriptorFactoryImpl(
             MetadataFactories.DefaultDescriptorFactory,
             MetadataFactories.DefaultPackageFragmentsFactory,
-            MetadataFactories.flexibleTypeDeserializer,
-            MetadataFactories.platformDependentTypeTransformer
+            MetadataFactories.flexibleTypeDeserializer
         )
     }
 
@@ -138,6 +136,5 @@ internal class DokkaKlibMetadataCommonDependencyContainer(
 private val MetadataFactories =
     KlibMetadataFactories(
         { DefaultBuiltIns.Instance },
-        NullFlexibleTypeDeserializer,
-        NativeTypeTransformer()
+        NullFlexibleTypeDeserializer
     )


### PR DESCRIPTION
The current changes are related to https://github.com/JetBrains/kotlin/commit/d797505f06d640b666829bbfb4b7d7c67f812026