### PR TITLE
Improve task cacheability

### DIFF
--- a/build-logic/src/main/kotlin/dokkabuild.setup-maven-cli.gradle.kts
+++ b/build-logic/src/main/kotlin/dokkabuild.setup-maven-cli.gradle.kts
@@ -84,12 +84,12 @@ val installMavenBinary by tasks.registering(Sync::class) {
     val archives = serviceOf<ArchiveOperations>()
     from(
         mavenBinary.flatMap { conf ->
-            @Suppress("UnstableApiUsage")
-            val resolvedArtifacts = conf.incoming.artifacts.resolvedArtifacts
-
-            resolvedArtifacts.map { artifacts ->
-                artifacts.map { archives.zipTree(it.file) }
-            }
+            conf.incoming
+                .artifacts
+                .resolvedArtifacts
+                .map { artifacts ->
+                    artifacts.map { archives.zipTree(it.file) }
+                }
         }
     ) {
         eachFile {
@@ -99,4 +99,6 @@ val installMavenBinary by tasks.registering(Sync::class) {
         includeEmptyDirs = false
     }
     into(mavenCliSetupExtension.mavenInstallDir)
+
+    outputs.cacheIf { true }
 }

--- a/dokka-integration-tests/cli/build.gradle.kts
+++ b/dokka-integration-tests/cli/build.gradle.kts
@@ -3,6 +3,7 @@
  */
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.gradle.api.tasks.PathSensitivity.RELATIVE
 
 plugins {
     id("dokkabuild.test-integration")
@@ -59,6 +60,8 @@ tasks.integrationTest {
     dependsOn(basePluginShadowJar)
 
     inputs.dir(file("projects"))
+        .withPropertyName("projectsDir")
+        .withPathSensitivity(RELATIVE)
     environment("CLI_JAR_PATH", cliConfiguration.singleFile)
     environment("BASE_PLUGIN_JAR_PATH", basePluginShadowJar.archiveFile.get())
 }

--- a/dokka-integration-tests/gradle/build.gradle.kts
+++ b/dokka-integration-tests/gradle/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.tasks.PathSensitivity.RELATIVE
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
 
 /*
@@ -33,6 +34,8 @@ tasks.integrationTest {
     environment("DOKKA_VERSION", project.version)
 
     inputs.dir(file("projects"))
+        .withPropertyName("projectsDir")
+        .withPathSensitivity(RELATIVE)
 
     javaLauncher.set(javaToolchains.launcherFor {
         // kotlinx.coroutines requires Java 11+

--- a/dokka-runners/runner-maven-plugin/build.gradle.kts
+++ b/dokka-runners/runner-maven-plugin/build.gradle.kts
@@ -47,6 +47,8 @@ val generatePom by tasks.registering(Sync::class) {
     }
 
     into(temporaryDir)
+
+    outputs.cacheIf { true }
 }
 
 val prepareHelpMojoDir by tasks.registering(Sync::class) {
@@ -55,6 +57,8 @@ val prepareHelpMojoDir by tasks.registering(Sync::class) {
 
     into(layout.buildDirectory.dir("maven-help-mojo"))
     from(generatePom)
+
+    outputs.cacheIf { true }
 }
 
 val helpMojo by tasks.registering(Exec::class) {
@@ -68,6 +72,9 @@ val helpMojo by tasks.registering(Exec::class) {
     args("-e", "-B", "org.apache.maven.plugins:maven-plugin-plugin:helpmojo")
 
     outputs.dir(workingDir)
+        .withPropertyName("outputDir")
+
+    outputs.cacheIf { true }
 }
 
 val helpMojoSources by tasks.registering(Sync::class) {
@@ -82,6 +89,8 @@ val helpMojoSources by tasks.registering(Sync::class) {
     includeEmptyDirs = false
     into(temporaryDir)
     include("**/*.java")
+
+    outputs.cacheIf { true }
 }
 
 val helpMojoResources by tasks.registering(Sync::class) {
@@ -91,6 +100,8 @@ val helpMojoResources by tasks.registering(Sync::class) {
     into(temporaryDir)
     include("**/**")
     exclude("**/*.java")
+
+    outputs.cacheIf { true }
 }
 
 sourceSets.main {
@@ -108,6 +119,8 @@ val preparePluginDescriptorDir by tasks.registering(Sync::class) {
     from(tasks.compileKotlin) { into("classes/java/main") }
     from(tasks.compileJava) { into("classes/java/main") }
     from(helpMojoResources)
+
+    outputs.cacheIf { true }
 }
 
 val pluginDescriptor by tasks.registering(Exec::class) {
@@ -121,6 +134,9 @@ val pluginDescriptor by tasks.registering(Exec::class) {
     args("-e", "-B", "org.apache.maven.plugins:maven-plugin-plugin:descriptor")
 
     outputs.dir("$workingDir/classes/java/main/META-INF/maven")
+        .withPropertyName("outputDir")
+
+    outputs.cacheIf { true }
 }
 
 tasks.jar {

--- a/dokka-subprojects/plugin-base-frontend/build.gradle.kts
+++ b/dokka-subprojects/plugin-base-frontend/build.gradle.kts
@@ -3,6 +3,7 @@
  */
 
 import com.github.gradle.node.npm.task.NpmTask
+import org.gradle.api.tasks.PathSensitivity.RELATIVE
 import org.jetbrains.kotlin.util.parseSpaceSeparatedArgs
 
 @Suppress("DSL_SCOPE_VIOLATION") // fixed in Gradle 8.1 https://github.com/gradle/gradle/pull/23639
@@ -21,18 +22,29 @@ node {
 
 val distributionDirectory = layout.projectDirectory.dir("dist")
 
+tasks.npmInstall {
+    outputs.cacheIf { true }
+}
+
 val npmRunBuild by tasks.registering(NpmTask::class) {
     dependsOn(tasks.npmInstall)
 
     npmCommand.set(parseSpaceSeparatedArgs("run build"))
 
     inputs.dir("src/main")
+        .withPropertyName("mainSources")
+        .withPathSensitivity(RELATIVE)
+
     inputs.files(
         "package.json",
         "webpack.config.js",
     )
+        .withPropertyName("javascriptConfigFiles")
+        .withPathSensitivity(RELATIVE)
 
     outputs.dir(distributionDirectory)
+        .withPropertyName("distributionDirectory")
+
     outputs.cacheIf { true }
 }
 

--- a/dokka-subprojects/plugin-base/build.gradle.kts
+++ b/dokka-subprojects/plugin-base/build.gradle.kts
@@ -37,7 +37,12 @@ dependencies {
     testImplementation(libs.junit.jupiterParams)
 
     symbolsTestConfiguration(project(path = ":dokka-subprojects:analysis-kotlin-symbols", configuration = "shadow"))
-    descriptorsTestConfiguration(project(path = ":dokka-subprojects:analysis-kotlin-descriptors", configuration = "shadow"))
+    descriptorsTestConfiguration(
+        project(
+            path = ":dokka-subprojects:analysis-kotlin-descriptors",
+            configuration = "shadow"
+        )
+    )
     testImplementation(projects.dokkaSubprojects.pluginBaseTestUtils) {
         exclude(module = "analysis-kotlin-descriptors")
     }
@@ -56,7 +61,7 @@ val dokkaHtmlFrontendFiles: Provider<FileCollection> =
         frontendFiles.incoming.artifacts.artifactFiles
     }
 
-val preparedokkaHtmlFrontendFiles by tasks.registering(Sync::class) {
+val prepareDokkaHtmlFrontendFiles by tasks.registering(Sync::class) {
     description = "copy Dokka Base frontend files into the resources directory"
 
     from(dokkaHtmlFrontendFiles) {
@@ -70,10 +75,12 @@ val preparedokkaHtmlFrontendFiles by tasks.registering(Sync::class) {
     }
 
     into(layout.buildDirectory.dir("generated/src/main/resources"))
+
+    outputs.cacheIf { true }
 }
 
 sourceSets.main {
-    resources.srcDir(preparedokkaHtmlFrontendFiles.map { it.destinationDir })
+    resources.srcDir(prepareDokkaHtmlFrontendFiles.map { it.destinationDir })
 }
 
 tasks.test {


### PR DESCRIPTION
- manually set [`cacheIf { true }`](https://docs.gradle.org/8.5/userguide/build_cache.html#using_the_runtime_api) on Sync/Exec tasks
  - by default Sync tasks are not cached because they are usually 'light' and just move files. But there are knock-on effects on later tasks if they are not cached.
  - Exec tasks aren't usually cached because they don't have well-defined outputs, but in our case they do
- use [path normalization](https://docs.gradle.org/8.5/userguide/build_cache_concepts.html#normalization) on Task file inputs
- add property names to task inputs (improves debugging/reporting)