### PR TITLE
Accessibility: add outline when section-tab is focused

### DIFF
--- a/dokka-subprojects/plugin-base/src/main/resources/dokka/styles/style.css
+++ b/dokka-subprojects/plugin-base/src/main/resources/dokka/styles/style.css
@@ -580,7 +580,7 @@ td:first-child {
     border-bottom: 2px solid var(--active-tab-border-color);
 }
 
-.section-tab:focus, .section-tab:active {
+.section-tab:focus-visible {
     outline: 2px solid var(--active-tab-border-color);
 }
 

--- a/dokka-subprojects/plugin-base/src/main/resources/dokka/styles/style.css
+++ b/dokka-subprojects/plugin-base/src/main/resources/dokka/styles/style.css
@@ -580,6 +580,10 @@ td:first-child {
     border-bottom: 2px solid var(--active-tab-border-color);
 }
 
+.section-tab:focus, .section-tab:active {
+    outline: 2px solid var(--active-tab-border-color);
+}
+
 .tabs-section-body > div {
     margin-top: 12px;
 }

--- a/dokka-subprojects/plugin-base/src/main/resources/dokka/styles/style.css
+++ b/dokka-subprojects/plugin-base/src/main/resources/dokka/styles/style.css
@@ -580,7 +580,7 @@ td:first-child {
     border-bottom: 2px solid var(--active-tab-border-color);
 }
 
-.section-tab:focus-visible {
+.section-tab:focus-visible, .platform-bookmark:focus-visible {
     outline: 2px solid var(--active-tab-border-color);
 }
 


### PR DESCRIPTION
Adds an outline to section-tabs when they are focused. The color matches the underline color when they are hovered over. 

Solves violation number 4 in this issue: https://github.com/Kotlin/dokka/issues/3414