### PR TITLE
Support parsing javadoc `@param` for classes

### DIFF
--- a/dokka-subprojects/analysis-java-psi/api/analysis-java-psi.api
+++ b/dokka-subprojects/analysis-java-psi/api/analysis-java-psi.api
@@ -43,8 +43,7 @@ public abstract class org/jetbrains/dokka/analysis/java/JavadocTag {
 public final class org/jetbrains/dokka/analysis/java/ParamJavadocTag : org/jetbrains/dokka/analysis/java/JavadocTag {
 	public static final field Companion Lorg/jetbrains/dokka/analysis/java/ParamJavadocTag$Companion;
 	public static final field name Ljava/lang/String;
-	public fun <init> (Lcom/intellij/psi/PsiMethod;Ljava/lang/String;I)V
-	public final fun getMethod ()Lcom/intellij/psi/PsiMethod;
+	public fun <init> (Ljava/lang/String;I)V
 	public final fun getParamIndex ()I
 	public final fun getParamName ()Ljava/lang/String;
 }

--- a/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/JavadocTag.kt
+++ b/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/JavadocTag.kt
@@ -4,7 +4,6 @@
 
 package org.jetbrains.dokka.analysis.java
 
-import com.intellij.psi.PsiMethod
 import org.jetbrains.dokka.InternalDokkaApi
 
 @InternalDokkaApi
@@ -19,7 +18,6 @@ public object ReturnJavadocTag : JavadocTag("return")
 public object SinceJavadocTag : JavadocTag("since")
 
 public class ParamJavadocTag(
-    public val method: PsiMethod,
     public val paramName: String,
     public val paramIndex: Int
 ) : JavadocTag(name) {

--- a/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/doccomment/JavaDocComment.kt
+++ b/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/doccomment/JavaDocComment.kt
@@ -39,9 +39,7 @@ internal class JavaDocComment(val comment: PsiDocComment) : DocComment {
         val resolvedParamElements = comment.resolveTag(tag)
             .filterIsInstance<PsiDocTag>()
             .map { it.contentElementsWithSiblingIfNeeded() }
-            .firstOrNull {
-                it.firstOrNull()?.text == tag.method.parameterList.parameters[tag.paramIndex].name
-            }.orEmpty()
+            .firstOrNull { it.firstOrNull()?.text == tag.paramName }.orEmpty()
 
         return resolvedParamElements
             .withoutReferenceLink()

--- a/dokka-subprojects/analysis-kotlin-api/src/test/kotlin/org/jetbrains/dokka/analysis/test/jvm/java/JavadocAnalysisTest.kt
+++ b/dokka-subprojects/analysis-kotlin-api/src/test/kotlin/org/jetbrains/dokka/analysis/test/jvm/java/JavadocAnalysisTest.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2014-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package org.jetbrains.dokka.analysis.test.jvm.java
+
+import org.jetbrains.dokka.analysis.test.api.javaTestProject
+import org.jetbrains.dokka.analysis.test.api.parse
+import org.jetbrains.dokka.model.SourceSetDependent
+import org.jetbrains.dokka.model.doc.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class JavadocAnalysisTest {
+
+    @Test
+    fun `should parse javadoc @param for type parameter on class`() {
+        val testProject = javaTestProject {
+            javaFile(pathFromSrc = "Foo.java") {
+                +"""
+                    /**
+                     * class
+                     *
+                     * @param <Bar> type parameter,
+                     *  long type parameter description
+                     */
+                    public class Foo<Bar> {}
+                """
+            }
+        }
+
+        val module = testProject.parse()
+        val pkg = module.packages.single()
+        val cls = pkg.classlikes.single()
+
+        assertDocumentationNodeContains(
+            cls.documentation,
+            listOf(
+                Description(customDocTag("class")),
+                Param(customDocTag("type parameter, long type parameter description"), "<Bar>"),
+            )
+        )
+    }
+
+    @Test
+    fun `should parse javadoc @param for type parameter on function`() {
+        val testProject = javaTestProject {
+            javaFile(pathFromSrc = "Foo.java") {
+                +"""
+                    public class Foo {
+                        /**
+                         * function
+                         *
+                         * @param <Bar> type parameter,
+                         *  long type parameter description
+                         */
+                        public <Bar> void something(Bar bar) {}
+                    }
+                """
+            }
+        }
+
+        val module = testProject.parse()
+        val pkg = module.packages.single()
+        val cls = pkg.classlikes.single()
+        val function = cls.functions.single { it.name == "something" }
+
+        assertDocumentationNodeContains(
+            function.documentation,
+            listOf(
+                Description(customDocTag("function")),
+                Param(customDocTag("type parameter, long type parameter description"), "<Bar>"),
+            )
+        )
+    }
+
+    @Test
+    fun `should parse javadoc @param for parameter on function`() {
+        val testProject = javaTestProject {
+            javaFile(pathFromSrc = "Foo.java") {
+                +"""
+                    public class Foo {
+                        /**
+                         * function
+                         *
+                         * @param bar parameter,
+                         *  long parameter description
+                         */
+                        public void something(String bar) {}
+                    }
+                """
+            }
+        }
+
+        val module = testProject.parse()
+        val pkg = module.packages.single()
+        val cls = pkg.classlikes.single()
+        val function = cls.functions.single { it.name == "something" }
+
+        assertDocumentationNodeContains(
+            function.documentation,
+            listOf(
+                Description(customDocTag("function")),
+                Param(customDocTag("parameter, long parameter description"), "bar"),
+            )
+        )
+    }
+
+    private fun customDocTag(text: String): CustomDocTag {
+        return CustomDocTag(listOf(P(listOf(Text(text)))), name = "MARKDOWN_FILE")
+    }
+
+    private fun assertDocumentationNodeContains(
+        node: SourceSetDependent<DocumentationNode>,
+        expected: List<TagWrapper>
+    ) {
+        assertEquals(
+            DocumentationNode(expected),
+            node.values.single()
+        )
+    }
+}


### PR DESCRIPTION
Fixes #3199 