### PR TITLE
Remove `<a href="TODO">` in enum constant summary

### DIFF
--- a/dokka-subprojects/plugin-javadoc/src/main/resources/views/class.korte
+++ b/dokka-subprojects/plugin-javadoc/src/main/resources/views/class.korte
@@ -169,8 +169,7 @@
                                     </tr>
                                     {% for entry in entries %}
                                     <tr class="{{ rowColor(loop.index0) }}">
-                                        <th class="colFirst" scope="row"><code><span class="memberNameLink"><a
-                                                href="TODO">{{ entry.signature.signatureWithoutModifiers|raw }}</a></span></code></th>
+                                        <th class="colFirst" scope="row"><code><span class="memberNameLink">{{ entry.signature.signatureWithoutModifiers|raw }}</span></code></th>
                                         <td class="colLast">{{ entry.brief|raw }}</td>
                                     </tr>
                                     {% endfor %}


### PR DESCRIPTION
The rendered signature already contains the correct link, but was accidentally wrapped in another `<a>` with a placeholder `href` link. This PR removes that dummy `<a>` wrapper.