### PR TITLE
fix link to license in readme badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![JetBrains official project](https://jb.gg/badges/official.svg)](https://github.com/JetBrains#jetbrains-on-github)
 [![Maven Central](https://img.shields.io/maven-central/v/org.jetbrains.dokka/org.jetbrains.dokka.gradle.plugin?label=MavenCentral&logo=apache-maven)](https://search.maven.org/artifact/org.jetbrains.dokka/org.jetbrains.dokka.gradle.plugin)
 [![Gradle Plugin](https://img.shields.io/gradle-plugin-portal/v/org.jetbrains.dokka?label=Gradle&logo=gradle)](https://plugins.gradle.org/plugin/org.jetbrains.dokka)
-[![License](https://img.shields.io/github/license/Kotlin/dokka.svg)](LICENSE)
+[![License](https://img.shields.io/github/license/Kotlin/dokka.svg)](LICENSE.txt)
 
 Dokka is an API documentation engine for Kotlin.
 


### PR DESCRIPTION
Fix minor typo, `LICENSE` -> `LICENSE.txt`

[Rendered preview](https://github.com/Kotlin/dokka/blob/fix/readme-license-link/README.md)