### PR TITLE
Fix fastutil shadowing

### DIFF
--- a/dokka-integration-tests/cli/build.gradle.kts
+++ b/dokka-integration-tests/cli/build.gradle.kts
@@ -15,21 +15,21 @@ dependencies {
     implementation(projects.utilities)
 }
 
-// Configuration for plugins/dependencies required to run CLI with base plugin
 val cliPluginsClasspath: Configuration by configurations.creating {
+    description = "plugins/dependencies required to run CLI with base plugin"
     attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage::class.java, "java-runtime"))
+        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage.JAVA_RUNTIME))
     }
 
     // we don't fetch transitive dependencies here to be able to control external dependencies explicitly
     isTransitive = false
 }
 
-// Configuration for CLI jar
 val cliClasspath: Configuration by configurations.creating {
+    description = "dependency on CLI JAR"
     attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage::class.java, Usage.JAVA_RUNTIME))
-        attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling::class.java, Bundling.SHADOWED))
+        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage.JAVA_RUNTIME))
+        attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling.SHADOWED))
     }
     // we should have single artifact here
     isTransitive = false
@@ -55,7 +55,7 @@ dependencies {
 
     cliPluginsClasspath(analysisDependency) {
         attributes {
-            attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling::class.java, Bundling.SHADOWED))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling.SHADOWED))
         }
     }
 }

--- a/dokka-integration-tests/cli/projects/it-cli/src/main/kotlin/RootPackageClass.kt
+++ b/dokka-integration-tests/cli/projects/it-cli/src/main/kotlin/RootPackageClass.kt
@@ -1,0 +1,10 @@
+@file:Suppress("unused")
+
+/**
+ * A class that lives inside the root package
+ *
+ * <me@mail.com>
+ */
+class RootPackageClass {
+    val description = "I do live in the root package!"
+}

--- a/dokka-integration-tests/cli/projects/it-cli/src/main/kotlin/RootPackageClass.kt
+++ b/dokka-integration-tests/cli/projects/it-cli/src/main/kotlin/RootPackageClass.kt
@@ -3,7 +3,7 @@
 /**
  * A class that lives inside the root package
  *
- * <me@mail.com>
+ * <me@mail.com> - checks markdown parsing of emails and non-trivial cases like #3329, should compile
  */
 class RootPackageClass {
     val description = "I do live in the root package!"

--- a/dokka-subprojects/analysis-kotlin-descriptors/build.gradle.kts
+++ b/dokka-subprojects/analysis-kotlin-descriptors/build.gradle.kts
@@ -2,6 +2,7 @@
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import dokkabuild.overridePublicationArtifactId
 
 plugins {
@@ -22,7 +23,7 @@ dependencies {
     implementation(projects.dokkaSubprojects.analysisKotlinDescriptorsIde)
 }
 
-tasks.shadowJar {
+tasks.withType<ShadowJar>().configureEach {
     // service files are merged to make sure all Dokka plugins
     // from the dependencies are loaded, and not just a single one.
     mergeServiceFiles()
@@ -34,9 +35,8 @@ tasks.shadowJar {
  * KT issue: https://youtrack.jetbrains.com/issue/KT-47150
  *
  * what is happening here?
- *   fastutil is removed from shadow-jar completely,
- *   instead we declare a maven RUNTIME dependency on fastutil;
- *   this dependency will be fetched by Gradle at build time (as any other dependency from maven-central)
+ * 1. we create intermediate `shadowDependenciesJar` with dependencies but without fastutil classes in it
+ * 2. then we create final `shadowJar` with full fastutil from maven and dependencies from `shadowDependenciesJar` instead of original dependencies
  *
  * why do we need this?
  *   because `kotlin-compiler` artifact includes unshaded (not-relocated) STRIPPED `fastutil` dependency,
@@ -47,5 +47,34 @@ tasks.shadowJar {
  *   and so such classes are not replaced afterward by `shadowJar` task - it visits every class once
  *
  */
-dependencies.shadow(libs.fastutil)
-tasks.shadowJar { exclude("it/unimi/dsi/fastutil/**") }
+
+// configuration for dependencies which we need to replace with original ones because `kotlin-compiler` minimizes them
+val shadowOverride: Configuration by configurations.creating {
+    attributes {
+        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage::class.java, "java-runtime"))
+    }
+}
+
+dependencies {
+    shadowOverride(libs.fastutil)
+}
+
+val shadowDependenciesJar by tasks.registering(ShadowJar::class) {
+    group = "shadow"
+    description = "Create a shadow jar from dependencies without fastutil"
+
+    archiveClassifier.set("dependencies")
+    destinationDirectory.set(project.layout.buildDirectory.dir("shadowDependenciesLibs"))
+
+    // we need to create JAR with dependencies, but without fastutil,
+    // so we include `runtimeClasspath` configuration (the same configuration which is used by default `shadowJar` task)
+    // and include `fastutil` from the result
+    configurations = listOf(project.configurations.runtimeClasspath.get())
+    exclude("it/unimi/dsi/fastutil/**")
+}
+
+tasks.shadowJar {
+    // override configurations to remove dependencies handled in `shadowJarDependencies`
+    configurations = emptyList()
+    from(shadowOverride, shadowDependenciesJar)
+}

--- a/dokka-subprojects/analysis-kotlin-descriptors/build.gradle.kts
+++ b/dokka-subprojects/analysis-kotlin-descriptors/build.gradle.kts
@@ -48,10 +48,10 @@ tasks.withType<ShadowJar>().configureEach {
  *
  */
 
-// configuration for dependencies which we need to replace with original ones because `kotlin-compiler` minimizes them
 val shadowOverride: Configuration by configurations.creating {
+    description = "dependencies which we need to replace with original ones because `kotlin-compiler` minimizes them"
     attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage::class.java, "java-runtime"))
+        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage.JAVA_RUNTIME))
     }
 }
 

--- a/dokka-subprojects/analysis-kotlin-symbols/build.gradle.kts
+++ b/dokka-subprojects/analysis-kotlin-symbols/build.gradle.kts
@@ -2,6 +2,7 @@
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import dokkabuild.overridePublicationArtifactId
 
 plugins {
@@ -84,12 +85,11 @@ dependencies {
     compileOnly(libs.kotlinx.coroutines.core)
 }
 
-tasks.shadowJar {
+tasks.withType<ShadowJar>().configureEach {
     // service files are merged to make sure all Dokka plugins
     // from the dependencies are loaded, and not just a single one.
     mergeServiceFiles()
 }
-
 
 /**
  * hack for shadow jar and fastutil because of kotlin-compiler
@@ -97,9 +97,8 @@ tasks.shadowJar {
  * KT issue: https://youtrack.jetbrains.com/issue/KT-47150
  *
  * what is happening here?
- *   fastutil is removed from shadow-jar completely,
- *   instead we declare a maven RUNTIME dependency on fastutil;
- *   this dependency will be fetched by Gradle at build time (as any other dependency from maven-central)
+ * 1. we create intermediate `shadowDependenciesJar` with dependencies but without fastutil classes in it
+ * 2. then we create final `shadowJar` with full fastutil from maven and dependencies from `shadowDependenciesJar` instead of original dependencies
  *
  * why do we need this?
  *   because `kotlin-compiler` artifact includes unshaded (not-relocated) STRIPPED `fastutil` dependency,
@@ -110,6 +109,34 @@ tasks.shadowJar {
  *   and so such classes are not replaced afterward by `shadowJar` task - it visits every class once
  *
  */
-dependencies.shadow(libs.fastutil)
-tasks.shadowJar { exclude("it/unimi/dsi/fastutil/**") }
 
+// configuration for dependencies which we need to replace with original ones because `kotlin-compiler` minimizes them
+val shadowOverride: Configuration by configurations.creating {
+    attributes {
+        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage::class.java, "java-runtime"))
+    }
+}
+
+dependencies {
+    shadowOverride(libs.fastutil)
+}
+
+val shadowDependenciesJar by tasks.registering(ShadowJar::class) {
+    group = "shadow"
+    description = "Create a shadow jar from dependencies without fastutil"
+
+    archiveClassifier.set("dependencies")
+    destinationDirectory.set(project.layout.buildDirectory.dir("shadowDependenciesLibs"))
+
+    // we need to create JAR with dependencies, but without fastutil,
+    // so we include `runtimeClasspath` configuration (the same configuration which is used by default `shadowJar` task)
+    // and include `fastutil` from the result
+    configurations = listOf(project.configurations.runtimeClasspath.get())
+    exclude("it/unimi/dsi/fastutil/**")
+}
+
+tasks.shadowJar {
+    // override configurations to remove dependencies handled in `shadowJarDependencies`
+    configurations = emptyList()
+    from(shadowOverride, shadowDependenciesJar)
+}

--- a/dokka-subprojects/analysis-kotlin-symbols/build.gradle.kts
+++ b/dokka-subprojects/analysis-kotlin-symbols/build.gradle.kts
@@ -110,10 +110,10 @@ tasks.withType<ShadowJar>().configureEach {
  *
  */
 
-// configuration for dependencies which we need to replace with original ones because `kotlin-compiler` minimizes them
 val shadowOverride: Configuration by configurations.creating {
+    description = "dependencies which we need to replace with original ones because `kotlin-compiler` minimizes them"
     attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage::class.java, "java-runtime"))
+        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage.JAVA_RUNTIME))
     }
 }
 


### PR DESCRIPTION
Fixes: https://github.com/Kotlin/dokka/issues/3329#issuecomment-1906072161

I've updated the description of the fix in files, where the workaround is applied.

Also there are two changes in CLI integration tests:
1. set `isTransitive = false` when building `shadowJar` which is used as `pluginsClasspath` in CLI - this way we can better control/understand which dependencies are provided to CLI. This will help to find issues with missing dependencies in future.
2. support for running tests with K2 with property - this was done to correctly test, that the the current fix works.

If needed, I can split CLI integration tests changes to separate PR.