### PR TITLE
remove usages of Project during task-execution

### DIFF
--- a/dokka-runners/runner-maven-plugin/build.gradle.kts
+++ b/dokka-runners/runner-maven-plugin/build.gradle.kts
@@ -30,7 +30,8 @@ val generatePom by tasks.registering(Sync::class) {
     description = "Generate pom.xml for Maven Plugin Plugin"
     group = mavenPluginTaskGroup
 
-    inputs.property("dokka_version", project.version)
+    val dokkaVersion = provider { project.version.toString() }
+    inputs.property("dokkaVersion", dokkaVersion)
 
     val pomTemplateFile = layout.projectDirectory.file("pom.template.xml")
 
@@ -42,7 +43,7 @@ val generatePom by tasks.registering(Sync::class) {
 
         expand(
             "mavenVersion" to mavenVersion,
-            "dokka_version" to project.version,
+            "dokka_version" to dokkaVersion.get(),
             "mavenPluginToolsVersion" to mavenPluginToolsVersion,
         )
     }

--- a/dokka-subprojects/core/build.gradle.kts
+++ b/dokka-subprojects/core/build.gradle.kts
@@ -26,15 +26,14 @@ dependencies {
     testImplementation(projects.dokkaSubprojects.coreTestApi)
 }
 
-tasks {
-    processResources {
-        inputs.property("dokkaVersion", project.version)
-        eachFile {
-            if (name == "dokka-version.properties") {
-                filter { line ->
-                    line.replace("<dokka-version>", project.version.toString())
-                }
-            }
+tasks.processResources {
+    val dokkaVersion = provider { project.version.toString() }
+    inputs.property("dokkaVersion", dokkaVersion)
+    eachFile {
+        if (name == "dokka-version.properties") {
+            expand(
+                "dokkaVersion" to dokkaVersion.get()
+            )
         }
     }
 }

--- a/dokka-subprojects/core/src/main/resources/META-INF/dokka/dokka-version.properties
+++ b/dokka-subprojects/core/src/main/resources/META-INF/dokka/dokka-version.properties
@@ -1,5 +1,4 @@
 #
 # Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
 #
-
-dokka-version=<dokka-version>
+dokka-version=${dokkaVersion}


### PR DESCRIPTION
Preparing Dokka build-logic (not Dokka Gradle Plugin!) for Configuration Cache

Replace [usages of Project during task execution](https://docs.gradle.org/8.6/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution) with a Provider.

Also, replace custom text find/replace with Gradle `expand()` util (matches existing usage in runner-maven-plugin project).