### PR TITLE
Allow publishing to a pre-defined staging repository

### DIFF
--- a/build-logic/src/main/kotlin/dokkabuild.publish-base.gradle.kts
+++ b/build-logic/src/main/kotlin/dokkabuild.publish-base.gradle.kts
@@ -1,3 +1,5 @@
+import java.net.URI
+
 /*
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
@@ -13,7 +15,7 @@ publishing {
     repositories {
         maven {
             name = "mavenCentral"
-            url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+            url = mavenCentralRepositoryUri()
             credentials {
                 username = System.getenv("DOKKA_SONATYPE_USER")
                 password = System.getenv("DOKKA_SONATYPE_PASSWORD")
@@ -65,6 +67,22 @@ publishing {
                 url.convention("https://github.com/Kotlin/dokka")
             }
         }
+    }
+}
+
+/**
+ * Due to Gradle running publishing tasks in parallel, multiple staging repositories
+ * can be created within a couple of seconds with all artifact files scattered throughout them.
+ *
+ * While Gradle's parallelism can be disabled, the simplest and most reliable option is
+ * to just publish to a pre-defined staging repository.
+ */
+fun mavenCentralRepositoryUri(): URI {
+    val repositoryId: String? = System.getenv("DOKKA_MVN_CENTRAL_REPOSITORY_ID")
+    return if (repositoryId.isNullOrBlank()) {
+        URI("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+    } else {
+        URI("https://oss.sonatype.org/service/local/staging/deployByRepositoryId/$repositoryId")
     }
 }
 


### PR DESCRIPTION
Due to Gradle running publishing tasks in parallel, multiple staging repositories can be created within a couple of seconds with all artifact files scattered throughout them. Even though the publishing in done on the same build agent.

Interestingly enough, setting `-Dorg.gradle.parallel=false` didn't help, I believe it's due to us using included builds, but I'm not sure.

Setting `--max-workers=1` additionally did help, but significant time was spent to find and test this solution.

Given it's easy to forget to set these params (especially when adding new build steps in TC), I think it's much easier to just allow to publish to a predefined staging repo, which will be created before the publishing build is run (as a prerequisite).