### PR TITLE
Update Analysis API to 2.0.20-dev-7

### DIFF
--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/AnalysisContext.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/AnalysisContext.kt
@@ -33,7 +33,6 @@ internal fun ProjectKotlinAnalysis(
 internal class KotlinAnalysis(
     private val sourceModules: SourceSetDependent<KtSourceModule>,
     private val analysisSession: StandaloneAnalysisAPISession,
-    private val applicationDisposable: Disposable,
     private val projectDisposable: Disposable
 ) : Closeable {
 
@@ -47,7 +46,6 @@ internal class KotlinAnalysis(
         get() = analysisSession.modulesWithFiles
 
     override fun close() {
-        Disposer.dispose(applicationDisposable)
         Disposer.dispose(projectDisposable)
     }
 }

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/KotlinAnalysis.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/KotlinAnalysis.kt
@@ -63,14 +63,12 @@ internal fun getLanguageVersionSettings(
 internal fun createAnalysisSession(
     sourceSets: List<DokkaConfiguration.DokkaSourceSet>,
     logger: DokkaLogger,
-    applicationDisposable: Disposable = Disposer.newDisposable("StandaloneAnalysisAPISession.application"),
     projectDisposable: Disposable = Disposer.newDisposable("StandaloneAnalysisAPISession.project"),
     isSampleProject: Boolean = false
 ): KotlinAnalysis {
     val sourcesModule = mutableMapOf<DokkaConfiguration.DokkaSourceSet, KtSourceModule>()
 
     val analysisSession = buildStandaloneAnalysisAPISession(
-        applicationDisposable = applicationDisposable,
         projectDisposable = projectDisposable,
         withPsiDeclarationFromBinaryModuleProvider = false
     ) {
@@ -135,7 +133,7 @@ internal fun createAnalysisSession(
                 ?: Platform.common.toTargetPlatform()
         }
     }
-    return KotlinAnalysis(sourcesModule, analysisSession, applicationDisposable, projectDisposable)
+    return KotlinAnalysis(sourcesModule, analysisSession, projectDisposable)
 }
 
 private enum class State {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ kotlinx-bcv = "0.13.2"
 
 ## Analysis
 kotlin-compiler = "1.9.22"
-kotlin-compiler-k2 = "2.0.0-dev-14242"
+kotlin-compiler-k2 = "2.0.20-dev-7"
 
 # MUST match the version of the intellij platform used in the kotlin compiler,
 # otherwise this will lead to different versions of psi API and implementations

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ kotlinx-bcv = "0.13.2"
 
 ## Analysis
 kotlin-compiler = "1.9.22"
-kotlin-compiler-k2 = "2.0.0-dev-8561"
+kotlin-compiler-k2 = "2.0.0-dev-14242"
 
 # MUST match the version of the intellij platform used in the kotlin compiler,
 # otherwise this will lead to different versions of psi API and implementations


### PR DESCRIPTION
**Fixed**(_Blocked by https://youtrack.jetbrains.com/issue/KT-65561/Analysis-API-dummy.kt-is-not-a-physical-file_)

**Changes:**
https://github.com/JetBrains/kotlin/commit/bba5447b12ff227c3b159159d9b952d07dfd0116 : `applicationDisposable` parameter is removed from `buildStandaloneAnalysisAPISession` because:
- It wasn’t used as the actual disposable for the shared application under the hood. In fact, logically it was just a second project disposable.
- The client should not need to care about application disposal, as signaling that the project is no longer used via the projectDisposable is sufficient.