### PR TITLE
fix: made empty search notification visible in both themes

### DIFF
--- a/dokka-subprojects/plugin-base-frontend/src/main/components/search/search.scss
+++ b/dokka-subprojects/plugin-base-frontend/src/main/components/search/search.scss
@@ -43,6 +43,7 @@ $secondary-font-color: hsla(0, 0%, 100%, 0.6);
   border: 1px solid hsla(0, 0%, 100%, 0.2) !important;
 
   background-color: #27282c !important;
+  color: $font-color;
 
   [class^="filterWrapper"] {
     border-bottom: 1px solid hsla(0, 0%, 100%, 0.2);


### PR DESCRIPTION
fixes #3281 

Demo:

<img width="837" alt="ee" src="https://github.com/Kotlin/dokka/assets/4469732/e34781a9-ede3-4ca4-830e-663476c5251d">
<img width="839" alt="r" src="https://github.com/Kotlin/dokka/assets/4469732/3a7a0ec1-582f-46a9-a83f-55bec8382ede">
