### PR TITLE
Update GitHub workflows to use latest versions of actions

### DIFF
--- a/.github/workflows/check-api.yml
+++ b/.github/workflows/check-api.yml
@@ -11,13 +11,12 @@ jobs:
     name: binary compatibility
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 17
-          cache: 'maven'
-      - uses: gradle/gradle-build-action@v2
+      - uses: gradle/actions/setup-gradle@v3
         with:
           gradle-home-cache-cleanup: true
-          arguments: apiCheck --stacktrace
+      - run: ./gradlew apiCheck --stacktrace

--- a/.github/workflows/check-gradle.yml
+++ b/.github/workflows/check-gradle.yml
@@ -13,5 +13,5 @@ jobs:
     name: wrapper checksums
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/checkout@v4
+      - uses: gradle/wrapper-validation-action@v2

--- a/.github/workflows/examples-build.yml
+++ b/.github/workflows/examples-build.yml
@@ -23,19 +23,18 @@ jobs:
         ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: dorny/paths-filter@v2
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
             examples_changed:
               - '${{ matrix.projects }}/**'
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 17
-          cache: 'maven'
-      - uses: gradle/gradle-build-action@v2
+      - uses: gradle/actions/setup-gradle@v3
         with:
           gradle-home-cache-cleanup: true
       - run: ./gradlew build --no-daemon --stacktrace
@@ -54,19 +53,18 @@ jobs:
         ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: dorny/paths-filter@v2
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
             examples_changed:
               - '${{ matrix.projects }}/**'
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 17
-          cache: 'maven'
-      - uses: gradle/gradle-build-action@v2
+      - uses: gradle/actions/setup-gradle@v3
         with:
           gradle-home-cache-cleanup: true
       - run: ./gradlew dokkaHtml --no-daemon --stacktrace
@@ -79,19 +77,18 @@ jobs:
         tasks: [ dokkaJavadocJar, dokkaHtmlJar ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: dorny/paths-filter@v2
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
             examples_changed:
               - 'examples/gradle/dokka-library-publishing-example/**'
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 17
-          cache: 'maven'
-      - uses: gradle/gradle-build-action@v2
+      - uses: gradle/actions/setup-gradle@v3
         with:
           gradle-home-cache-cleanup: true
       - run: ./gradlew ${{ matrix.tasks }} --no-daemon --stacktrace
@@ -106,19 +103,18 @@ jobs:
           - task: "dokkaHtmlMultiModule"
             dir: "examples/gradle/dokka-multimodule-example"
     steps:
-      - uses: actions/checkout@v3
-      - uses: dorny/paths-filter@v2
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
             examples_changed:
               - '${{ matrix.dir }}/**'
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 17
-          cache: 'maven'
-      - uses: gradle/gradle-build-action@v2
+      - uses: gradle/actions/setup-gradle@v3
         with:
           gradle-home-cache-cleanup: true
       - run: ./gradlew ${{ matrix.task }} --no-daemon --stacktrace
@@ -128,15 +124,15 @@ jobs:
   run-dokka-maven-example:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: dorny/paths-filter@v2
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
             examples_changed:
               - 'examples/maven/**'
           working-directory: examples/maven
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 17

--- a/.github/workflows/gh-pages-deploy-dev-docs.yml
+++ b/.github/workflows/gh-pages-deploy-dev-docs.yml
@@ -15,15 +15,14 @@ jobs:
     if: github.repository == 'Kotlin/dokka'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: dokka
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 17
-          cache: 'maven'
-      - uses: gradle/gradle-build-action@v2
+      - uses: gradle/actions/setup-gradle@v3
         with:
           gradle-home-cache-cleanup: true
       - name: Get current Dokka version

--- a/.github/workflows/gh-pages-deploy-examples.yml
+++ b/.github/workflows/gh-pages-deploy-examples.yml
@@ -21,19 +21,18 @@ jobs:
           dokka-customFormat-example
         ]
     steps:
-      - uses: actions/checkout@v3
-      - uses: dorny/paths-filter@v2
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
             examples_changed:
               - 'examples/gradle/${{ matrix.projects }}/**'
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 17
-          cache: 'maven'
-      - uses: gradle/gradle-build-action@v2
+      - uses: gradle/actions/setup-gradle@v3
         with:
           gradle-home-cache-cleanup: true
       - name: Build html
@@ -41,7 +40,7 @@ jobs:
         working-directory: examples/gradle/${{ matrix.projects }}
         if: steps.filter.outputs.examples_changed == 'true'
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: steps.filter.outputs.examples_changed == 'true'
         with:
           name: ${{ matrix.projects }}
@@ -57,19 +56,19 @@ jobs:
           dokka-multimodule-example
         ]
     steps:
-      - uses: actions/checkout@v3
-      - uses: dorny/paths-filter@v2
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
             examples_changed:
               - 'examples/gradle/${{ matrix.projects }}/**'
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 17
           cache: 'maven'
-      - uses: gradle/gradle-build-action@v2
+      - uses: gradle/actions/setup-gradle@v3
         with:
           gradle-home-cache-cleanup: true
       - name: Build html
@@ -77,7 +76,7 @@ jobs:
         working-directory: examples/gradle/${{ matrix.projects }}
         if: steps.filter.outputs.examples_changed == 'true'
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: steps.filter.outputs.examples_changed == 'true'
         with:
           name: ${{ matrix.projects }}
@@ -87,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ build-examples, build-multimodule-examples ]
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           path: public/examples
       - name: Deploy

--- a/.github/workflows/preview-cleanup-web-s3.yml
+++ b/.github/workflows/preview-cleanup-web-s3.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials for S3 access
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/preview-publish-ga.yml
+++ b/.github/workflows/preview-publish-ga.yml
@@ -15,21 +15,20 @@ jobs:
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'Kotlin/dokka')
     steps:
       - name: Checkout dokka
-        uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 17
-          cache: 'maven'
-      - name: Document coroutines
-        uses: gradle/gradle-build-action@v2
+      - uses: gradle/actions/setup-gradle@v3
         with:
           gradle-home-cache-cleanup: true
-          arguments: :dokka-integration-tests:gradle:testExternalProjectKotlinxCoroutines --stacktrace "-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=500m"
+      - name: Document coroutines
+        run: ./gradlew :dokka-integration-tests:gradle:testExternalProjectKotlinxCoroutines --stacktrace "-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=500m"
         env:
           DOKKA_TEST_OUTPUT_PATH: /home/runner/work/dokka/coroutines
       - name: Copy files to GitHub Actions Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dokka-coroutines
           path: /home/runner/work/dokka/coroutines
@@ -42,21 +41,20 @@ jobs:
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'Kotlin/dokka')
     steps:
       - name: Checkout dokka
-        uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 17
-          cache: 'maven'
-      - name: Document serialization
-        uses: gradle/gradle-build-action@v2
+      - uses: gradle/actions/setup-gradle@v3
         with:
           gradle-home-cache-cleanup: true
-          arguments: :dokka-integration-tests:gradle:testExternalProjectKotlinxSerialization --stacktrace "-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=500m"
+      - name: Document serialization
+        run: ./gradlew :dokka-integration-tests:gradle:testExternalProjectKotlinxSerialization --stacktrace "-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=500m"
         env:
           DOKKA_TEST_OUTPUT_PATH: /home/runner/work/dokka/serialization
       - name: Copy files to GitHub Actions Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dokka-serialization
           path: /home/runner/work/dokka/serialization
@@ -69,21 +67,20 @@ jobs:
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'Kotlin/dokka')
     steps:
       - name: Checkout dokka
-        uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 17
-          cache: 'maven'
-      - name: Document biojava-core
-        uses: gradle/gradle-build-action@v2
+      - uses: gradle/actions/setup-gradle@v3
         with:
           gradle-home-cache-cleanup: true
-          arguments: :dokka-integration-tests:maven:integrationTest --tests org.jetbrains.dokka.it.maven.BiojavaIntegrationTest --stacktrace
+      - name: Document biojava-core
+        run: ./gradlew :dokka-integration-tests:maven:integrationTest --tests org.jetbrains.dokka.it.maven.BiojavaIntegrationTest --stacktrace
         env:
           DOKKA_TEST_OUTPUT_PATH: /home/runner/work/dokka/biojava
       - name: Copy files to GitHub Actions Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dokka-biojava
           path: /home/runner/work/dokka/biojava

--- a/.github/workflows/preview-publish-web-s3.yml
+++ b/.github/workflows/preview-publish-web-s3.yml
@@ -12,21 +12,20 @@ jobs:
     if: github.repository == 'Kotlin/dokka'
     steps:
       - name: Checkout dokka
-        uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 17
-          cache: 'maven'
-      - name: Document coroutines
-        uses: gradle/gradle-build-action@v2
+      - uses: gradle/actions/setup-gradle@v3
         with:
           gradle-home-cache-cleanup: true
-          arguments: :dokka-integration-tests:gradle:testExternalProjectKotlinxCoroutines --stacktrace "-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=500m"
+      - name: Document coroutines
+        run: ./gradlew :dokka-integration-tests:gradle:testExternalProjectKotlinxCoroutines --stacktrace "-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=500m"
         env:
           DOKKA_TEST_OUTPUT_PATH: /home/runner/work/dokka/coroutines
       - name: Configure AWS credentials for S3 access
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -41,21 +40,20 @@ jobs:
     if: github.repository == 'Kotlin/dokka'
     steps:
       - name: Checkout dokka
-        uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 17
-          cache: 'maven'
-      - name: Document serialization
-        uses: gradle/gradle-build-action@v2
+      - uses: gradle/actions/setup-gradle@v3
         with:
           gradle-home-cache-cleanup: true
-          arguments: :dokka-integration-tests:gradle:testExternalProjectKotlinxSerialization --stacktrace "-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=500m"
+      - name: Document serialization
+        run: ./gradlew :dokka-integration-tests:gradle:testExternalProjectKotlinxSerialization --stacktrace "-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=500m"
         env:
           DOKKA_TEST_OUTPUT_PATH: /home/runner/work/dokka/serialization
       - name: Configure AWS credentials for S3 access
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -70,21 +68,21 @@ jobs:
     if: github.repository == 'Kotlin/dokka'
     steps:
       - name: Checkout dokka
-        uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 17
           cache: 'maven'
-      - name: Document biojava-core
-        uses: gradle/gradle-build-action@v2
+      - uses: gradle/actions/setup-gradle@v3
         with:
           gradle-home-cache-cleanup: true
-          arguments: :dokka-integration-tests:maven:integrationTest --tests org.jetbrains.dokka.it.maven.BiojavaIntegrationTest --stacktrace
+      - name: Document biojava-core
+        run: ./gradlew :dokka-integration-tests:maven:integrationTest --tests org.jetbrains.dokka.it.maven.BiojavaIntegrationTest --stacktrace
         env:
           DOKKA_TEST_OUTPUT_PATH: /home/runner/work/dokka/biojava
       - name: Configure AWS credentials for S3 access
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -15,7 +15,7 @@ jobs:
   inspection:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: 'Qodana Scan'

--- a/.github/workflows/tests-smoke.yml
+++ b/.github/workflows/tests-smoke.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: gradle/actions/setup-gradle@v3
         with:
           gradle-home-cache-cleanup: true
-      - run: ./gradlew clean
       - name: Run tests under Windows
         if: matrix.os == 'windows-latest'
         # Running tests with the Gradle daemon on windows agents leads to some very strange

--- a/.github/workflows/tests-smoke.yml
+++ b/.github/workflows/tests-smoke.yml
@@ -25,16 +25,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v3
         with:
           gradle-home-cache-cleanup: true
-      - name: Run tests under Windows
-        if: matrix.os == 'windows-latest'
-        # Running tests with the Gradle daemon on windows agents leads to some very strange
-        # JVM crashes for some reason. Most likely a problem of Gradle/GitHub/Windows server
+      - name: Run tests
         run: >
-          ./gradlew test --stacktrace --no-daemon --no-parallel 
-          "-Dorg.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=500m"
-          "-Porg.jetbrains.dokka.javaToolchain.testLauncher=${{ env.JAVA_TEST_VERSION }}"
-      - name: Run tests under Ubuntu
-        if: matrix.os != 'windows-latest'
-        run: >
-          ./gradlew test --stacktrace 
+          ./gradlew test --stacktrace --continue 
           "-Porg.jetbrains.dokka.javaToolchain.testLauncher=${{ env.JAVA_TEST_VERSION }}"

--- a/.github/workflows/tests-smoke.yml
+++ b/.github/workflows/tests-smoke.yml
@@ -17,16 +17,15 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 17
-          cache: 'maven'
-      - uses: gradle/gradle-build-action@v2
+      - uses: gradle/actions/setup-gradle@v3
         with:
           gradle-home-cache-cleanup: true
-          arguments: clean
+      - run: ./gradlew clean
       - name: Run tests under Windows
         if: matrix.os == 'windows-latest'
         # Running tests with the Gradle daemon on windows agents leads to some very strange

--- a/.github/workflows/tests-thorough.yml
+++ b/.github/workflows/tests-thorough.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: gradle/actions/setup-gradle@v3
         with:
           gradle-home-cache-cleanup: true
-      - run: ./gradlew clean
       - name: Run tests under Windows
         if: matrix.os == 'windows-latest'
         # Running tests with the Gradle daemon on windows agents leads to some very strange

--- a/.github/workflows/tests-thorough.yml
+++ b/.github/workflows/tests-thorough.yml
@@ -15,16 +15,15 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 17
-          cache: 'maven'
-      - uses: gradle/gradle-build-action@v2
+      - uses: gradle/actions/setup-gradle@v3
         with:
           gradle-home-cache-cleanup: true
-          arguments: clean
+      - run: ./gradlew clean
       - name: Run tests under Windows
         if: matrix.os == 'windows-latest'
         # Running tests with the Gradle daemon on windows agents leads to some very strange

--- a/.github/workflows/tests-thorough.yml
+++ b/.github/workflows/tests-thorough.yml
@@ -23,16 +23,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v3
         with:
           gradle-home-cache-cleanup: true
-      - name: Run tests under Windows
-        if: matrix.os == 'windows-latest'
-        # Running tests with the Gradle daemon on windows agents leads to some very strange
-        # JVM crashes for some reason. Most likely a problem of Gradle/GitHub/Windows server
-        run: >
-          ./gradlew test --stacktrace --no-daemon --no-parallel --continue 
-          "-Dorg.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=500m"
-          "-Porg.jetbrains.dokka.javaToolchain.testLauncher=${{ matrix.javaVersion }}"
-      - name: Run tests under Ubuntu/Macos
-        if: matrix.os != 'windows-latest'
+      - name: Run tests
         run: >
           ./gradlew test --stacktrace --continue
           "-Porg.jetbrains.dokka.javaToolchain.testLauncher=${{ matrix.javaVersion }}"


### PR DESCRIPTION
this will remove warnings like this and so future errors

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-java@v3, gradle/gradle-build-action@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.