### PR TITLE
Accessibility: Wrap links and code blocks

### DIFF
--- a/dokka-subprojects/plugin-base/src/main/resources/dokka/styles/style.css
+++ b/dokka-subprojects/plugin-base/src/main/resources/dokka/styles/style.css
@@ -802,6 +802,7 @@ code:not(.block) {
     top: 8px;
     right: 8px;
     overflow-wrap: break-word;
+    word-break: break-word;
 }
 
 .sideMenuPart > .overview {

--- a/dokka-subprojects/plugin-base/src/main/resources/dokka/styles/style.css
+++ b/dokka-subprojects/plugin-base/src/main/resources/dokka/styles/style.css
@@ -1024,7 +1024,7 @@ h1.cover {
     font-size: inherit;
     line-height: inherit;
     transition: color .1s, border-color .1s;
-    word-wrap: break-word;
+    overflow-wrap: break-word;
 }
 
 .main-content a:hover {

--- a/dokka-subprojects/plugin-base/src/main/resources/dokka/styles/style.css
+++ b/dokka-subprojects/plugin-base/src/main/resources/dokka/styles/style.css
@@ -801,6 +801,7 @@ code:not(.block) {
     position: absolute;
     top: 8px;
     right: 8px;
+    overflow-wrap: break-word;
 }
 
 .sideMenuPart > .overview {
@@ -1023,6 +1024,7 @@ h1.cover {
     font-size: inherit;
     line-height: inherit;
     transition: color .1s, border-color .1s;
+    word-wrap: break-word;
 }
 
 .main-content a:hover {

--- a/dokka-subprojects/plugin-base/src/main/resources/dokka/styles/style.css
+++ b/dokka-subprojects/plugin-base/src/main/resources/dokka/styles/style.css
@@ -1025,6 +1025,7 @@ h1.cover {
     line-height: inherit;
     transition: color .1s, border-color .1s;
     overflow-wrap: break-word;
+    word-break: break-word;
 }
 
 .main-content a:hover {


### PR DESCRIPTION
Wrap links and code blocks to prevent two-dimensional scrollbar from appearing on small screens.

Solves violation number 5 in this issue: https://github.com/Kotlin/dokka/issues/3414