### PR TITLE
Fix enum test, add toolchains and running on JDK 21

### DIFF
--- a/.github/workflows/tests-thorough.yml
+++ b/.github/workflows/tests-thorough.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        javaVersion: [ 8, 11, 17 ]
+        javaVersion: [ 8, 11, 17, 21 ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/dokka-integration-tests/settings.gradle.kts
+++ b/dokka-integration-tests/settings.gradle.kts
@@ -15,6 +15,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+}
+
 dependencyResolutionManagement {
     repositories {
         mavenCentral()

--- a/dokka-runners/runner-cli/settings.gradle.kts
+++ b/dokka-runners/runner-cli/settings.gradle.kts
@@ -15,6 +15,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+}
+
 dependencyResolutionManagement {
     repositories {
         mavenCentral()

--- a/dokka-runners/runner-gradle-plugin-classic/settings.gradle.kts
+++ b/dokka-runners/runner-gradle-plugin-classic/settings.gradle.kts
@@ -15,6 +15,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+}
+
 dependencyResolutionManagement {
     repositories {
         mavenCentral()

--- a/dokka-runners/runner-maven-plugin/settings.gradle.kts
+++ b/dokka-runners/runner-maven-plugin/settings.gradle.kts
@@ -15,6 +15,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+}
+
 dependencyResolutionManagement {
     repositories {
         mavenCentral()

--- a/dokka-subprojects/analysis-kotlin-api/src/test/kotlin/org/jetbrains/dokka/analysis/test/documentable/ObviousFunctionsTest.kt
+++ b/dokka-subprojects/analysis-kotlin-api/src/test/kotlin/org/jetbrains/dokka/analysis/test/documentable/ObviousFunctionsTest.kt
@@ -121,13 +121,24 @@ class ObviousFunctionsTest {
             assertNotNull(enum)
             assertEquals("Enum", enum.name)
 
+            val javaVersion = when (val specVersion = System.getProperty("java.specification.version")) {
+                "1.8" -> 8
+                else -> specVersion.toInt()
+            }
+
+            // inherited from java enum
+            val jdkEnumInheritedFunctions = when {
+                // starting from JDK 18, 'finalize' is not available (finalization is deprecated in JDK 18)
+                javaVersion >= 18 -> setOf("clone", "getDeclaringClass", "describeConstable")
+                // starting from JDK 12, there is a new member in enum 'describeConstable'
+                javaVersion >= 12 -> setOf("clone", "getDeclaringClass", "describeConstable", "finalize")
+                else -> setOf("clone", "getDeclaringClass", "finalize")
+            }
+
             assertObviousFunctions(
                 expectedObviousFunctions = emptySet(),
-                expectedNonObviousFunctions = setOf(
-                    "compareTo", "equals", "hashCode", "toString",
-                    // inherited from java enum
-                    "clone", "finalize", "getDeclaringClass"
-                ),
+                expectedNonObviousFunctions = setOf("compareTo", "equals", "hashCode", "toString") +
+                        jdkEnumInheritedFunctions,
                 actualFunctions = enum.functions
             )
         }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -56,6 +56,7 @@ dependencyResolutionManagement {
 
 plugins {
     `gradle-enterprise`
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
 }
 
 includeBuild("dokka-integration-tests")


### PR DESCRIPTION
After merging PR #3349 to master, enum test failed on JDK 17: https://github.com/Kotlin/dokka/actions/runs/6983352619/job/19004323879#step:6:362

Cause: in JDK 12 one new method was added to Enum class - https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Enum.html#describeConstable()

Also checked on JDK 21 - one more failure, now because of deprecation for removal of finalize in JDK 18 - https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Enum.html#finalize()

Added running tests for JDK 21 on CI + gradle toolchain auto-resolve - https://docs.gradle.org/current/userguide/toolchains.html#sub:download_repositories - it's hard to extract it into version catalog as it's applied in settings.gradle.kts....