### PR TITLE
Implement custom code block renderers support

### DIFF
--- a/dokka-subprojects/plugin-base/api/plugin-base.api
+++ b/dokka-subprojects/plugin-base/api/plugin-base.api
@@ -60,6 +60,7 @@ public final class org/jetbrains/dokka/base/DokkaBase : org/jetbrains/dokka/plug
 	public final fun getExternalLocationProviderFactory ()Lorg/jetbrains/dokka/plugability/ExtensionPoint;
 	public final fun getFallbackMerger ()Lorg/jetbrains/dokka/plugability/Extension;
 	public final fun getFileWriter ()Lorg/jetbrains/dokka/plugability/Extension;
+	public final fun getHtmlCodeBlockRenderers ()Lorg/jetbrains/dokka/plugability/ExtensionPoint;
 	public final fun getHtmlPreprocessors ()Lorg/jetbrains/dokka/plugability/ExtensionPoint;
 	public final fun getHtmlRenderer ()Lorg/jetbrains/dokka/plugability/Extension;
 	public final fun getImmediateHtmlCommandConsumer ()Lorg/jetbrains/dokka/plugability/ExtensionPoint;
@@ -295,6 +296,11 @@ public final class org/jetbrains/dokka/base/renderers/html/CustomResourceInstall
 	public fun <init> (Lorg/jetbrains/dokka/plugability/DokkaContext;)V
 	public final fun getDokkaContext ()Lorg/jetbrains/dokka/plugability/DokkaContext;
 	public fun invoke (Lorg/jetbrains/dokka/pages/RootPageNode;)Lorg/jetbrains/dokka/pages/RootPageNode;
+}
+
+public abstract interface class org/jetbrains/dokka/base/renderers/html/HtmlCodeBlockRenderer {
+	public abstract fun buildCodeBlock (Lkotlinx/html/FlowContent;Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun isApplicable (Ljava/lang/String;Ljava/lang/String;)Z
 }
 
 public final class org/jetbrains/dokka/base/renderers/html/HtmlFormatingUtilsKt {

--- a/dokka-subprojects/plugin-base/api/plugin-base.api
+++ b/dokka-subprojects/plugin-base/api/plugin-base.api
@@ -300,7 +300,7 @@ public final class org/jetbrains/dokka/base/renderers/html/CustomResourceInstall
 
 public abstract interface class org/jetbrains/dokka/base/renderers/html/HtmlCodeBlockRenderer {
 	public abstract fun buildCodeBlock (Lkotlinx/html/FlowContent;Ljava/lang/String;Ljava/lang/String;)V
-	public abstract fun isApplicable (Ljava/lang/String;Ljava/lang/String;)Z
+	public abstract fun isApplicable (Ljava/lang/String;)Z
 }
 
 public final class org/jetbrains/dokka/base/renderers/html/HtmlFormatingUtilsKt {

--- a/dokka-subprojects/plugin-base/api/plugin-base.api
+++ b/dokka-subprojects/plugin-base/api/plugin-base.api
@@ -300,7 +300,8 @@ public final class org/jetbrains/dokka/base/renderers/html/CustomResourceInstall
 
 public abstract interface class org/jetbrains/dokka/base/renderers/html/HtmlCodeBlockRenderer {
 	public abstract fun buildCodeBlock (Lkotlinx/html/FlowContent;Ljava/lang/String;Ljava/lang/String;)V
-	public abstract fun isApplicable (Ljava/lang/String;)Z
+	public abstract fun isApplicableForDefinedLanguage (Ljava/lang/String;)Z
+	public abstract fun isApplicableForUndefinedLanguage (Ljava/lang/String;)Z
 }
 
 public final class org/jetbrains/dokka/base/renderers/html/HtmlFormatingUtilsKt {

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/DokkaBase.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/DokkaBase.kt
@@ -48,6 +48,7 @@ public class DokkaBase : DokkaPlugin() {
     public val externalLocationProviderFactory: ExtensionPoint<ExternalLocationProviderFactory> by extensionPoint()
     public val outputWriter: ExtensionPoint<OutputWriter> by extensionPoint()
     public val htmlPreprocessors: ExtensionPoint<PageTransformer> by extensionPoint()
+    public val htmlCodeBlockRenderers: ExtensionPoint<HtmlCodeBlockRenderer> by extensionPoint()
 
     @Deprecated("It is not used anymore")
     public val tabSortingStrategy: ExtensionPoint<TabSortingStrategy> by extensionPoint()

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/DokkaBase.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/DokkaBase.kt
@@ -48,6 +48,13 @@ public class DokkaBase : DokkaPlugin() {
     public val externalLocationProviderFactory: ExtensionPoint<ExternalLocationProviderFactory> by extensionPoint()
     public val outputWriter: ExtensionPoint<OutputWriter> by extensionPoint()
     public val htmlPreprocessors: ExtensionPoint<PageTransformer> by extensionPoint()
+
+    /**
+     * Extension point for providing custom HTML code block renderers.
+     *
+     * This extension point allows overriding the rendering of code blocks in different programming languages.
+     * Multiple renderers can be installed to support different languages independently.
+     */
     public val htmlCodeBlockRenderers: ExtensionPoint<HtmlCodeBlockRenderer> by extensionPoint()
 
     @Deprecated("It is not used anymore")

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/renderers/html/HtmlCodeBlockRenderer.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/renderers/html/HtmlCodeBlockRenderer.kt
@@ -14,11 +14,9 @@ import kotlinx.html.FlowContent
 public interface HtmlCodeBlockRenderer {
 
     /**
-     * Whether this renderer supports given [language].
-     *
-     * [code] can be useful to determine applicability if [language] is not provided (empty string)
+     * Whether this renderer supports given [language]
      */
-    public fun isApplicable(language: String, code: String): Boolean
+    public fun isApplicable(language: String): Boolean
 
     /**
      * Defines how to render [code] for specified [language] via HTML tags

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/renderers/html/HtmlCodeBlockRenderer.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/renderers/html/HtmlCodeBlockRenderer.kt
@@ -14,12 +14,36 @@ import kotlinx.html.FlowContent
 public interface HtmlCodeBlockRenderer {
 
     /**
-     * Whether this renderer supports given [language]
+     * Whether this renderer supports rendering Markdown code blocks
+     * for the given [language] explicitly specified in the fenced code block definition,
      */
-    public fun isApplicable(language: String): Boolean
+    public fun isApplicableForDefinedLanguage(language: String): Boolean
 
     /**
-     * Defines how to render [code] for specified [language] via HTML tags
+     * Whether this renderer supports rendering Markdown code blocks
+     * for the given [code] when language is not specified in fenced code blocks
+     * or indented code blocks are used.
      */
-    public fun FlowContent.buildCodeBlock(language: String, code: String)
+    public fun isApplicableForUndefinedLanguage(code: String): Boolean
+
+    /**
+     * Defines how to render [code] for specified [language] via HTML tags.
+     *
+     * The value of the [language] will be the same as in the input Markdown fenced code block definition.
+     * In the following example [language] = `kotlin` and [code] = `val a`:
+     * ~~~markdown
+     * ```kotlin
+     * val a
+     * ```
+     * ~~~
+     * The value of the [language] will be `null` if language is not specified in the fenced code block definition
+     * or indented code blocks are used.
+     * In the following example [language] = `null` and [code] = `val a`:
+     * ~~~markdown
+     * ```
+     * val a
+     * ```
+     * ~~~
+     */
+    public fun FlowContent.buildCodeBlock(language: String?, code: String)
 }

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/renderers/html/HtmlCodeBlockRenderer.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/renderers/html/HtmlCodeBlockRenderer.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2014-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package org.jetbrains.dokka.base.renderers.html
+
+import kotlinx.html.FlowContent
+
+/**
+ * Provides an ability to override code blocks rendering differently dependent on the code language.
+ *
+ * Multiple renderers can be installed to support different languages in an independent way.
+ */
+public interface HtmlCodeBlockRenderer {
+
+    /**
+     * Whether this renderer supports given [language].
+     *
+     * [code] can be useful to determine applicability if [language] is not provided (empty string)
+     */
+    public fun isApplicable(language: String, code: String): Boolean
+
+    /**
+     * Defines how to render [code] for specified [language] via HTML tags
+     */
+    public fun FlowContent.buildCodeBlock(language: String, code: String)
+}

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/renderers/html/HtmlRenderer.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/renderers/html/HtmlRenderer.kt
@@ -817,25 +817,24 @@ public open class HtmlRenderer(
         code: ContentCodeBlock,
         pageContext: ContentPage
     ) {
-        val codeText = buildString {
-            code.children.forEach {
-                when (it) {
-                    is ContentText -> append(it.text)
-                    is ContentBreakLine -> appendLine()
-                }
-            }
-        }
-
         customCodeBlockRenderers.forEach { renderer ->
-            if (renderer.isApplicable(code.language, codeText)) {
+            if (renderer.isApplicable(code.language)) {
                 // we use first applicable renderer to override rendering
+                val codeText = buildString {
+                    code.children.forEach {
+                        when (it) {
+                            is ContentText -> append(it.text)
+                            is ContentBreakLine -> appendLine()
+                        }
+                    }
+                }
                 return with(renderer) {
-                    buildCodeBlock(code.language,codeText)
+                    buildCodeBlock(code.language, codeText)
                 }
             }
         }
 
-        // if there are no custom renderers - fall back to default
+        // if there are no applicable custom renderers - fall back to default
 
         div("sample-container") {
             val codeLang = "lang-" + code.language.ifEmpty { "kotlin" }
@@ -843,7 +842,7 @@ public open class HtmlRenderer(
             pre {
                 code(stylesWithBlock.joinToString(" ") { it.toString().toLowerCase() }) {
                     attributes["theme"] = "idea"
-                    text(codeText)
+                    code.children.forEach { buildContentNode(it, pageContext) }
                 }
             }
             /*

--- a/dokka-subprojects/plugin-base/src/test/kotlin/renderers/html/CodeBlocksTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/renderers/html/CodeBlocksTest.kt
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2014-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package renderers.html
+
+import kotlinx.html.FlowContent
+import kotlinx.html.div
+import org.jetbrains.dokka.base.DokkaBase
+import org.jetbrains.dokka.base.renderers.html.HtmlCodeBlockRenderer
+import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
+import org.jetbrains.dokka.plugability.DokkaPlugin
+import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
+import org.jetbrains.dokka.plugability.PluginApiPreviewAcknowledgement
+import signatures.renderedContent
+import utils.TestOutputWriter
+import utils.TestOutputWriterPlugin
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CodeBlocksTest : BaseAbstractTest() {
+
+    private val configuration = dokkaConfiguration {
+        sourceSets {
+            sourceSet {
+                sourceRoots = listOf("src/")
+            }
+        }
+    }
+
+    @Test
+    fun `default code block rendering`() = testCode(
+        """
+            /src/test.kt
+            package test
+            
+            /**
+             * Hello, world!
+             *
+             * ```kotlin
+             * test("hello kotlin")
+             * ```
+             *
+             * ```custom
+             * test("hello custom")
+             * ```
+             *
+             * ```other
+             * test("hello other")
+             * ```
+             */
+            fun test(string: String) {}
+            """.trimIndent(),
+        emptyList()
+    ) {
+        val content = renderedContent("root/test/test.html")
+
+        // by default, every code block is rendered as an element with `lang-XXX` class,
+        //  where XXX=language of code block
+        assertEquals(
+            """test("hello kotlin")""",
+            content.getElementsByClass("lang-kotlin").singleOrNull()?.text()
+        )
+        assertEquals(
+            """test("hello custom")""",
+            content.getElementsByClass("lang-custom").singleOrNull()?.text()
+        )
+        assertEquals(
+            """test("hello other")""",
+            content.getElementsByClass("lang-other").singleOrNull()?.text()
+        )
+    }
+
+    @Test
+    fun `code block rendering with custom renderer`() = testCode(
+        """
+            /src/test.kt
+            package test
+            
+            /**
+             * Hello, world!
+             *
+             * ```kotlin
+             * test("hello kotlin")
+             * ```
+             *
+             * ```custom
+             * test("hello custom")
+             * ```
+             *
+             * ```other
+             * test("hello other")
+             * ```
+             */
+            fun test(string: String) {}
+            """.trimIndent(),
+        listOf(CustomPlugin(applyOtherRenderer = false)) // we add only one custom renderer
+    ) {
+        val content = renderedContent("root/test/test.html")
+        assertEquals(
+            """test("hello kotlin")""",
+            content.getElementsByClass("lang-kotlin").singleOrNull()?.text()
+        )
+        assertEquals(
+            """test("hello custom")""",
+            content.getElementsByClass("custom-language-block").singleOrNull()?.text()
+        )
+        assertEquals(
+            """test("hello other")""",
+            content.getElementsByClass("lang-other").singleOrNull()?.text()
+        )
+    }
+
+    @Test
+    fun `code block rendering with multiple custom renderers`() = testCode(
+        """
+            /src/test.kt
+            package test
+            
+            /**
+             * Hello, world!
+             *
+             * ```kotlin
+             * test("hello kotlin")
+             * ```
+             *
+             * ```custom
+             * test("hello custom")
+             * ```
+             *
+             * ```other
+             * test("hello other")
+             * ```
+             */
+            fun test(string: String) {}
+            """.trimIndent(),
+        listOf(CustomPlugin(applyOtherRenderer = true))
+    ) {
+        val content = renderedContent("root/test/test.html")
+        assertEquals(
+            """test("hello kotlin")""",
+            content.getElementsByClass("lang-kotlin").singleOrNull()?.text()
+        )
+        assertEquals(
+            """test("hello custom")""",
+            content.getElementsByClass("custom-language-block").singleOrNull()?.text()
+        )
+        assertEquals(
+            """test("hello other")""",
+            content.getElementsByClass("other-language-block").singleOrNull()?.text()
+        )
+    }
+
+    private fun testCode(
+        source: String,
+        pluginOverrides: List<DokkaPlugin>,
+        block: TestOutputWriter.() -> Unit
+    ) {
+        val writerPlugin = TestOutputWriterPlugin()
+        testInline(source, configuration, pluginOverrides = pluginOverrides + listOf(writerPlugin)) {
+            renderingStage = { _, _ ->
+                writerPlugin.writer.block()
+            }
+        }
+    }
+
+    private object CustomHtmlBlockRenderer : HtmlCodeBlockRenderer {
+        override fun isApplicable(language: String, code: String): Boolean = language == "custom"
+
+        override fun FlowContent.buildCodeBlock(language: String, code: String) {
+            div("custom-language-block") {
+                text(code)
+            }
+        }
+    }
+
+    private object CustomOtherHtmlBlockRenderer : HtmlCodeBlockRenderer {
+        override fun isApplicable(language: String, code: String): Boolean = language == "other"
+
+        override fun FlowContent.buildCodeBlock(language: String, code: String) {
+            div("other-language-block") {
+                text(code)
+            }
+        }
+    }
+
+    class CustomPlugin(applyOtherRenderer: Boolean) : DokkaPlugin() {
+        val customHtmlBlockRenderer by extending {
+            plugin<DokkaBase>().htmlCodeBlockRenderers with CustomHtmlBlockRenderer
+        }
+
+        val otherHtmlBlockRenderer by extending {
+            plugin<DokkaBase>().htmlCodeBlockRenderers with CustomOtherHtmlBlockRenderer applyIf {
+                applyOtherRenderer
+            }
+        }
+
+        @OptIn(DokkaPluginApiPreview::class)
+        override fun pluginApiPreviewAcknowledgement(): PluginApiPreviewAcknowledgement =
+            PluginApiPreviewAcknowledgement
+    }
+}

--- a/dokka-subprojects/plugin-base/src/test/kotlin/renderers/html/CodeBlocksTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/renderers/html/CodeBlocksTest.kt
@@ -59,15 +59,15 @@ class CodeBlocksTest : BaseAbstractTest() {
         //  where XXX=language of code block
         assertEquals(
             """test("hello kotlin")""",
-            content.getElementsByClass("lang-kotlin").singleOrNull()?.text()
+            content.getElementsByClass("lang-kotlin").singleOrNull()?.wholeText()
         )
         assertEquals(
             """test("hello custom")""",
-            content.getElementsByClass("lang-custom").singleOrNull()?.text()
+            content.getElementsByClass("lang-custom").singleOrNull()?.wholeText()
         )
         assertEquals(
             """test("hello other")""",
-            content.getElementsByClass("lang-other").singleOrNull()?.text()
+            content.getElementsByClass("lang-other").singleOrNull()?.wholeText()
         )
     }
 
@@ -99,15 +99,15 @@ class CodeBlocksTest : BaseAbstractTest() {
         val content = renderedContent("root/test/test.html")
         assertEquals(
             """test("hello kotlin")""",
-            content.getElementsByClass("lang-kotlin").singleOrNull()?.text()
+            content.getElementsByClass("lang-kotlin").singleOrNull()?.wholeText()
         )
         assertEquals(
             """test("hello custom")""",
-            content.getElementsByClass("custom-language-block").singleOrNull()?.text()
+            content.getElementsByClass("custom-language-block").singleOrNull()?.wholeText()
         )
         assertEquals(
             """test("hello other")""",
-            content.getElementsByClass("lang-other").singleOrNull()?.text()
+            content.getElementsByClass("lang-other").singleOrNull()?.wholeText()
         )
     }
 
@@ -139,15 +139,73 @@ class CodeBlocksTest : BaseAbstractTest() {
         val content = renderedContent("root/test/test.html")
         assertEquals(
             """test("hello kotlin")""",
-            content.getElementsByClass("lang-kotlin").singleOrNull()?.text()
+            content.getElementsByClass("lang-kotlin").singleOrNull()?.wholeText()
         )
         assertEquals(
             """test("hello custom")""",
-            content.getElementsByClass("custom-language-block").singleOrNull()?.text()
+            content.getElementsByClass("custom-language-block").singleOrNull()?.wholeText()
         )
         assertEquals(
             """test("hello other")""",
-            content.getElementsByClass("other-language-block").singleOrNull()?.text()
+            content.getElementsByClass("other-language-block").singleOrNull()?.wholeText()
+        )
+    }
+
+    @Test
+    fun `multiline code block rendering with linebreaks`() = testCode(
+        """
+            /src/test.kt
+            package test
+            
+            /**
+             * Hello, world!
+             *
+             * ```kotlin
+             * // something before linebreak
+             *
+             * test("hello kotlin")
+             * ```
+             *
+             * ```custom
+             * // something before linebreak
+             *
+             * test("hello custom")
+             * ```
+             *
+             * ```other
+             * // something before linebreak
+             *
+             * test("hello other")
+             * ```
+             */
+            fun test(string: String) {}
+            """.trimIndent(),
+        listOf(CustomPlugin(applyOtherRenderer = false)) // we add only one custom renderer
+    ) {
+        val content = renderedContent("root/test/test.html")
+        assertEquals(
+            """
+            // something before linebreak
+            
+            test("hello kotlin")
+            """.trimIndent(),
+            content.getElementsByClass("lang-kotlin").singleOrNull()?.wholeText()
+        )
+        assertEquals(
+            """
+            // something before linebreak
+            
+            test("hello custom")
+            """.trimIndent(),
+            content.getElementsByClass("custom-language-block").singleOrNull()?.wholeText()
+        )
+        assertEquals(
+            """
+            // something before linebreak
+            
+            test("hello other")
+            """.trimIndent(),
+            content.getElementsByClass("lang-other").singleOrNull()?.wholeText()
         )
     }
 
@@ -165,7 +223,7 @@ class CodeBlocksTest : BaseAbstractTest() {
     }
 
     private object CustomHtmlBlockRenderer : HtmlCodeBlockRenderer {
-        override fun isApplicable(language: String, code: String): Boolean = language == "custom"
+        override fun isApplicable(language: String): Boolean = language == "custom"
 
         override fun FlowContent.buildCodeBlock(language: String, code: String) {
             div("custom-language-block") {
@@ -175,7 +233,7 @@ class CodeBlocksTest : BaseAbstractTest() {
     }
 
     private object CustomOtherHtmlBlockRenderer : HtmlCodeBlockRenderer {
-        override fun isApplicable(language: String, code: String): Boolean = language == "other"
+        override fun isApplicable(language: String): Boolean = language == "other"
 
         override fun FlowContent.buildCodeBlock(language: String, code: String) {
             div("other-language-block") {


### PR DESCRIPTION
Fixes #3244

Notes:
* multiple custom renderers can be installed to support different languages independently
* if no custom renderers is applicable for rendering code blocks, default (original) code will be used
* as was discussed internally, in extension, only `language` and `code` properties are provided instead of full `ContentCodeBlock` type

Example of usage in mermaid plugin: https://github.com/whyoleg/dokka-mermaid/commit/0c0cd231514ff6a508526ecff715fe4fc00fda93