### PR TITLE
Gradle TestKit: reduce daemon timeouts

### DIFF
--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleIntegrationTest.kt
@@ -13,6 +13,7 @@ import org.jetbrains.dokka.it.AbstractIntegrationTest
 import java.io.File
 import java.net.URI
 import kotlin.test.BeforeTest
+import kotlin.time.Duration.Companion.seconds
 
 abstract class AbstractGradleIntegrationTest : AbstractIntegrationTest() {
 
@@ -47,6 +48,12 @@ abstract class AbstractGradleIntegrationTest : AbstractIntegrationTest() {
                         "-P${TestEnvironment.TRY_K2}=true"
                     else
                         null,
+
+                    "-Porg.gradle.workers.max=1",
+                    // Decrease Gradle daemon idle timeout to prevent old agents lingering on CI.
+                    // A lower timeout means slower tests, which is preferred over OOMs and locked processes.
+                    "-Dorg.gradle.daemon.idletimeout=" + 10.seconds.inWholeMilliseconds, // default is 3 hours!
+                    "-Pkotlin.daemon.options.autoshutdownIdleSeconds=10",
 
                     * arguments
                 )

--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleIntegrationTest.kt
@@ -49,7 +49,7 @@ abstract class AbstractGradleIntegrationTest : AbstractIntegrationTest() {
                     else
                         null,
 
-                    "-Porg.gradle.workers.max=1",
+                    "-Dorg.gradle.workers.max=1",
                     // Decrease Gradle daemon idle timeout to prevent old agents lingering on CI.
                     // A lower timeout means slower tests, which is preferred over OOMs and locked processes.
                     "-Dorg.gradle.daemon.idletimeout=" + 10.seconds.inWholeMilliseconds, // default is 3 hours!

--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleIntegrationTest.kt
@@ -49,7 +49,6 @@ abstract class AbstractGradleIntegrationTest : AbstractIntegrationTest() {
                     else
                         null,
 
-                    "-Dorg.gradle.workers.max=1",
                     // Decrease Gradle daemon idle timeout to prevent old agents lingering on CI.
                     // A lower timeout means slower tests, which is preferred over OOMs and locked processes.
                     "-Dorg.gradle.daemon.idletimeout=" + 10.seconds.inWholeMilliseconds, // default is 3 hours!


### PR DESCRIPTION
Limit Gradle Workers:

- decreases the memory pressure 
- prevents daemons from previously failed build lingering on TeamCity agents, which then sabotage future builds by preventing directories from being deleted.

The aim is improved CI test consistency, which might increase overall test execution duration. I expect that the increased duration will be mitigated by other measures (aiming for enabling configuration-cache to allow for parallel test execution, and build-cache compliance allowing for avoiding re-running tests where possible).