### PR TITLE
Configure JetBrains Gradle Enterprise & Build Cache

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,7 @@ Notable builds:
 ### Gradle Build Scans
 
 [Gradle Build Scans](https://scans.gradle.com/) can provide insights into a Dokka Build. 
-JetBrains runs a Gradle Build Scan server that can be used to automatically upload reports.
+JetBrains runs a Gradle Build Scan server https://ge.jetbrains.com/ that can be used to automatically upload reports.
 
 To automatically opt in add the following to `$GRADLE_USER_HOME/gradle.properties`. 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,8 @@ Notable builds:
 ### Gradle Build Scans
 
 [Gradle Build Scans](https://scans.gradle.com/) can provide insights into a Dokka Build. 
-JetBrains runs a Gradle Build Scan server https://ge.jetbrains.com/ that can be used to automatically upload reports.
+JetBrains runs a Gradle Build Scan server https://ge.jetbrains.com/scans?search.rootProjectNames=dokka
+that can be used to automatically upload reports.
 
 To automatically opt in add the following to `$GRADLE_USER_HOME/gradle.properties`. 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,21 @@ Notable builds:
   runs Dokka's integration tests, which are designed to test compatibility with different Kotlin versions, with different
   multiplatform targets and with various user scenarios.
 
+### Gradle Build Scans
+
+[Gradle Build Scans](https://scans.gradle.com/) can provide insights into a Dokka Build. 
+JetBrains runs a Gradle Build Scan server that can be used to automatically upload reports.
+
+To automatically opt in add the following to `$GRADLE_USER_HOME/gradle.properties`. 
+
+```properties
+org.jetbrains.dokka.build.scan.url=https\://ge.jetbrains.com/
+# optionally provide a username that will be attached to each report
+org.jetbrains.dokka.build.scan.username=Hannah Clarke
+```
+
+A Build Scan may contain identifiable information. See the Terms of Use https://gradle.com/legal/terms-of-use/.
+
 ## Contacting maintainers
 
 * If something cannot be done, not convenient, or does not work &mdash; submit an [issue](#submitting-issues).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,7 @@ Notable builds:
 ### Gradle Build Scans
 
 [Gradle Build Scans](https://scans.gradle.com/) can provide insights into a Dokka Build. 
-JetBrains runs a Gradle Build Scan server https://ge.jetbrains.com/scans?search.rootProjectNames=dokka
+JetBrains runs a [Gradle Develocity server](https://ge.jetbrains.com/scans?search.rootProjectNames=dokka).
 that can be used to automatically upload reports.
 
 To automatically opt in add the following to `$GRADLE_USER_HOME/gradle.properties`. 

--- a/build-settings-logic/build.gradle.kts
+++ b/build-settings-logic/build.gradle.kts
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2014-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+plugins {
+    `kotlin-dsl`
+}
+
+description = "Conventions for use in settings.gradle.kts scripts"
+
+dependencies {
+    implementation(libs.gradlePlugin.gradle.enterprise)
+    implementation(libs.gradlePlugin.gradle.customUserData)
+}

--- a/build-settings-logic/settings.gradle.kts
+++ b/build-settings-logic/settings.gradle.kts
@@ -1,0 +1,29 @@
+import org.gradle.api.initialization.resolve.RepositoriesMode.PREFER_SETTINGS
+
+/*
+ * Copyright 2014-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+rootProject.name = "build-settings-logic"
+
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+@Suppress("UnstableApiUsage")
+dependencyResolutionManagement {
+    repositoriesMode.set(PREFER_SETTINGS)
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/build-settings-logic/src/main/kotlin/DokkaBuildSettingsProperties.kt
+++ b/build-settings-logic/src/main/kotlin/DokkaBuildSettingsProperties.kt
@@ -22,7 +22,7 @@ abstract class DokkaBuildSettingsProperties @Inject constructor(
 
 
     //region Gradle Build Scan
-    val buildScanServer: Provider<String> =
+    val buildScanUrl: Provider<String> =
         dokkaProperty("build.scan.url")
     val buildScanUsername: Provider<String> =
         dokkaProperty("build.scan.username")

--- a/build-settings-logic/src/main/kotlin/DokkaBuildSettingsProperties.kt
+++ b/build-settings-logic/src/main/kotlin/DokkaBuildSettingsProperties.kt
@@ -38,7 +38,6 @@ abstract class DokkaBuildSettingsProperties @Inject constructor(
     val buildCacheLocalEnabled: Provider<Boolean> =
         dokkaProperty("build.cache.local.enabled", String::toBoolean)
             .orElse(!buildingOnCi)
-            .orElse(true)
     val buildCacheLocalDirectory: Provider<String> =
         dokkaProperty("build.cache.local.directory")
     val buildCacheUrl: Provider<String> =
@@ -46,7 +45,6 @@ abstract class DokkaBuildSettingsProperties @Inject constructor(
     val buildCachePushEnabled: Provider<Boolean> =
         dokkaProperty("build.cache.push", String::toBoolean)
             .orElse(buildingOnTeamCity)
-            .orElse(false)
     val buildCacheUser: Provider<String> =
         dokkaProperty("build.cache.user")
     val buildCachePassword: Provider<String> =

--- a/build-settings-logic/src/main/kotlin/DokkaBuildSettingsProperties.kt
+++ b/build-settings-logic/src/main/kotlin/DokkaBuildSettingsProperties.kt
@@ -25,9 +25,7 @@ abstract class DokkaBuildSettingsProperties @Inject constructor(
     val buildScanUrl: Provider<String> =
         dokkaProperty("build.scan.url")
     val buildScanUsername: Provider<String> =
-        dokkaProperty("build.scan.username")
-            .orElse(BUILD_SCAN_USERNAME_DEFAULT)
-            .map(String::trim)
+        dokkaProperty("build.scan.username").map(String::trim)
     //endregion
 
 

--- a/build-settings-logic/src/main/kotlin/DokkaBuildSettingsProperties.kt
+++ b/build-settings-logic/src/main/kotlin/DokkaBuildSettingsProperties.kt
@@ -25,7 +25,9 @@ abstract class DokkaBuildSettingsProperties @Inject constructor(
     val buildScanUrl: Provider<String> =
         dokkaProperty("build.scan.url")
     val buildScanUsername: Provider<String> =
-        dokkaProperty("build.scan.username").map(String::trim)
+        dokkaProperty("build.scan.username")
+            .orElse(BUILD_SCAN_USERNAME_DEFAULT)
+            .map(String::trim)
     //endregion
 
 
@@ -52,7 +54,7 @@ abstract class DokkaBuildSettingsProperties @Inject constructor(
     private fun dokkaProperty(name: String): Provider<String> =
         providers.gradleProperty("org.jetbrains.dokka.$name")
 
-    private fun <T : Any> dokkaProperty(name: String, convert: (String) -> T) =
+    private fun <T : Any> dokkaProperty(name: String, convert: (String) -> T): Provider<T> =
         dokkaProperty(name).map(convert)
 
     companion object {

--- a/build-settings-logic/src/main/kotlin/DokkaBuildSettingsProperties.kt
+++ b/build-settings-logic/src/main/kotlin/DokkaBuildSettingsProperties.kt
@@ -22,8 +22,12 @@ abstract class DokkaBuildSettingsProperties @Inject constructor(
 
 
     //region Gradle Build Scan
+    // NOTE: build scan properties are documented in CONTRIBUTING.md
+    /** If unset, the user has not opted in to publish Build Scans. */
     val buildScanUrl: Provider<String> =
         dokkaProperty("build.scan.url")
+
+    /** Optionally override the default name attached to a Build Scan. */
     val buildScanUsername: Provider<String> =
         dokkaProperty("build.scan.username")
             .orElse(BUILD_SCAN_USERNAME_DEFAULT)

--- a/build-settings-logic/src/main/kotlin/DokkaBuildSettingsProperties.kt
+++ b/build-settings-logic/src/main/kotlin/DokkaBuildSettingsProperties.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+import org.gradle.api.initialization.Settings
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.findByType
+import javax.inject.Inject
+
+/**
+ * Shared properties in `settings.gradle.kts` files.
+ *
+ * Fetch an instance using [DokkaBuildSettingsProperties.Companion.dokkaBuildSettingsProperties].
+ */
+abstract class DokkaBuildSettingsProperties @Inject constructor(
+    private val providers: ProviderFactory
+) {
+    val buildingOnTeamCity: Boolean = System.getenv("TEAMCITY_VERSION") != null
+    val buildingOnCi: Boolean = System.getenv("CI") != null || buildingOnTeamCity
+
+
+    //region Gradle Build Scan
+    val buildScanServer: Provider<String> =
+        dokkaProperty("build.scan.url")
+    val buildScanUsername: Provider<String> =
+        dokkaProperty("build.scan.username")
+            .orElse(BUILD_SCAN_USERNAME_DEFAULT)
+            .map(String::trim)
+    //endregion
+
+
+    //region Gradle Build Cache
+    val buildCacheLocalEnabled: Provider<Boolean> =
+        dokkaProperty("build.cache.local.enabled", String::toBoolean)
+            .orElse(!buildingOnCi)
+            .orElse(true)
+    val buildCacheLocalDirectory: Provider<String> =
+        dokkaProperty("build.cache.local.directory")
+    val buildCacheUrl: Provider<String> =
+        dokkaProperty("build.cache.url").map(String::trim)
+    val buildCachePushEnabled: Provider<Boolean> =
+        dokkaProperty("build.cache.push", String::toBoolean)
+            .orElse(buildingOnTeamCity)
+            .orElse(false)
+    val buildCacheUser: Provider<String> =
+        dokkaProperty("build.cache.user")
+    val buildCachePassword: Provider<String> =
+        dokkaProperty("build.cache.password")
+    //endregion
+
+
+    private fun dokkaProperty(name: String): Provider<String> =
+        providers.gradleProperty("org.jetbrains.dokka.$name")
+
+    private fun <T : Any> dokkaProperty(name: String, convert: (String) -> T) =
+        dokkaProperty(name).map(convert)
+
+    companion object {
+        const val BUILD_SCAN_USERNAME_DEFAULT = "<default>"
+
+        val Settings.dokkaBuildSettingsProperties: DokkaBuildSettingsProperties
+            get() {
+                return extensions.findByType<DokkaBuildSettingsProperties>()
+                    ?: extensions.create<DokkaBuildSettingsProperties>("dokkaBuildSettingsProperties")
+            }
+    }
+}

--- a/build-settings-logic/src/main/kotlin/DokkaBuildSettingsProperties.kt
+++ b/build-settings-logic/src/main/kotlin/DokkaBuildSettingsProperties.kt
@@ -1,7 +1,6 @@
 /*
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
-
 import org.gradle.api.initialization.Settings
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory

--- a/build-settings-logic/src/main/kotlin/dokkasettings.build-cache.settings.gradle.kts
+++ b/build-settings-logic/src/main/kotlin/dokkasettings.build-cache.settings.gradle.kts
@@ -1,3 +1,6 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
 import DokkaBuildSettingsProperties.Companion.dokkaBuildSettingsProperties
 
 /**

--- a/build-settings-logic/src/main/kotlin/dokkasettings.build-cache.settings.gradle.kts
+++ b/build-settings-logic/src/main/kotlin/dokkasettings.build-cache.settings.gradle.kts
@@ -3,9 +3,9 @@ import DokkaBuildSettingsProperties.Companion.dokkaBuildSettingsProperties
 /**
  * Gradle Build Cache conventions.
  *
- * See [KotlinBuildProperties] for properties.
+ * See [DokkaBuildSettingsProperties] for properties.
  *
- * https://github.com/JetBrains/kotlin/blob/2675531624d42851af502a993bbefd65ee3e38ef/repo/gradle-settings-conventions/build-cache/src/main/kotlin/build-cache.settings.gradle.kts
+ * Based on https://github.com/JetBrains/kotlin/blob/2675531624d42851af502a993bbefd65ee3e38ef/repo/gradle-settings-conventions/build-cache/src/main/kotlin/build-cache.settings.gradle.kts
  */
 
 val buildSettingsProps = dokkaBuildSettingsProperties

--- a/build-settings-logic/src/main/kotlin/dokkasettings.build-cache.settings.gradle.kts
+++ b/build-settings-logic/src/main/kotlin/dokkasettings.build-cache.settings.gradle.kts
@@ -5,6 +5,9 @@ import DokkaBuildSettingsProperties.Companion.dokkaBuildSettingsProperties
  *
  * See [DokkaBuildSettingsProperties] for properties.
  *
+ * Because Dokka uses Composite Builds, Build Cache should only be configured on the root `settings.gradle.kts`.
+ * See https://docs.gradle.org/8.4/userguide/build_cache.html#sec:build_cache_composite.
+ *
  * Based on https://github.com/JetBrains/kotlin/blob/2675531624d42851af502a993bbefd65ee3e38ef/repo/gradle-settings-conventions/build-cache/src/main/kotlin/build-cache.settings.gradle.kts
  */
 

--- a/build-settings-logic/src/main/kotlin/dokkasettings.build-cache.settings.gradle.kts
+++ b/build-settings-logic/src/main/kotlin/dokkasettings.build-cache.settings.gradle.kts
@@ -1,0 +1,35 @@
+import DokkaBuildSettingsProperties.Companion.dokkaBuildSettingsProperties
+
+/**
+ * Gradle Build Cache conventions.
+ *
+ * See [KotlinBuildProperties] for properties.
+ *
+ * https://github.com/JetBrains/kotlin/blob/2675531624d42851af502a993bbefd65ee3e38ef/repo/gradle-settings-conventions/build-cache/src/main/kotlin/build-cache.settings.gradle.kts
+ */
+
+val buildSettingsProps = dokkaBuildSettingsProperties
+
+buildCache {
+    local {
+        isEnabled = buildSettingsProps.buildCacheLocalEnabled.get()
+        if (buildSettingsProps.buildCacheLocalDirectory.orNull != null) {
+            directory = buildSettingsProps.buildCacheLocalDirectory.get()
+        }
+    }
+
+    val remoteBuildCacheUrl = buildSettingsProps.buildCacheUrl.orNull
+    if (!remoteBuildCacheUrl.isNullOrEmpty()) {
+        remote<HttpBuildCache> {
+            url = uri(remoteBuildCacheUrl)
+            isPush = buildSettingsProps.buildCachePushEnabled.get()
+
+            if (buildSettingsProps.buildCacheUser.isPresent &&
+                buildSettingsProps.buildCachePassword.isPresent
+            ) {
+                credentials.username = buildSettingsProps.buildCacheUser.get()
+                credentials.password = buildSettingsProps.buildCachePassword.get()
+            }
+        }
+    }
+}

--- a/build-settings-logic/src/main/kotlin/dokkasettings.gradle-enterprise.settings.gradle.kts
+++ b/build-settings-logic/src/main/kotlin/dokkasettings.gradle-enterprise.settings.gradle.kts
@@ -47,9 +47,9 @@ gradleEnterprise {
                 when {
                     buildSettingsProps.buildingOnTeamCity -> "TeamCity"
                     buildSettingsProps.buildingOnCi -> "CI"
-                    overriddenName.isNullOrBlank() -> "concealed"
+                    overriddenName.isNullOrBlank() -> overriddenName
                     overriddenName == BUILD_SCAN_USERNAME_DEFAULT -> originalUsername
-                    else -> overriddenName
+                    else -> "unknown"
                 }
             }
         }

--- a/build-settings-logic/src/main/kotlin/dokkasettings.gradle-enterprise.settings.gradle.kts
+++ b/build-settings-logic/src/main/kotlin/dokkasettings.gradle-enterprise.settings.gradle.kts
@@ -6,7 +6,17 @@ import DokkaBuildSettingsProperties.Companion.dokkaBuildSettingsProperties
  *
  * See [DokkaBuildSettingsProperties] for properties.
  *
+ * To use JetBrain's Gradle Enterprise set the URL
+ * https://ge.jetbrains.com/
+ * in `$GRADLE_USER_HOME/gradle.properties`†
+ *
+ * ```properties
+ * org.jetbrains.dokka.build.scan.url=https\://ge.jetbrains.com/
+ * ```
+ *
  * Based on https://github.com/JetBrains/kotlin/blob/19073b96a7ed53dbda61337465ca898c1482e090/repo/gradle-settings-conventions/gradle-enterprise/src/main/kotlin/gradle-enterprise.settings.gradle.kts
+ *
+ * † _See [`GRADLE_USER_HOME`](https://docs.gradle.org/8.5/userguide/directory_layout.html#dir:gradle_user_home)_
  */
 
 plugins {
@@ -16,7 +26,7 @@ plugins {
 
 val buildSettingsProps = dokkaBuildSettingsProperties
 
-val buildScanServer = buildSettingsProps.buildScanUrl.orNull
+val buildScanServer = buildSettingsProps.buildScanUrl.orNull?.ifBlank { null }
 
 if (buildScanServer != null) {
     plugins.apply("com.gradle.common-custom-user-data-gradle-plugin")
@@ -34,9 +44,6 @@ gradleEnterprise {
                 isBuildLogging = true
                 isUploadInBackground = true
             }
-        } else {
-            termsOfServiceUrl = "https://gradle.com/terms-of-service"
-            termsOfServiceAgree = "yes"
         }
 
         val overriddenName = buildSettingsProps.buildScanUsername.orNull

--- a/build-settings-logic/src/main/kotlin/dokkasettings.gradle-enterprise.settings.gradle.kts
+++ b/build-settings-logic/src/main/kotlin/dokkasettings.gradle-enterprise.settings.gradle.kts
@@ -1,0 +1,57 @@
+import DokkaBuildSettingsProperties.Companion.BUILD_SCAN_USERNAME_DEFAULT
+import DokkaBuildSettingsProperties.Companion.dokkaBuildSettingsProperties
+
+/**
+ * Gradle Enterprise conventions.
+ *
+ * See [KotlinBuildProperties] for properties.
+ *
+ * Copied from https://github.com/JetBrains/kotlin/blob/19073b96a7ed53dbda61337465ca898c1482e090/repo/gradle-settings-conventions/gradle-enterprise/src/main/kotlin/gradle-enterprise.settings.gradle.kts
+ */
+
+plugins {
+    id("com.gradle.enterprise")
+    id("com.gradle.common-custom-user-data-gradle-plugin") apply false
+}
+
+val buildSettingsProps = dokkaBuildSettingsProperties
+
+val buildScanServer = buildSettingsProps.buildScanServer.orNull
+
+if (buildScanServer != null) {
+    plugins.apply("com.gradle.common-custom-user-data-gradle-plugin")
+}
+
+gradleEnterprise {
+    buildScan {
+        if (buildScanServer != null) {
+            server = buildScanServer
+            publishAlways()
+
+            capture {
+                isTaskInputFiles = true
+                isBuildLogging = true
+                isBuildLogging = true
+                isUploadInBackground = true
+            }
+        } else {
+            termsOfServiceUrl = "https://gradle.com/terms-of-service"
+            termsOfServiceAgree = "yes"
+        }
+
+        val overriddenName = buildSettingsProps.buildScanUsername.orNull
+        obfuscation {
+            ipAddresses { _ -> listOf("0.0.0.0") }
+            hostname { _ -> "concealed" }
+            username { originalUsername ->
+                when {
+                    buildSettingsProps.buildingOnTeamCity -> "TeamCity"
+                    buildSettingsProps.buildingOnCi -> "CI"
+                    overriddenName.isNullOrBlank() -> "concealed"
+                    overriddenName == BUILD_SCAN_USERNAME_DEFAULT -> originalUsername
+                    else -> overriddenName
+                }
+            }
+        }
+    }
+}

--- a/build-settings-logic/src/main/kotlin/dokkasettings.gradle-enterprise.settings.gradle.kts
+++ b/build-settings-logic/src/main/kotlin/dokkasettings.gradle-enterprise.settings.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 
 val buildSettingsProps = dokkaBuildSettingsProperties
 
-val buildScanServer = buildSettingsProps.buildScanServer.orNull
+val buildScanServer = buildSettingsProps.buildScanUrl.orNull
 
 if (buildScanServer != null) {
     plugins.apply("com.gradle.common-custom-user-data-gradle-plugin")

--- a/build-settings-logic/src/main/kotlin/dokkasettings.gradle-enterprise.settings.gradle.kts
+++ b/build-settings-logic/src/main/kotlin/dokkasettings.gradle-enterprise.settings.gradle.kts
@@ -44,7 +44,6 @@ gradleEnterprise {
             capture {
                 isTaskInputFiles = true
                 isBuildLogging = true
-                isBuildLogging = true
                 isUploadInBackground = true
             }
         }

--- a/build-settings-logic/src/main/kotlin/dokkasettings.gradle-enterprise.settings.gradle.kts
+++ b/build-settings-logic/src/main/kotlin/dokkasettings.gradle-enterprise.settings.gradle.kts
@@ -4,9 +4,9 @@ import DokkaBuildSettingsProperties.Companion.dokkaBuildSettingsProperties
 /**
  * Gradle Enterprise conventions.
  *
- * See [KotlinBuildProperties] for properties.
+ * See [DokkaBuildSettingsProperties] for properties.
  *
- * Copied from https://github.com/JetBrains/kotlin/blob/19073b96a7ed53dbda61337465ca898c1482e090/repo/gradle-settings-conventions/gradle-enterprise/src/main/kotlin/gradle-enterprise.settings.gradle.kts
+ * Based on https://github.com/JetBrains/kotlin/blob/19073b96a7ed53dbda61337465ca898c1482e090/repo/gradle-settings-conventions/gradle-enterprise/src/main/kotlin/gradle-enterprise.settings.gradle.kts
  */
 
 plugins {

--- a/build-settings-logic/src/main/kotlin/dokkasettings.gradle-enterprise.settings.gradle.kts
+++ b/build-settings-logic/src/main/kotlin/dokkasettings.gradle-enterprise.settings.gradle.kts
@@ -1,3 +1,6 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
 import DokkaBuildSettingsProperties.Companion.BUILD_SCAN_USERNAME_DEFAULT
 import DokkaBuildSettingsProperties.Companion.dokkaBuildSettingsProperties
 

--- a/dokka-integration-tests/settings.gradle.kts
+++ b/dokka-integration-tests/settings.gradle.kts
@@ -19,8 +19,8 @@ pluginManagement {
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
     id("dokkasettings.gradle-enterprise")
-    id("dokkasettings.build-cache")
 }
+
 dependencyResolutionManagement {
     repositories {
         mavenCentral()

--- a/dokka-integration-tests/settings.gradle.kts
+++ b/dokka-integration-tests/settings.gradle.kts
@@ -8,17 +8,19 @@ rootProject.name = "dokka-integration-tests"
 
 pluginManagement {
     includeBuild("../build-logic")
+    includeBuild("../build-settings-logic")
 
     repositories {
-        gradlePluginPortal()
         mavenCentral()
+        gradlePluginPortal()
     }
 }
 
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+    id("dokkasettings.gradle-enterprise")
+    id("dokkasettings.build-cache")
 }
-
 dependencyResolutionManagement {
     repositories {
         mavenCentral()

--- a/dokka-runners/runner-cli/settings.gradle.kts
+++ b/dokka-runners/runner-cli/settings.gradle.kts
@@ -19,7 +19,6 @@ pluginManagement {
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
     id("dokkasettings.gradle-enterprise")
-    id("dokkasettings.build-cache")
 }
 
 dependencyResolutionManagement {

--- a/dokka-runners/runner-cli/settings.gradle.kts
+++ b/dokka-runners/runner-cli/settings.gradle.kts
@@ -8,6 +8,7 @@ rootProject.name = "runner-cli"
 
 pluginManagement {
     includeBuild("../../build-logic")
+    includeBuild("../../build-settings-logic")
 
     repositories {
         mavenCentral()
@@ -17,6 +18,8 @@ pluginManagement {
 
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+    id("dokkasettings.gradle-enterprise")
+    id("dokkasettings.build-cache")
 }
 
 dependencyResolutionManagement {

--- a/dokka-runners/runner-gradle-plugin-classic/settings.gradle.kts
+++ b/dokka-runners/runner-gradle-plugin-classic/settings.gradle.kts
@@ -19,7 +19,6 @@ pluginManagement {
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
     id("dokkasettings.gradle-enterprise")
-    id("dokkasettings.build-cache")
 }
 
 dependencyResolutionManagement {

--- a/dokka-runners/runner-gradle-plugin-classic/settings.gradle.kts
+++ b/dokka-runners/runner-gradle-plugin-classic/settings.gradle.kts
@@ -8,6 +8,7 @@ rootProject.name = "runner-gradle-plugin-classic"
 
 pluginManagement {
     includeBuild("../../build-logic")
+    includeBuild("../../build-settings-logic")
 
     repositories {
         mavenCentral()
@@ -17,6 +18,8 @@ pluginManagement {
 
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+    id("dokkasettings.gradle-enterprise")
+    id("dokkasettings.build-cache")
 }
 
 dependencyResolutionManagement {

--- a/dokka-runners/runner-maven-plugin/settings.gradle.kts
+++ b/dokka-runners/runner-maven-plugin/settings.gradle.kts
@@ -19,7 +19,6 @@ pluginManagement {
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
     id("dokkasettings.gradle-enterprise")
-    id("dokkasettings.build-cache")
 }
 
 dependencyResolutionManagement {

--- a/dokka-runners/runner-maven-plugin/settings.gradle.kts
+++ b/dokka-runners/runner-maven-plugin/settings.gradle.kts
@@ -8,6 +8,7 @@ rootProject.name = "runner-maven-plugin"
 
 pluginManagement {
     includeBuild("../../build-logic")
+    includeBuild("../../build-settings-logic")
 
     repositories {
         mavenCentral()
@@ -17,6 +18,8 @@ pluginManagement {
 
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+    id("dokkasettings.gradle-enterprise")
+    id("dokkasettings.build-cache")
 }
 
 dependencyResolutionManagement {

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,6 @@ org.jetbrains.dokka.javaToolchain.mainCompiler=8
 org.jetbrains.dokka.javaToolchain.testLauncher=8
 org.jetbrains.dokka.kotlinLanguageLevel=1.4
 
-org.jetbrains.dokka.build.scan.url=https\://ge.jetbrains.com/
 org.jetbrains.dokka.build.cache.url=https\://ge.jetbrains.com/cache/
 
 # Code style

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,9 @@ org.jetbrains.dokka.javaToolchain.mainCompiler=8
 org.jetbrains.dokka.javaToolchain.testLauncher=8
 org.jetbrains.dokka.kotlinLanguageLevel=1.4
 
+org.jetbrains.dokka.build.scan.url=https\://ge.jetbrains.com/
+org.jetbrains.dokka.build.cache.url=https\://ge.jetbrains.com/cache/
+
 # Code style
 kotlin.code.style=official
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,10 @@ gradlePlugin-kotlin = "1.9.22"
 gradlePlugin-android = "4.2.2"
 gradlePlugin-android-dokkatoo = "8.0.2"
 gradlePlugin-dokka = "1.9.10"
+gradlePlugin-gradle-customUserData = "1.12"
+gradlePlugin-gradle-enterprise = "3.14.1"
 
+kotlin-buildGradlePlugin = "0.0.40"
 kotlinx-coroutines = "1.7.3"
 kotlinx-collections-immutable = "0.3.6"
 kotlinx-serialization = "1.6.0"
@@ -63,6 +66,11 @@ eclipse-jgit = "5.13.2.202306221912-r" # jgit 6.X requires Java 11 to run
 
 [libraries]
 
+
+#### Build tools ####
+kotlin-buildGradlePlugin = { module = "org.jetbrains.kotlin:kotlin-build-gradle-plugin", version.ref = "kotlin-buildGradlePlugin" }
+
+#### Kotlin Libs ####
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm", version.ref = "kotlinx-collections-immutable" }
 kotlinx-serialization-bom = { module = "org.jetbrains.kotlinx:kotlinx-serialization-bom", version.ref = "kotlinx-serialization" }
@@ -83,7 +91,10 @@ gradlePlugin-android-dokkatoo = { module = "com.android.tools.build:gradle", ver
 gradlePlugin-androidApi-dokkatoo = { module = "com.android.tools.build:gradle-api", version.ref = "gradlePlugin-android-dokkatoo" }
 gradlePlugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "gradlePlugin-dokka" }
 gradlePlugin-shadow = { module = "com.github.johnrengelman:shadow", version.ref = "gradlePlugin-shadow" }
-gradlePlugin-gradlePublish= { module = "com.gradle.publish:plugin-publish-plugin", version.ref = "gradlePlugin-gradlePluginPublish" }
+gradlePlugin-gradlePublish = { module = "com.gradle.publish:plugin-publish-plugin", version.ref = "gradlePlugin-gradlePluginPublish" }
+
+gradlePlugin-gradle-customUserData = { module = "com.gradle:common-custom-user-data-gradle-plugin", version.ref = "gradlePlugin-gradle-customUserData" }
+gradlePlugin-gradle-enterprise = { module = "com.gradle:gradle-enterprise-gradle-plugin", version.ref = "gradlePlugin-gradle-enterprise" }
 
 #### Kotlin analysis ####
 kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref = "kotlin-compiler" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,6 @@ gradlePlugin-dokka = "1.9.10"
 gradlePlugin-gradle-customUserData = "1.12"
 gradlePlugin-gradle-enterprise = "3.14.1"
 
-kotlin-buildGradlePlugin = "0.0.40"
 kotlinx-coroutines = "1.7.3"
 kotlinx-collections-immutable = "0.3.6"
 kotlinx-serialization = "1.6.0"
@@ -65,10 +64,6 @@ kotest = "5.6.2"
 eclipse-jgit = "5.13.2.202306221912-r" # jgit 6.X requires Java 11 to run
 
 [libraries]
-
-
-#### Build tools ####
-kotlin-buildGradlePlugin = { module = "org.jetbrains.kotlin:kotlin-build-gradle-plugin", version.ref = "kotlin-buildGradlePlugin" }
 
 #### Kotlin Libs ####
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,7 +4,6 @@
 
 @file:Suppress("UnstableApiUsage")
 
-
 rootProject.name = "dokka"
 
 pluginManagement {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,27 +4,29 @@
 
 @file:Suppress("UnstableApiUsage")
 
+
 rootProject.name = "dokka"
 
 pluginManagement {
     includeBuild("build-logic")
+    includeBuild("build-settings-logic")
 
     repositories {
-        gradlePluginPortal()
         mavenCentral()
+        gradlePluginPortal()
     }
 }
 
 dependencyResolutionManagement {
     repositories {
-        mavenCentral()
-        google()
-
         maven("https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-ide")
         maven("https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-ide-plugin-dependencies")
 
         maven("https://cache-redirector.jetbrains.com/intellij-repository/releases")
         maven("https://cache-redirector.jetbrains.com/intellij-third-party-dependencies")
+
+        mavenCentral()
+        google()
 
         // Declare the Node.js & Yarn download repositories
         // Required by Gradle Node plugin: https://github.com/node-gradle/gradle-node-plugin/blob/3.5.1/docs/faq.md#is-this-plugin-compatible-with-centralized-repositories-declaration
@@ -55,8 +57,9 @@ dependencyResolutionManagement {
 }
 
 plugins {
-    `gradle-enterprise`
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+    id("dokkasettings.gradle-enterprise")
+    id("dokkasettings.build-cache")
 }
 
 includeBuild("dokka-integration-tests")
@@ -93,16 +96,6 @@ include(
     ":dokka-subprojects:plugin-templating",
     ":dokka-subprojects:plugin-versioning",
 )
-
-val isCiBuild = System.getenv("GITHUB_ACTIONS") != null || System.getenv("TEAMCITY_VERSION") != null
-
-gradleEnterprise {
-    buildScan {
-        termsOfServiceUrl = "https://gradle.com/terms-of-service"
-        termsOfServiceAgree = "yes"
-        publishAlwaysIf(isCiBuild)
-    }
-}
 
 // This hack is required for included build support.
 // The name of the published artifact is `dokka-core`, but the module is named `core`.


### PR DESCRIPTION
Use JetBrains Gradle Enterprise for builds.

This should improve the build speeds both for local development and on CI.

### Summary


* Introduces a new `build-settings-logic` project for settings conventions.

  It's named so that it's next to the existing `build-logic`.

* Convention plugins for Build Cache and Gradle Enterprise copied from https://github.com/JetBrains/kotlin/
  * https://github.com/JetBrains/kotlin/blob/2675531624d42851af502a993bbefd65ee3e38ef/repo/gradle-settings-conventions/build-cache/src/main/kotlin/build-cache.settings.gradle.kts
  * https://github.com/JetBrains/kotlin/blob/19073b96a7ed53dbda61337465ca898c1482e090/repo/gradle-settings-conventions/gradle-enterprise/src/main/kotlin/gradle-enterprise.settings.gradle.kts

### TODO

- [x] ~Update the readme/contributing guide? What properties are necessary?~ I added some brief docs. Build Scans aren't as important so I've opted out by default. 
- [x] ~update TeamCity config to add necessary properties.~ Dokka has a Build Cache account. I've added the user/pass to TeamCity
- [ ] update GitHub Actions config to add environment variable `ORG_GRADLE_PROJECT_org.jetbrains.dokka.build.scan.url=https://ge.jetbrains.com/` @IgnatBeresnev are you able to do this? I don't have access [to the config](https://docs.github.com/en/actions/learn-github-actions/variables#creating-configuration-variables-for-a-repository).
