### PR TITLE
[K2] fix DRI.callable.name of constructor to be just class name in nested classes

### DIFF
--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/DRIFactory.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/DRIFactory.kt
@@ -59,7 +59,7 @@ internal fun KtAnalysisSession.getDRIFromConstructor(symbol: KtConstructorSymbol
     (symbol.containingClassIdIfNonLocal
         ?: throw IllegalStateException("Can not get class Id due to it is local")).createDRI().copy(
         callable = Callable(
-            name = symbol.containingClassIdIfNonLocal?.relativeClassName?.asString() ?: "",
+            name = symbol.containingClassIdIfNonLocal?.shortClassName?.asString() ?: "",
             params = symbol.valueParameters.map { getTypeReferenceFrom(it.returnType) })
     )
 

--- a/dokka-subprojects/plugin-base/src/test/kotlin/basic/DRITest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/basic/DRITest.kt
@@ -348,4 +348,49 @@ class DRITest : BaseAbstractTest() {
             }
         }
     }
+
+    @Test
+    fun `nested classes constructor should have callable name equal to class name`() = testInline(
+        """
+        |/src/main/kotlin/Test.kt
+        |class Parent { class Nested { class DoubleNested } }
+    """.trimMargin(),
+        dokkaConfiguration {
+            sourceSets {
+                sourceSet {
+                    sourceRoots = listOf("src/")
+                }
+            }
+        }
+    ) {
+        documentablesMergingStage = { module ->
+            fun findConstructorDriOfClass(className: String) =
+                (module.dfs { it.name == className } as? DClass)?.constructors?.singleOrNull()?.dri
+
+            assertEquals(
+                findConstructorDriOfClass("Parent"),
+                DRI(
+                    packageName = "",
+                    classNames = "Parent",
+                    callable = Callable("Parent", null, emptyList())
+                )
+            )
+            assertEquals(
+                findConstructorDriOfClass("Nested"),
+                DRI(
+                    packageName = "",
+                    classNames = "Parent.Nested",
+                    callable = Callable("Nested", null, emptyList())
+                )
+            )
+            assertEquals(
+                findConstructorDriOfClass("DoubleNested"),
+                DRI(
+                    packageName = "",
+                    classNames = "Parent.Nested.DoubleNested",
+                    callable = Callable("DoubleNested", null, emptyList())
+                )
+            )
+        }
+    }
 }


### PR DESCRIPTION
fixes #3388