### PR TITLE
Use versioned code links in user-facing documentation

### DIFF
--- a/docs/topics/dokka-module-and-package-docs.md
+++ b/docs/topics/dokka-module-and-package-docs.md
@@ -45,7 +45,7 @@ It also appears under the first-level heading on your package's page.
 Content after this heading is also part of documentation for `org.jetbrains.kotlin.demo2`
 ```
 
-To explore an example project with Gradle, see [Dokka gradle example](https://github.com/Kotlin/dokka/tree/master/examples/gradle/dokka-gradle-example).
+To explore an example project with Gradle, see [Dokka gradle example](https://github.com/Kotlin/dokka/tree/%dokkaVersion%/examples/gradle/dokka-gradle-example).
 
 ## Pass files to Dokka
 

--- a/docs/topics/dokka-plugins.md
+++ b/docs/topics/dokka-plugins.md
@@ -24,7 +24,7 @@ From there, the plugin extends Dokka by itself - no further action is needed.
 > 
 {type="note"}
 
-Let's have a look at how you can apply the [mathjax plugin](https://github.com/Kotlin/dokka/tree/master/plugins/mathjax)
+Let's have a look at how you can apply the [mathjax plugin](https://github.com/Kotlin/dokka/tree/%dokkaVersion%/plugins/mathjax)
 to your project:
 
 <tabs group="build-script">
@@ -266,13 +266,13 @@ If you are using [JSON configuration](dokka-cli.md#run-with-json-configuration),
 
 Here are some notable Dokka plugins that you might find useful:
 
-| **Name**                                                                                                  | **Description**                                                                                              |
-|-----------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
-| [Android documentation plugin](https://github.com/Kotlin/dokka/tree/master/plugins/android-documentation) | Improves the documentation experience on Android                                                             |
-| [Versioning plugin](https://github.com/Kotlin/dokka/tree/master/plugins/versioning)                       | Adds version selector and helps to organize documentation for different versions of your application/library |
-| [MermaidJS HTML plugin](https://github.com/glureau/dokka-mermaid)                                         | Renders [MermaidJS](https://mermaid-js.github.io/mermaid/#/) diagrams and visualizations found in KDocs      |
-| [Mathjax HTML plugin](https://github.com/Kotlin/dokka/tree/master/plugins/mathjax)                        | Pretty prints mathematics found in KDocs                                                                     |
-| [Kotlin as Java plugin](https://github.com/Kotlin/dokka/tree/master/plugins/kotlin-as-java)               | Renders Kotlin signatures as seen from Java's perspective                                                    |
+| **Name**                                                                                                          | **Description**                                                                                              |
+|-------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
+| [Android documentation plugin](https://github.com/Kotlin/dokka/tree/%dokkaVersion%/plugins/android-documentation) | Improves the documentation experience on Android                                                             |
+| [Versioning plugin](https://github.com/Kotlin/dokka/tree/%dokkaVersion%/plugins/versioning)                       | Adds version selector and helps to organize documentation for different versions of your application/library |
+| [MermaidJS HTML plugin](https://github.com/glureau/dokka-mermaid)                                                 | Renders [MermaidJS](https://mermaid-js.github.io/mermaid/#/) diagrams and visualizations found in KDocs      |
+| [Mathjax HTML plugin](https://github.com/Kotlin/dokka/tree/%dokkaVersion%/plugins/mathjax)                        | Pretty prints mathematics found in KDocs                                                                     |
+| [Kotlin as Java plugin](https://github.com/Kotlin/dokka/tree/%dokkaVersion%/plugins/kotlin-as-java)               | Renders Kotlin signatures as seen from Java's perspective                                                    |
 
 If you are a Dokka plugin author and would like to add your plugin to this list, get in touch with maintainers
 via [Slack](dokka-introduction.md#community) or [GitHub](https://github.com/Kotlin/dokka/).

--- a/docs/topics/formats/dokka-html.md
+++ b/docs/topics/formats/dokka-html.md
@@ -275,8 +275,8 @@ context and thus they need to be resolved at later stages by the [MultiModule](d
 
 You can also use the following Dokka-defined [directives](https://freemarker.apache.org/docs/ref_directive_userDefined.html):
 
-| **Variable**    | **Description**                                                                                                                                                                              |
-|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `<@content/>`   | The main page content.                                                                                                                                                                       |
-| `<@resources/>` | Resources such as scripts and stylesheets.                                                                                                                                                   |
-| `<@version/>`   | The module version taken from configuration. If the [versioning plugin](https://github.com/Kotlin/dokka/tree/master/plugins/versioning) is applied, it is replaced with a version navigator. |
+| **Variable**    | **Description**                                                                                                                                                                                      |
+|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `<@content/>`   | The main page content.                                                                                                                                                                               |
+| `<@resources/>` | Resources such as scripts and stylesheets.                                                                                                                                                           |
+| `<@version/>`   | The module version taken from configuration. If the [versioning plugin](https://github.com/Kotlin/dokka/tree/%dokkaVersion%/plugins/versioning) is applied, it is replaced with a version navigator. |

--- a/docs/topics/formats/dokka-javadoc.md
+++ b/docs/topics/formats/dokka-javadoc.md
@@ -15,11 +15,11 @@ or an exact copy.
 ![Screenshot of javadoc output format](javadoc-format-example.png){width=706}
 
 All Kotlin code and signatures are rendered as seen from Java's perspective. This is achieved with our
-[Kotlin as Java Dokka plugin](https://github.com/Kotlin/dokka/tree/master/plugins/kotlin-as-java), which comes bundled and
+[Kotlin as Java Dokka plugin](https://github.com/Kotlin/dokka/tree/%dokkaVersion%/plugins/kotlin-as-java), which comes bundled and
 applied by default for this format.
 
 The Javadoc output format is implemented as a [Dokka plugin](dokka-plugins.md), and it is maintained by the Dokka team.
-It is open source and you can find the source code on [GitHub](https://github.com/Kotlin/dokka/tree/master/plugins/javadoc).
+It is open source and you can find the source code on [GitHub](https://github.com/Kotlin/dokka/tree/%dokkaVersion%/plugins/javadoc).
 
 ## Generate Javadoc documentation
 

--- a/docs/topics/runners/dokka-gradle.md
+++ b/docs/topics/runners/dokka-gradle.md
@@ -90,14 +90,14 @@ and [multi-project](#multi-project-builds) builds.
 
 Use the following tasks to build documentation for simple, single-project applications and libraries:
 
-| **Task**       | **Description**                                                                     |
-|----------------|-------------------------------------------------------------------------------------|
-| `dokkaHtml`    | Generates documentation in [HTML](dokka-html.md) format.                                  |
+| **Task**    | **Description**                                          |
+|-------------|----------------------------------------------------------|
+| `dokkaHtml` | Generates documentation in [HTML](dokka-html.md) format. |
 
 #### Experimental formats
 
-| **Task**       | **Description**                                                                     |
-|----------------|-------------------------------------------------------------------------------------|
+| **Task**       | **Description**                                                                           |
+|----------------|-------------------------------------------------------------------------------------------|
 | `dokkaGfm`     | Generates documentation in [GitHub Flavored Markdown](dokka-markdown.md#gfm) format.      |
 | `dokkaJavadoc` | Generates documentation in [Javadoc](dokka-javadoc.md) format.                            |
 | `dokkaJekyll`  | Generates documentation in [Jekyll compatible Markdown](dokka-markdown.md#jekyll) format. |
@@ -119,14 +119,14 @@ cross-project references.
 
 Dokka creates the following tasks for **parent** projects automatically:
 
-| **Task**                 | **Description**                                                        |
-|--------------------------|------------------------------------------------------------------------|
-| `dokkaHtmlMultiModule`   | Generates multi-module documentation in [HTML](dokka-html.md) output format. |
+| **Task**               | **Description**                                                              |
+|------------------------|------------------------------------------------------------------------------|
+| `dokkaHtmlMultiModule` | Generates multi-module documentation in [HTML](dokka-html.md) output format. |
 
 #### Experimental formats (multi-module)
 
-| **Task**                 | **Description**                                                                                         |
-|--------------------------|---------------------------------------------------------------------------------------------------------|
+| **Task**                 | **Description**                                                                                               |
+|--------------------------|---------------------------------------------------------------------------------------------------------------|
 | `dokkaGfmMultiModule`    | Generates multi-module documentation in [GitHub Flavored Markdown](dokka-markdown.md#gfm) output format.      |
 | `dokkaJekyllMultiModule` | Generates multi-module documentation in [Jekyll compatible Markdown](dokka-markdown.md#jekyll) output format. |
 
@@ -155,7 +155,7 @@ These pages are generated after running `dokkaHtmlMultiModule`:
 
 ![Screenshot for output of dokkaHtmlMultiModule task](dokkaHtmlMultiModule-example.png){width=600}
 
-See our [multi-module project example](https://github.com/Kotlin/dokka/tree/master/examples/gradle/dokka-multimodule-example)
+See our [multi-module project example](https://github.com/Kotlin/dokka/tree/%dokkaVersion%/examples/gradle/dokka-multimodule-example)
 for more details.
 
 #### Collector tasks
@@ -192,7 +192,7 @@ These pages are generated after running `dokkaHtmlCollector`:
 
 ![Screenshot for output of dokkaHtmlCollector task](dokkaHtmlCollector-example.png){width=706}
 
-See our [multi-module project example](https://github.com/Kotlin/dokka/tree/master/examples/gradle/dokka-multimodule-example)
+See our [multi-module project example](https://github.com/Kotlin/dokka/tree/%dokkaVersion%/examples/gradle/dokka-multimodule-example)
 for more details.
 
 #### Partial tasks


### PR DESCRIPTION
This PR removes non-versioned code links pointing to master from the user-facing documentation.

There are two primary reasons for that:
1. After #3174, some links pointing to master have become outdated.
2. The readers that followed the link might see something in `master` which is not yet available in the latest release, so it would lead to confusion.

The links themselves will be updated to point to the new locations once 1.9.20 is out

___

This is intentionally done as a separate PR and not as part of #3174, because if the internal TeamCity build that publishes documentation fails, it will be easier to find the reason.
