### PR TITLE
Improve Build Caching of Maven plugin tasks

### DIFF
--- a/build-logic/src/main/kotlin/dokkabuild/tasks/MvnExec.kt
+++ b/build-logic/src/main/kotlin/dokkabuild/tasks/MvnExec.kt
@@ -10,6 +10,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitivity.NONE
+import org.gradle.api.tasks.PathSensitivity.RELATIVE
 import org.gradle.process.ExecOperations
 import org.gradle.work.NormalizeLineEndings
 import java.util.*
@@ -46,7 +47,7 @@ constructor(
 
     /** Input resource files - will be synced to [workDirectory]. */
     @get:InputFiles
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(RELATIVE)
     @get:NormalizeLineEndings
     abstract val resources: ConfigurableFileCollection
 

--- a/build-logic/src/main/kotlin/dokkabuild/tasks/MvnExec.kt
+++ b/build-logic/src/main/kotlin/dokkabuild/tasks/MvnExec.kt
@@ -11,6 +11,7 @@ import org.gradle.api.tasks.*
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitivity.NONE
 import org.gradle.process.ExecOperations
+import org.gradle.work.NormalizeLineEndings
 import java.util.*
 import javax.inject.Inject
 
@@ -43,8 +44,10 @@ constructor(
     protected val filteredClasses: FileCollection
         get() = classes.asFileTree.matching { include("**/*.class") }
 
-    /** Resource files - will be synced to [workDirectory]. */
-    @get:Internal
+    /** Input resource files - will be synced to [workDirectory]. */
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:NormalizeLineEndings
     abstract val resources: ConfigurableFileCollection
 
     @get:InputFile

--- a/dokka-runners/runner-maven-plugin/build.gradle.kts
+++ b/dokka-runners/runner-maven-plugin/build.gradle.kts
@@ -94,8 +94,8 @@ val helpMojoResources by tasks.registering(Sync::class) {
     include("**/**")
     // this is a _resources_ task, so don't include source files
     exclude("**/*.java")
-    // `maven-plugin-help.properties` contains an absolute path, destinationDirectory.
-    // Exclude it, so that this task is reproducible and can be Build Cached.
+    // `maven-plugin-help.properties` contains an absolute path: destinationDirectory.
+    // Exclude it, so that Build Cache is relocatable.
     exclude("**/maven-plugin-help.properties")
 
     includeEmptyDirs = false

--- a/dokka-runners/runner-maven-plugin/build.gradle.kts
+++ b/dokka-runners/runner-maven-plugin/build.gradle.kts
@@ -33,10 +33,10 @@ val generatePom by tasks.registering(Sync::class) {
     val dokkaVersion = provider { project.version.toString() }
     inputs.property("dokkaVersion", dokkaVersion)
 
-    val mavenVersion = mavenCliSetup.mavenVersion.orNull
+    val mavenVersion = mavenCliSetup.mavenVersion
     inputs.property("mavenVersion", mavenVersion)
 
-    val mavenPluginToolsVersion = mavenCliSetup.mavenPluginToolsVersion.orNull
+    val mavenPluginToolsVersion = mavenCliSetup.mavenPluginToolsVersion
     inputs.property("mavenPluginToolsVersion", mavenPluginToolsVersion)
 
     val pomTemplateFile = layout.projectDirectory.file("pom.template.xml")
@@ -45,9 +45,9 @@ val generatePom by tasks.registering(Sync::class) {
         rename { it.replace(".template.xml", ".xml") }
 
         expand(
-            "mavenVersion" to mavenVersion,
+            "mavenVersion" to mavenVersion.get(),
             "dokka_version" to dokkaVersion.get(),
-            "mavenPluginToolsVersion" to mavenPluginToolsVersion,
+            "mavenPluginToolsVersion" to mavenPluginToolsVersion.get(),
         )
     }
 

--- a/dokka-runners/runner-maven-plugin/build.gradle.kts
+++ b/dokka-runners/runner-maven-plugin/build.gradle.kts
@@ -33,10 +33,13 @@ val generatePom by tasks.registering(Sync::class) {
     val dokkaVersion = provider { project.version.toString() }
     inputs.property("dokkaVersion", dokkaVersion)
 
-    val pomTemplateFile = layout.projectDirectory.file("pom.template.xml")
-
     val mavenVersion = mavenCliSetup.mavenVersion.orNull
+    inputs.property("mavenVersion", mavenVersion)
+
     val mavenPluginToolsVersion = mavenCliSetup.mavenPluginToolsVersion.orNull
+    inputs.property("mavenPluginToolsVersion", mavenPluginToolsVersion)
+
+    val pomTemplateFile = layout.projectDirectory.file("pom.template.xml")
 
     from(pomTemplateFile) {
         rename { it.replace(".template.xml", ".xml") }

--- a/dokka-runners/runner-maven-plugin/build.gradle.kts
+++ b/dokka-runners/runner-maven-plugin/build.gradle.kts
@@ -70,7 +70,8 @@ val helpMojoSources by tasks.registering(Sync::class) {
 
     from(generateHelpMojo) {
         eachFile {
-            // drop 2 leading directories
+            // Maven generates sources into `generated-sources/plugin/`,
+            // so drop 2 leading directories:
             relativePath = RelativePath(true, *relativePath.segments.drop(2).toTypedArray())
         }
     }
@@ -78,6 +79,7 @@ val helpMojoSources by tasks.registering(Sync::class) {
 
     into(temporaryDir)
 
+    // this is a _sources_ task, so only include source files
     include("**/*.java")
 }
 
@@ -90,7 +92,13 @@ val helpMojoResources by tasks.registering(Sync::class) {
     into(temporaryDir)
 
     include("**/**")
+    // this is a _resources_ task, so don't include source files
     exclude("**/*.java")
+    // `maven-plugin-help.properties` contains an absolute path, destinationDirectory.
+    // Exclude it, so that this task is reproducible and can be Build Cached.
+    exclude("**/maven-plugin-help.properties")
+
+    includeEmptyDirs = false
 }
 
 sourceSets.main {

--- a/dokka-runners/runner-maven-plugin/build.gradle.kts
+++ b/dokka-runners/runner-maven-plugin/build.gradle.kts
@@ -55,7 +55,7 @@ val generateHelpMojo by tasks.registering(MvnExec::class) {
     description = "Generate the Maven Plugin HelpMojo"
     group = mavenPluginTaskGroup
 
-    inputFiles.from(generatePom)
+    resources.from(generatePom)
     arguments.addAll(
         "org.apache.maven.plugins:maven-plugin-plugin:helpmojo"
     )
@@ -96,22 +96,14 @@ sourceSets.main {
     resources.srcDirs(helpMojoResources)
 }
 
-val preparePluginDescriptorDir by tasks.registering(Sync::class) {
-    description = "Prepare files for generating the Maven Plugin descriptor"
-    group = mavenPluginTaskGroup
-
-    from(tasks.compileKotlin) { into("classes/java/main") }
-    from(tasks.compileJava) { into("classes/java/main") }
-    from(helpMojoResources)
-
-    into(temporaryDir)
-}
-
 val generatePluginDescriptor by tasks.registering(MvnExec::class) {
     description = "Generate the Maven Plugin descriptor"
     group = mavenPluginTaskGroup
 
-    inputFiles.from(preparePluginDescriptorDir)
+    classes.from(tasks.compileKotlin)
+    classes.from(tasks.compileJava)
+
+    resources.from(helpMojoResources)
 
     arguments.addAll(
         "org.apache.maven.plugins:maven-plugin-plugin:descriptor"

--- a/dokka-runners/runner-maven-plugin/build.gradle.kts
+++ b/dokka-runners/runner-maven-plugin/build.gradle.kts
@@ -79,7 +79,7 @@ val helpMojoSources by tasks.registering(Sync::class) {
 
     into(temporaryDir)
 
-    // this is a _sources_ task, so only include source files
+    // this task prepares generated helpmojo _sources_, so only include source files
     include("**/*.java")
 }
 
@@ -91,9 +91,9 @@ val helpMojoResources by tasks.registering(Sync::class) {
 
     into(temporaryDir)
 
-    include("**/**")
-    // this is a _resources_ task, so don't include source files
-    exclude("**/*.java")
+    // this task prepares generated helpmojo _resources_, so...
+    include("**/**")       // include everything by default
+    exclude("**/*.java")   // don't include source files
     // `maven-plugin-help.properties` contains an absolute path: destinationDirectory.
     // Exclude it, so that Build Cache is relocatable.
     exclude("**/maven-plugin-help.properties")
@@ -102,7 +102,7 @@ val helpMojoResources by tasks.registering(Sync::class) {
 }
 
 sourceSets.main {
-    // use the generated HelpMojo as compilation input, so Gradle will automatically generate the mojo
+    // use the generated HelpMojo tasks as compilation input: Gradle will automatically trigger the tasks when required
     java.srcDirs(helpMojoSources)
     resources.srcDirs(helpMojoResources)
 }


### PR DESCRIPTION
Update tasks for building the Dokka Maven plugin, so that Build Cache works across machines.

(Alternative title: TIL that the compileKotlin task output includes caches)

### Summary

- Update MvnExec task:
  - separate classes/resources inputs
  - filter and annotate classes input:
     1. only include `.class` files (the compileKotlin file includes caches)
     2. annotate with `@Classpath` so Gradle will be able to normalize the files

- Update `generatePom` task to manually register the version inputs, to ensure Gradle will re-run the task if they change.
- Update `helpMojoResources` to exclude `maven-plugin-help.properties`, because it contains a property with an absolute file path, meaning that Build Cache cannot be shared between CI and local machines.