### PR TITLE
Adjust Gradle memory settings

### DIFF
--- a/build-logic/src/main/kotlin/dokkabuild.test-integration.gradle.kts
+++ b/build-logic/src/main/kotlin/dokkabuild.test-integration.gradle.kts
@@ -44,7 +44,7 @@ val integrationTestRuntimeOnly: Configuration by configurations.getting {
 abstract class NonCacheableIntegrationTest : Test()
 
 val integrationTest by tasks.registering(NonCacheableIntegrationTest::class) {
-    maxHeapSize = "2G"
+//    maxHeapSize = "2G"
     description = "Runs integration tests."
     group = "verification"
     testClassesDirs = integrationTestSourceSet.output.classesDirs
@@ -56,9 +56,9 @@ val integrationTest by tasks.registering(NonCacheableIntegrationTest::class) {
 
     systemProperty("org.jetbrains.dokka.experimental.tryK2", dokkaBuild.integrationTestUseK2.get())
 
-    dokkaBuild.integrationTestParallelism.orNull?.let { parallelism ->
-        maxParallelForks = parallelism
-    }
+//    dokkaBuild.integrationTestParallelism.orNull?.let { parallelism ->
+//        maxParallelForks = parallelism
+//    }
 
     environment("isExhaustive", dokkaBuild.integrationTestExhaustive.get())
     

--- a/dokka-integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/SequentialTasksExecutionStressTest.kt
+++ b/dokka-integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/SequentialTasksExecutionStressTest.kt
@@ -40,7 +40,6 @@ class SequentialTasksExecutionStressTest : AbstractGradleIntegrationTest() {
             "--info",
             "--stacktrace",
             "-Ptask_number=100",
-            jvmArgs = listOf("-Xmx1G", "-XX:MaxMetaspaceSize=400m")
         ).buildRelaxed()
 
         assertEquals(TaskOutcome.SUCCESS, assertNotNull(result.task(":runTasks")).outcome)

--- a/dokka-integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/kotlin/CoroutinesGradleIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/integrationTest/kotlin/org/jetbrains/dokka/it/gradle/kotlin/CoroutinesGradleIntegrationTest.kt
@@ -53,7 +53,6 @@ class CoroutinesGradleIntegrationTest : AbstractGradleIntegrationTest(), TestOut
         val result = createGradleRunner(
             buildVersions,
             ":dokkaHtmlMultiModule", "-i", "-s",
-            jvmArgs = listOf("-Xmx2G", "-XX:MaxMetaspaceSize=500m")
         ).buildRelaxed()
 
         assertEquals(TaskOutcome.SUCCESS, assertNotNull(result.task(":dokkaHtmlMultiModule")).outcome)

--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleIntegrationTest.kt
@@ -27,7 +27,6 @@ abstract class AbstractGradleIntegrationTest : AbstractIntegrationTest() {
     fun createGradleRunner(
         buildVersions: BuildVersions,
         vararg arguments: String,
-        jvmArgs: List<String> = listOf("-Xmx2G", "-XX:MaxMetaspaceSize=1G")
     ): GradleRunner {
         return GradleRunner.create()
             .withProjectDir(projectDir)
@@ -50,8 +49,7 @@ abstract class AbstractGradleIntegrationTest : AbstractIntegrationTest() {
 
                     * arguments
                 )
-            ).run { this as DefaultGradleRunner }
-            .withJvmArguments(jvmArgs)
+            )
     }
 
     fun GradleRunner.buildRelaxed(): BuildResult {

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,6 @@ org.jetbrains.dokka.build.cache.url=https\://ge.jetbrains.com/cache/
 kotlin.code.style=official
 
 # Gradle settings
-org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=2g
+org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx6g -XX:MaxMetaspaceSize=2g -XX:+HeapDumpOnOutOfMemoryError -XX:+AlwaysPreTouch
 org.gradle.parallel=true
 org.gradle.caching=true


### PR DESCRIPTION
Adjust memory settings to try to help performance issues on TeamCity.

* remove custom jvmArgs from TestKit GradleRunner. Custom JVM args might cause additional Gradle TestKit daemons and OOMs on TeamCity - see https://github.com/gradle/gradle/issues/1043
* Remove integration test parallelism - this will be added later in KT-64377 when configuration cache is enabled
* Update default jvmargs - most significantly add `AlwaysPreTouch` which might help prevent OOM by forcing Java to ensure the memory is available.