### PR TITLE
improve NPM Gradle task caching

### DIFF
--- a/dokka-subprojects/plugin-base-frontend/build.gradle.kts
+++ b/dokka-subprojects/plugin-base-frontend/build.gradle.kts
@@ -17,6 +17,9 @@ node {
     // https://github.com/node-gradle/gradle-node-plugin/blob/3.5.1/docs/faq.md#is-this-plugin-compatible-with-centralized-repositories-declaration
     download.set(true)
     distBaseUrl.set(null as String?) // Strange cast to avoid overload ambiguity
+
+    // Stop Gradle from monitoring node_modules dir; it will be managed by NPM. This helps performance and task-avoidance.
+    fastNpmInstall = true
 }
 
 val distributionDirectory = layout.projectDirectory.dir("dist")

--- a/dokka-subprojects/plugin-base-frontend/build.gradle.kts
+++ b/dokka-subprojects/plugin-base-frontend/build.gradle.kts
@@ -31,9 +31,13 @@ val npmRunBuild by tasks.registering(NpmTask::class) {
         .withPathSensitivity(RELATIVE)
 
     inputs.files(
-        "package.json",
-        "tsconfig.json",
-        "*.config.js",
+        layout.projectDirectory.asFileTree.matching {
+            include(
+                "package.json",
+                "tsconfig.json",
+                "*.config.js",
+            )
+        }
     )
         .withPropertyName("javascriptConfigFiles")
         .withPathSensitivity(RELATIVE)

--- a/dokka-subprojects/plugin-base-frontend/build.gradle.kts
+++ b/dokka-subprojects/plugin-base-frontend/build.gradle.kts
@@ -3,6 +3,7 @@
  */
 
 import com.github.gradle.node.npm.task.NpmTask
+import org.gradle.api.tasks.PathSensitivity.RELATIVE
 import org.jetbrains.kotlin.util.parseSpaceSeparatedArgs
 
 @Suppress("DSL_SCOPE_VIOLATION") // fixed in Gradle 8.1 https://github.com/gradle/gradle/pull/23639
@@ -21,18 +22,36 @@ node {
 
 val distributionDirectory = layout.projectDirectory.dir("dist")
 
+tasks.npmInstall {
+    // enable caching - workaround for https://github.com/node-gradle/gradle-node-plugin/issues/81
+    outputs.file(layout.projectDirectory.file("node_modules/.package-lock.json"))
+        .withPropertyName("nodeModulesPackageLock")
+    outputs.cacheIf { true }
+}
+
 val npmRunBuild by tasks.registering(NpmTask::class) {
     dependsOn(tasks.npmInstall)
 
     npmCommand.set(parseSpaceSeparatedArgs("run build"))
 
     inputs.dir("src/main")
+        .withPropertyName("mainSources")
+        .withPathSensitivity(RELATIVE)
+
     inputs.files(
         "package.json",
         "webpack.config.js",
     )
+        .withPropertyName("javascriptConfigFiles")
+        .withPathSensitivity(RELATIVE)
+
+    inputs.dir(layout.projectDirectory.dir("node_modules"))
+        .withPathSensitivity(RELATIVE)
+        .withPropertyName("nodeModulesDir")
 
     outputs.dir(distributionDirectory)
+        .withPropertyName("distributionDirectory")
+
     outputs.cacheIf { true }
 }
 

--- a/dokka-subprojects/plugin-base/build.gradle.kts
+++ b/dokka-subprojects/plugin-base/build.gradle.kts
@@ -37,7 +37,12 @@ dependencies {
     testImplementation(libs.junit.jupiterParams)
 
     symbolsTestConfiguration(project(path = ":dokka-subprojects:analysis-kotlin-symbols", configuration = "shadow"))
-    descriptorsTestConfiguration(project(path = ":dokka-subprojects:analysis-kotlin-descriptors", configuration = "shadow"))
+    descriptorsTestConfiguration(
+        project(
+            path = ":dokka-subprojects:analysis-kotlin-descriptors",
+            configuration = "shadow"
+        )
+    )
     testImplementation(projects.dokkaSubprojects.pluginBaseTestUtils) {
         exclude(module = "analysis-kotlin-descriptors")
     }
@@ -56,7 +61,7 @@ val dokkaHtmlFrontendFiles: Provider<FileCollection> =
         frontendFiles.incoming.artifacts.artifactFiles
     }
 
-val preparedokkaHtmlFrontendFiles by tasks.registering(Sync::class) {
+val prepareDokkaHtmlFrontendFiles by tasks.registering(Sync::class) {
     description = "copy Dokka Base frontend files into the resources directory"
 
     from(dokkaHtmlFrontendFiles) {
@@ -70,10 +75,12 @@ val preparedokkaHtmlFrontendFiles by tasks.registering(Sync::class) {
     }
 
     into(layout.buildDirectory.dir("generated/src/main/resources"))
+
+    outputs.cacheIf { true }
 }
 
 sourceSets.main {
-    resources.srcDir(preparedokkaHtmlFrontendFiles.map { it.destinationDir })
+    resources.srcDir(prepareDokkaHtmlFrontendFiles.map { it.destinationDir })
 }
 
 tasks.test {

--- a/dokka-subprojects/plugin-base/build.gradle.kts
+++ b/dokka-subprojects/plugin-base/build.gradle.kts
@@ -76,7 +76,7 @@ val prepareDokkaHtmlFrontendFiles by tasks.registering(Sync::class) {
 
     into(layout.buildDirectory.dir("generated/src/main/resources"))
 
-    outputs.cacheIf { true }
+    outputs.cacheIf("always cache: avoid fetching files from another subproject") { true }
 }
 
 sourceSets.main {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,7 +56,7 @@ node = "16.13.0"
 ## Publishing
 gradlePlugin-shadow = "8.1.1"
 gradlePlugin-gradlePluginPublish = "1.2.1"
-gradlePlugin-gradleNode = "3.5.1"
+gradlePlugin-gradleNode = "7.0.1"
 
 ## Test
 junit = "5.9.3"


### PR DESCRIPTION
- bump Gradle Node Plugin version
- fix npmInstall caching
- amend Gradle Node Plugin settings to allow npm (not Gradle) to manage `node_modules/` caching
- add path-sensitivity to task inputs, so cache can be re-used across machines
- add property names to task inputs (easier debugging/reporting)

This should improve build performance, and avoid an issue where npmInstall could not be up-to-date.

https://ge.jetbrains.com/s/rumw2jkk7scia/timeline?details=xhxfjcjtknpfe

<img width="582" alt="build scan screenshot showing npmInstall warning: Not cacheable Overlapping outputs: Gradle does not know how file 'package-lock.json' was created (output property" src="https://github.com/Kotlin/dokka/assets/152864218/a0e5a6f9-f664-44ff-bb07-8fbe0b2242e2">
