### PR TITLE
set jvmToolchain 11 for build-settings-logic

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -9,9 +9,7 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
-    }
+    jvmToolchain(11)
 }
 
 dependencies {

--- a/build-settings-logic/build.gradle.kts
+++ b/build-settings-logic/build.gradle.kts
@@ -8,6 +8,10 @@ plugins {
 
 description = "Conventions for use in settings.gradle.kts scripts"
 
+kotlin {
+    jvmToolchain(11)
+}
+
 dependencies {
     implementation(libs.gradlePlugin.gradle.enterprise)
     implementation(libs.gradlePlugin.gradle.customUserData)


### PR DESCRIPTION
`build-settings-logic/build.gradle.kts` is missing a JVM toolchain, which means in some cases builds are not reproducible. This may be causing Build Cache misses.

Also, update the syntax to use the new, shorter util function.