### PR TITLE
apply foojay-resolver plugin for build-logic

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -25,3 +25,7 @@ dependencyResolutionManagement {
         }
     }
 }
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+}

--- a/build-settings-logic/settings.gradle.kts
+++ b/build-settings-logic/settings.gradle.kts
@@ -31,3 +31,7 @@ dependencyResolutionManagement {
         }
     }
 }
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+}


### PR DESCRIPTION
Apply foojay convention plugin for `build-logic` and `build-settings-logic`. 
Without the plugin, Dokka build may lead to  
```
Failed to query the value of property 'buildFlowServiceProperty'.
> Could not isolate value org.jetbrains.kotlin.gradle.plugin.statistics.BuildFlowService$Parameters_Decorated@16b10ae7 of type BuildFlowService.Parameters
   > A problem occurred configuring project ':build-logic'.
      > Failed to calculate the value of task ':build-logic:compileJava' property 'javaCompiler'.
         > No matching toolchains found for requested specification: {languageVersion=11, vendor=any, implementation=vendor-specific} for LINUX on x86_64.
            > No locally installed toolchains match and toolchain download repositories have not been configured.
```
If JDK 11 missed on the host.