### PR TITLE
Update task-selector workaround to use task rules

### DIFF
--- a/build-logic/src/main/kotlin/dokkabuild.base.gradle.kts
+++ b/build-logic/src/main/kotlin/dokkabuild.base.gradle.kts
@@ -28,3 +28,72 @@ val integrationTestPreparation by tasks.registering {
         "lifecycle task for preparing the project for integration tests (for example, publishing to the test Maven repo)"
     group = VERIFICATION_GROUP
 }
+
+
+val subprojectTasksPrefix = "subprojectTasks_"
+val includedBuildTasksPrefix = "includedBuildTasks_"
+
+//region Workarounds for running all tasks in included builds
+// https://github.com/gradle/gradle/issues/22335
+if (project == rootProject) {
+
+    tasks.addRule("Pattern: ${includedBuildTasksPrefix}<TASK>") {
+        // Propagate <TASK> to all included builds.
+        // (Except build-logic subprojects, because they don't need to be published/tested/etc).
+        val taskName = this
+
+        if (startsWith(includedBuildTasksPrefix)) {
+            task(taskName) {
+                val requestedTaskName = taskName.removePrefix(includedBuildTasksPrefix)
+                val includedBuildTasks = gradle.includedBuilds
+                    .filter { it.name != "build-logic" }
+                    .filter { it.name != "build-settings-logic" }
+                    .map { includedBuild ->
+                        includedBuild.task(":${subprojectTasksPrefix}${requestedTaskName}")
+                    }
+                dependsOn(includedBuildTasks)
+            }
+        }
+    }
+
+    tasks.addRule("Pattern: $subprojectTasksPrefix<TASK>") {
+        // Run all <TASK>s in the current project's subprojects.
+        // This should only be run via the 'includedBuildTasks' rule.
+        val taskName = this
+
+        if (startsWith(subprojectTasksPrefix)) {
+            task(taskName) {
+                val requestedTaskName = taskName.removePrefix(subprojectTasksPrefix)
+                val allProjectTasks = subprojects.map { project ->
+                    project.tasks.matching { it.name == requestedTaskName }
+                }
+                dependsOn(allProjectTasks)
+            }
+        }
+    }
+
+    // Setup lifecycle tasks dependencies, so each is propagated to included builds.
+    tasks.assemble {
+        dependsOn("${includedBuildTasksPrefix}assemble")
+    }
+
+    tasks.build {
+        dependsOn("${includedBuildTasksPrefix}build")
+    }
+
+    tasks.clean {
+        dependsOn("${includedBuildTasksPrefix}clean")
+    }
+
+    tasks.check {
+        dependsOn("${includedBuildTasksPrefix}check")
+    }
+}
+//endregion
+
+val testTasks = tasks.matching { it.name == "test" }
+val apiCheckTasks = tasks.matching { it.name == "apiCheck" }
+
+testTasks.configureEach {
+    dependsOn(apiCheckTasks)
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,84 +1,84 @@
 /*
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
+import org.gradle.api.publish.plugins.PublishingPlugin.PUBLISH_TASK_GROUP
+import org.gradle.language.base.plugins.LifecycleBasePlugin.VERIFICATION_GROUP
 
 plugins {
     id("dokkabuild.base")
 }
 
-val publishedIncludedBuilds = listOf("runner-cli", "runner-gradle-plugin-classic", "runner-maven-plugin")
-val gradlePluginIncludedBuilds = listOf("runner-gradle-plugin-classic")
-
-addDependencyOnSameTasksOfIncludedBuilds("assemble", "build", "clean", "check")
-
-registerParentGroupTasks("publishing", taskNames = listOf(
-    "publishAllPublicationsToMavenCentralRepository",
-    "publishAllPublicationsToProjectLocalRepository",
-    "publishAllPublicationsToSnapshotRepository",
-    "publishAllPublicationsToSpaceDevRepository",
-    "publishAllPublicationsToSpaceTestRepository",
-    "publishToMavenLocal"
-)) {
-    it.name in publishedIncludedBuilds
+//region Workarounds for running all tasks in included builds
+// https://github.com/gradle/gradle/issues/22335
+// See build-logic/src/main/kotlin/dokkabuild.base.gradle.kts
+fun Task.dependsOnIncludedBuildTasks(
+    taskName: String = name
+) {
+    description = "Lifecycle task that runs '$taskName' in all included builds"
+    dependsOn("includedBuildTasks_$taskName")
 }
 
-registerParentGroupTasks("gradle plugin", taskNames = listOf(
-    "publishPlugins",
-    "validatePlugins"
-)) {
-    it.name in gradlePluginIncludedBuilds
+val publishPlugins by tasks.registering {
+    group = "gradle plugin"
+    dependsOnIncludedBuildTasks()
 }
 
-registerParentGroupTasks("bcv", taskNames = listOf(
-    "apiDump",
-    "apiCheck",
-    "apiBuild"
-)) {
-    it.name in publishedIncludedBuilds
+val validatePlugins by tasks.registering {
+    group = "gradle plugin"
+    dependsOnIncludedBuildTasks()
 }
 
-registerParentGroupTasks("verification", taskNames = listOf(
-    "test"
-))
+val apiDump by tasks.registering {
+    group = "$VERIFICATION_GROUP bcv"
+    dependsOnIncludedBuildTasks()
+}
 
-tasks.register("integrationTest") {
-    group = "verification"
+val apiCheck by tasks.registering {
+    group = "$VERIFICATION_GROUP bcv"
+    dependsOnIncludedBuildTasks()
+}
+
+val test by tasks.registering {
+    group = VERIFICATION_GROUP
+    dependsOnIncludedBuildTasks()
+    dependsOn(apiCheck)
+}
+
+val integrationTest by tasks.registering {
+    group = VERIFICATION_GROUP
+    dependsOnIncludedBuildTasks()
     description = "Runs integration tests of this project. Might take a while and require additional setup."
-
-    dependsOn(includedBuildTasks("integrationTest") {
-        it.name == "dokka-integration-tests"
-    })
 }
 
-fun addDependencyOnSameTasksOfIncludedBuilds(vararg taskNames: String) {
-    taskNames.forEach { taskName ->
-        tasks.named(taskName) {
-            dependsOn(includedBuildTasks(taskName))
-        }
-    }
+val publishAllPublicationsToRemoteRepositories by tasks.registering {
+    group = PUBLISH_TASK_GROUP
+    dependsOnIncludedBuildTasks("publishAllPublicationsToMavenCentralRepository")
+    dependsOnIncludedBuildTasks("publishAllPublicationsToProjectLocalRepository")
+    dependsOnIncludedBuildTasks("publishAllPublicationsToSnapshotRepository")
+    dependsOnIncludedBuildTasks("publishAllPublicationsToSpaceDevRepository")
 }
-
-fun registerParentGroupTasks(
-    groupName: String,
-    taskNames: List<String>,
-    includedBuildFilter: (IncludedBuild) -> Boolean = { true }
-) = taskNames.forEach { taskName ->
-    tasks.register(taskName) {
-        group = groupName
-        description = "A parent task that calls tasks with the same name in all subprojects and included builds"
-
-        dependsOn(subprojectTasks(taskName), includedBuildTasks(taskName, includedBuildFilter))
-    }
+val publishAllPublicationsToMavenCentralRepository by tasks.registering {
+    group = PUBLISH_TASK_GROUP
+    dependsOnIncludedBuildTasks()
 }
-
-fun subprojectTasks(taskName: String): List<String> =
-    subprojects
-        .filter { it.getTasksByName(taskName, false).isNotEmpty() }
-        .map { ":${it.path}:$taskName" }
-
-
-fun includedBuildTasks(taskName: String, filter: (IncludedBuild) -> Boolean = { true }): List<TaskReference> =
-    gradle.includedBuilds
-        .filter { it.name != "build-logic" }
-        .filter(filter)
-        .mapNotNull { it.task(":$taskName") }
+val publishAllPublicationsToProjectLocalRepository by tasks.registering {
+    group = PUBLISH_TASK_GROUP
+    dependsOnIncludedBuildTasks()
+}
+val publishAllPublicationsToSnapshotRepository by tasks.registering {
+    group = PUBLISH_TASK_GROUP
+    dependsOnIncludedBuildTasks()
+}
+val publishAllPublicationsToSpaceDevRepository by tasks.registering {
+    group = PUBLISH_TASK_GROUP
+    dependsOnIncludedBuildTasks()
+}
+val publishAllPublicationsToSpaceTestRepository by tasks.registering {
+    group = PUBLISH_TASK_GROUP
+    dependsOnIncludedBuildTasks()
+}
+val publishToMavenLocal by tasks.registering {
+    group = PUBLISH_TASK_GROUP
+    dependsOnIncludedBuildTasks()
+}
+//endregion


### PR DESCRIPTION
Update the workaround for https://github.com/gradle/gradle/issues/22335 to use [task rules](https://docs.gradle.org/8.5/userguide/more_about_tasks.html#sec:task_rules).


[Discussed here.](https://github.com/Kotlin/dokka/pull/3427#discussion_r1463547746)

### Goals

* It should be more clear how to add/link tasks.
* Tasks should be easier to use, understand, run.
* tasks should follow conventions (specifically: `check` runs all verifications, `test` runs JVM verifications, `integrationTest` runs all integration tests)


### Details

* Create task rules for propagating tasks:
  * `includedBuildTasks_<TASK>` → runs <TASK> in included builds
  * `subprojectTasks_<TASK>` → runs <TASK> in subprojects (this shouldn't be invoked manually, only in by the `includedBuildTasks_` rule, otherwise it creates cyclical task dependencies).

* Update tasks:
  - check runs all validations
  - test runs apiCheck
  - introduce 'publishAllPublicationsToRemoteRepositories' lifecycle task