### PR TITLE
Enable Configuration Cache for Dokka Build

### DIFF
--- a/build-logic/src/main/kotlin/dokkabuild.base.gradle.kts
+++ b/build-logic/src/main/kotlin/dokkabuild.base.gradle.kts
@@ -14,7 +14,10 @@ plugins {
     base
 }
 
-extensions.create<DokkaBuildProperties>(DokkaBuildProperties.EXTENSION_NAME)
+extensions.create<DokkaBuildProperties>(
+    DokkaBuildProperties.EXTENSION_NAME,
+    provider { project.version.toString() },
+)
 
 tasks.withType<AbstractArchiveTask>().configureEach {
     // https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives

--- a/build-logic/src/main/kotlin/dokkabuild.publish-base.gradle.kts
+++ b/build-logic/src/main/kotlin/dokkabuild.publish-base.gradle.kts
@@ -88,3 +88,10 @@ tasks.withType<AbstractPublishToMaven>().configureEach {
     val signingTasks = tasks.withType<Sign>()
     mustRunAfter(signingTasks)
 }
+
+tasks.withType<PublishToMavenRepository>().configureEach {
+    // Configuration Cache allows tasks to run in parallel. Maven repositories (especially Maven Central)
+    // can't cope with parallel uploads, and might drop or split publications.
+    // As a workaround, disable Configuration Cache whenever publishing to remote Maven repos.
+    notCompatibleWithConfigurationCache("Prevent parallel publishing tasks")
+}

--- a/build-logic/src/main/kotlin/dokkabuild/DokkaBuildProperties.kt
+++ b/build-logic/src/main/kotlin/dokkabuild/DokkaBuildProperties.kt
@@ -19,10 +19,13 @@ import javax.inject.Inject
  *
  * Default values are set in the root `gradle.properties`, and can be overridden via
  * [project properties](https://docs.gradle.org/current/userguide/build_environment.html#sec:project_properties)
+ *
+ * @param projectVersion Provides the value of [org.gradle.api.Project.getVersion], lazily evaluated.
  */
 abstract class DokkaBuildProperties @Inject constructor(
     private val providers: ProviderFactory,
     private val layout: ProjectLayout,
+    val projectVersion: Provider<String>,
 ) {
 
     private val buildingOnTeamCity: Provider<Boolean> =

--- a/build-settings-logic/src/main/kotlin/dokkasettings.gradle-enterprise.settings.gradle.kts
+++ b/build-settings-logic/src/main/kotlin/dokkasettings.gradle-enterprise.settings.gradle.kts
@@ -27,15 +27,15 @@ plugins {
     id("com.gradle.common-custom-user-data-gradle-plugin") apply false
 }
 
-val buildSettingsProps = dokkaBuildSettingsProperties
-
-val buildScanEnabled = buildSettingsProps.buildScanEnabled.get()
-
-if (buildScanEnabled) {
-    plugins.apply("com.gradle.common-custom-user-data-gradle-plugin")
-}
-
 gradleEnterprise {
+    val buildSettingsProps = dokkaBuildSettingsProperties
+
+    val buildScanEnabled = buildSettingsProps.buildScanEnabled.get()
+
+    if (buildScanEnabled) {
+        plugins.apply("com.gradle.common-custom-user-data-gradle-plugin")
+    }
+
     buildScan {
         if (buildScanEnabled) {
             server = "https://ge.jetbrains.com/"

--- a/dokka-runners/runner-maven-plugin/build.gradle.kts
+++ b/dokka-runners/runner-maven-plugin/build.gradle.kts
@@ -30,7 +30,7 @@ val generatePom by tasks.registering(Sync::class) {
     description = "Generate pom.xml for Maven Plugin Plugin"
     group = mavenPluginTaskGroup
 
-    val dokkaVersion = provider { project.version.toString() }
+    val dokkaVersion = dokkaBuild.projectVersion
     inputs.property("dokkaVersion", dokkaVersion)
 
     val mavenVersion = mavenCliSetup.mavenVersion

--- a/dokka-subprojects/core/build.gradle.kts
+++ b/dokka-subprojects/core/build.gradle.kts
@@ -27,8 +27,9 @@ dependencies {
 }
 
 tasks.processResources {
-    val dokkaVersion = provider { project.version.toString() }
+    val dokkaVersion = dokkaBuild.projectVersion
     inputs.property("dokkaVersion", dokkaVersion)
+
     eachFile {
         if (name == "dokka-version.properties") {
             expand(

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,5 +15,7 @@ kotlin.code.style=official
 
 # Gradle settings
 org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=2g
-org.gradle.parallel=true
 org.gradle.caching=true
+org.gradle.configuration-cache-problems=warn
+org.gradle.configuration-cache=true
+org.gradle.parallel=true


### PR DESCRIPTION
Enables [Configuration Cache](https://docs.gradle.org/8.7/userguide/configuration_cache.html) for Dokka's build configuration.


### Summary

- Enabled CC.
- Set CC error level to 'warn'. (Future build script or plugin changes might cause CC issues. Although such problems should be fixed, I'd rather that developers aren't blocked with CC errors.)
- Updated some build script config to avoid CC issues
  - update usages of project version, to avoid `Task.getProject()`
  - move variables into `gradleEnterprise {}` block, to avoid references to the build script context
- Disabled CC for remote Maven publishing tasks. Remote Maven Repos (particularly Maven Central) struggle to cope with parallel uploads, and artifacts may be lost, or split. To prevent issues, CC is manually disabled for all publishing tasks.
- Removed `--no-daemon` from TeamCity Gradle Steps. TeamCity will instead launch Gradle using the Tooling API (TAPI). ([internal discussion](https://jetbrains.slack.com/archives/CDA4DR2US/p1711547334610339)).