### PR TITLE
fix: aligned inline code vertically #3228

### DIFF
--- a/dokka-subprojects/plugin-base/src/main/resources/dokka/styles/style.css
+++ b/dokka-subprojects/plugin-base/src/main/resources/dokka/styles/style.css
@@ -714,7 +714,7 @@ code {
 
 code:not(.block) {
     display: inline-block;
-    vertical-align: middle;
+    vertical-align: bottom;
 }
 
 .symbol > a {


### PR DESCRIPTION
fixes #3228 

### After
<img width="342" alt="after" src="https://github.com/Kotlin/dokka/assets/4469732/d5f6146d-f4b1-4346-9c8c-36721a476dcf">


### before
<img width="372" alt="before" src="https://github.com/Kotlin/dokka/assets/4469732/e9608cad-d742-48ee-a797-76ac3e4c29b0">

By the way, I was able to reproduce it both in Firefox and Chrome. And now it'll be fixed in both browsers