### PR TITLE
Remove no-op `parallelMapNotNull { it }`

### DIFF
--- a/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/DefaultPsiToDocumentableTranslator.kt
+++ b/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/DefaultPsiToDocumentableTranslator.kt
@@ -48,7 +48,7 @@ internal class DefaultPsiToDocumentableTranslator : AsyncSourceToDocumentableTra
 
             DModule(
                 name = context.configuration.moduleName,
-                packages = psiFiles.parallelMapNotNull { it }.groupBy { it.packageName }.toList()
+                packages = psiFiles.groupBy { it.packageName }.toList()
                     .parallelMap { (packageName: String, psiFiles: List<PsiJavaFile>) ->
                         docParser.parsePackage(packageName, psiFiles)
                     },


### PR DESCRIPTION
I presume that `parallelMapNotNull { it }` does nothing.

Alternatively: is it supposed to do something, but it doesn't?