### PR TITLE
Fix checking for annotations when rendering constructor keyword

### DIFF
--- a/dokka-subprojects/plugin-base/api/plugin-base.api
+++ b/dokka-subprojects/plugin-base/api/plugin-base.api
@@ -892,6 +892,7 @@ public abstract interface class org/jetbrains/dokka/base/signatures/JvmSignature
 	public abstract fun annotationsBlockWithIgnored (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;Ljava/util/Set;Lorg/jetbrains/dokka/base/signatures/AtStrategy;Lkotlin/Pair;Ljava/lang/String;)V
 	public abstract fun annotationsInline (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;)V
 	public abstract fun annotationsInlineWithIgnored (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;Ljava/util/Set;Lorg/jetbrains/dokka/base/signatures/AtStrategy;Lkotlin/Pair;Ljava/lang/String;)V
+	public abstract fun isIgnored (Lorg/jetbrains/dokka/model/Annotations$Annotation;)Z
 	public abstract fun modifiers (Lorg/jetbrains/dokka/model/properties/WithExtraProperties;)Ljava/util/Map;
 	public abstract fun parametersBlock (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/DFunction;Lkotlin/jvm/functions/Function2;)V
 	public abstract fun plus (Ljava/util/Map;Ljava/util/Map;)Ljava/util/Map;
@@ -925,6 +926,7 @@ public final class org/jetbrains/dokka/base/signatures/KotlinSignatureProvider :
 	public fun annotationsBlockWithIgnored (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;Ljava/util/Set;Lorg/jetbrains/dokka/base/signatures/AtStrategy;Lkotlin/Pair;Ljava/lang/String;)V
 	public fun annotationsInline (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;)V
 	public fun annotationsInlineWithIgnored (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;Ljava/util/Set;Lorg/jetbrains/dokka/base/signatures/AtStrategy;Lkotlin/Pair;Ljava/lang/String;)V
+	public fun isIgnored (Lorg/jetbrains/dokka/model/Annotations$Annotation;)Z
 	public fun modifiers (Lorg/jetbrains/dokka/model/properties/WithExtraProperties;)Ljava/util/Map;
 	public fun parametersBlock (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/DFunction;Lkotlin/jvm/functions/Function2;)V
 	public fun plus (Ljava/util/Map;Ljava/util/Map;)Ljava/util/Map;
@@ -947,6 +949,7 @@ public final class org/jetbrains/dokka/base/signatures/KotlinSignatureUtils : or
 	public final fun getDri (Lorg/jetbrains/dokka/model/PrimitiveJavaType;)Lorg/jetbrains/dokka/links/DRI;
 	public final fun getDriOrNull (Lorg/jetbrains/dokka/model/Bound;)Lorg/jetbrains/dokka/links/DRI;
 	public final fun getDrisOfAllNestedBounds (Lorg/jetbrains/dokka/model/Projection;)Ljava/util/List;
+	public fun isIgnored (Lorg/jetbrains/dokka/model/Annotations$Annotation;)Z
 	public fun modifiers (Lorg/jetbrains/dokka/model/properties/WithExtraProperties;)Ljava/util/Map;
 	public fun parametersBlock (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/DFunction;Lkotlin/jvm/functions/Function2;)V
 	public fun plus (Ljava/util/Map;Ljava/util/Map;)Ljava/util/Map;

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/signatures/JvmSignatureUtils.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/signatures/JvmSignatureUtils.kt
@@ -21,6 +21,8 @@ public interface JvmSignatureUtils {
 
     public fun <T : Documentable> WithExtraProperties<T>.modifiers(): SourceSetDependent<Set<ExtraModifiers>>
 
+    public fun Annotations.Annotation.isIgnored(): Boolean
+
     public fun Collection<ExtraModifiers>.toSignatureString(): String =
         joinToString("") { it.name.toLowerCase() + " " }
 
@@ -71,7 +73,7 @@ public interface JvmSignatureUtils {
         else -> null
     }?.let {
         it.entries.forEach {
-            it.value.filter { it !in ignored && it.mustBeDocumented }.takeIf { it.isNotEmpty() }?.let { annotations ->
+            it.value.filter { it.mustBeDocumented && it !in ignored }.takeIf { it.isNotEmpty() }?.let { annotations ->
                 group(sourceSets = setOf(it.key), styles = styles, kind = ContentKind.Annotations) {
                     annotations.forEach {
                         operation(it)

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/signatures/KotlinSignatureProvider.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/signatures/KotlinSignatureProvider.kt
@@ -196,7 +196,11 @@ public class KotlinSignatureProvider(
             if (c is WithConstructors) {
                 val pConstructor = c.constructors.singleOrNull { it.extra[PrimaryConstructorExtra] != null }
                 if (pConstructor?.sourceSets?.contains(sourceSet) == true) {
-                    if (pConstructor.annotations().values.any { it.isNotEmpty() }) {
+                    // `constructor` keyword should present only when there are annotations that should be rendered
+                    val needConstructorKeyword = pConstructor.annotations().values.any { annotations ->
+                        annotations.any { it.mustBeDocumented && !it.isIgnored() }
+                    }
+                    if (needConstructorKeyword) {
                         text(nbsp.toString())
                         annotationsInline(pConstructor)
                         keyword("constructor")

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/signatures/KotlinSignatureUtils.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/signatures/KotlinSignatureUtils.kt
@@ -49,6 +49,7 @@ public object KotlinSignatureUtils : JvmSignatureUtils {
         } ?: emptyMap()
     }
 
+    override fun Annotations.Annotation.isIgnored(): Boolean = this in ignoredAnnotations
 
     public val PrimitiveJavaType.dri: DRI get() = DRI("kotlin", name.capitalize())
 

--- a/dokka-subprojects/plugin-base/src/test/kotlin/signatures/SignatureTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/signatures/SignatureTest.kt
@@ -1368,7 +1368,7 @@ class SignatureTest : BaseAbstractTest() {
 
     @OnlyDescriptors("#3354")
     @Test
-    fun `should not render constructor for Any from Wasm sources`() = testRender(
+    fun `should not render parameterless constructor with annotation without mustBeDocumented annotation - for kotlin Any `() = testRender(
         """
             |/src/main/kotlin/Any.kt
             |package kotlin

--- a/dokka-subprojects/plugin-javadoc/api/plugin-javadoc.api
+++ b/dokka-subprojects/plugin-javadoc/api/plugin-javadoc.api
@@ -641,6 +641,7 @@ public final class org/jetbrains/dokka/javadoc/signatures/JavadocSignatureProvid
 	public fun annotationsBlockWithIgnored (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;Ljava/util/Set;Lorg/jetbrains/dokka/base/signatures/AtStrategy;Lkotlin/Pair;Ljava/lang/String;)V
 	public fun annotationsInline (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;)V
 	public fun annotationsInlineWithIgnored (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;Ljava/util/Set;Lorg/jetbrains/dokka/base/signatures/AtStrategy;Lkotlin/Pair;Ljava/lang/String;)V
+	public fun isIgnored (Lorg/jetbrains/dokka/model/Annotations$Annotation;)Z
 	public fun modifiers (Lorg/jetbrains/dokka/model/properties/WithExtraProperties;)Ljava/util/Map;
 	public fun parametersBlock (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/DFunction;Lkotlin/jvm/functions/Function2;)V
 	public fun plus (Ljava/util/Map;Ljava/util/Map;)Ljava/util/Map;

--- a/dokka-subprojects/plugin-kotlin-as-java/api/plugin-kotlin-as-java.api
+++ b/dokka-subprojects/plugin-kotlin-as-java/api/plugin-kotlin-as-java.api
@@ -32,6 +32,7 @@ public final class org/jetbrains/dokka/kotlinAsJava/signatures/JavaSignatureProv
 	public fun annotationsBlockWithIgnored (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;Ljava/util/Set;Lorg/jetbrains/dokka/base/signatures/AtStrategy;Lkotlin/Pair;Ljava/lang/String;)V
 	public fun annotationsInline (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;)V
 	public fun annotationsInlineWithIgnored (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;Ljava/util/Set;Lorg/jetbrains/dokka/base/signatures/AtStrategy;Lkotlin/Pair;Ljava/lang/String;)V
+	public fun isIgnored (Lorg/jetbrains/dokka/model/Annotations$Annotation;)Z
 	public fun modifiers (Lorg/jetbrains/dokka/model/properties/WithExtraProperties;)Ljava/util/Map;
 	public fun parametersBlock (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/DFunction;Lkotlin/jvm/functions/Function2;)V
 	public fun plus (Ljava/util/Map;Ljava/util/Map;)Ljava/util/Map;
@@ -51,6 +52,7 @@ public final class org/jetbrains/dokka/kotlinAsJava/signatures/JavaSignatureUtil
 	public fun annotationsBlockWithIgnored (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;Ljava/util/Set;Lorg/jetbrains/dokka/base/signatures/AtStrategy;Lkotlin/Pair;Ljava/lang/String;)V
 	public fun annotationsInline (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;)V
 	public fun annotationsInlineWithIgnored (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/AnnotationTarget;Ljava/util/Set;Lorg/jetbrains/dokka/base/signatures/AtStrategy;Lkotlin/Pair;Ljava/lang/String;)V
+	public fun isIgnored (Lorg/jetbrains/dokka/model/Annotations$Annotation;)Z
 	public fun modifiers (Lorg/jetbrains/dokka/model/properties/WithExtraProperties;)Ljava/util/Map;
 	public fun parametersBlock (Lorg/jetbrains/dokka/base/translators/documentables/PageContentBuilder$DocumentableContentBuilder;Lorg/jetbrains/dokka/model/DFunction;Lkotlin/jvm/functions/Function2;)V
 	public fun plus (Ljava/util/Map;Ljava/util/Map;)Ljava/util/Map;

--- a/dokka-subprojects/plugin-kotlin-as-java/src/main/kotlin/org/jetbrains/dokka/kotlinAsJava/signatures/JavaSignatureUtils.kt
+++ b/dokka-subprojects/plugin-kotlin-as-java/src/main/kotlin/org/jetbrains/dokka/kotlinAsJava/signatures/JavaSignatureUtils.kt
@@ -41,4 +41,6 @@ public object JavaSignatureUtils : JvmSignatureUtils {
         } ?: emptyMap()
     }
 
+    override fun Annotations.Annotation.isIgnored(): Boolean = this in ignoredAnnotations
+
 }


### PR DESCRIPTION
Fixes #3426

There are 2 cases when annotation is not rendered and so no `constructor` keyword should be rendered:
1. when annotation is not annotated with `MustBeDocumented`
2. when annotation is ignored (and so handled in some other way, like `Deprecated`)

Note: PR has small API/ABI changes (no breaking changes), that's because ignored annotations are ignored later in pipeline, only during rendering. We can't ignore annotations in `JvmSignatureUtils`, as we need all annotations in other places to make a special handling of those ignored annotations (like `Deprecated`).
Also, we can introduce something like `Annotation.shouldBeRendered` instead of `Annotation.isIgnored` inside `JvmSignatureUtils`, but to use it under the hood in `annotationsInline`/`annotationsBlock` we will need to break API/ABI (or introduce new declaration + deprecate old one) as on current moment `ignored` annotations there provided explicitly...
So I've decided not to go this road.
If we think that it's fine to break API/ABI in `JvmSignatureUtils` and its inheritors (can be seen in API dump changes), then I can update PR.