### PR TITLE
[K1] Fix KDoc and Javadoc link to a package

### DIFF
--- a/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/util/PsiUtil.kt
+++ b/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/util/PsiUtil.kt
@@ -18,6 +18,11 @@ internal val PsiElement.parentsWithSelf: Sequence<PsiElement>
 
 @InternalDokkaApi
 public fun DRI.Companion.from(psi: PsiElement): DRI = psi.parentsWithSelf.run {
+    if (psi is PsiPackage) {
+        return@run DRI(
+            packageName = psi.qualifiedName,
+        )
+    }
     val psiMethod = firstIsInstanceOrNull<PsiMethod>()
     val psiField = firstIsInstanceOrNull<PsiField>()
     val classes = filterIsInstance<PsiClass>().filterNot { it is PsiTypeParameter }

--- a/dokka-subprojects/analysis-kotlin-descriptors-compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/DRIFactory.kt
+++ b/dokka-subprojects/analysis-kotlin-descriptors-compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/DRIFactory.kt
@@ -13,6 +13,11 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.parentsWithSelf
 import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
 
 internal fun DRI.Companion.from(descriptor: DeclarationDescriptor) = descriptor.parentsWithSelf.run {
+    if (descriptor is PackageViewDescriptor) {
+        return@run DRI(
+            packageName = descriptor.fqName.asString()
+        )
+    }
     val parameter = firstIsInstanceOrNull<ValueParameterDescriptor>()
     val callable = parameter?.containingDeclaration ?: firstIsInstanceOrNull<CallableDescriptor>()
 

--- a/dokka-subprojects/plugin-base/src/test/kotlin/markdown/LinkTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/markdown/LinkTest.kt
@@ -553,7 +553,6 @@ class LinkTest : BaseAbstractTest() {
     }
 
     @Test
-    @OnlySymbols("#3455 - KDoc links to a package are unresolved ")
     fun `fully qualified link should lead to package`() {
         // for the test case, there is the only one link candidate in K1 and K2
         val configuration = dokkaConfiguration {
@@ -696,7 +695,6 @@ class LinkTest : BaseAbstractTest() {
     }
 
     @Test
-    @OnlySymbols("#3455 - KDoc links to a package are unresolved ")
     fun `short link should lead to package rather than function`() {
         val configuration = dokkaConfiguration {
             sourceSets {

--- a/dokka-subprojects/plugin-base/src/test/kotlin/model/JavaTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/model/JavaTest.kt
@@ -10,6 +10,7 @@ import org.jetbrains.dokka.base.transformers.documentables.InheritorsInfo
 import org.jetbrains.dokka.links.*
 import org.jetbrains.dokka.model.*
 import org.jetbrains.dokka.model.doc.Param
+import org.jetbrains.dokka.model.doc.See
 import org.jetbrains.dokka.model.doc.Text
 import utils.AbstractModelTest
 import utils.assertContains
@@ -488,4 +489,25 @@ class JavaTest : AbstractModelTest("/src/main/kotlin/java/Test.java", "java") {
         }
     }
 
+    @Test
+    fun `should have a link to a package in see doctag`() {
+        inlineModelTest(
+            """
+            |/**
+            | * @see java
+            | */
+            |public class Foo {
+            |}
+            """, configuration = configuration
+        ) {
+            with((this / "java" / "Foo").cast<DClass>()) {
+                val doc = this.documentation.values.single()
+                val expectedDRI = DRI(
+                    packageName = "java", classNames = null,
+                    target = PointingToDeclaration,
+                )
+                assertEquals(expectedDRI, (doc.dfs { it is See } as See).address)
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fixes  #3004
The PR is based on @nea89o's solution #3371.

KDoc links to a package is a question of KDoc specification #3455.
They are already fixed in K2, bot not in K1.


