### PR TITLE
consistently apply Gradle Build Cache config in all includedBuild projects

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -9,6 +9,7 @@ pluginManagement {
         gradlePluginPortal()
         mavenCentral()
     }
+    includeBuild("../build-settings-logic")
 }
 
 @Suppress("UnstableApiUsage")
@@ -28,4 +29,5 @@ dependencyResolutionManagement {
 
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+    id("dokkasettings.build-cache")
 }

--- a/build-settings-logic/settings.gradle.kts
+++ b/build-settings-logic/settings.gradle.kts
@@ -4,10 +4,6 @@
 
 import org.gradle.api.initialization.resolve.RepositoriesMode.PREFER_SETTINGS
 
-/*
- * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
- */
-
 rootProject.name = "build-settings-logic"
 
 pluginManagement {
@@ -35,3 +31,10 @@ dependencyResolutionManagement {
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
 }
+
+// We have to make sure the build-cache config is consistent in the settings.gradle.kts
+// files of all projects. The natural way to share logic is with a convention plugin,
+// but we can't apply a convention plugin in build-settings-logic to itself, unless we
+// do it with a dumb hack:
+apply(from = "src/main/kotlin/dokkasettings.build-cache.settings.gradle.kts")
+// We could publish build-settings-logic to a Maven repo? But this is quicker and easier.

--- a/build-settings-logic/src/main/kotlin/DokkaBuildSettingsProperties.kt
+++ b/build-settings-logic/src/main/kotlin/DokkaBuildSettingsProperties.kt
@@ -38,24 +38,6 @@ abstract class DokkaBuildSettingsProperties @Inject constructor(
     //endregion
 
 
-    //region Gradle Build Cache
-    val buildCacheLocalEnabled: Provider<Boolean> =
-        dokkaProperty("build.cache.local.enabled", String::toBoolean)
-            .orElse(!buildingOnCi)
-    val buildCacheLocalDirectory: Provider<String> =
-        dokkaProperty("build.cache.local.directory")
-    val buildCacheUrl: Provider<String> =
-        dokkaProperty("build.cache.url").map(String::trim)
-    val buildCachePushEnabled: Provider<Boolean> =
-        dokkaProperty("build.cache.push", String::toBoolean)
-            .orElse(buildingOnTeamCity)
-    val buildCacheUser: Provider<String> =
-        dokkaProperty("build.cache.user")
-    val buildCachePassword: Provider<String> =
-        dokkaProperty("build.cache.password")
-    //endregion
-
-
     private fun dokkaProperty(name: String): Provider<String> =
         providers.gradleProperty("org.jetbrains.dokka.$name")
 

--- a/build-settings-logic/src/main/kotlin/dokkasettings.build-cache.settings.gradle.kts
+++ b/build-settings-logic/src/main/kotlin/dokkasettings.build-cache.settings.gradle.kts
@@ -1,41 +1,62 @@
 /*
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
-import DokkaBuildSettingsProperties.Companion.dokkaBuildSettingsProperties
 
 /**
  * Gradle Build Cache conventions.
  *
- * See [DokkaBuildSettingsProperties] for properties.
+ * Because Dokka uses Composite Builds, Build Cache must be configured consistently on
+ * - the root settings.gradle.kts,
+ * - and the settings.gradle.kts of any projects added with `pluginManagement { includedBuild("...") }`
  *
- * Because Dokka uses Composite Builds, Build Cache should only be configured on the root `settings.gradle.kts`.
  * See https://docs.gradle.org/8.4/userguide/build_cache.html#sec:build_cache_composite.
  *
  * Based on https://github.com/JetBrains/kotlin/blob/2675531624d42851af502a993bbefd65ee3e38ef/repo/gradle-settings-conventions/build-cache/src/main/kotlin/build-cache.settings.gradle.kts
  */
 
-val buildSettingsProps = dokkaBuildSettingsProperties
+val buildingOnTeamCity: Boolean = System.getenv("TEAMCITY_VERSION") != null
+val buildingOnGitHub: Boolean = System.getenv("GITHUB_ACTION") != null
+val buildingOnCi: Boolean = System.getenv("CI") != null || buildingOnTeamCity || buildingOnGitHub
+
+fun dokkaProperty(name: String): Provider<String> =
+    providers.gradleProperty("org.jetbrains.dokka.$name")
+
+fun <T : Any> dokkaProperty(name: String, convert: (String) -> T): Provider<T> =
+    dokkaProperty(name).map(convert)
+
+//region Gradle Build Cache
+val buildCacheLocalEnabled: Provider<Boolean> =
+    dokkaProperty("build.cache.local.enabled", String::toBoolean)
+        .orElse(!buildingOnCi)
+val buildCacheLocalDirectory: Provider<String> =
+    dokkaProperty("build.cache.local.directory")
+val buildCacheUrl: Provider<String> =
+    dokkaProperty("build.cache.url").map(String::trim)
+val buildCachePushEnabled: Provider<Boolean> =
+    dokkaProperty("build.cache.push", String::toBoolean)
+        .orElse(buildingOnTeamCity)
+val buildCacheUser: Provider<String> =
+    dokkaProperty("build.cache.user")
+val buildCachePassword: Provider<String> =
+    dokkaProperty("build.cache.password")
+//endregion
 
 buildCache {
     local {
-        isEnabled = buildSettingsProps.buildCacheLocalEnabled.get()
-        if (buildSettingsProps.buildCacheLocalDirectory.orNull != null) {
-            directory = buildSettingsProps.buildCacheLocalDirectory.get()
+        isEnabled = buildCacheLocalEnabled.get()
+        if (buildCacheLocalDirectory.orNull != null) {
+            directory = buildCacheLocalDirectory.get()
         }
     }
+    remote<HttpBuildCache> {
+        url = uri("https://ge.jetbrains.com/cache/")
+        isPush = buildCachePushEnabled.get()
 
-    val remoteBuildCacheUrl = buildSettingsProps.buildCacheUrl.orNull
-    if (!remoteBuildCacheUrl.isNullOrEmpty()) {
-        remote<HttpBuildCache> {
-            url = uri(remoteBuildCacheUrl)
-            isPush = buildSettingsProps.buildCachePushEnabled.get()
-
-            if (buildSettingsProps.buildCacheUser.isPresent &&
-                buildSettingsProps.buildCachePassword.isPresent
-            ) {
-                credentials.username = buildSettingsProps.buildCacheUser.get()
-                credentials.password = buildSettingsProps.buildCachePassword.get()
-            }
+        if (buildCacheUser.isPresent &&
+            buildCachePassword.isPresent
+        ) {
+            credentials.username = buildCacheUser.get()
+            credentials.password = buildCachePassword.get()
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,6 @@ org.jetbrains.dokka.kotlinLanguageLevel=1.4
 
 # Build Scans are disabled by default - see CONTRIBUTING.md to opt in
 org.jetbrains.dokka.build.scan.url=https\://ge.jetbrains.com/
-org.jetbrains.dokka.build.cache.url=https\://ge.jetbrains.com/cache/
 
 # Code style
 kotlin.code.style=official


### PR DESCRIPTION
Currently the plugin-includedBuild projects `build-logic` and `build-settings-logic` do not have Build Cache enabled. This hurts build performance, and Dokka gets dinged with a build scan warning.

> [The build cache configuration of the root build differs from the build cache configuration of the early evaluated ':build-logic', ':build-settings-logic' included builds.](https://ge.jetbrains.com/s/hy6qye4r7yi4e/performance/build-cache#warning-different_configurations)

This PR shares the build cache config in all projects, improving build performance.

### Convention plugin workaround.

In `build-settings-logic` there's a chicken-and-egg situation: a project can't apply its own convention plugin to itself.

Instead, I've applied a hack to apply the build cache config as a script plugin. ([Space also applies the same quick-fix.](https://jetbrains.team/p/crl/repositories/space/files/bdbcb4955b269e8d578b00c2d0b28efce7dfee2f/gradle-settings-conventions/settings.gradle.kts?tab=source&line=22&lines-count=1))