### PR TITLE
Support for providing sourceRoots as relative paths

### DIFF
--- a/dokka-subprojects/analysis-kotlin-descriptors-compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/translator/DefaultDescriptorToDocumentableTranslator.kt
+++ b/dokka-subprojects/analysis-kotlin-descriptors-compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/translator/DefaultDescriptorToDocumentableTranslator.kt
@@ -168,9 +168,14 @@ private class DokkaDescriptorVisitor(
     private val syntheticDocProvider = SyntheticDescriptorDocumentationProvider(kDocFinder, sourceSet)
 
     private fun Collection<DeclarationDescriptor>.filterDescriptorsInSourceSet() = filter {
-        it.toSourceElement.containingFile.toString().let { path ->
-            path.isNotBlank() && sourceSet.sourceRoots.any { root ->
-                Paths.get(path).startsWith(root.toPath())
+        val pathString = it.toSourceElement.containingFile.toString()
+        when {
+            pathString.isBlank() -> false
+            else -> {
+                val absolutePath = Paths.get(pathString).toAbsolutePath()
+                sourceSet.sourceRoots.any { root ->
+                    absolutePath.startsWith(root.toPath().toAbsolutePath())
+                }
             }
         }
     }

--- a/dokka-subprojects/analysis-kotlin-descriptors-compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/translator/DefaultDescriptorToDocumentableTranslator.kt
+++ b/dokka-subprojects/analysis-kotlin-descriptors-compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/translator/DefaultDescriptorToDocumentableTranslator.kt
@@ -172,9 +172,9 @@ private class DokkaDescriptorVisitor(
         when {
             pathString.isBlank() -> false
             else -> {
-                val absolutePath = Paths.get(pathString).toAbsolutePath()
+                val absolutePath = Paths.get(pathString).toRealPath()
                 sourceSet.sourceRoots.any { root ->
-                    absolutePath.startsWith(root.toPath().toAbsolutePath())
+                    absolutePath.startsWith(root.toPath().toRealPath())
                 }
             }
         }

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/DefaultSymbolToDocumentableTranslator.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/DefaultSymbolToDocumentableTranslator.kt
@@ -116,9 +116,9 @@ internal class DokkaSymbolVisitor(
         when {
             pathString.isNullOrBlank() -> false
             else -> {
-                val absolutePath = Paths.get(pathString).toAbsolutePath()
+                val absolutePath = Paths.get(pathString).toRealPath()
                 sourceSet.sourceRoots.any { root ->
-                    absolutePath.startsWith(root.toPath().toAbsolutePath())
+                    absolutePath.startsWith(root.toPath().toRealPath())
                 }
             }
         }

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/DefaultSymbolToDocumentableTranslator.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/DefaultSymbolToDocumentableTranslator.kt
@@ -112,11 +112,16 @@ internal class DokkaSymbolVisitor(
         get() = (psi as? KtModifierListOwner)?.hasExpectModifier() == true
 
     private fun <T : KtSymbol> Collection<T>.filterSymbolsInSourceSet() = filter {
-        it.psi?.containingFile?.virtualFile?.path?.let { path ->
-            path.isNotBlank() && sourceSet.sourceRoots.any { root ->
-                Paths.get(path).startsWith(root.toPath())
+        val pathString = it.psi?.containingFile?.virtualFile?.path
+        when {
+            pathString.isNullOrBlank() -> false
+            else -> {
+                val absolutePath = Paths.get(pathString).toAbsolutePath()
+                sourceSet.sourceRoots.any { root ->
+                    absolutePath.startsWith(root.toPath().toAbsolutePath())
+                }
             }
-        } == true
+        }
     }
 
     fun visitModule(): DModule {

--- a/dokka-subprojects/plugin-base/src/test/kotlin/content/inheritors/ContentForInheritorsTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/content/inheritors/ContentForInheritorsTest.kt
@@ -258,6 +258,11 @@ class ContentForInheritorsTest : BaseAbstractTest() {
                 |
                 |class Child : Parent()
                 |
+                |/src/linuxX64Main/kotlin/pageMerger/Test.kt
+                |package pageMerger
+                |
+                |class Child : Parent()
+                |
             """.trimMargin(),
             mppTestConfiguration
         ) {


### PR DESCRIPTION
Fixes #2571

Note, that only integration test was added, as it's not easily possible to test it via unit test:
1. because we need to materialise files somewhere and to use relative paths of them, we need to materialise them somewhere in project directory - which is not good
2. all our test-apis convert all paths to absolute before providing them to configuration

I think, that for this case, integration test will be enough, as supporting testing relative paths will cause a lot of refactoring for sole of this specific use-case.

I have also checked code around other files provided via configuration, and looks like only sourceRoots are now affected. But may be we need to add more tests for relative paths for other properties (classpath, samples, includes, etc).

One more additional note for future. First idea of mine was to make all `File`s to become absolute during deserialisation of config, but I've stumbled upon `DokkaConfiguration.DokkaModuleDescription#getRelativePathToOutputDirectory`, which is `File`, but should be still relative.