### PR TITLE
Replace git submodules for test projects with custom GitCheckoutTask

### DIFF
--- a/.github/workflows/preview-publish-ga.yml
+++ b/.github/workflows/preview-publish-ga.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - name: Checkout dokka
         uses: actions/checkout@v3
-        with:
-          submodules: true
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
@@ -45,8 +43,6 @@ jobs:
     steps:
       - name: Checkout dokka
         uses: actions/checkout@v3
-        with:
-          submodules: true
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
@@ -74,8 +70,6 @@ jobs:
     steps:
       - name: Checkout dokka
         uses: actions/checkout@v3
-        with:
-          submodules: true
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'

--- a/.github/workflows/preview-publish-web-s3.yml
+++ b/.github/workflows/preview-publish-web-s3.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Checkout dokka
         uses: actions/checkout@v3
-        with:
-          submodules: true
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
@@ -44,8 +42,6 @@ jobs:
     steps:
       - name: Checkout dokka
         uses: actions/checkout@v3
-        with:
-          submodules: true
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
@@ -75,8 +71,6 @@ jobs:
     steps:
       - name: Checkout dokka
         uses: actions/checkout@v3
-        with:
-          submodules: true
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,0 @@
-[submodule "integration-tests/gradle/projects/coroutines/kotlinx-coroutines"]
-	path = dokka-integration-tests/gradle/projects/coroutines/kotlinx-coroutines
-	url = https://github.com/Kotlin/kotlinx.coroutines
-[submodule "integration-tests/gradle/projects/serialization/kotlinx-serialization"]
-	path = dokka-integration-tests/gradle/projects/serialization/kotlinx-serialization
-	url = https://github.com/Kotlin/kotlinx.serialization
-[submodule "integration-tests/maven/projects/biojava/biojava"]
-	path = dokka-integration-tests/maven/projects/biojava/biojava
-	url = https://github.com/biojava/biojava

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -12,8 +12,5 @@
   </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/dokka-integration-tests/gradle/projects/coroutines/kotlinx-coroutines" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/dokka-integration-tests/gradle/projects/serialization/kotlinx-serialization" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/dokka-integration-tests/maven/projects/biojava/biojava" vcs="Git" />
   </component>
 </project>

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -21,6 +21,8 @@ dependencies {
     implementation("org.gradle.kotlin:gradle-kotlin-dsl-plugins:$expectedKotlinDslPluginsVersion")
     implementation(libs.gradlePlugin.gradlePublish)
 
+    implementation(libs.eclipse.jgit)
+
     // workaround for accessing version-catalog in convention plugins
     // https://github.com/gradle/gradle/issues/15383#issuecomment-779893192
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -21,10 +21,7 @@ dependencies {
     implementation("org.gradle.kotlin:gradle-kotlin-dsl-plugins:$expectedKotlinDslPluginsVersion")
     implementation(libs.gradlePlugin.gradlePublish)
 
-    // different JGit version to libs.versions.toml:
-    //   - JGit version 6+ is required for setting cloning depth
-    //   - build-logic uses jvm11, so it's okay to use v6+, while the main project is limited to jvm8
-    implementation("org.eclipse.jgit:org.eclipse.jgit:6.8.0.202311291450-r")
+    implementation(libs.eclipse.jgit)
 
     // workaround for accessing version-catalog in convention plugins
     // https://github.com/gradle/gradle/issues/15383#issuecomment-779893192

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -21,7 +21,10 @@ dependencies {
     implementation("org.gradle.kotlin:gradle-kotlin-dsl-plugins:$expectedKotlinDslPluginsVersion")
     implementation(libs.gradlePlugin.gradlePublish)
 
-    implementation(libs.eclipse.jgit)
+    // different JGit version to libs.versions.toml:
+    //   - JGit version 6+ is required for setting cloning depth
+    //   - build-logic uses jvm11, so it's okay to use v6+, while the main project is limited to jvm8
+    implementation("org.eclipse.jgit:org.eclipse.jgit:6.8.0.202311291450-r")
 
     // workaround for accessing version-catalog in convention plugins
     // https://github.com/gradle/gradle/issues/15383#issuecomment-779893192

--- a/build-logic/src/main/kotlin/dokkabuild/tasks/GitCheckoutTask.kt
+++ b/build-logic/src/main/kotlin/dokkabuild/tasks/GitCheckoutTask.kt
@@ -58,7 +58,7 @@ abstract class GitCheckoutTask @Inject constructor(
                 fs.sync {
                     from(temporaryDir)
                     into(destination)
-                    // exclude the .git dir to prevent the root Dokka repo getting confused with the nested subproject
+                    // exclude the .git dir to prevent the root git repo getting confused with a nested git repo
                     exclude(".git/")
                 }
 

--- a/build-logic/src/main/kotlin/dokkabuild/tasks/GitCheckoutTask.kt
+++ b/build-logic/src/main/kotlin/dokkabuild/tasks/GitCheckoutTask.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+package dokkabuild.tasks
+
+import org.eclipse.jgit.api.Git
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import javax.inject.Inject
+
+/**
+ * Clones a remote Git repository into [GitCheckoutTask.destination].
+ */
+@CacheableTask
+abstract class GitCheckoutTask @Inject constructor(
+    private val fs: FileSystemOperations
+) : DefaultTask() {
+
+    @get:OutputDirectory
+    abstract val destination: DirectoryProperty
+
+    /** Public HTTP URI of the Git repo. */
+    @get:Input
+    abstract val uri: Property<String>
+
+    /** Specific git hash to checkout. */
+    @get:Input
+    abstract val commitId: Property<String>
+
+    init {
+        group = "git checkout"
+    }
+
+    @TaskAction
+    fun action() {
+        val uri = uri.get()
+        val commitId = commitId.get()
+
+        fs.delete { delete(temporaryDir) }
+
+        Git.cloneRepository()
+            .setURI(uri)
+            .setDirectory(temporaryDir)
+            .call().use { git ->
+                git.pull().call()
+
+                git.checkout()
+                    .setName(commitId)
+                    .call()
+
+
+                fs.sync {
+                    from(temporaryDir)
+                    into(destination)
+                    // exclude the .git dir to prevent the root Dokka repo getting confused with the nested subproject
+                    exclude(".git/")
+                }
+
+                logger.lifecycle("initialized git repo $uri in ${destination.asFile.orNull}")
+            }
+    }
+}

--- a/build-logic/src/main/kotlin/dokkabuild/tasks/GitCheckoutTask.kt
+++ b/build-logic/src/main/kotlin/dokkabuild/tasks/GitCheckoutTask.kt
@@ -4,6 +4,12 @@
 package dokkabuild.tasks
 
 import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.api.ResetCommand.ResetType.HARD
+import org.eclipse.jgit.lib.NullProgressMonitor
+import org.eclipse.jgit.lib.ProgressMonitor
+import org.eclipse.jgit.lib.RepositoryCache
+import org.eclipse.jgit.lib.TextProgressMonitor
+import org.eclipse.jgit.util.FS
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileSystemOperations
@@ -12,6 +18,7 @@ import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+import java.io.File
 import javax.inject.Inject
 
 /**
@@ -33,30 +40,26 @@ abstract class GitCheckoutTask @Inject constructor(
     @get:Input
     abstract val commitId: Property<String>
 
+    private val localRepoDir: File
+        get() = temporaryDir.resolve("repo")
+
+    private val gitOperationsPrinter: ProgressMonitor =
+        if (logger.isInfoEnabled) {
+            TextProgressMonitor()
+        } else {
+            NullProgressMonitor.INSTANCE
+        }
+
     init {
         group = "git checkout"
     }
 
     @TaskAction
     fun action() {
-        val uri = uri.get()
-        val commitId = commitId.get()
-
-        fs.delete { delete(temporaryDir) }
-
-        Git.cloneRepository()
-            .setURI(uri)
-            .setDirectory(temporaryDir)
-            .call().use { git ->
-                git.pull().call()
-
-                git.checkout()
-                    .setName(commitId)
-                    .call()
-            }
+        initializeRepo()
 
         fs.sync {
-            from(temporaryDir)
+            from(localRepoDir)
             into(destination)
             // exclude the .git dir:
             // - prevent the root git repo getting confused with a nested git repo
@@ -65,5 +68,49 @@ abstract class GitCheckoutTask @Inject constructor(
         }
 
         logger.lifecycle("initialized git repo $uri in ${destination.asFile.orNull}")
+    }
+
+    /**
+     * Initialized [uri] in [localRepoDir], forcibly resetting it and deleting any untracked files or changes.
+     */
+    private fun initializeRepo() {
+        val uri = uri.get()
+        val commitId = commitId.get()
+
+        val gitRepoInitialized = RepositoryCache.FileKey.isGitRepository(localRepoDir, FS.DETECTED)
+
+        val repo = if (gitRepoInitialized) {
+            Git.open(localRepoDir)
+        } else {
+            fs.delete { delete(localRepoDir) }
+
+            Git.cloneRepository()
+                .setProgressMonitor(gitOperationsPrinter)
+                .setNoCheckout(true)
+                .setURI(uri)
+                .setDirectory(localRepoDir)
+                .call()
+        }
+
+        repo.use { git ->
+            git.checkout()
+                .setProgressMonitor(gitOperationsPrinter)
+                .setForced(true)
+                .setName(commitId)
+                .call()
+
+            // git reset --hard
+            git.reset()
+                .setProgressMonitor(gitOperationsPrinter)
+                .setMode(HARD)
+                .call()
+
+            // git clean -fdx
+            git.clean()
+                .setForce(true)
+                .setCleanDirectories(true)
+                .setIgnore(false)
+                .call()
+        }
     }
 }

--- a/build-logic/src/main/kotlin/dokkabuild/tasks/GitCheckoutTask.kt
+++ b/build-logic/src/main/kotlin/dokkabuild/tasks/GitCheckoutTask.kt
@@ -53,17 +53,17 @@ abstract class GitCheckoutTask @Inject constructor(
                 git.checkout()
                     .setName(commitId)
                     .call()
-
-                fs.sync {
-                    from(temporaryDir)
-                    into(destination)
-                    // exclude the .git dir:
-                    // - prevent the root git repo getting confused with a nested git repo
-                    // - improves Gradle caching
-                    exclude(".git/")
-                }
-
-                logger.lifecycle("initialized git repo $uri in ${destination.asFile.orNull}")
             }
+
+            fs.sync {
+                from(temporaryDir)
+                into(destination)
+                // exclude the .git dir:
+                // - prevent the root git repo getting confused with a nested git repo
+                // - improves Gradle caching
+                exclude(".git/")
+            }
+
+            logger.lifecycle("initialized git repo $uri in ${destination.asFile.orNull}")
     }
 }

--- a/build-logic/src/main/kotlin/dokkabuild/tasks/GitCheckoutTask.kt
+++ b/build-logic/src/main/kotlin/dokkabuild/tasks/GitCheckoutTask.kt
@@ -46,7 +46,6 @@ abstract class GitCheckoutTask @Inject constructor(
 
         Git.cloneRepository()
             .setURI(uri)
-            .setDepth(1) // only checkout a single commit, to aid speed and Gradle caching
             .setDirectory(temporaryDir)
             .call().use { git ->
                 git.pull().call()
@@ -58,7 +57,9 @@ abstract class GitCheckoutTask @Inject constructor(
                 fs.sync {
                     from(temporaryDir)
                     into(destination)
-                    // exclude the .git dir to prevent the root git repo getting confused with a nested git repo
+                    // exclude the .git dir:
+                    // - prevent the root git repo getting confused with a nested git repo
+                    // - improves Gradle caching
                     exclude(".git/")
                 }
 

--- a/build-logic/src/main/kotlin/dokkabuild/tasks/GitCheckoutTask.kt
+++ b/build-logic/src/main/kotlin/dokkabuild/tasks/GitCheckoutTask.kt
@@ -46,6 +46,7 @@ abstract class GitCheckoutTask @Inject constructor(
 
         Git.cloneRepository()
             .setURI(uri)
+            .setDepth(1) // only checkout a single commit, to aid speed and Gradle caching
             .setDirectory(temporaryDir)
             .call().use { git ->
                 git.pull().call()
@@ -53,7 +54,6 @@ abstract class GitCheckoutTask @Inject constructor(
                 git.checkout()
                     .setName(commitId)
                     .call()
-
 
                 fs.sync {
                     from(temporaryDir)

--- a/build-logic/src/main/kotlin/dokkabuild/tasks/GitCheckoutTask.kt
+++ b/build-logic/src/main/kotlin/dokkabuild/tasks/GitCheckoutTask.kt
@@ -55,15 +55,15 @@ abstract class GitCheckoutTask @Inject constructor(
                     .call()
             }
 
-            fs.sync {
-                from(temporaryDir)
-                into(destination)
-                // exclude the .git dir:
-                // - prevent the root git repo getting confused with a nested git repo
-                // - improves Gradle caching
-                exclude(".git/")
-            }
+        fs.sync {
+            from(temporaryDir)
+            into(destination)
+            // exclude the .git dir:
+            // - prevent the root git repo getting confused with a nested git repo
+            // - improves Gradle caching
+            exclude(".git/")
+        }
 
-            logger.lifecycle("initialized git repo $uri in ${destination.asFile.orNull}")
+        logger.lifecycle("initialized git repo $uri in ${destination.asFile.orNull}")
     }
 }

--- a/dokka-integration-tests/gradle/projects/coroutines/.gitignore
+++ b/dokka-integration-tests/gradle/projects/coroutines/.gitignore
@@ -1,0 +1,2 @@
+# kotlinx-coroutines is automatically downloaded with a Gradle task
+kotlinx-coroutines/

--- a/dokka-integration-tests/gradle/projects/serialization/.gitignore
+++ b/dokka-integration-tests/gradle/projects/serialization/.gitignore
@@ -1,0 +1,2 @@
+# kotlinx-serialization is automatically downloaded with a Gradle task
+kotlinx-serialization/

--- a/dokka-integration-tests/maven/build.gradle.kts
+++ b/dokka-integration-tests/maven/build.gradle.kts
@@ -1,6 +1,7 @@
 /*
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
+import dokkabuild.tasks.GitCheckoutTask
 
 plugins {
     id("dokkabuild.test-integration")
@@ -14,6 +15,8 @@ dependencies {
     implementation(libs.junit.jupiterApi)
 }
 
+val templateProjectsDir = layout.projectDirectory.dir("projects")
+
 val dokkaSubprojects = gradle.includedBuild("dokka")
 val mavenPlugin = gradle.includedBuild("runner-maven-plugin")
 
@@ -21,6 +24,7 @@ tasks.integrationTest {
     dependsOn(
         dokkaSubprojects.task(":publishToMavenLocal"),
         mavenPlugin.task(":publishToMavenLocal"),
+        checkoutBioJava,
     )
 
     dependsOn(tasks.installMavenBinary)
@@ -32,4 +36,10 @@ tasks.integrationTest {
         environment("DOKKA_VERSION", project.version)
         environment("MVN_BINARY_PATH", mvn.get().asFile.invariantSeparatorsPath)
     }
+}
+
+val checkoutBioJava by tasks.registering(GitCheckoutTask::class) {
+    uri = "https://github.com/biojava/biojava.git"
+    commitId = "059fbf1403d0704801df1427b0ec925102a645cd"
+    destination = templateProjectsDir.dir("biojava/biojava")
 }

--- a/dokka-integration-tests/maven/projects/biojava/.gitignore
+++ b/dokka-integration-tests/maven/projects/biojava/.gitignore
@@ -1,0 +1,2 @@
+# biojava is automatically downloaded with a Gradle task
+biojava/


### PR DESCRIPTION
This improves the experience when running Dokka integration tests. 

* Automatically checking out the external projects used for integration tests means that anyone can checkout and run all tests without needed to setup and configure git submodules.
* Because the commitId is defined in code it's easier to see what version the external projects are used.

I have made the minimal number of changes in this PR to make it small and focused. I plan to replace the git-diff files with a less fragile alternative in a later PR.

### TODO

- [ ] Verify that the documentation is up to date.
    
   I thought there were some instructions on how to checkout and setup the Git submodules, but I couldn't find any. Do any docs need to be updated?