### PR TITLE
add 'enabled' flag for Build Scans

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,7 @@ that can be used to automatically upload reports.
 To automatically opt in add the following to `$GRADLE_USER_HOME/gradle.properties`. 
 
 ```properties
-org.jetbrains.dokka.build.scan.url=https\://ge.jetbrains.com/
+org.jetbrains.dokka.build.scan.enabled=true
 # optionally provide a username that will be attached to each report
 org.jetbrains.dokka.build.scan.username=Hannah Clarke
 ```

--- a/build-settings-logic/src/main/kotlin/DokkaBuildSettingsProperties.kt
+++ b/build-settings-logic/src/main/kotlin/DokkaBuildSettingsProperties.kt
@@ -22,6 +22,10 @@ abstract class DokkaBuildSettingsProperties @Inject constructor(
 
     //region Gradle Build Scan
     // NOTE: build scan properties are documented in CONTRIBUTING.md
+    val buildScanEnabled: Provider<Boolean> =
+        dokkaProperty("build.scan.enabled", String::toBoolean)
+            .orElse(buildingOnCi)
+
     /** If unset, the user has not opted in to publish Build Scans. */
     val buildScanUrl: Provider<String> =
         dokkaProperty("build.scan.url")

--- a/build-settings-logic/src/main/kotlin/dokkasettings.gradle-enterprise.settings.gradle.kts
+++ b/build-settings-logic/src/main/kotlin/dokkasettings.gradle-enterprise.settings.gradle.kts
@@ -30,16 +30,17 @@ plugins {
 val buildSettingsProps = dokkaBuildSettingsProperties
 
 val buildScanServer = buildSettingsProps.buildScanUrl.orNull?.ifBlank { null }
+val buildScanEnabled = buildSettingsProps.buildScanEnabled.get() && buildScanServer != null
 
-if (buildScanServer != null) {
+if (buildScanEnabled) {
     plugins.apply("com.gradle.common-custom-user-data-gradle-plugin")
 }
 
 gradleEnterprise {
     buildScan {
-        if (buildScanServer != null) {
+        if (buildScanEnabled) {
             server = buildScanServer
-            publishAlways()
+            publishAlwaysIf(buildScanEnabled)
 
             capture {
                 isTaskInputFiles = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,8 @@ org.jetbrains.dokka.javaToolchain.mainCompiler=8
 org.jetbrains.dokka.javaToolchain.testLauncher=8
 org.jetbrains.dokka.kotlinLanguageLevel=1.4
 
+# Build Scans are disabled by default - see CONTRIBUTING.md to opt in
+org.jetbrains.dokka.build.scan.url=https\://ge.jetbrains.com/
 org.jetbrains.dokka.build.cache.url=https\://ge.jetbrains.com/cache/
 
 # Code style


### PR DESCRIPTION
GitHub can't have default environment variables with dots `.` in them, so defining the build scan server URL in all actions would have to be manually done for each GitHub action. That's annoying and is work to maintain.

Instead, this PR adds a 'build.scan.enabled' flag that defaults to 'true' on CI.