### PR TITLE
add explicit dependency on JUnit Platform Launcher

### DIFF
--- a/build-logic/src/main/kotlin/dokkabuild.java.gradle.kts
+++ b/build-logic/src/main/kotlin/dokkabuild.java.gradle.kts
@@ -33,6 +33,7 @@ tasks.withType<Test>().configureEach {
 
 dependencies {
     testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.platformLauncher)
 }
 
 tasks.processResources {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -148,6 +148,7 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test-junit5", version.ref 
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junit-jupiterApi = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
 junit-jupiterParams = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
+junit-platformLauncher = { module = "org.junit.platform:junit-platform-launcher" }
 
 kotest-bom = { module = "io.kotest:kotest-bom", version.ref = "kotest" }
 kotest-datatest = { module = "io.kotest:kotest-framework-datatest" }


### PR DESCRIPTION
Avoid warning regarding "The automatic loading of test framework implementation dependencies has been deprecated."

https://ge.jetbrains.com/s/hnoer7sb3saqa/deprecations?expanded=WyIyMTEiXQ

https://docs.gradle.org/8.4/userguide/upgrading_version_8.html#test_framework_implementation_dependencies