### PR TITLE
fix: proper strikethrough in navigation for Fifefox #3156

### DIFF
--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/renderers/html/NavigationPage.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/renderers/html/NavigationPage.kt
@@ -77,7 +77,7 @@ public class NavigationPage(
 
     private fun FlowContent.nodeText(node: NavigationNode) {
         if (node.styles.contains(TextStyle.Strikethrough)) {
-            strike {
+            strike(classes = "strikethrough") {
                 buildBreakableText(node.name)
             }
         } else {

--- a/dokka-subprojects/plugin-base/src/main/resources/dokka/styles/style.css
+++ b/dokka-subprojects/plugin-base/src/main/resources/dokka/styles/style.css
@@ -686,6 +686,26 @@ code.paragraph {
     text-decoration: line-through;
 }
 
+/* Workaround for Firefox  https://github.com/Kotlin/dokka/issues/3156 */
+@-moz-document url-prefix() {
+    .strikethrough {
+        position: relative;
+        text-decoration: none;
+    }
+
+    /* complex selectors here are required to handle multiline cases */
+    .strikethrough::after, .strikethrough span:after  {
+        content: '';
+        position: absolute;
+        top: 7px;
+        left: 0;
+        right: 0;
+        height: 1px;
+        background-color: currentColor;
+        z-index: 1;
+    }
+}
+
 .symbol:empty {
     padding: 0;
 }


### PR DESCRIPTION
fixes #3156 

### After
<img width="143" alt="after" src="https://github.com/Kotlin/dokka/assets/4469732/d8040730-4cb6-439f-9d54-32730a39ce6e">

### Before
<img width="141" alt="before" src="https://github.com/Kotlin/dokka/assets/4469732/dceba53c-4e0f-4bf0-a0f5-be33b6f03c88">
