### PR TITLE
Add GitHub issues navigation for IDEA

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="IssueNavigationConfiguration">
+    <option name="links">
+      <list>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="#(\d+)" />
+          <option name="linkRegexp" value="https://github.com/Kotlin/dokka/issues/$1" />
+        </IssueNavigationLink>
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -10,4 +10,10 @@
       </list>
     </option>
   </component>
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/dokka-integration-tests/gradle/projects/coroutines/kotlinx-coroutines" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/dokka-integration-tests/gradle/projects/serialization/kotlinx-serialization" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/dokka-integration-tests/maven/projects/biojava/biojava" vcs="Git" />
+  </component>
 </project>


### PR DESCRIPTION
Allows to click on issue/PR numbers in VCS history and be redirected to GitHub

Example:

<img width="1517" alt="image" src="https://github.com/Kotlin/dokka/assets/50462752/13d2da49-bc56-4ac0-b7e5-e7e7b5cf59cd">

Here on screenshot we can see Git window and 3 highlighted links: `#3333` and `#3327` in the left panel + `#3333` in the right panel. All of them are clickable and will redirect to `https://github.com/Kotlin/dokka/pull/3333` or `https://github.com/Kotlin/dokka/pull/3327`.

## Why do we need this?

This simplifies a lot following Git Blame, and so understanding of context on why one or another change were implemented (via PR comments or issue description).
In last couple of days, while investigating behaviour of CodeBlocks I've done a lot of copy-pasting of issue number to GitHub and I was tired of this :) So I've configured this for local development.

Later I've found, that it's possible to share this config via Git, like in kotlinx-coroutines: https://github.com/Kotlin/kotlinx.coroutines/blob/ecb5b3e1e3c94cf377b9b3d21a8ad455bc83f0d0/.idea/vcs.xml#L13. 
PR in coroutines: https://github.com/Kotlin/kotlinx.coroutines/pull/1920
And so here we are

P.S. If possible, please check, that after fetching this branch, changes are applied at your side. I have not added `vcs.xml` to `.gitignore` for a reason: it can contain other settings, which we are not interested in