### PR TITLE
Do not require signing artifacts when publishing locally

### DIFF
--- a/build-logic/src/main/kotlin/dokkabuild.publish-base.gradle.kts
+++ b/build-logic/src/main/kotlin/dokkabuild.publish-base.gradle.kts
@@ -75,7 +75,15 @@ signing {
         System.getenv("DOKKA_SIGN_KEY_PASSPHRASE")?.takeIf(String::isNotBlank),
     )
     sign(publishing.publications)
-    setRequired(provider { !project.version.toString().endsWith("-SNAPSHOT") })
+    setRequired(provider {
+        // no signing should be required for locally published artifacts,
+        // as they are used for manual testing and running integration tests only
+        val isPublishingLocally = gradle.taskGraph.allTasks.any {
+            it.name in listOf("publishToMavenLocal", "publishToDevMavenRepo")
+        }
+
+        !isPublishingLocally
+    })
 }
 
 // This is a hack for a Gradle 8 problem, see https://github.com/gradle/gradle/issues/26091

--- a/build-logic/src/main/kotlin/dokkabuild.publish-base.gradle.kts
+++ b/build-logic/src/main/kotlin/dokkabuild.publish-base.gradle.kts
@@ -75,15 +75,9 @@ signing {
         System.getenv("DOKKA_SIGN_KEY_PASSPHRASE")?.takeIf(String::isNotBlank),
     )
     sign(publishing.publications)
-    setRequired(provider {
-        // no signing should be required for locally published artifacts,
-        // as they are used for manual testing and running integration tests only
-        val isPublishingLocally = gradle.taskGraph.allTasks.any {
-            it.name in listOf("publishToMavenLocal", "publishToDevMavenRepo")
-        }
-
-        !isPublishingLocally
-    })
+    // no signing should be required for locally published artifacts,
+    // as they are used for manual testing and running integration tests only
+    setRequired(provider { gradle.taskGraph.allTasks.any { it is PublishToMavenRepository } })
 }
 
 // This is a hack for a Gradle 8 problem, see https://github.com/gradle/gradle/issues/26091


### PR DESCRIPTION
Currently, the requirement for signing is set as

```kotlin
setRequired(provider { !project.version.toString().endsWith("-SNAPSHOT") })
```

which works fine when it comes to day-to-day stuff, but I found it to be insufficient when preparing the 1.9.20 release.

In release branches, the `version` property doesn't have any suffixes, example here: https://github.com/Kotlin/dokka/blob/1.9.20/gradle.properties#L7

It is needed because there are cases when this version is also used for publishing of other things that are not related to artifacts, such as publishing [developer docs](https://github.com/Kotlin/dokka/blob/5d4dc7148adf6abc9b579eb2948cca6d5fb2c4e8/docs-developer/build.gradle.kts#L13) (updating the documentation in the release branch should lead to the docs being deployed under the release version).

If you remove the `-SNAPSHOT` suffix, however, and try to run integration tests, the build will fail due to missing keys as the integration tests publish Dokka's artifacts locally, which requires signing (as it's not a `-SNAPSHOT`). Given that commits are sometimes cherry-picked into the release branch, the integration tests must be runnable. 

Thus the proposed solution was born - do not require signing if the artifacts are being published locally (maven local, maven dev) as there's no real need for it. This makes integration tests work in release branches.

___

I don't remember if `project.version` is used someplace else aside from the `docs-developer` module, but if it isn't - the alternative would be to introduce a separate version property for publishing developer docs, but
1. it would require us to not forget to update it. Given that it's always 1 to 1 with the main Dokka version, I think the same version property should be used
2. it's sometimes helpful that the version inside release branches doesn't have the `-SNAPSHOT` suffix, it helps to differentiate between branches: `master` always has the `-SNAPSHOT` suffix, release branches never do.

So I'd vote to keep the current workflow with removing the `-SNAPSHOT` suffix in release branches, but this requires some changes when it comes to signing to make the integration tests runnable

I'm not insisting on the proposed approach per se, this was the best solution we found when fixing the 1.9.20 release branch - maybe there are other options / solutions that solve this problem?