### PR TITLE
Remove a publishing-related config-cache disabler

### DIFF
--- a/build-logic/src/main/kotlin/dokkabuild.publish-base.gradle.kts
+++ b/build-logic/src/main/kotlin/dokkabuild.publish-base.gradle.kts
@@ -1,8 +1,8 @@
-import java.net.URI
-
 /*
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
+
+import java.net.URI
 
 plugins {
     id("dokkabuild.base")
@@ -105,11 +105,4 @@ signing {
 tasks.withType<AbstractPublishToMaven>().configureEach {
     val signingTasks = tasks.withType<Sign>()
     mustRunAfter(signingTasks)
-}
-
-tasks.withType<PublishToMavenRepository>().configureEach {
-    // Configuration Cache allows tasks to run in parallel. Maven repositories (especially Maven Central)
-    // can't cope with parallel uploads, and might drop or split publications.
-    // As a workaround, disable Configuration Cache whenever publishing to remote Maven repos.
-    notCompatibleWithConfigurationCache("Prevent parallel publishing tasks")
 }


### PR DESCRIPTION
(continuation from https://github.com/Kotlin/dokka/pull/3562#issuecomment-2049268041)

This PR drops the workaround for disabling configuration cache during publishing. There were proposals to replace it with `MavenPublishLimiter`, but it looks like it's not needed _for now_? We'll be publishing to Maven Central with `DOKKA_MVN_CENTRAL_REPOSITORY_ID`, and Gradle Plugin Portal and Space seem to handle parallelization well

___

I'm definitely missing some lazy verifications around publishing in Gradle :) It'd be nice to check that `DOKKA_MVN_CENTRAL_REPOSITORY_ID` is set and not blank when publishing to Maven Central, then we would be able to drop `https://oss.sonatype.org/service/local/staging/deploy/maven2/` completely. But since the configuration is resolved during build time, it doesn't seem like there's an easy way to do it? Not a huge deal at all, just something that I think would be nice to have to enforce the publishing rules