### PR TITLE
Introduce API to rewrite samples

### DIFF
--- a/dokka-subprojects/analysis-kotlin-api/api/analysis-kotlin-api.api
+++ b/dokka-subprojects/analysis-kotlin-api/api/analysis-kotlin-api.api
@@ -2,6 +2,7 @@ public final class org/jetbrains/dokka/analysis/kotlin/KotlinAnalysisPlugin : or
 	public fun <init> ()V
 	public final fun getExternalDocumentableProvider ()Lorg/jetbrains/dokka/plugability/ExtensionPoint;
 	public final fun getSampleAnalysisEnvironmentCreator ()Lorg/jetbrains/dokka/plugability/ExtensionPoint;
+	public final fun getSampleRewriter ()Lorg/jetbrains/dokka/plugability/ExtensionPoint;
 }
 
 public abstract interface class org/jetbrains/dokka/analysis/kotlin/documentable/ExternalDocumentableProvider {
@@ -73,12 +74,25 @@ public final class org/jetbrains/dokka/analysis/kotlin/markdown/MarkdownApiKt {
 	public static final field MARKDOWN_ELEMENT_FILE_NAME Ljava/lang/String;
 }
 
+public abstract interface class org/jetbrains/dokka/analysis/kotlin/sample/FunctionCallRewriter {
+	public abstract fun rewrite (Ljava/util/List;Ljava/util/List;)Ljava/lang/String;
+}
+
 public abstract interface class org/jetbrains/dokka/analysis/kotlin/sample/SampleAnalysisEnvironment {
 	public abstract fun resolveSample (Lorg/jetbrains/dokka/DokkaConfiguration$DokkaSourceSet;Ljava/lang/String;)Lorg/jetbrains/dokka/analysis/kotlin/sample/SampleSnippet;
 }
 
 public abstract interface class org/jetbrains/dokka/analysis/kotlin/sample/SampleAnalysisEnvironmentCreator {
 	public abstract fun use (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public abstract interface class org/jetbrains/dokka/analysis/kotlin/sample/SampleRewriter {
+	public abstract fun getFunctionCallRewriters ()Ljava/util/Map;
+	public abstract fun rewriteImportDirective (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class org/jetbrains/dokka/analysis/kotlin/sample/SampleRewriter$DefaultImpls {
+	public static fun rewriteImportDirective (Lorg/jetbrains/dokka/analysis/kotlin/sample/SampleRewriter;Ljava/lang/String;)Ljava/lang/String;
 }
 
 public final class org/jetbrains/dokka/analysis/kotlin/sample/SampleSnippet {

--- a/dokka-subprojects/analysis-kotlin-api/api/analysis-kotlin-api.api
+++ b/dokka-subprojects/analysis-kotlin-api/api/analysis-kotlin-api.api
@@ -87,7 +87,7 @@ public abstract interface class org/jetbrains/dokka/analysis/kotlin/sample/Sampl
 }
 
 public abstract interface class org/jetbrains/dokka/analysis/kotlin/sample/SampleRewriter {
-	public abstract fun getFunctionCallRewriters ()Ljava/util/Map;
+	public abstract fun getFunctionCallRewriter (Ljava/lang/String;)Lorg/jetbrains/dokka/analysis/kotlin/sample/FunctionCallRewriter;
 	public abstract fun rewriteImportDirective (Ljava/lang/String;)Ljava/lang/String;
 }
 

--- a/dokka-subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/KotlinAnalysisPlugin.kt
+++ b/dokka-subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/KotlinAnalysisPlugin.kt
@@ -7,6 +7,7 @@ package org.jetbrains.dokka.analysis.kotlin
 import org.jetbrains.dokka.analysis.kotlin.documentable.ExternalDocumentableProvider
 import org.jetbrains.dokka.analysis.kotlin.sample.SampleAnalysisEnvironmentCreator
 import org.jetbrains.dokka.analysis.kotlin.sample.SampleAnalysisEnvironment
+import org.jetbrains.dokka.analysis.kotlin.sample.SampleRewriter
 import org.jetbrains.dokka.plugability.DokkaPlugin
 import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
 import org.jetbrains.dokka.plugability.ExtensionPoint
@@ -28,6 +29,16 @@ public class KotlinAnalysisPlugin : DokkaPlugin() {
      * @see ExternalDocumentableProvider for more details
      */
     public val externalDocumentableProvider: ExtensionPoint<ExternalDocumentableProvider> by extensionPoint()
+
+    /**
+     * An extensions can rewrite Kotlin sample functions that come from the `@sample` KDoc tag.
+     * For example, it could be convenient to transform unit tests to samples.
+     * Dokka supports no more than one rewriter. By default, Dokka provides no rewriter.
+     *
+     * @see SampleRewriter for more details
+     * @see sampleAnalysisEnvironmentCreator
+     */
+    public val sampleRewriter: ExtensionPoint<SampleRewriter> by extensionPoint()
 
     @OptIn(DokkaPluginApiPreview::class)
     override fun pluginApiPreviewAcknowledgement(): PluginApiPreviewAcknowledgement = PluginApiPreviewAcknowledgement

--- a/dokka-subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/sample/SampleRewriter.kt
+++ b/dokka-subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/sample/SampleRewriter.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package org.jetbrains.dokka.analysis.kotlin.sample
+
+public typealias ShortFunctionName = String
+
+public interface FunctionCallRewriter{
+    /**
+     * In the case of a [trailing lambda](https://kotlinlang.org/docs/lambdas.html#passing-trailing-lambdas),
+     * it will be passed as it in the last element of [argumentList]
+     * E.g., the snippet `f(0) { i++ }` will have `"0"` and `"{ i++ }"` arguments
+     */
+    public fun rewrite(argumentList: List<String>, typeArgumentList: List<String>): String?
+}
+
+/**
+ * For simplicity's sake, it process sample code syntactically and does not have the information about semantics of code, e.g. resolved types.
+ *
+ *
+ * TODO write KDoc
+ */
+public interface SampleRewriter {
+    /**
+     * `null` to delete a whole import directive
+     */
+    public fun rewriteImportDirective(importPath: String): String? = importPath
+    public val functionCallRewriters: Map<ShortFunctionName, FunctionCallRewriter>
+}
+

--- a/dokka-subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/sample/SampleRewriter.kt
+++ b/dokka-subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/sample/SampleRewriter.kt
@@ -12,7 +12,7 @@ public typealias ShortFunctionName = String
 /**
  * Rewrites an expression of function call to an arbitrary string
  *
- * @see rewrite
+ * @see FunctionCallRewriter.rewrite
  */
 public interface FunctionCallRewriter{
     /**
@@ -25,11 +25,13 @@ public interface FunctionCallRewriter{
      * E.g., the snippet `f(0) { i++ }` will have `"0"` and `"{ i++ }"` arguments
      *
      * @param arguments a list of arguments represented as a string from source code
+     *        _Note:_ en empty string is possible, e.g. for `fun f(,,,)`
      * @param typeArguments a list of type parameters represented as a string from source code
+     *        _Note:_ en empty string is possible
      *
-     * @return a string or `null` to delete the call expression
+     * @return a string or an empty string to delete the call expression
      */
-    public fun rewrite(arguments: List<String>, typeArguments: List<String>): String?
+    public fun rewrite(arguments: List<String>, typeArguments: List<String>): String
 }
 
 /**
@@ -60,8 +62,8 @@ public interface SampleRewriter {
      * Allows to rewrite a function call expressions
      * It also includes calls of constructors
      *
-     * The remain call expressions of functions that are not in this map will be left unchanged
+     * @return [FunctionCallRewriter] or null if a call should be left unchanged
      */
-    public val functionCallRewriters: Map<ShortFunctionName, FunctionCallRewriter>
+    public fun getFunctionCallRewriter(name: String): FunctionCallRewriter?
 }
 

--- a/dokka-subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/sample/SampleRewriter.kt
+++ b/dokka-subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/sample/SampleRewriter.kt
@@ -17,19 +17,19 @@ public typealias ShortFunctionName = String
 public interface FunctionCallRewriter{
     /**
      *
-     * A value argument and type arguments represents a string from source code in [argumentList] and [typeArgumentList]
+     * A value argument and type arguments represents a string from source code in [arguments] and [typeArguments]
      * E.g., `f(1, "s")` will be passed to [rewrite] as `"1"` and `"\"s\""`
      *
      * In the case of a [trailing lambda](https://kotlinlang.org/docs/lambdas.html#passing-trailing-lambdas),
-     * it will be passed as it in the last element of [argumentList]
+     * it will be passed as it in the last element of [arguments]
      * E.g., the snippet `f(0) { i++ }` will have `"0"` and `"{ i++ }"` arguments
      *
-     * @param argumentList a list of arguments represented as a string from source code
-     * @param typeArgumentList a list of type parameters represented as a string from source code
+     * @param arguments a list of arguments represented as a string from source code
+     * @param typeArguments a list of type parameters represented as a string from source code
      *
      * @return a string or `null` to delete the call expression
      */
-    public fun rewrite(argumentList: List<String>, typeArgumentList: List<String>): String?
+    public fun rewrite(arguments: List<String>, typeArguments: List<String>): String?
 }
 
 /**

--- a/dokka-subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/sample/SampleRewriter.kt
+++ b/dokka-subprojects/analysis-kotlin-api/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/sample/SampleRewriter.kt
@@ -4,28 +4,64 @@
 
 package org.jetbrains.dokka.analysis.kotlin.sample
 
+/**
+ * Represents a function name
+ */
 public typealias ShortFunctionName = String
 
+/**
+ * Rewrites an expression of function call to an arbitrary string
+ *
+ * @see rewrite
+ */
 public interface FunctionCallRewriter{
     /**
+     *
+     * A value argument and type arguments represents a string from source code in [argumentList] and [typeArgumentList]
+     * E.g., `f(1, "s")` will be passed to [rewrite] as `"1"` and `"\"s\""`
+     *
      * In the case of a [trailing lambda](https://kotlinlang.org/docs/lambdas.html#passing-trailing-lambdas),
      * it will be passed as it in the last element of [argumentList]
      * E.g., the snippet `f(0) { i++ }` will have `"0"` and `"{ i++ }"` arguments
+     *
+     * @param argumentList a list of arguments represented as a string from source code
+     * @param typeArgumentList a list of type parameters represented as a string from source code
+     *
+     * @return a string or `null` to delete the call expression
      */
     public fun rewrite(argumentList: List<String>, typeArgumentList: List<String>): String?
 }
 
 /**
- * For simplicity's sake, it process sample code syntactically and does not have the information about semantics of code, e.g. resolved types.
+ * Rewrites Kotlin sample snippet
  *
+ * For simplicity's sake, it processes sample code syntactically (AST) and
+ * does not have the information about semantics of code, e.g. resolved types.
+ * So it works only with strings without addition abstractions.
  *
- * TODO write KDoc
+ * @see SampleSnippet
  */
 public interface SampleRewriter {
     /**
-     * `null` to delete a whole import directive
+     * Allows to rewrite paths of [import directives](https://kotlinlang.org/spec/packages-and-imports.html#importing)
+     * E.g., for `import org.example` the path `org.example` will be used as an argument of [rewriteImportDirective]
+     *
+     * The default implementation is the identity function that return unchanged an import path
+     *
+     * @param importPath a path of value of import directive
+     *
+     * @return a string or `null` to delete a whole import directive in [SampleSnippet.imports]
+     *
+     * @see SampleSnippet.imports
      */
     public fun rewriteImportDirective(importPath: String): String? = importPath
+
+    /**
+     * Allows to rewrite a function call expressions
+     * It also includes calls of constructors
+     *
+     * The remain call expressions of functions that are not in this map will be left unchanged
+     */
     public val functionCallRewriters: Map<ShortFunctionName, FunctionCallRewriter>
 }
 

--- a/dokka-subprojects/analysis-kotlin-api/src/test/kotlin/org/jetbrains/dokka/analysis/test/sample/SampleRewriterTest.kt
+++ b/dokka-subprojects/analysis-kotlin-api/src/test/kotlin/org/jetbrains/dokka/analysis/test/sample/SampleRewriterTest.kt
@@ -36,7 +36,7 @@ class SampleRewriterTest {
         class DefaultSampleRewriter(ctx: DokkaContext) : SampleRewriter {
             private val importsToIgnore = arrayOf("samples.*", "samples.Sample")
 
-            override val functionCallRewriters: Map<ShortFunctionName, FunctionCallRewriter> = mapOf(
+            private val functionCallRewriters: Map<ShortFunctionName, FunctionCallRewriter> = mapOf(
                 "assertTrue" to object : FunctionCallRewriter {
                     override fun rewrite(
                         arguments: List<String>,
@@ -96,6 +96,9 @@ class SampleRewriterTest {
                 return if (importPath in importsToIgnore) null else importPath
             }
 
+            override fun getFunctionCallRewriter(name: String): FunctionCallRewriter? {
+                return functionCallRewriters[name]
+            }
         }
 
         private val kotlinAnalysisPlugin by lazy { plugin<KotlinAnalysisPlugin>() }
@@ -423,7 +426,7 @@ class SampleRewriterTest {
         @Suppress("UNUSED_PARAMETER")
         class ConstructorSampleRewriter(ctx: DokkaContext) : SampleRewriter {
 
-            override val functionCallRewriters: Map<ShortFunctionName, FunctionCallRewriter> = mapOf(
+            private val functionCallRewriters: Map<ShortFunctionName, FunctionCallRewriter> = mapOf(
                 "IntArray" to object : FunctionCallRewriter {
                     override fun rewrite(
                         arguments: List<String>,
@@ -434,6 +437,10 @@ class SampleRewriterTest {
                     }
                 }
             )
+
+            override fun getFunctionCallRewriter(name: String): FunctionCallRewriter? {
+                return functionCallRewriters[name]
+            }
         }
 
         private val kotlinAnalysisPlugin by lazy { plugin<KotlinAnalysisPlugin>() }
@@ -496,7 +503,7 @@ class SampleRewriterTest {
         @Suppress("UNUSED_PARAMETER")
         class ConstructorSampleRewriter(ctx: DokkaContext) : SampleRewriter {
 
-            override val functionCallRewriters: Map<ShortFunctionName, FunctionCallRewriter> = mapOf(
+            private val functionCallRewriters: Map<ShortFunctionName, FunctionCallRewriter> = mapOf(
                 "IntArray" to object : FunctionCallRewriter {
                     override fun rewrite(
                         arguments: List<String>,
@@ -506,6 +513,10 @@ class SampleRewriterTest {
                     }
                 }
             )
+
+            override fun getFunctionCallRewriter(name: String): FunctionCallRewriter? {
+                return functionCallRewriters[name]
+            }
         }
 
         private val kotlinAnalysisPlugin by lazy { plugin<KotlinAnalysisPlugin>() }

--- a/dokka-subprojects/analysis-kotlin-api/src/test/kotlin/org/jetbrains/dokka/analysis/test/sample/SampleRewriterTest.kt
+++ b/dokka-subprojects/analysis-kotlin-api/src/test/kotlin/org/jetbrains/dokka/analysis/test/sample/SampleRewriterTest.kt
@@ -563,11 +563,7 @@ class SampleRewriterTest {
             assertEquals(1, logger.warningsCount)
             assertNotNull(logger.collectedLogMessages.firstOrNull {
                 it.startsWith(
-                    "Exception thrown while sample rewriting at collections.kt: (6, 12)\n" +
-                            "```\n" +
-                            "IntArray(10)\n" +
-                            "```\n" +
-                            "java.lang.IllegalStateException: error text\n"
+                    "Exception thrown while sample rewriting at collections.kt"
                 )
             })
         }

--- a/dokka-subprojects/analysis-kotlin-api/src/test/kotlin/org/jetbrains/dokka/analysis/test/sample/SampleRewriterTest.kt
+++ b/dokka-subprojects/analysis-kotlin-api/src/test/kotlin/org/jetbrains/dokka/analysis/test/sample/SampleRewriterTest.kt
@@ -1,0 +1,444 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package org.jetbrains.dokka.analysis.test.sample
+
+import org.jetbrains.dokka.analysis.kotlin.KotlinAnalysisPlugin
+import org.jetbrains.dokka.analysis.kotlin.sample.FunctionCallRewriter
+import org.jetbrains.dokka.analysis.kotlin.sample.SampleRewriter
+import org.jetbrains.dokka.analysis.kotlin.sample.ShortFunctionName
+import org.jetbrains.dokka.analysis.test.api.kotlinJvmTestProject
+import org.jetbrains.dokka.analysis.test.api.useServices
+import org.jetbrains.dokka.analysis.test.api.util.singleSourceSet
+import org.jetbrains.dokka.plugability.DokkaContext
+import org.jetbrains.dokka.plugability.DokkaPlugin
+import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
+import org.jetbrains.dokka.plugability.PluginApiPreviewAcknowledgement
+import kotlin.test.*
+
+class SampleRewriterTest {
+
+    /**
+     *  The same plugin rewriter should be used in stdlib.
+     *
+     * For StdLib, Dokka should have a possibility to
+     * - rewrite `assertTrue(_)` to `println(_ is _ ${_}) \\ true`.
+     * - rewrite `assertFalse(_)` to `println(_ is _ ${_}) \\ false`.
+     * - rewrite `assertFails<T>(_)` or `assertFails<T>{ _ }` to `_ \\ will fail with T`
+     * - rewrite stdlib's `assertPrints(_)` to `println(_) \\ _`.
+     * _Note:_ it would be nice to rewrite it to `for(i in it) { println(i) }`
+     * - ignore import directive `samples.*` and  `samples.Sample`
+     */
+    class SomeSampleRewriterPlugin : DokkaPlugin() {
+        @Suppress("UNUSED_PARAMETER")
+        class DefaultSampleRewriter(ctx: DokkaContext) : SampleRewriter {
+            private val importsToIgnore = arrayOf("samples.*", "samples.Sample")
+
+            override val functionCallRewriters: Map<ShortFunctionName, FunctionCallRewriter> = mapOf(
+                "assertTrue" to object : FunctionCallRewriter {
+                    override fun rewrite(
+                        argumentList: List<String>,
+                        typeArgumentList: List<String>
+                    ): String {
+                        val argument = argumentList[0]
+                        return "println(\"$argument is \${$argument}\") // true"
+                    }
+                },
+                "assertFalse" to object : FunctionCallRewriter {
+                    override fun rewrite(
+                        argumentList: List<String>,
+                        typeArgumentList: List<String>
+                    ): String {
+                        val argument = argumentList[0]
+                        return "println(\"$argument is \${$argument}\") // false"
+                    }
+                },
+                "assertPrints" to object : FunctionCallRewriter {
+                    override fun rewrite(
+                        argumentList: List<String>,
+                        typeArgumentList: List<String>
+                    ): String {
+                        val argument = argumentList[0]
+                        val expected = argumentList[1].removeSurrounding("\"")
+                        return "println($argument) // $expected"
+                    }
+                },
+                "assertFails" to object : FunctionCallRewriter {
+                    override fun rewrite(
+                        argumentList: List<String>,
+                        typeArgumentList: List<String>
+                    ): String {
+                        val funcBody =
+                            (if (argumentList.size > 1) argumentList.last() else argumentList.first()).removeSurrounding(
+                                "{",
+                                "}"
+                            ).trim()
+                        val message =
+                            if (argumentList.size > 1) argumentList.first() + " will fail" else "will fail" // in current stdlib, there is no sample with a message, but it was in the old sample transform
+                        return "// $funcBody // $message"
+                    }
+                },
+                "assertFailsWith" to object : FunctionCallRewriter {
+                    override fun rewrite(
+                        argumentList: List<String>,
+                        typeArgumentList: List<String>
+                    ): String {
+                        val funcBody = argumentList.first().removeSurrounding("{", "}").trim()
+                        val exceptionType = typeArgumentList.first()
+                        return "// $funcBody // will fail with $exceptionType"
+                    }
+                }
+            )
+
+            override fun rewriteImportDirective(importPath: String): String? {
+                return if (importPath in importsToIgnore) null else importPath
+            }
+
+        }
+
+        private val kotlinAnalysisPlugin by lazy { plugin<KotlinAnalysisPlugin>() }
+
+        @Suppress("unused")
+        val stdLibKotlinAnalysis by extending {
+            kotlinAnalysisPlugin.sampleRewriter providing ::DefaultSampleRewriter
+        }
+
+        @OptIn(DokkaPluginApiPreview::class)
+        override fun pluginApiPreviewAcknowledgement(): PluginApiPreviewAcknowledgement =
+            PluginApiPreviewAcknowledgement
+    }
+
+    @Test
+    fun `should rewrite assertTrue and assertPrints`() {
+        val testProject = kotlinJvmTestProject {
+            plugin(SomeSampleRewriterPlugin())
+            dokkaConfiguration {
+                kotlinSourceSet {
+                    samples = setOf("/samples/collections/collections.kt", "/samples/_sampleUtils.kt")
+                }
+            }
+            sampleFile("/samples/_sampleUtils.kt", fqPackageName = "samples") {
+                +"""
+                    import kotlin.test.assertEquals
+
+                    typealias Sample = org.junit.Test
+                    typealias RunWith = org.junit.runner.RunWith
+                    typealias Enclosed = org.junit.experimental.runners.Enclosed
+                    
+                    fun assertPrints(expression: Any?, expectedOutput: String) = assertEquals(expectedOutput, expression.toString())
+                """
+            }
+            // the sample is from https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/is-not-empty.html
+            sampleFile("/samples/collections/collections.kt", fqPackageName = "samples.collections") {
+                +"""
+                    import samples.*
+                    import kotlin.test.*
+
+                    @RunWith(Enclosed::class)
+                    class Collections {
+                        class Collections {
+                    
+                            @Sample
+                            fun indicesOfCollection() {
+                                val empty = emptyList<Any>()
+                                assertTrue(empty.indices.isEmpty())
+                                val collection = listOf('a', 'b', 'c')
+                                assertPrints(collection.indices, "0..2")
+                            }
+                        }
+                    }
+                """
+            }
+        }
+
+        testProject.useServices { context ->
+            val sample = sampleAnalysisEnvironmentCreator.use {
+                resolveSample(
+                    sourceSet = context.singleSourceSet(),
+                    fullyQualifiedLink = "samples.collections.Collections.Collections.indicesOfCollection"
+                )
+            }
+            assertNotNull(sample)
+
+            val expectedImports = listOf(
+                "kotlin.test.*"
+            )
+
+            val expectedBody = "val empty = emptyList<Any>()\n" +
+                    "println(\"empty.indices.isEmpty() is \${empty.indices.isEmpty()}\") // true\n" +
+                    "val collection = listOf('a', 'b', 'c')\n" +
+                    "println(collection.indices) // 0..2"
+
+            assertEquals(expectedImports, sample.imports)
+            assertEquals(expectedBody, sample.body)
+        }
+    }
+
+    @Test
+    fun `should rewrite assertFalse and assertPrints`() {
+        val testProject = kotlinJvmTestProject {
+            plugin(SomeSampleRewriterPlugin())
+            dokkaConfiguration {
+                kotlinSourceSet {
+                    samples = setOf("/samples/collections/collections.kt", "/samples/_sampleUtils.kt")
+                }
+            }
+            sampleFile("/samples/_sampleUtils.kt", fqPackageName = "samples") {
+                +"""
+                    import kotlin.test.assertEquals
+
+                    typealias Sample = org.junit.Test
+                    typealias RunWith = org.junit.runner.RunWith
+                    typealias Enclosed = org.junit.experimental.runners.Enclosed
+                    
+                    fun assertPrints(expression: Any?, expectedOutput: String) = assertEquals(expectedOutput, expression.toString())
+                """
+            }
+            // the sample is from https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/indices.html
+            sampleFile("/samples/collections/collections.kt", fqPackageName = "samples.collections") {
+                +"""
+                    import samples.*
+                    import kotlin.test.*
+
+                    @RunWith(Enclosed::class)
+                    class Collections {
+                        class Collections {
+                    
+                            @Sample
+                            fun collectionIsNotEmpty() {
+                                val empty = emptyList<Any>()
+                                assertFalse(empty.isNotEmpty())
+                    
+                                val collection = listOf('a', 'b', 'c')
+                                assertTrue(collection.isNotEmpty())
+                            }
+                        }
+                    }
+                """
+            }
+        }
+
+        testProject.useServices { context ->
+            val sample = sampleAnalysisEnvironmentCreator.use {
+                resolveSample(
+                    sourceSet = context.singleSourceSet(),
+                    fullyQualifiedLink = "samples.collections.Collections.Collections.collectionIsNotEmpty"
+                )
+            }
+            assertNotNull(sample)
+
+            val expectedImports = listOf(
+                "kotlin.test.*"
+            )
+
+            val expectedBody = "val empty = emptyList<Any>()\n" +
+                    "println(\"empty.isNotEmpty() is \${empty.isNotEmpty()}\") // false\n" +
+                    "\n" +
+                    "val collection = listOf('a', 'b', 'c')\n" +
+                    "println(\"collection.isNotEmpty() is \${collection.isNotEmpty()}\") // true"
+
+            assertEquals(expectedImports, sample.imports)
+            assertEquals(expectedBody, sample.body)
+        }
+    }
+
+
+    @Test
+    fun `should rewrite assertFails and assertPrints`() {
+        val testProject = kotlinJvmTestProject {
+            plugin(SomeSampleRewriterPlugin())
+            dokkaConfiguration {
+                kotlinSourceSet {
+                    samples = setOf("/samples/collections/collections.kt", "/samples/_sampleUtils.kt")
+                }
+            }
+            sampleFile("/samples/_sampleUtils.kt", fqPackageName = "samples") {
+                +"""
+                    import kotlin.test.assertEquals
+
+                    typealias Sample = org.junit.Test
+                    typealias RunWith = org.junit.runner.RunWith
+                    typealias Enclosed = org.junit.experimental.runners.Enclosed
+                    
+                    fun assertPrints(expression: Any?, expectedOutput: String) = assertEquals(expectedOutput, expression.toString())
+                """
+            }
+            // the sample is from https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/last.html
+            sampleFile("/samples/collections/collections.kt", fqPackageName = "samples.collections") {
+                +"""
+                    import samples.*
+                    import kotlin.test.*
+
+                    @RunWith(Enclosed::class)
+                    class Collections {
+                        class Elements {
+                    
+                            @Sample
+                            fun last() {
+                                val list = listOf(1, 2, 3, 4)
+                                assertPrints(list.last(), "4")
+                                assertPrints(list.last { it % 2 == 1 }, "3")
+                                assertPrints(list.lastOrNull { it < 0 }, "null")
+                                assertFails { list.last { it < 0 } }
+                    
+                                val emptyList = emptyList<Int>()
+                                assertPrints(emptyList.lastOrNull(), "null")
+                                assertFails { emptyList.last() }
+                            }
+                        }
+                    }
+                """
+            }
+        }
+
+        testProject.useServices { context ->
+            val sample = sampleAnalysisEnvironmentCreator.use {
+                resolveSample(
+                    sourceSet = context.singleSourceSet(),
+                    fullyQualifiedLink = "samples.collections.Collections.Elements.last"
+                )
+            }
+            assertNotNull(sample)
+
+            val expectedImports = listOf(
+                "kotlin.test.*"
+            )
+
+            val expectedBody = """
+                val list = listOf(1, 2, 3, 4)
+                println(list.last()) // 4
+                println(list.last { it % 2 == 1 }) // 3
+                println(list.lastOrNull { it < 0 }) // null
+                // list.last { it < 0 } // will fail
+
+                val emptyList = emptyList<Int>()
+                println(emptyList.lastOrNull()) // null
+                // emptyList.last() // will fail
+            """.trimIndent()
+
+            assertEquals(expectedImports, sample.imports)
+            assertEquals(expectedBody, sample.body)
+        }
+    }
+
+    @Test
+    fun `should rewrite assertFailsWith and assertPrints`() {
+        val testProject = kotlinJvmTestProject {
+            plugin(SomeSampleRewriterPlugin())
+            dokkaConfiguration {
+                kotlinSourceSet {
+                    samples = setOf("/samples/collections/collections.kt", "/samples/_sampleUtils.kt")
+                }
+            }
+            sampleFile("/samples/_sampleUtils.kt", fqPackageName = "samples") {
+                +"""
+                    import kotlin.test.assertEquals
+
+                    typealias Sample = org.junit.Test
+                    typealias RunWith = org.junit.runner.RunWith
+                    typealias Enclosed = org.junit.experimental.runners.Enclosed
+                    
+                    fun assertPrints(expression: Any?, expectedOutput: String) = assertEquals(expectedOutput, expression.toString())
+                """
+            }
+            // the sample is from https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/element-at.html
+            sampleFile("/samples/collections/collections.kt", fqPackageName = "samples.collections") {
+                +"""
+                    import samples.*
+                    import kotlin.test.*
+
+                    @RunWith(Enclosed::class)
+                    class Collections {
+                        class Elements {
+                    
+                            @Sample
+                            fun elementAt() {
+                                val list = listOf(1, 2, 3)
+                                assertPrints(list.elementAt(0), "1")
+                                assertPrints(list.elementAt(2), "3")
+                                assertFailsWith<IndexOutOfBoundsException> { list.elementAt(3) }
+                    
+                                val emptyList = emptyList<Int>()
+                                assertFailsWith<IndexOutOfBoundsException> { emptyList.elementAt(0) }
+                            }
+                        }
+                    }
+                """
+            }
+        }
+
+        testProject.useServices { context ->
+            val sample = sampleAnalysisEnvironmentCreator.use {
+                resolveSample(
+                    sourceSet = context.singleSourceSet(),
+                    fullyQualifiedLink = "samples.collections.Collections.Elements.elementAt"
+                )
+            }
+            assertNotNull(sample)
+
+            val expectedImports = listOf(
+                "kotlin.test.*"
+            )
+
+            val expectedBody = """
+                    val list = listOf(1, 2, 3)
+                    println(list.elementAt(0)) // 1
+                    println(list.elementAt(2)) // 3
+                    // list.elementAt(3) // will fail with IndexOutOfBoundsException
+                    
+                    val emptyList = emptyList<Int>()
+                    // emptyList.elementAt(0) // will fail with IndexOutOfBoundsException
+            """.trimIndent()
+
+            assertEquals(expectedImports, sample.imports)
+            assertEquals(expectedBody, sample.body)
+        }
+    }
+
+
+    @Test
+    fun `should rewrite call of assertFalse with fully qualified name`() {
+        val testProject = kotlinJvmTestProject {
+            plugin(SomeSampleRewriterPlugin())
+            dokkaConfiguration {
+                kotlinSourceSet {
+                    samples = setOf("/samples/collections/collections.kt")
+                }
+            }
+
+            sampleFile("/samples/collections/collections.kt", fqPackageName = "samples.collections") {
+                +"""
+                    import samples.*
+                    import kotlin.test.*
+
+                    @RunWith(Enclosed::class)
+                    class Collections {
+                            fun someSample() {
+                                kotlin.test.assertFalse(empty.isNotEmpty())
+                            }
+                        }
+                    }
+                """
+            }
+        }
+        testProject.useServices { context ->
+            val sample = sampleAnalysisEnvironmentCreator.use {
+                resolveSample(
+                    sourceSet = context.singleSourceSet(),
+                    fullyQualifiedLink = "samples.collections.Collections.someSample"
+                )
+            }
+            assertNotNull(sample)
+
+            val expectedImports = listOf(
+                "kotlin.test.*"
+            )
+
+            val expectedBody = "kotlin.test.println(\"empty.isNotEmpty() is \${empty.isNotEmpty()}\") // false"
+
+            assertEquals(expectedImports, sample.imports)
+            assertEquals(expectedBody, sample.body)
+        }
+    }
+}

--- a/dokka-subprojects/analysis-kotlin-api/src/testFixtures/kotlin/org/jetbrains/dokka/analysis/test/api/TestProject.kt
+++ b/dokka-subprojects/analysis-kotlin-api/src/testFixtures/kotlin/org/jetbrains/dokka/analysis/test/api/TestProject.kt
@@ -14,7 +14,21 @@ import org.jetbrains.dokka.analysis.test.api.configuration.TestDokkaConfiguratio
 import org.jetbrains.dokka.analysis.test.api.util.CollectingDokkaConsoleLogger
 import org.jetbrains.dokka.analysis.test.api.util.withTempDirectory
 import org.jetbrains.dokka.model.DModule
+import org.jetbrains.dokka.plugability.DokkaContext
+import org.jetbrains.dokka.plugability.DokkaPlugin
 import org.jetbrains.dokka.utilities.DokkaLogger
+
+/**
+ * Declares a capability that a project can have plugins
+ */
+interface Pluggable {
+    /**
+     * Add a plugin instance to a project
+     */
+    fun plugin(
+        instance: DokkaPlugin
+    )
+}
 
 /**
  * Represents a virtual test project (as if it's user-defined) that will be used to run Dokka.
@@ -47,6 +61,13 @@ interface TestProject {
      * This is typically constructed using [BaseTestDokkaConfigurationBuilder].
      */
     fun getConfiguration(): TestDokkaConfiguration
+
+    /**
+     * Returns the list of plugins, which will then be directly passed to [DokkaContext].
+     *
+     * Unlike [DokkaConfiguration.pluginsClasspath], it does not require a JAR file with a configuration of [java.util.ServiceLoader]
+     */
+    fun getPluginList(): List<DokkaPlugin>
 
     /**
      * Returns this project's test data - a collection of source code files, markdown files

--- a/dokka-subprojects/analysis-kotlin-api/src/testFixtures/kotlin/org/jetbrains/dokka/analysis/test/api/analysis/TestProjectAnalyzer.kt
+++ b/dokka-subprojects/analysis-kotlin-api/src/testFixtures/kotlin/org/jetbrains/dokka/analysis/test/api/analysis/TestProjectAnalyzer.kt
@@ -2,10 +2,13 @@
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
+@file:OptIn(InternalDokkaApi::class)
+
 package org.jetbrains.dokka.analysis.test.api.analysis
 
 import org.jetbrains.dokka.CoreExtensions
 import org.jetbrains.dokka.DokkaConfiguration
+import org.jetbrains.dokka.InternalDokkaApi
 import org.jetbrains.dokka.analysis.kotlin.KotlinAnalysisPlugin
 import org.jetbrains.dokka.analysis.kotlin.internal.InternalKotlinAnalysisPlugin
 import org.jetbrains.dokka.analysis.test.api.TestDataFile
@@ -16,6 +19,7 @@ import org.jetbrains.dokka.analysis.test.api.useServices
 import org.jetbrains.dokka.analysis.test.api.util.withTempDirectory
 import org.jetbrains.dokka.model.DModule
 import org.jetbrains.dokka.plugability.DokkaContext
+import org.jetbrains.dokka.plugability.DokkaPlugin
 import org.jetbrains.dokka.plugability.plugin
 import org.jetbrains.dokka.plugability.querySingle
 import org.jetbrains.dokka.transformers.documentation.DefaultDocumentableMerger
@@ -112,7 +116,7 @@ internal object TestProjectAnalyzer {
         val dokkaConfiguration = testDokkaConfiguration.toDokkaConfiguration(projectDir = outputDirectory).also {
             it.verify()
         }
-        return dokkaConfiguration to createContext(dokkaConfiguration, logger)
+        return dokkaConfiguration to createContext(dokkaConfiguration, logger, getPluginList())
     }
 
     /**
@@ -166,12 +170,16 @@ internal object TestProjectAnalyzer {
         }
     }
 
-    private fun createContext(dokkaConfiguration: DokkaConfiguration, logger: DokkaLogger): DokkaContext {
+    private fun createContext(
+        dokkaConfiguration: DokkaConfiguration,
+        logger: DokkaLogger,
+        pluginOverrides: List<DokkaPlugin>
+    ): DokkaContext {
         logger.progress("Creating DokkaContext from test configuration")
         return DokkaContext.create(
             configuration = dokkaConfiguration,
             logger = logger,
-            pluginOverrides = listOf()
+            pluginOverrides = pluginOverrides
         )
     }
 

--- a/dokka-subprojects/analysis-kotlin-api/src/testFixtures/kotlin/org/jetbrains/dokka/analysis/test/api/jvm/java/JavaTestProject.kt
+++ b/dokka-subprojects/analysis-kotlin-api/src/testFixtures/kotlin/org/jetbrains/dokka/analysis/test/api/jvm/java/JavaTestProject.kt
@@ -5,26 +5,25 @@
 package org.jetbrains.dokka.analysis.test.api.jvm.java
 
 import org.jetbrains.dokka.DokkaSourceSetID
-import org.jetbrains.dokka.analysis.test.api.TestData
-import org.jetbrains.dokka.analysis.test.api.TestDataFile
-import org.jetbrains.dokka.analysis.test.api.TestProject
+import org.jetbrains.dokka.analysis.test.api.*
 import org.jetbrains.dokka.analysis.test.api.configuration.TestDokkaConfiguration
-import org.jetbrains.dokka.analysis.test.api.javaTestProject
 import org.jetbrains.dokka.analysis.test.api.markdown.MarkdownTestData
 import org.jetbrains.dokka.analysis.test.api.markdown.MarkdownTestDataFile
 import org.jetbrains.dokka.analysis.test.api.markdown.MdFileCreator
 import org.jetbrains.dokka.analysis.test.api.util.AnalysisTestDslMarker
 import org.jetbrains.dokka.analysis.test.api.util.flatListOf
+import org.jetbrains.dokka.plugability.DokkaPlugin
 
 /**
  * @see javaTestProject for an explanation and a convenient way to construct this project
  */
-class JavaTestProject : TestProject, JavaFileCreator, MdFileCreator {
+class JavaTestProject : TestProject, JavaFileCreator, MdFileCreator, Pluggable {
 
     private val projectConfigurationBuilder = JavaTestConfigurationBuilder()
 
     private val javaSourceSet = JavaTestData(pathToJavaSources = DEFAULT_SOURCE_ROOT)
     private val markdownTestData = MarkdownTestData()
+    private val pluginsList = mutableListOf<DokkaPlugin>()
 
     @AnalysisTestDslMarker
     fun dokkaConfiguration(fillConfiguration: JavaTestConfigurationBuilder.() -> Unit) {
@@ -41,12 +40,21 @@ class JavaTestProject : TestProject, JavaFileCreator, MdFileCreator {
         markdownTestData.mdFile(pathFromProjectRoot, fillFile)
     }
 
+    @AnalysisTestDslMarker
+    override fun plugin(instance: DokkaPlugin) {
+        pluginsList.add(instance)
+    }
+
     override fun verify() {
         projectConfigurationBuilder.verify()
     }
 
     override fun getConfiguration(): TestDokkaConfiguration {
         return projectConfigurationBuilder.build()
+    }
+
+    override fun getPluginList(): List<DokkaPlugin> {
+        return pluginsList
     }
 
     override fun getTestData(): TestData {

--- a/dokka-subprojects/analysis-kotlin-api/src/testFixtures/kotlin/org/jetbrains/dokka/analysis/test/api/jvm/kotlin/KotlinJvmTestProject.kt
+++ b/dokka-subprojects/analysis-kotlin-api/src/testFixtures/kotlin/org/jetbrains/dokka/analysis/test/api/jvm/kotlin/KotlinJvmTestProject.kt
@@ -5,9 +5,7 @@
 package org.jetbrains.dokka.analysis.test.api.jvm.kotlin
 
 import org.jetbrains.dokka.DokkaSourceSetID
-import org.jetbrains.dokka.analysis.test.api.TestData
-import org.jetbrains.dokka.analysis.test.api.TestDataFile
-import org.jetbrains.dokka.analysis.test.api.TestProject
+import org.jetbrains.dokka.analysis.test.api.*
 import org.jetbrains.dokka.analysis.test.api.configuration.TestDokkaConfiguration
 import org.jetbrains.dokka.analysis.test.api.kotlin.KotlinTestData
 import org.jetbrains.dokka.analysis.test.api.kotlin.KotlinTestDataFile
@@ -15,23 +13,24 @@ import org.jetbrains.dokka.analysis.test.api.kotlin.KtFileCreator
 import org.jetbrains.dokka.analysis.test.api.kotlin.sample.KotlinSampleFileCreator
 import org.jetbrains.dokka.analysis.test.api.kotlin.sample.KotlinSampleTestData
 import org.jetbrains.dokka.analysis.test.api.kotlin.sample.KotlinSampleTestDataFile
-import org.jetbrains.dokka.analysis.test.api.kotlinJvmTestProject
 import org.jetbrains.dokka.analysis.test.api.markdown.MarkdownTestData
 import org.jetbrains.dokka.analysis.test.api.markdown.MarkdownTestDataFile
 import org.jetbrains.dokka.analysis.test.api.markdown.MdFileCreator
 import org.jetbrains.dokka.analysis.test.api.util.AnalysisTestDslMarker
 import org.jetbrains.dokka.analysis.test.api.util.flatListOf
+import org.jetbrains.dokka.plugability.DokkaPlugin
 
 /**
  * @see kotlinJvmTestProject for an explanation and a convenient way to construct this project
  */
-class KotlinJvmTestProject : TestProject, KtFileCreator, MdFileCreator, KotlinSampleFileCreator {
+class KotlinJvmTestProject : TestProject, KtFileCreator, MdFileCreator, KotlinSampleFileCreator, Pluggable {
 
     private val projectConfigurationBuilder = KotlinJvmTestConfigurationBuilder()
 
     private val kotlinSourceSet = KotlinTestData(pathToKotlinSources = DEFAULT_SOURCE_ROOT)
     private val markdownTestData = MarkdownTestData()
     private val kotlinSampleTestData = KotlinSampleTestData()
+    private val pluginsList = mutableListOf<DokkaPlugin>()
 
     @AnalysisTestDslMarker
     fun dokkaConfiguration(fillConfiguration: KotlinJvmTestConfigurationBuilder.() -> Unit) {
@@ -57,12 +56,21 @@ class KotlinJvmTestProject : TestProject, KtFileCreator, MdFileCreator, KotlinSa
         kotlinSampleTestData.sampleFile(pathFromProjectRoot, fqPackageName, fillFile)
     }
 
+    @AnalysisTestDslMarker
+    override fun plugin(instance: DokkaPlugin) {
+        pluginsList.add(instance)
+    }
+
     override fun verify() {
         projectConfigurationBuilder.verify()
     }
 
     override fun getConfiguration(): TestDokkaConfiguration {
         return projectConfigurationBuilder.build()
+    }
+
+    override fun getPluginList(): List<DokkaPlugin> {
+        return pluginsList
     }
 
     override fun getTestData(): TestData {

--- a/dokka-subprojects/analysis-kotlin-api/src/testFixtures/kotlin/org/jetbrains/dokka/analysis/test/api/jvm/mixed/MixedJvmTestProject.kt
+++ b/dokka-subprojects/analysis-kotlin-api/src/testFixtures/kotlin/org/jetbrains/dokka/analysis/test/api/jvm/mixed/MixedJvmTestProject.kt
@@ -4,9 +4,7 @@
 
 package org.jetbrains.dokka.analysis.test.api.jvm.mixed
 
-import org.jetbrains.dokka.analysis.test.api.TestData
-import org.jetbrains.dokka.analysis.test.api.TestDataFile
-import org.jetbrains.dokka.analysis.test.api.TestProject
+import org.jetbrains.dokka.analysis.test.api.*
 import org.jetbrains.dokka.analysis.test.api.configuration.TestDokkaConfiguration
 import org.jetbrains.dokka.analysis.test.api.jvm.java.JavaTestProject
 import org.jetbrains.dokka.analysis.test.api.jvm.kotlin.KotlinJvmTestProject
@@ -16,14 +14,14 @@ import org.jetbrains.dokka.analysis.test.api.kotlin.sample.KotlinSampleTestDataF
 import org.jetbrains.dokka.analysis.test.api.markdown.MarkdownTestData
 import org.jetbrains.dokka.analysis.test.api.markdown.MarkdownTestDataFile
 import org.jetbrains.dokka.analysis.test.api.markdown.MdFileCreator
-import org.jetbrains.dokka.analysis.test.api.mixedJvmTestProject
 import org.jetbrains.dokka.analysis.test.api.util.AnalysisTestDslMarker
 import org.jetbrains.dokka.analysis.test.api.util.flatListOf
+import org.jetbrains.dokka.plugability.DokkaPlugin
 
 /**
  * @see mixedJvmTestProject for an explanation and a convenient way to construct this project
  */
-class MixedJvmTestProject : TestProject, MdFileCreator, KotlinSampleFileCreator {
+class MixedJvmTestProject : TestProject, MdFileCreator, KotlinSampleFileCreator, Pluggable {
 
     private val projectConfigurationBuilder = MixedJvmTestConfigurationBuilder()
 
@@ -31,6 +29,7 @@ class MixedJvmTestProject : TestProject, MdFileCreator, KotlinSampleFileCreator 
     private val javaSourceDirectory = MixedJvmTestData(pathToSources = JavaTestProject.DEFAULT_SOURCE_ROOT)
     private val markdownTestData = MarkdownTestData()
     private val kotlinSampleTestData = KotlinSampleTestData()
+    private val pluginsList = mutableListOf<DokkaPlugin>()
 
     @AnalysisTestDslMarker
     fun dokkaConfiguration(fillConfiguration: MixedJvmTestConfigurationBuilder.() -> Unit) {
@@ -61,12 +60,21 @@ class MixedJvmTestProject : TestProject, MdFileCreator, KotlinSampleFileCreator 
         kotlinSampleTestData.sampleFile(pathFromProjectRoot, fqPackageName, fillFile)
     }
 
+    @AnalysisTestDslMarker
+    override fun plugin(instance: DokkaPlugin) {
+        pluginsList.add(instance)
+    }
+
     override fun verify() {
         projectConfigurationBuilder.verify()
     }
 
     override fun getConfiguration(): TestDokkaConfiguration {
         return projectConfigurationBuilder.build()
+    }
+
+    override fun getPluginList(): List<DokkaPlugin> {
+        return pluginsList
     }
 
     override fun getTestData(): TestData {

--- a/dokka-subprojects/analysis-kotlin-descriptors-compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/impl/DescriptorSampleAnalysisEnvironment.kt
+++ b/dokka-subprojects/analysis-kotlin-descriptors-compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/impl/DescriptorSampleAnalysisEnvironment.kt
@@ -32,8 +32,6 @@ import org.jetbrains.kotlin.resolve.lazy.ResolveSession
 import org.jetbrains.kotlin.resolve.lazy.descriptors.LazyPackageDescriptor
 import org.jetbrains.kotlin.resolve.source.KotlinSourceElement
 import org.jetbrains.kotlin.utils.addToStdlib.applyIf
-import java.io.PrintWriter
-import java.io.StringWriter
 
 internal class DescriptorSampleAnalysisEnvironmentCreator(
     private val context: DokkaContext,
@@ -199,7 +197,7 @@ internal class DescriptorSampleAnalysisEnvironment(
                 val bodyExpression = psiElement.bodyExpression
                 val bodyExpressionText = bodyExpression!!.buildSampleText()
                 when (bodyExpression) {
-                    is KtBlockExpression -> bodyExpressionText.removeSurrounding("{", "}")
+                    is KtBlockExpression -> bodyExpressionText.removeSurrounding("{", "}") // without braces according to the documentation of [SampleSnippet.body]
                     else -> bodyExpressionText
                 }
             }
@@ -213,11 +211,9 @@ internal class DescriptorSampleAnalysisEnvironment(
         this.accept(sampleBuilder)
 
         sampleBuilder.errors.forEach {
-            val sw = StringWriter()
-            val pw = PrintWriter(sw)
-            it.e.printStackTrace(pw)
+            val st = it.e.stackTraceToString()
 
-            dokkaLogger.warn("${containingFile.name}: (${it.loc}): Exception thrown while converting \n```\n${it.text}\n```\n$sw")
+            dokkaLogger.warn("Exception thrown while sample rewriting at ${containingFile.name}: (${it.loc})\n```\n${it.text}\n```\n$st")
         }
         return sampleBuilder.text
     }
@@ -236,8 +232,8 @@ private class SampleBuilder(private val sampleRewriter: SampleRewriter?) : KtTre
         val callRewriter = sampleRewriter?.functionCallRewriters?.get(expression.calleeExpression?.text)
         if(callRewriter != null) {
             val rewritedResult = callRewriter.rewrite(
-                argumentList = expression.valueArguments.map { it.text ?: "" },
-                typeArgumentList = expression.typeArguments.map { it.text ?: "" }
+                arguments = expression.valueArguments.map { it.text ?: "" },
+                typeArguments = expression.typeArguments.map { it.text ?: "" }
             )
 
             if(rewritedResult != null) {
@@ -262,8 +258,10 @@ private class SampleBuilder(private val sampleRewriter: SampleRewriter?) : KtTre
     }
 
     override fun visitElement(element: PsiElement) {
-        if (element is LeafPsiElement)
+        if (element is LeafPsiElement) {
             builder.append(element.text)
+            return
+        }
 
         element.acceptChildren(object : PsiElementVisitor() {
             override fun visitElement(element: PsiElement) {

--- a/dokka-subprojects/analysis-kotlin-descriptors-compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/impl/DescriptorSampleAnalysisEnvironment.kt
+++ b/dokka-subprojects/analysis-kotlin-descriptors-compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/impl/DescriptorSampleAnalysisEnvironment.kt
@@ -4,38 +4,47 @@
 
 package org.jetbrains.dokka.analysis.kotlin.descriptors.compiler.impl
 
+import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.impl.source.tree.LeafPsiElement
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.dokka.DokkaConfiguration
+import org.jetbrains.dokka.analysis.kotlin.KotlinAnalysisPlugin
 import org.jetbrains.dokka.analysis.kotlin.descriptors.compiler.CompilerDescriptorAnalysisPlugin
 import org.jetbrains.dokka.analysis.kotlin.descriptors.compiler.KDocFinder
 import org.jetbrains.dokka.analysis.kotlin.descriptors.compiler.configuration.KotlinAnalysis
 import org.jetbrains.dokka.analysis.kotlin.descriptors.compiler.configuration.SamplesKotlinAnalysis
 import org.jetbrains.dokka.analysis.kotlin.sample.SampleAnalysisEnvironment
 import org.jetbrains.dokka.analysis.kotlin.sample.SampleAnalysisEnvironmentCreator
+import org.jetbrains.dokka.analysis.kotlin.sample.SampleRewriter
 import org.jetbrains.dokka.analysis.kotlin.sample.SampleSnippet
-import org.jetbrains.dokka.plugability.DokkaContext
-import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
-import org.jetbrains.dokka.plugability.plugin
-import org.jetbrains.dokka.plugability.querySingle
+import org.jetbrains.dokka.plugability.*
 import org.jetbrains.dokka.utilities.DokkaLogger
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.load.kotlin.toSourceElement
 import org.jetbrains.kotlin.name.FqName
-import org.jetbrains.kotlin.psi.KtBlockExpression
-import org.jetbrains.kotlin.psi.KtDeclarationWithBody
-import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
 import org.jetbrains.kotlin.resolve.DescriptorToSourceUtils
 import org.jetbrains.kotlin.resolve.lazy.ResolveSession
 import org.jetbrains.kotlin.resolve.lazy.descriptors.LazyPackageDescriptor
 import org.jetbrains.kotlin.resolve.source.KotlinSourceElement
+import org.jetbrains.kotlin.utils.addToStdlib.applyIf
+import java.io.PrintWriter
+import java.io.StringWriter
 
 internal class DescriptorSampleAnalysisEnvironmentCreator(
     private val context: DokkaContext,
 ) : SampleAnalysisEnvironmentCreator {
 
     private val descriptorAnalysisPlugin = context.plugin<CompilerDescriptorAnalysisPlugin>()
+    private val sampleRewriter by lazy {
+        val rewriters = context.plugin<KotlinAnalysisPlugin>().query { sampleRewriter }
+        if (rewriters.size > 1) context.logger.warn("There are more than one samples rewriters. Dokka does not support it.")
+        rewriters.singleOrNull()
+    }
 
     override fun <T> use(block: SampleAnalysisEnvironment.() -> T): T {
         // Run from the thread of Dispatchers.Default as it can help
@@ -51,6 +60,7 @@ internal class DescriptorSampleAnalysisEnvironmentCreator(
                 val sampleAnalysis = DescriptorSampleAnalysisEnvironment(
                     kdocFinder = descriptorAnalysisPlugin.querySingle { kdocFinder },
                     kotlinAnalysis = kotlinAnalysis,
+                    sampleRewriter = sampleRewriter,
                     dokkaLogger = context.logger
                 )
                 block(sampleAnalysis)
@@ -62,6 +72,7 @@ internal class DescriptorSampleAnalysisEnvironmentCreator(
 internal class DescriptorSampleAnalysisEnvironment(
     private val kdocFinder: KDocFinder,
     private val kotlinAnalysis: KotlinAnalysis,
+    private val sampleRewriter: SampleRewriter?,
     private val dokkaLogger: DokkaLogger,
 ) : SampleAnalysisEnvironment {
 
@@ -164,13 +175,15 @@ internal class DescriptorSampleAnalysisEnvironment(
         return resolveNearestPackageDescriptor(supposedPackageName.substringBeforeLast("."))
     }
 
-    private fun processImports(sampleElement: PsiElement): List<String> {
-        val psiFile = sampleElement.containingFile
-
+    private fun processImports(psiElement: PsiElement): List<String> {
+        val psiFile = psiElement.containingFile
         val importsList = (psiFile as? KtFile)?.importList ?: return emptyList()
         return importsList.imports
             .map { it.text.removePrefix("import ") }
             .filter { it.isNotBlank() }
+            .applyIf(sampleRewriter != null) {
+                mapNotNull { sampleRewriter?.rewriteImportDirective(it) }
+            }
     }
 
     private fun processBody(sampleElement: PsiElement): String {
@@ -180,16 +193,90 @@ internal class DescriptorSampleAnalysisEnvironment(
             .trimIndent()
     }
 
-    private fun getSampleBody(sampleElement: PsiElement): String {
-        return when (sampleElement) {
+    private fun getSampleBody(psiElement: PsiElement): String {
+        return when (psiElement) {
             is KtDeclarationWithBody -> {
-                when (val bodyExpression = sampleElement.bodyExpression) {
-                    is KtBlockExpression -> bodyExpression.text.removeSurrounding("{", "}")
-                    else -> bodyExpression!!.text
+                val bodyExpression = psiElement.bodyExpression
+                val bodyExpressionText = bodyExpression!!.buildSampleText()
+                when (bodyExpression) {
+                    is KtBlockExpression -> bodyExpressionText.removeSurrounding("{", "}")
+                    else -> bodyExpressionText
                 }
             }
 
-            else -> sampleElement.text
+            else -> psiElement.text
         }
+    }
+
+    private fun PsiElement.buildSampleText(): String {
+        val sampleBuilder = SampleBuilder(sampleRewriter)
+        this.accept(sampleBuilder)
+
+        sampleBuilder.errors.forEach {
+            val sw = StringWriter()
+            val pw = PrintWriter(sw)
+            it.e.printStackTrace(pw)
+
+            dokkaLogger.warn("${containingFile.name}: (${it.loc}): Exception thrown while converting \n```\n${it.text}\n```\n$sw")
+        }
+        return sampleBuilder.text
+    }
+}
+
+private class SampleBuilder(private val sampleRewriter: SampleRewriter?) : KtTreeVisitorVoid() {
+    val builder = StringBuilder()
+    val text: String
+        get() = builder.toString()
+
+    val errors = mutableListOf<ConvertError>()
+
+    data class ConvertError(val e: Exception, val text: String, val loc: String)
+
+    override fun visitCallExpression(expression: KtCallExpression) {
+        val callRewriter = sampleRewriter?.functionCallRewriters?.get(expression.calleeExpression?.text)
+        if(callRewriter != null) {
+            val rewritedResult = callRewriter.rewrite(
+                argumentList = expression.valueArguments.map { it.text ?: "" },
+                typeArgumentList = expression.typeArguments.map { it.text ?: "" }
+            )
+
+            if(rewritedResult != null) {
+                builder.append(rewritedResult)
+            } // else just ignore
+        } else {
+            super.visitCallExpression(expression)
+        }
+    }
+
+    private fun reportProblemConvertingElement(element: PsiElement, e: Exception) {
+        val text = element.text
+        val document = PsiDocumentManager.getInstance(element.project).getDocument(element.containingFile)
+
+        val lineInfo = if (document != null) {
+            val lineNumber = document.getLineNumber(element.startOffset)
+            "$lineNumber, ${element.startOffset - document.getLineStartOffset(lineNumber)}"
+        } else {
+            "offset: ${element.startOffset}"
+        }
+        errors += ConvertError(e, text, lineInfo)
+    }
+
+    override fun visitElement(element: PsiElement) {
+        if (element is LeafPsiElement)
+            builder.append(element.text)
+
+        element.acceptChildren(object : PsiElementVisitor() {
+            override fun visitElement(element: PsiElement) {
+                try {
+                    element.accept(this@SampleBuilder)
+                } catch (e: Exception) {
+                    try {
+                        reportProblemConvertingElement(element, e)
+                    } finally {
+                        builder.append(element.text) //recover
+                    }
+                }
+            }
+        })
     }
 }

--- a/dokka-subprojects/analysis-kotlin-descriptors-compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/impl/DescriptorSampleAnalysisEnvironment.kt
+++ b/dokka-subprojects/analysis-kotlin-descriptors-compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/impl/DescriptorSampleAnalysisEnvironment.kt
@@ -229,7 +229,6 @@ private class SampleBuilder(
     val errors: MutableList<ConvertError>
 ) : KtTreeVisitorVoid() {
 
-
     data class ConvertError(val e: Exception, val text: String, val loc: String)
 
     override fun visitCallExpression(expression: KtCallExpression) {

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/services/SymbolSampleAnalysisEnvironment.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/services/SymbolSampleAnalysisEnvironment.kt
@@ -182,7 +182,6 @@ private class SampleBuilder(
     val errors: MutableList<ConvertError>
 ) : KtTreeVisitorVoid() {
 
-
     data class ConvertError(val e: Exception, val text: String, val loc: String)
 
     override fun visitCallExpression(expression: KtCallExpression) {

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/services/SymbolSampleAnalysisEnvironment.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/services/SymbolSampleAnalysisEnvironment.kt
@@ -160,38 +160,40 @@ private class SymbolSampleAnalysisEnvironment(
     }
 
     private fun PsiElement.buildSampleText(): String {
-        val sampleBuilder = SampleBuilder(sampleRewriter)
-        this.accept(sampleBuilder)
+        if (sampleRewriter == null) return this.text
 
-        sampleBuilder.errors.forEach {
+        val textBuilder = StringBuilder()
+        val errors = mutableListOf<SampleBuilder.ConvertError>()
+
+        this.accept(SampleBuilder(sampleRewriter, textBuilder, errors))
+
+        errors.forEach {
             val st = it.e.stackTraceToString()
 
             dokkaLogger.warn("Exception thrown while sample rewriting at ${containingFile.name}: (${it.loc})\n```\n${it.text}\n```\n$st")
         }
-        return sampleBuilder.text
+        return textBuilder.toString()
     }
 }
 
-private class SampleBuilder(private val sampleRewriter: SampleRewriter?) : KtTreeVisitorVoid() {
-    val builder = StringBuilder()
-    val text: String
-        get() = builder.toString()
+private class SampleBuilder(
+    private val sampleRewriter: SampleRewriter,
+    val textBuilder: StringBuilder,
+    val errors: MutableList<ConvertError>
+) : KtTreeVisitorVoid() {
 
-    val errors = mutableListOf<ConvertError>()
 
     data class ConvertError(val e: Exception, val text: String, val loc: String)
 
     override fun visitCallExpression(expression: KtCallExpression) {
-        val callRewriter = sampleRewriter?.functionCallRewriters?.get(expression.calleeExpression?.text)
+        val callRewriter = expression.calleeExpression?.text?.let { sampleRewriter.getFunctionCallRewriter(it) }
         if(callRewriter != null) {
-            val rewritedResult = callRewriter.rewrite(
-                arguments = expression.valueArguments.map { it.text ?: "" },
-                typeArguments = expression.typeArguments.map { it.text ?: "" }
+            val rewrittenResult = callRewriter.rewrite(
+                arguments = expression.valueArguments.map { it.text ?: "" }, // expect not nullable ASTDelegatePsiElement.text
+                typeArguments = expression.typeArguments.map { it.text ?: "" } // expect not nullable ASTDelegatePsiElement.text
             )
 
-            if(rewritedResult != null) {
-                builder.append(rewritedResult)
-            } // else just ignore
+            textBuilder.append(rewrittenResult)
         } else {
             super.visitCallExpression(expression)
         }
@@ -212,7 +214,7 @@ private class SampleBuilder(private val sampleRewriter: SampleRewriter?) : KtTre
 
     override fun visitElement(element: PsiElement) {
         if (element is LeafPsiElement) {
-            builder.append(element.text)
+            textBuilder.append(element.text)
             return
         }
 
@@ -224,7 +226,7 @@ private class SampleBuilder(private val sampleRewriter: SampleRewriter?) : KtTre
                     try {
                         reportProblemConvertingElement(element, e)
                     } finally {
-                        builder.append(element.text) //recover
+                        textBuilder.append(element.text) //recover
                     }
                 }
             }

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/transformers/pages/DefaultSamplesTransformer.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/transformers/pages/DefaultSamplesTransformer.kt
@@ -50,8 +50,6 @@ internal class DefaultSamplesTransformer(val context: DokkaContext) : PageTransf
             }
         }
     }
-
-
     private fun ContentNode.addSample(
         contentPage: ContentPage,
         fqLink: String,


### PR DESCRIPTION
#3108 
Finally I have decided to use `SampleRewriter` as an extension point.
In case of using it as an argument of `resolveSample`:
- I am not sure `SampleTransformer` will not changed in the future. It also changes pages resources. Maybe it even makes sense to get rid of it or transform it to `RunnableSampleTransformer`
- With overriding of some `SampleTransformer` 's functions we can have the same situation like with `HtmlRender`
- Using an extension point is more obvious for users to rewrite samples