### PR TITLE
fix: vulnerability of Woodstox 6.2.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,8 +29,8 @@ kotlinx-html = "0.9.1"
 jetbrains-markdown = "0.5.2"
 
 ## JSON
-jackson = "2.12.7" # jackson 2.13.X does not support kotlin language version 1.4, check before updating
-jacksonDatabind = "2.12.7.1" # fixes CVE-2022-42003
+jackson = "2.13.5" # jackson 2.13.X does not support kotlin language version 1.4, check before updating
+jacksonDatabind = "2.13.5" # fixes CVE-2022-42003
 
 ## Maven
 apacheMaven-core = "3.5.0"


### PR DESCRIPTION
This PR is to fix the vulnerability of Woodstox 6.2.4.
It is critical vulnerability from CVSS score (CVSS score 7.5).
It caused by jackson-databind which use vulnerable library.

It change impact is to need to change Kotlin support version to exclude 1.4, because jackson-databind 2.13 and later are not support Kotlin 1.4.

CLOSE #3194 