### PR TITLE
Remove modifier rendering if it empty

### DIFF
--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/signatures/KotlinSignatureProvider.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/signatures/KotlinSignatureProvider.kt
@@ -248,7 +248,7 @@ public class KotlinSignatureProvider(
                 p.modifier[sourceSet].takeIf { it !in ignoredModifiers }?.let {
                         if (it is JavaModifier.Empty) KotlinModifier.Open else it
                     }?.name?.let { keyword("$it ") }
-                p.modifiers()[sourceSet]?.toSignatureString()?.let { keyword(it) }
+                p.modifiers()[sourceSet]?.toSignatureString()?.takeIf { it.isNotEmpty() }?.let { keyword(it) }
                 if (p.isMutable()) keyword("var ") else keyword("val ")
                 list(p.generics, prefix = "<", suffix = "> ",
                     separatorStyles = mainStyles + TokenStyle.Punctuation,
@@ -303,7 +303,7 @@ public class KotlinSignatureProvider(
                     f.modifier[sourceSet]?.takeIf { it !in ignoredModifiers }?.let {
                         if (it is JavaModifier.Empty) KotlinModifier.Open else it
                     }?.name?.let { keyword("$it ") }
-                    f.modifiers()[sourceSet]?.toSignatureString()?.let { keyword(it) }
+                    f.modifiers()[sourceSet]?.toSignatureString()?.takeIf { it.isNotEmpty() }?.let { keyword(it) }
                     keyword("fun ")
                     list(
                         f.generics, prefix = "<", suffix = "> ",

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/signatures/KotlinSignatureProvider.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/signatures/KotlinSignatureProvider.kt
@@ -434,7 +434,7 @@ public class KotlinSignatureProvider(
                 }
 
             is Variance<*> -> group(styles = emptySet()) {
-                keyword("$p ".takeIf { it.isNotBlank() } ?: "")
+                p.takeIf { it.toString().isNotEmpty() }?.let { keyword("$it ") }
                 signatureForProjection(p.inner, showFullyQualifiedName)
             }
 

--- a/dokka-subprojects/plugin-base/src/test/kotlin/signatures/SignatureTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/signatures/SignatureTest.kt
@@ -356,6 +356,26 @@ class SignatureTest : BaseAbstractTest() {
     }
 
     @Test
+    fun `constructor property on class page`() {
+        val source = source("data class DataClass(val arg: String)")
+        val writerPlugin = TestOutputWriterPlugin()
+
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin)
+        ) {
+            renderingStage = { _, _ ->
+                assertEquals(
+                    writerPlugin.writer.renderedContent("root/example/-data-class/index.html").lastSignature().html(),
+                    "<span class=\"token keyword\">val </span><a href=\"arg.html\">arg</a><span class=\"token operator\">: </span><a href=\"https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html\">String</a>"
+
+                )
+            }
+        }
+    }
+
+    @Test
     fun `functional interface`() {
         val source = source("fun interface KRunnable")
         val writerPlugin = TestOutputWriterPlugin()


### PR DESCRIPTION
For testing K2 migration, I'm using the approach of comparing Dokka output with K1. There are a lot of places where the difference is not user-visible but just an empty block `<span class="token keyword"></span>` in signatures. This makes it challenging to analyze the results. The PR should help to omit such `span`s. 