### PR TITLE
Build Cache diagnositic logging of task jvmArgs on CI

### DIFF
--- a/build-logic/src/main/kotlin/dokkabuild.base.gradle.kts
+++ b/build-logic/src/main/kotlin/dokkabuild.base.gradle.kts
@@ -27,3 +27,19 @@ val integrationTestPreparation by tasks.registering {
         "lifecycle task for preparing the project for integration tests (for example, publishing to the test Maven repo)"
     group = VERIFICATION_GROUP
 }
+
+
+//region jvmArgs logging
+// jvmArgs seem to change on CI, which causes Build Cache misses, hampering build performance
+// The easiest way to investigate them is to log them on CI.
+if (dokkaBuild.isCI.get()) {
+    tasks
+        .matching { it is JavaForkOptions }
+        .configureEach {
+            val task = this as? JavaForkOptions? ?: return@configureEach
+            doFirst("log jvmArgs") {
+                logger.lifecycle("[$path] jvmArgs: ${task.jvmArgs}")
+            }
+        }
+}
+//endregion


### PR DESCRIPTION
This PR adds diagnostic logging for jvmArgs.

### Context

There are regular Build Cache misses on TeamCity because the jvmArgs have changed (example: https://ge.jetbrains.com/s/276macegbfjba/timeline?details=346nt7ubk6vy4&page=2).

(internal discussion: https://jetbrains.slack.com/archives/CRM3WBNTY/p1709657348389359?thread_ts=1709638176.431129&cid=CRM3WBNTY)

Build Cache misses hamper build performance, and cause the tasks to re-run even though there were no changes. It also harms local development, as the remote Build Cache is only updated in TeamCity.

Adding additional logging is the easiest way to debug these. This logging should be removed once the Build Cache misses have been resolved.
