### PR TITLE
Replace usages of deprecated in JDK 20 `java.net.URL` constructor in Gradle runner

### DIFF
--- a/dokka-runners/runner-gradle-plugin-classic/src/main/kotlin/org/jetbrains/dokka/gradle/GradleDokkaSourceSetBuilder.kt
+++ b/dokka-runners/runner-gradle-plugin-classic/src/main/kotlin/org/jetbrains/dokka/gradle/GradleDokkaSourceSetBuilder.kt
@@ -16,6 +16,7 @@ import org.gradle.kotlin.dsl.property
 import org.gradle.kotlin.dsl.setProperty
 import org.jetbrains.dokka.*
 import java.io.File
+import java.net.URI
 import java.net.URL
 
 /**
@@ -462,7 +463,7 @@ open class GradleDokkaSourceSetBuilder(
      * Convenient override to **append** external documentation links to [externalDocumentationLinks].
      */
     fun externalDocumentationLink(url: String, packageListUrl: String? = null) {
-        externalDocumentationLink(URL(url), packageListUrl = packageListUrl?.let(::URL))
+        externalDocumentationLink(URI(url).toURL(), packageListUrl = packageListUrl?.let(::URI)?.toURL())
     }
 
     /**

--- a/dokka-runners/runner-gradle-plugin-classic/src/main/kotlin/org/jetbrains/dokka/gradle/GradleExternalDocumentationLinkBuilder.kt
+++ b/dokka-runners/runner-gradle-plugin-classic/src/main/kotlin/org/jetbrains/dokka/gradle/GradleExternalDocumentationLinkBuilder.kt
@@ -30,9 +30,9 @@ import java.net.URL
  *
  * ```kotlin
  * externalDocumentationLink {
- *     url.set(URL("https://kotlinlang.org/api/kotlinx.serialization/"))
+ *     url.set(URI("https://kotlinlang.org/api/kotlinx.serialization/").toURL())
  *     packageListUrl.set(
- *         rootProject.projectDir.resolve("serialization.package.list").toURL()
+ *         rootProject.projectDir.resolve("serialization.package.list").toURI().toURL()
  *     )
  * }
  * ```
@@ -53,13 +53,13 @@ class GradleExternalDocumentationLinkBuilder(
      * Example:
      *
      * ```kotlin
-     * java.net.URL("https://kotlinlang.org/api/kotlinx.serialization/")
+     * java.net.URI("https://kotlinlang.org/api/kotlinx.serialization/").toURL()
      * ```
      */
     @Internal
     val url: Property<URL> = project.objects.property()
 
-    @Input // URL is deprecated in gradle inputs
+    @Input // URL is deprecated in Gradle inputs
     internal fun getUrlString() = url.map(URL::toString)
 
     /**
@@ -69,13 +69,13 @@ class GradleExternalDocumentationLinkBuilder(
      * Example:
      *
      * ```kotlin
-     * rootProject.projectDir.resolve("serialization.package.list").toURL()
+     * rootProject.projectDir.resolve("serialization.package.list").toURI().toURL()
      * ```
      */
     @Internal
     val packageListUrl: Property<URL> = project.objects.property()
 
-    @Input // URL is deprecated in gradle inputs
+    @Input // URL is deprecated in Gradle inputs
     @Optional
     internal fun getPackageListUrlString() = packageListUrl.map(URL::toString)
 

--- a/dokka-runners/runner-gradle-plugin-classic/src/main/kotlin/org/jetbrains/dokka/gradle/GradleSourceLinkBuilder.kt
+++ b/dokka-runners/runner-gradle-plugin-classic/src/main/kotlin/org/jetbrains/dokka/gradle/GradleSourceLinkBuilder.kt
@@ -26,7 +26,7 @@ import java.net.URL
  * ```kotlin
  * sourceLink {
  *     localDirectory.set(projectDir.resolve("src"))
- *     remoteUrl.set(URL("https://github.com/kotlin/dokka/tree/master/src"))
+ *     remoteUrl.set(URI("https://github.com/kotlin/dokka/tree/master/src").toURL())
  *     remoteLineSuffix.set("#L")
  * }
  * ```
@@ -68,13 +68,13 @@ class GradleSourceLinkBuilder(
      * Example:
      *
      * ```kotlin
-     * java.net.URL("https://github.com/username/projectname/tree/master/src"))
+     * java.net.URI("https://github.com/username/projectname/tree/master/src").toURL()
      * ```
      */
     @Internal
     val remoteUrl: Property<URL> = project.objects.property()
 
-    @Input // TODO: URL is deprecated in grapdle inputs
+    @Input // URL is deprecated in Gradle inputs
     internal fun getRemoteUrlString() = remoteUrl.map(URL::toString)
 
 

--- a/dokka-runners/runner-gradle-plugin-classic/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaConfigurationJsonTest.kt
+++ b/dokka-runners/runner-gradle-plugin-classic/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaConfigurationJsonTest.kt
@@ -14,7 +14,7 @@ import org.jetbrains.dokka.gradle.utils.externalDocumentationLink_
 import org.jetbrains.dokka.gradle.utils.withDependencies_
 import org.jetbrains.dokka.toCompactJsonString
 import java.io.File
-import java.net.URL
+import java.net.URI
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -50,8 +50,8 @@ class DokkaConfigurationJsonTest {
                 reportUndocumented.set(true)
 
                 externalDocumentationLink_ {
-                    packageListUrl.set(URL("http://some.url"))
-                    url.set(URL("http://some.other.url"))
+                    packageListUrl.set(URI("http://some.url").toURL())
+                    url.set(URI("http://some.other.url").toURL())
                 }
                 perPackageOption {
                     includeNonPublic.set(true)

--- a/dokka-runners/runner-gradle-plugin-classic/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaConfigurationSerializableTest.kt
+++ b/dokka-runners/runner-gradle-plugin-classic/src/test/kotlin/org/jetbrains/dokka/gradle/DokkaConfigurationSerializableTest.kt
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import java.io.ObjectInputStream
 import java.io.ObjectOutputStream
-import java.net.URL
+import java.net.URI
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -51,8 +51,8 @@ class DokkaConfigurationSerializableTest {
                 reportUndocumented.set(true)
 
                 externalDocumentationLink_ {
-                    packageListUrl.set(URL("http://some.url"))
-                    url.set(URL("http://some.other.url"))
+                    packageListUrl.set(URI("http://some.url").toURL())
+                    url.set(URI("http://some.other.url").toURL())
                 }
 
                 perPackageOption {

--- a/dokka-runners/runner-gradle-plugin-classic/src/test/kotlin/org/jetbrains/dokka/gradle/GradleDokkaSourceSetBuilderTest.kt
+++ b/dokka-runners/runner-gradle-plugin-classic/src/test/kotlin/org/jetbrains/dokka/gradle/GradleDokkaSourceSetBuilderTest.kt
@@ -10,7 +10,7 @@ import org.gradle.kotlin.dsl.closureOf
 import org.gradle.testfixtures.ProjectBuilder
 import org.jetbrains.dokka.*
 import org.jetbrains.kotlin.gradle.plugin.sources.DefaultKotlinSourceSet
-import java.net.URL
+import java.net.URI
 import kotlin.test.*
 
 class GradleDokkaSourceSetBuilderTest {
@@ -222,19 +222,19 @@ class GradleDokkaSourceSetBuilderTest {
             GradleSourceLinkBuilder(project).apply {
                 this.remoteLineSuffix.set("ls1")
                 this.localDirectory.set(project.file("p1"))
-                this.remoteUrl.set(URL("https://u1"))
+                this.remoteUrl.set(URI("https://u1").toURL())
             })
 
         sourceSet.sourceLink {
             remoteLineSuffix.set("ls2")
             localDirectory.set(project.file("p2"))
-            remoteUrl.set(URL("https://u2"))
+            remoteUrl.set(URI("https://u2").toURL())
         }
 
         sourceSet.sourceLink(project.closureOf<GradleSourceLinkBuilder> {
             this.remoteLineSuffix.set("ls3")
             this.localDirectory.set(project.file("p3"))
-            this.remoteUrl.set(URL("https://u3"))
+            this.remoteUrl.set(URI("https://u3").toURL())
         })
 
         assertEquals(
@@ -242,17 +242,17 @@ class GradleDokkaSourceSetBuilderTest {
                 SourceLinkDefinitionImpl(
                     remoteLineSuffix = "ls1",
                     localDirectory = project.file("p1").absolutePath,
-                    remoteUrl = URL("https://u1")
+                    remoteUrl = URI("https://u1").toURL()
                 ),
                 SourceLinkDefinitionImpl(
                     remoteLineSuffix = "ls2",
                     localDirectory = project.file("p2").absolutePath,
-                    remoteUrl = URL("https://u2")
+                    remoteUrl = URI("https://u2").toURL()
                 ),
                 SourceLinkDefinitionImpl(
                     remoteLineSuffix = "ls3",
                     localDirectory = project.file("p3").absolutePath,
-                    remoteUrl = URL("https://u3")
+                    remoteUrl = URI("https://u3").toURL()
                 )
             ),
             sourceSet.build().sourceLinks,
@@ -306,29 +306,29 @@ class GradleDokkaSourceSetBuilderTest {
 
         sourceSet.externalDocumentationLinks.add(
             GradleExternalDocumentationLinkBuilder(project).apply {
-                this.url.set(URL("https://u1"))
-                this.packageListUrl.set(URL("https://pl1"))
+                this.url.set(URI("https://u1").toURL())
+                this.packageListUrl.set(URI("https://pl1").toURL())
             }
         )
 
         sourceSet.externalDocumentationLink {
-            url.set(URL("https://u2"))
+            url.set(URI("https://u2").toURL())
         }
 
         sourceSet.externalDocumentationLink(project.closureOf<GradleExternalDocumentationLinkBuilder> {
-            url.set(URL("https://u3"))
+            url.set(URI("https://u3").toURL())
         })
 
         sourceSet.externalDocumentationLink(url = "https://u4", packageListUrl = "https://pl4")
-        sourceSet.externalDocumentationLink(url = URL("https://u5"))
+        sourceSet.externalDocumentationLink(url = URI("https://u5").toURL())
 
         assertEquals(
             setOf(
-                ExternalDocumentationLinkImpl(URL("https://u1"), URL("https://pl1")),
-                ExternalDocumentationLinkImpl(URL("https://u2"), URL("https://u2/package-list")),
-                ExternalDocumentationLinkImpl(URL("https://u3"), URL("https://u3/package-list")),
-                ExternalDocumentationLinkImpl(URL("https://u4"), URL("https://pl4")),
-                ExternalDocumentationLinkImpl(URL("https://u5"), URL("https://u5/package-list"))
+                ExternalDocumentationLinkImpl(URI("https://u1").toURL(), URI("https://pl1").toURL()),
+                ExternalDocumentationLinkImpl(URI("https://u2").toURL(), URI("https://u2/package-list").toURL()),
+                ExternalDocumentationLinkImpl(URI("https://u3").toURL(), URI("https://u3/package-list").toURL()),
+                ExternalDocumentationLinkImpl(URI("https://u4").toURL(), URI("https://pl4").toURL()),
+                ExternalDocumentationLinkImpl(URI("https://u5").toURL(), URI("https://u5/package-list").toURL())
             ),
             sourceSet.build().externalDocumentationLinks,
             "Expected all external documentation links being present after build"


### PR DESCRIPTION
The idea is at least to not suggest usage of deprecated in JDK 20 API. While it's not full direct replacement (as far as I understand by reading deprecation note on URL class), this should be fine for how we use it in Gradle plugin.

I've also investigated this migration in all code base here - https://github.com/Kotlin/dokka/commit/521d9e5f743915f38c92c007c40688b1b194ee8a
Though, I've decided not to do this, because of some questionable changes there. In the end it will be fixed in https://github.com/Kotlin/dokka/issues/2993. I will add this link there to be aware of the scope of the changes.