### PR TITLE
Don't suppress obvious members in kotlin.Enum and kotlin.Any

### DIFF
--- a/dokka-subprojects/analysis-kotlin-api/src/test/kotlin/org/jetbrains/dokka/analysis/test/TagsAnnotations.kt
+++ b/dokka-subprojects/analysis-kotlin-api/src/test/kotlin/org/jetbrains/dokka/analysis/test/TagsAnnotations.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2014-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package org.jetbrains.dokka.analysis.test
+
+import org.junit.jupiter.api.Tag
+
+// COPY OF dokka-subprojects/plugin-base/src/test/kotlin/utils/TagsAnnotations.kt
+
+/**
+ * Run a test only for descriptors, not symbols.
+ *
+ * In theory, these tests can be fixed
+ */
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY_GETTER,
+    AnnotationTarget.PROPERTY_SETTER
+)
+@Retention(
+    AnnotationRetention.RUNTIME
+)
+@Tag("onlyDescriptors")
+annotation class OnlyDescriptors(val reason: String = "")
+
+/**
+ * Run a test only for descriptors, not symbols.
+ *
+ * These tests cannot be fixed until Analysis API does not support MPP
+ */
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY_GETTER,
+    AnnotationTarget.PROPERTY_SETTER
+)
+@Retention(
+    AnnotationRetention.RUNTIME
+)
+@Tag("onlyDescriptorsMPP")
+annotation class OnlyDescriptorsMPP(val reason: String = "")

--- a/dokka-subprojects/analysis-kotlin-api/src/test/kotlin/org/jetbrains/dokka/analysis/test/documentable/ObviousFunctionsTest.kt
+++ b/dokka-subprojects/analysis-kotlin-api/src/test/kotlin/org/jetbrains/dokka/analysis/test/documentable/ObviousFunctionsTest.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2014-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package org.jetbrains.dokka.analysis.test.documentable
+
+import org.jetbrains.dokka.analysis.test.OnlyDescriptors
+import org.jetbrains.dokka.analysis.test.api.kotlinJvmTestProject
+import org.jetbrains.dokka.analysis.test.api.parse
+import org.jetbrains.dokka.analysis.test.api.useServices
+import org.jetbrains.dokka.links.DRI
+import org.jetbrains.dokka.model.DFunction
+import org.jetbrains.dokka.model.ObviousMember
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class ObviousFunctionsTest {
+
+    @OnlyDescriptors("#3354")
+    @Test
+    fun `kotlin_Any should not have obvious members`() {
+        val project = kotlinJvmTestProject {
+            ktFile("kotlin/Any.kt") {
+                +"""
+                    package kotlin
+                    public open class Any {
+                        public open fun equals(other: Any?): Boolean
+                        public open fun hashCode(): Int
+                        public open fun toString(): String
+                    }
+                """
+            }
+        }
+
+        val module = project.parse()
+
+        val pkg = module.packages.single()
+        val any = pkg.classlikes.single()
+
+        assertEquals("Any", any.name)
+
+        assertObviousFunctions(
+            expectedObviousFunctions = emptySet(),
+            expectedNonObviousFunctions = setOf("equals", "hashCode", "toString"),
+            actualFunctions = any.functions
+        )
+    }
+
+    @Test
+    fun `kotlin_Any should not have obvious members via external documentable provider`() {
+        val project = kotlinJvmTestProject {
+            ktFile("SomeClass.kt") {
+                +"class SomeClass"
+            }
+        }
+
+        project.useServices {
+            val any = externalDocumentableProvider.getClasslike(
+                DRI("kotlin", "Any"),
+                it.context.configuration.sourceSets.single()
+            )
+            assertNotNull(any)
+            assertEquals("Any", any.name)
+
+            assertObviousFunctions(
+                expectedObviousFunctions = emptySet(),
+                expectedNonObviousFunctions = setOf("equals", "hashCode", "toString"),
+                actualFunctions = any.functions
+            )
+        }
+    }
+
+    // when running with K2 - inherited from java enum functions available: "clone", "finalize", "getDeclaringClass"
+    @OnlyDescriptors("#3196")
+    @Test
+    fun `kotlin_Enum should not have obvious members`() {
+        val project = kotlinJvmTestProject {
+            ktFile("kotlin/Any.kt") {
+                +"""
+                    package kotlin
+                    public abstract class Enum<E : Enum<E>>(name: String, ordinal: Int): Comparable<E> {
+                        public override final fun compareTo(other: E): Int
+                        public override final fun equals(other: Any?): Boolean
+                        public override final fun hashCode(): Int
+                        public override fun toString(): String
+                    }
+                """
+            }
+        }
+
+        val module = project.parse()
+
+        val pkg = module.packages.single()
+        val any = pkg.classlikes.single()
+
+        assertEquals("Enum", any.name)
+
+        assertObviousFunctions(
+            expectedObviousFunctions = emptySet(),
+            expectedNonObviousFunctions = setOf("compareTo", "equals", "hashCode", "toString"),
+            actualFunctions = any.functions
+        )
+    }
+
+    // when running with K2 there is no equals, hashCode, toString present
+    @OnlyDescriptors("#3196")
+    @Test
+    fun `kotlin_Enum should not have obvious members via external documentable provider`() {
+        val project = kotlinJvmTestProject {
+            ktFile("SomeClass.kt") {
+                +"class SomeClass"
+            }
+        }
+
+        project.useServices {
+            val enum = externalDocumentableProvider.getClasslike(
+                DRI("kotlin", "Enum"),
+                it.context.configuration.sourceSets.single()
+            )
+            assertNotNull(enum)
+            assertEquals("Enum", enum.name)
+
+            assertObviousFunctions(
+                expectedObviousFunctions = emptySet(),
+                expectedNonObviousFunctions = setOf(
+                    "compareTo", "equals", "hashCode", "toString",
+                    // inherited from java enum
+                    "clone", "finalize", "getDeclaringClass"
+                ),
+                actualFunctions = enum.functions
+            )
+        }
+    }
+
+    private fun assertObviousFunctions(
+        expectedObviousFunctions: Set<String>,
+        expectedNonObviousFunctions: Set<String>,
+        actualFunctions: List<DFunction>
+    ) {
+        val (notObviousFunctions, obviousFunctions) = actualFunctions.partition {
+            it.extra[ObviousMember] == null
+        }
+
+        assertEquals(
+            expectedNonObviousFunctions,
+            notObviousFunctions.map { it.name }.toSet()
+        )
+
+        assertEquals(
+            expectedObviousFunctions,
+            obviousFunctions.map { it.name }.toSet()
+        )
+    }
+
+}

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/KotlinAnalysis.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/KotlinAnalysis.kt
@@ -54,7 +54,9 @@ internal fun getLanguageVersionSettings(
         apiVersion = apiVersion, analysisFlags = hashMapOf(
             // special flag for Dokka
             // force to resolve light classes (lazily by default)
-            AnalysisFlags.eagerResolveOfLightClasses to true
+            AnalysisFlags.eagerResolveOfLightClasses to true,
+            // TODO: looks like we need to hide it under a flag?
+            AnalysisFlags.allowKotlinPackage to true
         )
     )
 }

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/KotlinAnalysis.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/KotlinAnalysis.kt
@@ -54,9 +54,7 @@ internal fun getLanguageVersionSettings(
         apiVersion = apiVersion, analysisFlags = hashMapOf(
             // special flag for Dokka
             // force to resolve light classes (lazily by default)
-            AnalysisFlags.eagerResolveOfLightClasses to true,
-            // TODO: looks like we need to hide it under a flag?
-            AnalysisFlags.allowKotlinPackage to true
+            AnalysisFlags.eagerResolveOfLightClasses to true
         )
     )
 }

--- a/dokka-subprojects/plugin-base/src/test/kotlin/transformers/ObviousAndInheritedFunctionsDocumentableFilterTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/transformers/ObviousAndInheritedFunctionsDocumentableFilterTest.kt
@@ -9,6 +9,7 @@ import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import testApi.testRunner.dokkaConfiguration
+import utils.OnlyDescriptors
 import kotlin.test.assertEquals
 
 class ObviousAndInheritedFunctionsDocumentableFilterTest : BaseAbstractTest() {
@@ -202,7 +203,9 @@ class ObviousAndInheritedFunctionsDocumentableFilterTest : BaseAbstractTest() {
 
     @ParameterizedTest
     @MethodSource(value = ["nonSuppressingObviousConfiguration", "nonSuppressingInheritedConfiguration"])
-    fun `not should suppress toString, equals and hashcode for interface if custom config is provided`(nonSuppressingConfiguration: DokkaConfigurationImpl) {
+    fun `not should suppress toString, equals and hashcode for interface if custom config is provided`(
+        nonSuppressingConfiguration: DokkaConfigurationImpl
+    ) {
         testInline(
             """
             /src/suppressed/Suppressed.kt
@@ -220,7 +223,9 @@ class ObviousAndInheritedFunctionsDocumentableFilterTest : BaseAbstractTest() {
 
     @ParameterizedTest
     @MethodSource(value = ["nonSuppressingObviousConfiguration", "nonSuppressingInheritedConfiguration"])
-    fun `should not suppress toString, equals and hashcode if custom config is provided in Java`(nonSuppressingConfiguration: DokkaConfigurationImpl) {
+    fun `should not suppress toString, equals and hashcode if custom config is provided in Java`(
+        nonSuppressingConfiguration: DokkaConfigurationImpl
+    ) {
         testInline(
             """
             /src/suppressed/Suppressed.java
@@ -247,6 +252,7 @@ class ObviousAndInheritedFunctionsDocumentableFilterTest : BaseAbstractTest() {
         }
     }
 
+    @OnlyDescriptors("#3354")
     @ParameterizedTest
     @MethodSource(value = ["suppressingObviousConfiguration"])
     fun `should not suppress toString, equals and hashcode of kotlin Any`(suppressingConfiguration: DokkaConfigurationImpl) {
@@ -264,11 +270,12 @@ class ObviousAndInheritedFunctionsDocumentableFilterTest : BaseAbstractTest() {
         ) {
             preMergeDocumentablesTransformationStage = { modules ->
                 val functions = modules.flatMap { it.packages }.flatMap { it.classlikes }.flatMap { it.functions }
-                assertEquals(3, functions.size)
+                assertEquals(setOf("equals", "hashCode", "toString"), functions.map { it.name }.toSet())
             }
         }
     }
 
+    @OnlyDescriptors("#3196")
     @ParameterizedTest
     @MethodSource(value = ["suppressingObviousConfiguration"])
     fun `should not suppress toString, equals and hashcode of kotlin Enum`(suppressingConfiguration: DokkaConfigurationImpl) {
@@ -287,10 +294,7 @@ class ObviousAndInheritedFunctionsDocumentableFilterTest : BaseAbstractTest() {
         ) {
             preMergeDocumentablesTransformationStage = { modules ->
                 val functions = modules.flatMap { it.packages }.flatMap { it.classlikes }.flatMap { it.functions }
-                // TODO: fails on K2 (functions.size=5)
-                //  for some reason functions contains getDeclaringClass from Enum.java
-                //  no such function exists when using K1
-                assertEquals(4, functions.size)
+                assertEquals(setOf("compareTo", "equals", "hashCode", "toString"), functions.map { it.name }.toSet())
             }
         }
     }


### PR DESCRIPTION
Fixes #2863

This is draft because of 2 questions:
1. To allow Analysis API to analyse `kotlin` package, we need to provide flag `AnalysisFlags.allowKotlinPackage` - should we hide it under a flag at our side? And if so, what is the best way provide it to analysis? Or we can just set it `true` - Descriptor based analysis doesn't need any additional configuration
2. There is a test failing for `Enum`. During getting functions of class for `Enum` from test it fetches also methods from `Enum.java`: `clone`, `finalize`, `getDeclaringClass`. Somewhere later first 2 are filtered, but the last one is not, and so present in the documentation in the end. I was failed "to find why" and "what to do next" during debugging for 2 hours of FIR compiler internals... So asking for some help here :) 