### PR TITLE
KT-64377 disable explicit api in test utils

### DIFF
--- a/dokka-integration-tests/gradle/build.gradle.kts
+++ b/dokka-integration-tests/gradle/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
+
 /*
  * Copyright 2014-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
@@ -16,6 +18,11 @@ dependencies {
     implementation(gradleTestKit())
 
     implementation(libs.jsoup)
+}
+
+kotlin {
+    // this project only contains test utils and isn't published, so it doesn't matter about explicit API
+    explicitApi = ExplicitApiMode.Disabled
 }
 
 val aggregatingProject = gradle.includedBuild("dokka")

--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleIntegrationTest.kt
@@ -14,17 +14,17 @@ import java.io.File
 import java.net.URI
 import kotlin.test.BeforeTest
 
-public abstract class AbstractGradleIntegrationTest : AbstractIntegrationTest() {
+abstract class AbstractGradleIntegrationTest : AbstractIntegrationTest() {
 
     @BeforeTest
-    public fun copyTemplates() {
+    fun copyTemplates() {
         File("projects").listFiles().orEmpty()
             .filter { it.isFile }
             .filter { it.name.startsWith("template.") }
             .forEach { file -> file.copyTo(File(tempFolder, file.name)) }
     }
 
-    public fun createGradleRunner(
+    fun createGradleRunner(
         buildVersions: BuildVersions,
         vararg arguments: String,
         jvmArgs: List<String> = listOf("-Xmx2G", "-XX:MaxMetaspaceSize=1G")
@@ -54,7 +54,7 @@ public abstract class AbstractGradleIntegrationTest : AbstractIntegrationTest() 
             .withJvmArguments(jvmArgs)
     }
 
-    public fun GradleRunner.buildRelaxed(): BuildResult {
+    fun GradleRunner.buildRelaxed(): BuildResult {
         return try {
             build()
         } catch (e: Throwable) {

--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/BuildVersions.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/BuildVersions.kt
@@ -6,12 +6,12 @@ package org.jetbrains.dokka.it.gradle
 
 import org.gradle.util.GradleVersion
 
-public data class BuildVersions(
+data class BuildVersions(
     val gradleVersion: GradleVersion,
     val kotlinVersion: String,
     val androidGradlePluginVersion: String? = null,
 ) {
-    public constructor(
+    constructor(
         gradleVersion: String,
         kotlinVersion: String,
         androidGradlePluginVersion: String? = null
@@ -30,8 +30,8 @@ public data class BuildVersions(
         }
     }
 
-    public companion object {
-        public fun permutations(
+    companion object {
+        fun permutations(
             gradleVersions: List<String>,
             kotlinVersions: List<String>,
             androidGradlePluginVersions: List<String?> = listOf(null)

--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/TestEnvironment.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/TestEnvironment.kt
@@ -6,19 +6,19 @@ package org.jetbrains.dokka.it.gradle
 
 import org.junit.jupiter.api.Tag
 
-public object TestEnvironment {
-    public const val TRY_K2: String = "org.jetbrains.dokka.experimental.tryK2"
+object TestEnvironment {
+    const val TRY_K2: String = "org.jetbrains.dokka.experimental.tryK2"
 
-    public val isExhaustive: Boolean = checkNotNull(System.getenv("isExhaustive")) {
+    val isExhaustive: Boolean = checkNotNull(System.getenv("isExhaustive")) {
         "Missing `isExhaustive` environment variable"
     }.toBoolean()
 
-    public val isEnabledDebug: Boolean = System.getenv("ENABLE_DEBUG").toBoolean()
+    val isEnabledDebug: Boolean = System.getenv("ENABLE_DEBUG").toBoolean()
 
     /**
      * By default, it is disabled
      */
-    public fun shouldUseK2(): Boolean = getBooleanProperty(TRY_K2)
+    fun shouldUseK2(): Boolean = getBooleanProperty(TRY_K2)
 
     private fun getBooleanProperty(propertyName: String): Boolean {
         return System.getProperty(propertyName) in setOf("1", "true")
@@ -28,7 +28,7 @@ public object TestEnvironment {
 /**
  * Will only return values if [TestEnvironment.isExhaustive] is set to true
  */
-public inline fun <reified T> ifExhaustive(vararg values: T): Array<out T> {
+inline fun <reified T> ifExhaustive(vararg values: T): Array<out T> {
     return if (TestEnvironment.isExhaustive) values else emptyArray()
 }
 
@@ -46,4 +46,4 @@ public inline fun <reified T> ifExhaustive(vararg values: T): Array<out T> {
     AnnotationRetention.RUNTIME
 )
 @Tag("onlyDescriptors")
-public annotation class OnlyDescriptors(val reason: String = "")
+annotation class OnlyDescriptors(val reason: String = "")

--- a/dokka-integration-tests/utilities/build.gradle.kts
+++ b/dokka-integration-tests/utilities/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode.Disabled
+
 /*
  * Copyright 2014-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
@@ -14,4 +16,9 @@ dependencies {
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.jsoup)
     implementation(libs.eclipse.jgit)
+}
+
+kotlin {
+    // this project only contains test utils and isn't published, so it doesn't matter about explicit API
+    explicitApi = Disabled
 }

--- a/dokka-integration-tests/utilities/src/main/kotlin/org/jetbrains/dokka/it/AbstractIntegrationTest.kt
+++ b/dokka-integration-tests/utilities/src/main/kotlin/org/jetbrains/dokka/it/AbstractIntegrationTest.kt
@@ -13,19 +13,19 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
-public abstract class AbstractIntegrationTest {
+abstract class AbstractIntegrationTest {
 
     @field:TempDir
-    public lateinit var tempFolder: File
+    lateinit var tempFolder: File
 
-    public val projectDir: File get() = File(tempFolder, "project")
+    val projectDir: File get() = File(tempFolder, "project")
 
-    public fun File.allDescendentsWithExtension(extension: String): Sequence<File> =
+    fun File.allDescendentsWithExtension(extension: String): Sequence<File> =
         this.walkTopDown().filter { it.isFile && it.extension == extension }
 
-    public fun File.allHtmlFiles(): Sequence<File> = allDescendentsWithExtension("html")
+    fun File.allHtmlFiles(): Sequence<File> = allDescendentsWithExtension("html")
 
-    public fun File.allGfmFiles(): Sequence<File> = allDescendentsWithExtension("md")
+    fun File.allGfmFiles(): Sequence<File> = allDescendentsWithExtension("md")
 
     protected fun assertContainsNoErrorClass(file: File) {
         val fileText = file.readText()

--- a/dokka-integration-tests/utilities/src/main/kotlin/org/jetbrains/dokka/it/TestOutputCopier.kt
+++ b/dokka-integration-tests/utilities/src/main/kotlin/org/jetbrains/dokka/it/TestOutputCopier.kt
@@ -7,11 +7,11 @@ package org.jetbrains.dokka.it
 import java.io.File
 import kotlin.test.AfterTest
 
-public interface TestOutputCopier {
-    public val projectOutputLocation: File
+interface TestOutputCopier {
+    val projectOutputLocation: File
 
     @AfterTest
-    public fun copyToLocation() {
+    fun copyToLocation() {
         System.getenv("DOKKA_TEST_OUTPUT_PATH")?.also { location ->
             println("Copying to ${File(location).absolutePath}")
             projectOutputLocation.copyRecursively(File(location))

--- a/dokka-integration-tests/utilities/src/main/kotlin/org/jetbrains/dokka/it/gitSubmoduleUtils.kt
+++ b/dokka-integration-tests/utilities/src/main/kotlin/org/jetbrains/dokka/it/gitSubmoduleUtils.kt
@@ -9,14 +9,14 @@ import org.eclipse.jgit.storage.file.FileRepositoryBuilder
 import java.io.File
 import java.nio.file.Path
 
-public fun AbstractIntegrationTest.copyAndApplyGitDiff(diffFile: File) {
+fun AbstractIntegrationTest.copyAndApplyGitDiff(diffFile: File) {
     copyGitDiffFileToParent(diffFile).let(::applyGitDiffFromFile)
 }
 
-public fun AbstractIntegrationTest.copyGitDiffFileToParent(originalDiffFile: File): File =
+private fun AbstractIntegrationTest.copyGitDiffFileToParent(originalDiffFile: File): File =
     originalDiffFile.copyTo(File(projectDir.parent, originalDiffFile.name))
 
-public fun AbstractIntegrationTest.applyGitDiffFromFile(diffFile: File) {
+private fun AbstractIntegrationTest.applyGitDiffFromFile(diffFile: File) {
     val projectGitFile = projectDir.resolve(".git")
     val git = if (projectGitFile.exists()) {
         if (projectGitFile.isFile) {

--- a/dokka-integration-tests/utilities/src/main/kotlin/org/jetbrains/dokka/it/processUtils.kt
+++ b/dokka-integration-tests/utilities/src/main/kotlin/org/jetbrains/dokka/it/processUtils.kt
@@ -9,12 +9,12 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import kotlin.concurrent.thread
 
-public class ProcessResult(
-    public val exitCode: Int,
-    public val output: String
+class ProcessResult(
+    val exitCode: Int,
+    val output: String
 )
 
-public fun Process.awaitProcessResult(): ProcessResult = runBlocking {
+fun Process.awaitProcessResult(): ProcessResult = runBlocking {
     val exitCode = async { awaitExitCode() }
     val output = async { awaitOutput() }
     ProcessResult(


### PR DESCRIPTION
These utilities aren't published, so strict API checking isn't necessary.

Removing explicit API mode allows for more concise code. It also helps with verifying that code is actually required.

For example - `fun AbstractIntegrationTest.copyGitDiffFileToParent()` and `AbstractIntegrationTest.applyGitDiffFromFile()` could be private, but IJ because explicit API mode was enabled it didn't suggest they could be private.