### PR TITLE
Render member extensions correctly

### DIFF
--- a/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/model/documentableUtils.kt
+++ b/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/model/documentableUtils.kt
@@ -24,4 +24,8 @@ public fun DTypeParameter.filter(filteredSet: Set<DokkaSourceSet>): DTypeParamet
         )
     }
 
+@Deprecated(
+    "Deprecated for removal",
+    ReplaceWith("this is Callable && this.receiver != null")
+)
 public fun Documentable.isExtension(): Boolean = this is Callable && receiver != null

--- a/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/model/documentableUtils.kt
+++ b/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/model/documentableUtils.kt
@@ -24,8 +24,4 @@ public fun DTypeParameter.filter(filteredSet: Set<DokkaSourceSet>): DTypeParamet
         )
     }
 
-@Deprecated(
-    "Deprecated for removal",
-    ReplaceWith("this is Callable && this.receiver != null")
-)
 public fun Documentable.isExtension(): Boolean = this is Callable && receiver != null

--- a/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/pages/contentNodeProperties.kt
+++ b/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/pages/contentNodeProperties.kt
@@ -16,7 +16,30 @@ public class SimpleAttr(
 }
 
 public enum class BasicTabbedContentType : TabbedContentType {
-    TYPE, CONSTRUCTOR, FUNCTION, PROPERTY, ENTRY, EXTENSION_PROPERTY, EXTENSION_FUNCTION
+    TYPE, CONSTRUCTOR,
+
+    // property/function here means a different things depending on parent:
+    // - if parent=package - describes just `top-level` property/function without receiver
+    // - if parent=classlike - describes `member` property/function,
+    //   it could have receiver (becoming member extension property/function) or not (ordinary member property/function)
+    // for examples look at docs for `EXTENSION_PROPERTY`, `EXTENSION_FUNCTION`
+    FUNCTION, PROPERTY,
+
+    ENTRY,
+
+    // property/function here means a different things depending on parent,
+    // and not just `an extension property/function`:
+    // example 1: `fun Foo.bar()` - top-level extension function
+    // - on a page describing `Foo` class `bar` will have type=`EXTENSION_FUNCTION`
+    // - on a page describing package declarations `bar` will have type=`EXTENSION_FUNCTION`
+    // example 2: `object Namespace { fun Foo.bar() }` - member extension function
+    // - on a page describing `Foo` class `bar` will have type=`EXTENSION_FUNCTION`
+    // - on a page describing `Namespace` object `bar` will have type=`FUNCTION`
+    //
+    // These types are needed to separate member functions and extension function on classlike pages.
+    // The same split rules are also used
+    // when grouping functions/properties with the same name on pages for classlike and package
+    EXTENSION_PROPERTY, EXTENSION_FUNCTION
 }
 
 /**

--- a/dokka-subprojects/plugin-base/api/plugin-base.api
+++ b/dokka-subprojects/plugin-base/api/plugin-base.api
@@ -1371,7 +1371,8 @@ public class org/jetbrains/dokka/base/translators/documentables/DefaultPageCreat
 	protected fun contentForModule (Lorg/jetbrains/dokka/model/DModule;)Lorg/jetbrains/dokka/pages/ContentGroup;
 	protected fun contentForPackage (Lorg/jetbrains/dokka/model/DPackage;)Lorg/jetbrains/dokka/pages/ContentGroup;
 	protected fun contentForProperty (Lorg/jetbrains/dokka/model/DProperty;)Lorg/jetbrains/dokka/pages/ContentGroup;
-	protected fun contentForScope (Lorg/jetbrains/dokka/model/WithScope;Lorg/jetbrains/dokka/links/DRI;Ljava/util/Set;)Lorg/jetbrains/dokka/pages/ContentGroup;
+	protected fun contentForScope (Lorg/jetbrains/dokka/model/WithScope;Lorg/jetbrains/dokka/links/DRI;Ljava/util/Set;Ljava/util/List;)Lorg/jetbrains/dokka/pages/ContentGroup;
+	public static synthetic fun contentForScope$default (Lorg/jetbrains/dokka/base/translators/documentables/DefaultPageCreator;Lorg/jetbrains/dokka/model/WithScope;Lorg/jetbrains/dokka/links/DRI;Ljava/util/Set;Ljava/util/List;ILjava/lang/Object;)Lorg/jetbrains/dokka/pages/ContentGroup;
 	protected fun contentForScopes (Ljava/util/List;Ljava/util/Set;Ljava/util/List;)Lorg/jetbrains/dokka/pages/ContentGroup;
 	public static synthetic fun contentForScopes$default (Lorg/jetbrains/dokka/base/translators/documentables/DefaultPageCreator;Ljava/util/List;Ljava/util/Set;Ljava/util/List;ILjava/lang/Object;)Lorg/jetbrains/dokka/pages/ContentGroup;
 	protected fun getContentBuilder ()Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder;

--- a/dokka-subprojects/plugin-base/api/plugin-base.api
+++ b/dokka-subprojects/plugin-base/api/plugin-base.api
@@ -1371,12 +1371,9 @@ public class org/jetbrains/dokka/base/translators/documentables/DefaultPageCreat
 	protected fun contentForModule (Lorg/jetbrains/dokka/model/DModule;)Lorg/jetbrains/dokka/pages/ContentGroup;
 	protected fun contentForPackage (Lorg/jetbrains/dokka/model/DPackage;)Lorg/jetbrains/dokka/pages/ContentGroup;
 	protected fun contentForProperty (Lorg/jetbrains/dokka/model/DProperty;)Lorg/jetbrains/dokka/pages/ContentGroup;
-	protected fun contentForScope (Lorg/jetbrains/dokka/model/WithScope;Lorg/jetbrains/dokka/links/DRI;Ljava/util/Set;Ljava/util/List;)Lorg/jetbrains/dokka/pages/ContentGroup;
-	public static synthetic fun contentForScope$default (Lorg/jetbrains/dokka/base/translators/documentables/DefaultPageCreator;Lorg/jetbrains/dokka/model/WithScope;Lorg/jetbrains/dokka/links/DRI;Ljava/util/Set;Ljava/util/List;ILjava/lang/Object;)Lorg/jetbrains/dokka/pages/ContentGroup;
+	protected fun contentForScope (Lorg/jetbrains/dokka/model/WithScope;Lorg/jetbrains/dokka/links/DRI;Ljava/util/Set;)Lorg/jetbrains/dokka/pages/ContentGroup;
 	protected fun contentForScopes (Ljava/util/List;Ljava/util/Set;Ljava/util/List;)Lorg/jetbrains/dokka/pages/ContentGroup;
 	public static synthetic fun contentForScopes$default (Lorg/jetbrains/dokka/base/translators/documentables/DefaultPageCreator;Ljava/util/List;Ljava/util/Set;Ljava/util/List;ILjava/lang/Object;)Lorg/jetbrains/dokka/pages/ContentGroup;
-	protected fun divergentBlock (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Ljava/lang/String;Ljava/util/Collection;Lorg/jetbrains/dokka/pages/ContentKind;Lorg/jetbrains/dokka/model/properties/PropertyContainer;)V
-	public static synthetic fun divergentBlock$default (Lorg/jetbrains/dokka/base/translators/documentables/DefaultPageCreator;Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Ljava/lang/String;Ljava/util/Collection;Lorg/jetbrains/dokka/pages/ContentKind;Lorg/jetbrains/dokka/model/properties/PropertyContainer;ILjava/lang/Object;)V
 	protected fun getContentBuilder ()Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder;
 	public final fun getCustomTagContentProviders ()Ljava/util/List;
 	public final fun getDocumentableAnalyzer ()Lorg/jetbrains/dokka/analysis/kotlin/internal/DocumentableSourceLanguageParser;

--- a/dokka-subprojects/plugin-base/src/test/kotlin/content/ExtensionsTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/content/ExtensionsTest.kt
@@ -1,0 +1,714 @@
+/*
+ * Copyright 2014-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package content
+
+import matchers.content.*
+import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
+import org.jetbrains.dokka.pages.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ExtensionsTest : BaseAbstractTest() {
+    private val configuration = dokkaConfiguration {
+        sourceSets {
+            sourceSet {
+                sourceRoots = listOf("src/")
+            }
+        }
+    }
+
+    // function tests
+
+    @Test
+    fun `should render top-level extension function`() {
+        testInline(
+            """
+            /src/A.kt
+            fun String.extension() {}
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesGenerationStage = { modulePage ->
+                val pkgNode = modulePage.children.single() as ContentPage
+
+                pkgNode.content.assertTabbedNode {
+                    group {
+                        assertTabGroup("Functions", BasicTabbedContentType.EXTENSION_FUNCTION) {
+                            assertTableWithTabs(
+                                "extension" to BasicTabbedContentType.EXTENSION_FUNCTION
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should differentiate top-level function and extension function`() {
+        testInline(
+            """
+            /src/A.kt
+            fun function() {}
+            fun String.extension() {}
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesGenerationStage = { modulePage ->
+                val pkgNode = modulePage.children.single() as ContentPage
+
+                pkgNode.content.assertTabbedNode {
+                    group {
+                        assertTabGroup("Functions", BasicTabbedContentType.FUNCTION) {
+                            assertTableWithTabs(
+                                "extension" to BasicTabbedContentType.EXTENSION_FUNCTION,
+                                "function" to null
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should render member extension function for object`() {
+        testInline(
+            """
+            /src/A.kt
+            object A {
+                fun String.memberExtension() {}  
+            }
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesGenerationStage = { modulePage ->
+                val pkgNode = modulePage.children.single()
+                val objectNode = pkgNode.children.single { it.name == "A" } as ContentPage
+
+                objectNode.content.assertTabbedNode {
+                    group {
+                        assertTabGroup("Functions", BasicTabbedContentType.FUNCTION) {
+                            assertTableWithTabs(
+                                "memberExtension" to null,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should render top-level extension function for object`() {
+        testInline(
+            """
+            /src/A.kt
+            object A
+            fun A.topLevelExtension() {}
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesGenerationStage = { modulePage ->
+                val pkgNode = modulePage.children.single()
+                val objectNode = pkgNode.children.single { it.name == "A" } as ContentPage
+
+                objectNode.content.assertTabbedNode {
+                    group {
+                        assertTabGroup("Functions", BasicTabbedContentType.EXTENSION_FUNCTION) {
+                            assertTableWithTabs(
+                                "topLevelExtension" to BasicTabbedContentType.EXTENSION_FUNCTION
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should differentiate functions and extension functions for object`() {
+        testInline(
+            """
+            /src/A.kt
+            object A {
+                fun function() {}
+                fun String.memberExtension() {}  
+            }
+            fun A.extension() {}
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesGenerationStage = { modulePage ->
+                val pkgNode = modulePage.children.single()
+                val objectNode = pkgNode.children.single { it.name == "A" } as ContentPage
+
+                objectNode.content.assertTabbedNode {
+                    group {
+                        assertTabGroup("Functions", BasicTabbedContentType.FUNCTION) {
+                            assertTableWithTabs(
+                                "extension" to BasicTabbedContentType.EXTENSION_FUNCTION,
+                                "function" to null,
+                                "memberExtension" to null
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should render member extensions function for class`() {
+        testInline(
+            """
+            /src/A.kt
+            class A {
+                fun String.memberExtension() {}  
+                fun A.memberSelfExtension() {}  
+            }
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesGenerationStage = { modulePage ->
+                val pkgNode = modulePage.children.single()
+                val objectNode = pkgNode.children.single { it.name == "A" } as ContentPage
+
+                objectNode.content.assertTabbedNode {
+                    group {
+                        assertTabGroup("Constructors", BasicTabbedContentType.CONSTRUCTOR) { skipAllNotMatching() }
+                    }
+                    group {
+                        assertTabGroup("Functions", BasicTabbedContentType.FUNCTION) {
+                            assertTableWithTabs(
+                                "memberExtension" to null,
+                                "memberSelfExtension" to null,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should render top-level extension functions for class`() {
+        testInline(
+            """
+            /src/A.kt
+            class A  
+            fun A.topLevelExtension() {}  
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesGenerationStage = { modulePage ->
+                val pkgNode = modulePage.children.single()
+                val objectNode = pkgNode.children.single { it.name == "A" } as ContentPage
+
+                objectNode.content.assertTabbedNode {
+                    group {
+                        assertTabGroup("Constructors", BasicTabbedContentType.CONSTRUCTOR) { skipAllNotMatching() }
+                    }
+                    group {
+                        assertTabGroup("Functions", BasicTabbedContentType.EXTENSION_FUNCTION) {
+                            assertTableWithTabs(
+                                "topLevelExtension" to BasicTabbedContentType.EXTENSION_FUNCTION
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should render extension functions from object for class`() {
+        testInline(
+            """
+            /src/A.kt
+            class A
+            object B {
+                fun A.extensionFromB() {}
+            } 
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesGenerationStage = { modulePage ->
+                val pkgNode = modulePage.children.single()
+                val objectNode = pkgNode.children.single { it.name == "A" } as ContentPage
+
+                objectNode.content.assertTabbedNode {
+                    group {
+                        assertTabGroup("Constructors", BasicTabbedContentType.CONSTRUCTOR) { skipAllNotMatching() }
+                    }
+                    group {
+                        assertTabGroup("Functions", BasicTabbedContentType.EXTENSION_FUNCTION) {
+                            assertTableWithTabs(
+                                "extensionFromB" to BasicTabbedContentType.EXTENSION_FUNCTION
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should differentiate functions and extension functions for class`() {
+        testInline(
+            """
+            /src/A.kt
+            class A {
+                fun function() {}
+                fun String.memberExtension() {}  
+                fun A.memberSelfExtension() {}  
+            }
+            fun A.extension() {}
+            object B {
+                fun A.extensionFromB() {}
+            }
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesGenerationStage = { modulePage ->
+                val pkgNode = modulePage.children.single()
+                val objectNode = pkgNode.children.single { it.name == "A" } as ContentPage
+
+                objectNode.content.assertTabbedNode {
+                    group {
+                        assertTabGroup("Constructors", BasicTabbedContentType.CONSTRUCTOR) { skipAllNotMatching() }
+                    }
+                    group {
+                        assertTabGroup("Functions", BasicTabbedContentType.FUNCTION) {
+                            assertTableWithTabs(
+                                "extension" to BasicTabbedContentType.EXTENSION_FUNCTION,
+                                "extensionFromB" to BasicTabbedContentType.EXTENSION_FUNCTION,
+                                "function" to null,
+                                "memberExtension" to null,
+                                "memberSelfExtension" to null,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should render member extension functions for companion object of class`() {
+        testInline(
+            """
+            /src/A.kt
+            class A {
+                companion object {
+                    fun Int.companionMemberExtensionForInt() {}
+                    fun A.companionMemberExtensionForA() {}
+                }
+            }
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesGenerationStage = { modulePage ->
+                val pkgNode = modulePage.children.single()
+                val objectNode = pkgNode.children.single { it.name == "A" } as ContentPage
+
+                objectNode.content.assertTabbedNode {
+                    group {
+                        assertTabGroup("Constructors", BasicTabbedContentType.CONSTRUCTOR) { skipAllNotMatching() }
+                    }
+                    group {
+                        assertTabGroup("Types", BasicTabbedContentType.TYPE) { skipAllNotMatching() }
+                        assertTabGroup("Functions", BasicTabbedContentType.EXTENSION_FUNCTION) {
+                            assertTableWithTabs(
+                                "companionMemberExtensionForA" to BasicTabbedContentType.EXTENSION_FUNCTION,
+                            )
+                        }
+                    }
+                }
+
+                val companionPage = objectNode.children.single { it.name == "Companion" } as ContentPage
+
+                companionPage.content.assertTabbedNode {
+                    group {
+                        assertTabGroup("Functions", BasicTabbedContentType.FUNCTION) {
+                            assertTableWithTabs(
+                                "companionMemberExtensionForA" to null,
+                                "companionMemberExtensionForInt" to null
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // property tests
+
+    @Test
+    fun `should render top-level extension property`() {
+        testInline(
+            """
+            /src/A.kt
+            val String.extension: String get() = "" 
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesGenerationStage = { modulePage ->
+                val pkgNode = modulePage.children.single() as ContentPage
+
+                pkgNode.content.assertTabbedNode {
+                    group {
+                        assertTabGroup("Properties", BasicTabbedContentType.EXTENSION_PROPERTY) {
+                            assertTableWithTabs(
+                                "extension" to BasicTabbedContentType.EXTENSION_PROPERTY
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should differentiate top-level property and extension property`() {
+        testInline(
+            """
+            /src/A.kt
+            val property: String get() = ""
+            val String.extension: String get() = ""
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesGenerationStage = { modulePage ->
+                val pkgNode = modulePage.children.single() as ContentPage
+
+                pkgNode.content.assertTabbedNode {
+                    group {
+                        assertTabGroup("Properties", BasicTabbedContentType.PROPERTY) {
+                            assertTableWithTabs(
+                                "extension" to BasicTabbedContentType.EXTENSION_PROPERTY,
+                                "property" to null
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should render member extension property for object`() {
+        testInline(
+            """
+            /src/A.kt
+            object A {
+                val String.memberExtension: String get() = ""
+            }
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesGenerationStage = { modulePage ->
+                val pkgNode = modulePage.children.single()
+                val objectNode = pkgNode.children.single { it.name == "A" } as ContentPage
+
+                objectNode.content.assertTabbedNode {
+                    group {
+                        assertTabGroup("Properties", BasicTabbedContentType.PROPERTY) {
+                            assertTableWithTabs(
+                                "memberExtension" to null,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should render top-level extension property for object`() {
+        testInline(
+            """
+            /src/A.kt
+            object A
+            val A.topLevelExtension: String get() = ""
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesGenerationStage = { modulePage ->
+                val pkgNode = modulePage.children.single()
+                val objectNode = pkgNode.children.single { it.name == "A" } as ContentPage
+
+                objectNode.content.assertTabbedNode {
+                    group {
+                        assertTabGroup("Properties", BasicTabbedContentType.EXTENSION_PROPERTY) {
+                            assertTableWithTabs(
+                                "topLevelExtension" to BasicTabbedContentType.EXTENSION_PROPERTY
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should differentiate properties and extension properties for object`() {
+        testInline(
+            """
+            /src/A.kt
+            object A {
+                val property: String get() = ""
+                val String.memberExtension: String get() = ""
+            }
+            val A.extension: String get() = ""
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesGenerationStage = { modulePage ->
+                val pkgNode = modulePage.children.single()
+                val objectNode = pkgNode.children.single { it.name == "A" } as ContentPage
+
+                objectNode.content.assertTabbedNode {
+                    group {
+                        assertTabGroup("Properties", BasicTabbedContentType.PROPERTY) {
+                            assertTableWithTabs(
+                                "extension" to BasicTabbedContentType.EXTENSION_PROPERTY,
+                                "memberExtension" to null,
+                                "property" to null
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should render member extension properties for class`() {
+        testInline(
+            """
+            /src/A.kt
+            class A {
+                val String.memberExtension: String get() = ""
+                val A.memberSelfExtension: String get() = ""
+            }
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesGenerationStage = { modulePage ->
+                val pkgNode = modulePage.children.single()
+                val objectNode = pkgNode.children.single { it.name == "A" } as ContentPage
+
+                objectNode.content.assertTabbedNode {
+                    group {
+                        assertTabGroup("Constructors", BasicTabbedContentType.CONSTRUCTOR) { skipAllNotMatching() }
+                    }
+                    group {
+                        assertTabGroup("Properties", BasicTabbedContentType.PROPERTY) {
+                            assertTableWithTabs(
+                                "memberExtension" to null,
+                                "memberSelfExtension" to null,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should render top-level extension properties for class`() {
+        testInline(
+            """
+            /src/A.kt
+            class A  
+            val A.topLevelExtension: String get() = ""  
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesGenerationStage = { modulePage ->
+                val pkgNode = modulePage.children.single()
+                val objectNode = pkgNode.children.single { it.name == "A" } as ContentPage
+
+                objectNode.content.assertTabbedNode {
+                    group {
+                        assertTabGroup("Constructors", BasicTabbedContentType.CONSTRUCTOR) { skipAllNotMatching() }
+                    }
+                    group {
+                        assertTabGroup("Properties", BasicTabbedContentType.EXTENSION_PROPERTY) {
+                            assertTableWithTabs(
+                                "topLevelExtension" to BasicTabbedContentType.EXTENSION_PROPERTY
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should render extension properties from object for class`() {
+        testInline(
+            """
+            /src/A.kt
+            class A
+            object B {
+                val A.extensionFromB: String get() = ""
+            } 
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesGenerationStage = { modulePage ->
+                val pkgNode = modulePage.children.single()
+                val objectNode = pkgNode.children.single { it.name == "A" } as ContentPage
+
+                objectNode.content.assertTabbedNode {
+                    group {
+                        assertTabGroup("Constructors", BasicTabbedContentType.CONSTRUCTOR) { skipAllNotMatching() }
+                    }
+                    group {
+                        assertTabGroup("Properties", BasicTabbedContentType.EXTENSION_PROPERTY) {
+                            assertTableWithTabs(
+                                "extensionFromB" to BasicTabbedContentType.EXTENSION_PROPERTY
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should differentiate properties and extension properties for class`() {
+        testInline(
+            """
+            /src/A.kt
+            class A {
+                val property: String get() = ""
+                val String.memberExtension: String get() = ""  
+                val A.memberSelfExtension: String get() = ""  
+            }
+            val A.extension: String get() = ""
+            object B {
+                val A.extensionFromB: String get() = ""
+            }
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesGenerationStage = { modulePage ->
+                val pkgNode = modulePage.children.single()
+                val objectNode = pkgNode.children.single { it.name == "A" } as ContentPage
+
+                objectNode.content.assertTabbedNode {
+                    group {
+                        assertTabGroup("Constructors", BasicTabbedContentType.CONSTRUCTOR) { skipAllNotMatching() }
+                    }
+                    group {
+                        assertTabGroup("Properties", BasicTabbedContentType.PROPERTY) {
+                            assertTableWithTabs(
+                                "extension" to BasicTabbedContentType.EXTENSION_PROPERTY,
+                                "extensionFromB" to BasicTabbedContentType.EXTENSION_PROPERTY,
+                                "memberExtension" to null,
+                                "memberSelfExtension" to null,
+                                "property" to null,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should render member extension properties for companion object of class`() {
+        testInline(
+            """
+            /src/A.kt
+            class A {
+                companion object {
+                    val Int.companionMemberExtensionForInt: String get() = ""
+                    val A.companionMemberExtensionForA: String get() = ""
+                }
+            }
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesGenerationStage = { modulePage ->
+                val pkgNode = modulePage.children.single()
+                val objectNode = pkgNode.children.single { it.name == "A" } as ContentPage
+
+                objectNode.content.assertTabbedNode {
+                    group {
+                        assertTabGroup("Constructors", BasicTabbedContentType.CONSTRUCTOR) { skipAllNotMatching() }
+                    }
+                    group {
+                        assertTabGroup("Types", BasicTabbedContentType.TYPE) { skipAllNotMatching() }
+                        assertTabGroup("Properties", BasicTabbedContentType.EXTENSION_PROPERTY) {
+                            assertTableWithTabs(
+                                "companionMemberExtensionForA" to BasicTabbedContentType.EXTENSION_PROPERTY,
+                            )
+                        }
+                    }
+                }
+
+                val companionPage = objectNode.children.single { it.name == "Companion" } as ContentPage
+
+                companionPage.content.assertTabbedNode {
+                    group {
+                        assertTabGroup("Properties", BasicTabbedContentType.PROPERTY) {
+                            assertTableWithTabs(
+                                "companionMemberExtensionForA" to null,
+                                "companionMemberExtensionForInt" to null
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun ContentMatcherBuilder<ContentGroup>.assertTableWithTabs(
+        vararg expected: Pair<String, TabbedContentType?>
+    ) {
+        table {
+            expected.forEach { (name, tabType) ->
+                group {
+                    assertTabbedContentType(tabType)
+                    link { +name }
+                    skipAllNotMatching()
+                }
+            }
+        }
+    }
+
+    private fun ContentMatcherBuilder<ContentGroup>.assertTabbedContentType(expected: TabbedContentType?) {
+        check {
+            assertEquals(expected, extra[TabbedContentTypeExtra]?.value)
+        }
+    }
+
+    private fun ContentNode.assertTabbedNode(block: ContentMatcherBuilder<ContentGroup>.() -> Unit) {
+        assertNode {
+            group {
+                header { }
+                skipAllNotMatching()
+            }
+            tabbedGroup(block)
+        }
+    }
+
+    private fun ContentMatcherBuilder<ContentGroup>.assertTabGroup(
+        name: String,
+        type: TabbedContentType,
+        block: ContentMatcherBuilder<ContentGroup>.() -> Unit
+    ) {
+        group {
+            assertTabbedContentType(type)
+            header { +name }
+            block()
+        }
+    }
+
+}

--- a/dokka-subprojects/plugin-base/src/test/kotlin/content/ExtensionsTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/content/ExtensionsTest.kt
@@ -37,7 +37,7 @@ class ExtensionsTest : BaseAbstractTest() {
                     group {
                         assertTabGroup("Functions", BasicTabbedContentType.EXTENSION_FUNCTION) {
                             assertTableWithTabs(
-                                "extension" to BasicTabbedContentType.EXTENSION_FUNCTION
+                                "extension" to null
                             )
                         }
                     }
@@ -119,7 +119,7 @@ class ExtensionsTest : BaseAbstractTest() {
                     group {
                         assertTabGroup("Functions", BasicTabbedContentType.EXTENSION_FUNCTION) {
                             assertTableWithTabs(
-                                "topLevelExtension" to BasicTabbedContentType.EXTENSION_FUNCTION
+                                "topLevelExtension" to null
                             )
                         }
                     }
@@ -214,7 +214,7 @@ class ExtensionsTest : BaseAbstractTest() {
                     group {
                         assertTabGroup("Functions", BasicTabbedContentType.EXTENSION_FUNCTION) {
                             assertTableWithTabs(
-                                "topLevelExtension" to BasicTabbedContentType.EXTENSION_FUNCTION
+                                "topLevelExtension" to null
                             )
                         }
                     }
@@ -246,7 +246,7 @@ class ExtensionsTest : BaseAbstractTest() {
                     group {
                         assertTabGroup("Functions", BasicTabbedContentType.EXTENSION_FUNCTION) {
                             assertTableWithTabs(
-                                "extensionFromB" to BasicTabbedContentType.EXTENSION_FUNCTION
+                                "extensionFromB" to null
                             )
                         }
                     }
@@ -322,7 +322,7 @@ class ExtensionsTest : BaseAbstractTest() {
                         assertTabGroup("Types", BasicTabbedContentType.TYPE) { skipAllNotMatching() }
                         assertTabGroup("Functions", BasicTabbedContentType.EXTENSION_FUNCTION) {
                             assertTableWithTabs(
-                                "companionMemberExtensionForA" to BasicTabbedContentType.EXTENSION_FUNCTION,
+                                "companionMemberExtensionForA" to null,
                             )
                         }
                     }
@@ -362,7 +362,7 @@ class ExtensionsTest : BaseAbstractTest() {
                     group {
                         assertTabGroup("Properties", BasicTabbedContentType.EXTENSION_PROPERTY) {
                             assertTableWithTabs(
-                                "extension" to BasicTabbedContentType.EXTENSION_PROPERTY
+                                "extension" to null
                             )
                         }
                     }
@@ -444,7 +444,7 @@ class ExtensionsTest : BaseAbstractTest() {
                     group {
                         assertTabGroup("Properties", BasicTabbedContentType.EXTENSION_PROPERTY) {
                             assertTableWithTabs(
-                                "topLevelExtension" to BasicTabbedContentType.EXTENSION_PROPERTY
+                                "topLevelExtension" to null
                             )
                         }
                     }
@@ -539,7 +539,7 @@ class ExtensionsTest : BaseAbstractTest() {
                     group {
                         assertTabGroup("Properties", BasicTabbedContentType.EXTENSION_PROPERTY) {
                             assertTableWithTabs(
-                                "topLevelExtension" to BasicTabbedContentType.EXTENSION_PROPERTY
+                                "topLevelExtension" to null
                             )
                         }
                     }
@@ -571,7 +571,7 @@ class ExtensionsTest : BaseAbstractTest() {
                     group {
                         assertTabGroup("Properties", BasicTabbedContentType.EXTENSION_PROPERTY) {
                             assertTableWithTabs(
-                                "extensionFromB" to BasicTabbedContentType.EXTENSION_PROPERTY
+                                "extensionFromB" to null
                             )
                         }
                     }
@@ -647,7 +647,7 @@ class ExtensionsTest : BaseAbstractTest() {
                         assertTabGroup("Types", BasicTabbedContentType.TYPE) { skipAllNotMatching() }
                         assertTabGroup("Properties", BasicTabbedContentType.EXTENSION_PROPERTY) {
                             assertTableWithTabs(
-                                "companionMemberExtensionForA" to BasicTabbedContentType.EXTENSION_PROPERTY,
+                                "companionMemberExtensionForA" to null,
                             )
                         }
                     }


### PR DESCRIPTION
Fixes #3187 

**Context**
During building Classlike page, separate tabs for `members` and `members+extensions` are configured inside `divergentBlock`. Functions/Properties are divided in members and extensions by calling `Documentable.isExtension` (returns if function/property is extension or not based on existence of receiver).

**Problem**
Kotlin also has member extensions, which should be shown on `members` page, but `Documentable.isExtension` for them returns `true` because, you know, they are extensions.

To better illustrate the problem, here is a sample code:
```kotlin
interface Receiver {
    // 1. just ordinary member function
    // receiver = null
    fun memberFunction()

    // 2. member extension function
    // receiver = Int
    fun Int.intExtensionFunction()

    // 3. member extension function (yes it's valid Kotlin code)
    // receiver = Receiver
    fun Receiver.recieverExtensionFunction()

    companion object {
        // 4. extension function inside companion
        // receiver = Receiver
        fun Receiver.receiverCompanionExtensionFunction(): String = "bar"
    }
}

// 5. top-level extension function
// receiver = Receiver
fun Receiver.receiverTopLevelExtensionFunction(): String = "bar"
```

**Expected behaviour**
Functions 1, 2, 3 should be shown on `members` tab, and on `members+extensions` additionally shown 4 and 5

**Current behaviour**
Only function 1 is shown on `members` tab, and on `members+extensions` additionally shown 1, 2, 3, 4, 5.

**Code problem**
`DocumentableContentBuilder.divergentBlock` only accepts `List<Documentable>` (where `Documentable` could be function, property or type), and having only this we can't distinguish, is this function/property is `member extension in type Receiver` or it is `external extension with receiver of type Receiver`.
But we have this information upper in chain:
1. for Classlikes, member extensions are already present in functions/properties and extensions are coming from `CallableExtensions` extra
2. for packages, we can check `receiver != null` the same way as in `Documentable.isExtension`. We don't really render top-level declarations and top-level extensions differently in HTML or other formats, but we have tests for it :)

Another minor problem(inconvenience) that now processing types, functions and properties is done via single function (`DocumentableContentBuilder.divergentBlock`), and so it already has multiple checks, if we are processing different kinds of documentables and change behaviour accordingly

**Solution**
* Path extensions and members explicitly as separate lists and handle them correctly after it
* Split functions/properties and types logic, so that only related code for each kind of declarations is executed and code flow is easier to understand

**Questions**
* Do we really need `Documentable.isExtension` in core? (it was used only in `dokka-base`s `DefaultPageCreator.kt`)
* Is it ok to break `DefaultPageCreator` ABI? Now half of members there `protected open` and half `private`. In our codebase the only usage is in `kotlin-as-java` to override 1 function.
On GitHub there is also only one usage of it in [island-time](https://github.com/erikc5000/island-time/blob/fcb0e14d7b4e25e836e08ef6509296ed57031a45/tools/mkdocs-dokka-plugin/src/main/kotlin/MkdocsDocumentableToPageTranslator.kt#L69) - only `contentForModule` is overridden there (the only change is [headers of table](https://github.com/erikc5000/island-time/blob/fcb0e14d7b4e25e836e08ef6509296ed57031a45/tools/mkdocs-dokka-plugin/src/main/kotlin/MkdocsDocumentableToPageTranslator.kt#L92-L95) - looks like it is to fix rendering of packages in GHM format)