### PR TITLE
Update CLI Integration Tests to use JVM Test Suites

### DIFF
--- a/build-logic/src/main/kotlin/dokkabuild.test-cli-dependencies.gradle.kts
+++ b/build-logic/src/main/kotlin/dokkabuild.test-cli-dependencies.gradle.kts
@@ -1,6 +1,6 @@
- /*
- * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
- */
+/*
+* Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+*/
 import dokkabuild.utils.declarable
 import dokkabuild.utils.resolvable
 import org.gradle.api.attributes.Bundling.BUNDLING_ATTRIBUTE
@@ -33,10 +33,13 @@ val dokkaPluginsClasspath: Configuration by configurations.creating {
 }
 
 val dokkaPluginsClasspathResolver: Configuration by configurations.creating {
-    description = "Resolve Dokka CLI runtime dependencies required to run Dokka CLI, and its plugins."
+    description = "Resolve Dokka CLI runtime dependencies required to run Dokka CLI, and its plugins. " +
+            "Transitive dependencies are excluded, and so must be defined explicitly."
     resolvable()
     extendsFrom(dokkaPluginsClasspath)
     attributes {
         attribute(USAGE_ATTRIBUTE, objects.named(JAVA_RUNTIME))
     }
+    // we don't fetch transitive dependencies here to be able to control external dependencies explicitly
+    isTransitive = false
 }

--- a/build-logic/src/main/kotlin/dokkabuild.test-cli-dependencies.gradle.kts
+++ b/build-logic/src/main/kotlin/dokkabuild.test-cli-dependencies.gradle.kts
@@ -1,0 +1,42 @@
+ /*
+ * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+import dokkabuild.utils.declarable
+import dokkabuild.utils.resolvable
+import org.gradle.api.attributes.Bundling.BUNDLING_ATTRIBUTE
+import org.gradle.api.attributes.Bundling.SHADOWED
+import org.gradle.api.attributes.Usage.JAVA_RUNTIME
+import org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE
+
+
+val dokkaCli: Configuration by configurations.creating {
+    description = "Dependency on Dokka CLI JAR. Must only contain a single dependency."
+    declarable()
+}
+
+val dokkaCliResolver: Configuration by configurations.creating {
+    description = "Resolve the Dokka CLI JAR. Intransitive - must only contain a single JAR."
+    resolvable()
+    extendsFrom(dokkaCli)
+    attributes {
+        attribute(USAGE_ATTRIBUTE, objects.named(JAVA_RUNTIME))
+        attribute(BUNDLING_ATTRIBUTE, objects.named(SHADOWED))
+    }
+    // we should have single artifact here
+    isTransitive = false
+}
+
+
+val dokkaPluginsClasspath: Configuration by configurations.creating {
+    description = "Dokka CLI runtime dependencies required to run Dokka CLI, and its plugins."
+    declarable()
+}
+
+val dokkaPluginsClasspathResolver: Configuration by configurations.creating {
+    description = "Resolve Dokka CLI runtime dependencies required to run Dokka CLI, and its plugins."
+    resolvable()
+    extendsFrom(dokkaPluginsClasspath)
+    attributes {
+        attribute(USAGE_ATTRIBUTE, objects.named(JAVA_RUNTIME))
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,43 +11,35 @@ val gradlePluginIncludedBuilds = listOf("runner-gradle-plugin-classic")
 
 addDependencyOnSameTasksOfIncludedBuilds("assemble", "build", "clean", "check")
 
-registerParentGroupTasks(
-    "publishing", taskNames = listOf(
-        "publishAllPublicationsToMavenCentralRepository",
-        "publishAllPublicationsToProjectLocalRepository",
-        "publishAllPublicationsToSnapshotRepository",
-        "publishAllPublicationsToSpaceDevRepository",
-        "publishAllPublicationsToSpaceTestRepository",
-        "publishToMavenLocal"
-    )
-) {
+registerParentGroupTasks("publishing", taskNames = listOf(
+    "publishAllPublicationsToMavenCentralRepository",
+    "publishAllPublicationsToProjectLocalRepository",
+    "publishAllPublicationsToSnapshotRepository",
+    "publishAllPublicationsToSpaceDevRepository",
+    "publishAllPublicationsToSpaceTestRepository",
+    "publishToMavenLocal"
+)) {
     it.name in publishedIncludedBuilds
 }
 
-registerParentGroupTasks(
-    "gradle plugin", taskNames = listOf(
-        "publishPlugins",
-        "validatePlugins"
-    )
-) {
+registerParentGroupTasks("gradle plugin", taskNames = listOf(
+    "publishPlugins",
+    "validatePlugins"
+)) {
     it.name in gradlePluginIncludedBuilds
 }
 
-registerParentGroupTasks(
-    "bcv", taskNames = listOf(
-        "apiDump",
-        "apiCheck",
-        "apiBuild"
-    )
-) {
+registerParentGroupTasks("bcv", taskNames = listOf(
+    "apiDump",
+    "apiCheck",
+    "apiBuild"
+)) {
     it.name in publishedIncludedBuilds
 }
 
-registerParentGroupTasks(
-    "verification", taskNames = listOf(
-        "test"
-    )
-)
+registerParentGroupTasks("verification", taskNames = listOf(
+    "test"
+))
 
 tasks.register("integrationTest") {
     group = "verification"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,7 +90,3 @@ fun includedBuildTasks(taskName: String, filter: (IncludedBuild) -> Boolean = { 
         .filter { it.name != "build-logic" }
         .filter(filter)
         .mapNotNull { it.task(":$taskName") }
-
-tasks.check {
-    gradle.includedBuilds.forEach { dependsOn(it.task(":check")) }
-}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,35 +11,43 @@ val gradlePluginIncludedBuilds = listOf("runner-gradle-plugin-classic")
 
 addDependencyOnSameTasksOfIncludedBuilds("assemble", "build", "clean", "check")
 
-registerParentGroupTasks("publishing", taskNames = listOf(
-    "publishAllPublicationsToMavenCentralRepository",
-    "publishAllPublicationsToProjectLocalRepository",
-    "publishAllPublicationsToSnapshotRepository",
-    "publishAllPublicationsToSpaceDevRepository",
-    "publishAllPublicationsToSpaceTestRepository",
-    "publishToMavenLocal"
-)) {
+registerParentGroupTasks(
+    "publishing", taskNames = listOf(
+        "publishAllPublicationsToMavenCentralRepository",
+        "publishAllPublicationsToProjectLocalRepository",
+        "publishAllPublicationsToSnapshotRepository",
+        "publishAllPublicationsToSpaceDevRepository",
+        "publishAllPublicationsToSpaceTestRepository",
+        "publishToMavenLocal"
+    )
+) {
     it.name in publishedIncludedBuilds
 }
 
-registerParentGroupTasks("gradle plugin", taskNames = listOf(
-    "publishPlugins",
-    "validatePlugins"
-)) {
+registerParentGroupTasks(
+    "gradle plugin", taskNames = listOf(
+        "publishPlugins",
+        "validatePlugins"
+    )
+) {
     it.name in gradlePluginIncludedBuilds
 }
 
-registerParentGroupTasks("bcv", taskNames = listOf(
-    "apiDump",
-    "apiCheck",
-    "apiBuild"
-)) {
+registerParentGroupTasks(
+    "bcv", taskNames = listOf(
+        "apiDump",
+        "apiCheck",
+        "apiBuild"
+    )
+) {
     it.name in publishedIncludedBuilds
 }
 
-registerParentGroupTasks("verification", taskNames = listOf(
-    "test"
-))
+registerParentGroupTasks(
+    "verification", taskNames = listOf(
+        "test"
+    )
+)
 
 tasks.register("integrationTest") {
     group = "verification"
@@ -82,3 +90,7 @@ fun includedBuildTasks(taskName: String, filter: (IncludedBuild) -> Boolean = { 
         .filter { it.name != "build-logic" }
         .filter(filter)
         .mapNotNull { it.task(":$taskName") }
+
+tasks.check {
+    gradle.includedBuilds.forEach { dependsOn(it.task(":check")) }
+}

--- a/dokka-integration-tests/cli/build.gradle.kts
+++ b/dokka-integration-tests/cli/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
 
     dokkaCli("org.jetbrains.dokka:runner-cli")
 
+    //region required dependencies of plugin-base
     dokkaPluginsClasspath("org.jetbrains.dokka:plugin-base")
     dokkaPluginsClasspath(libs.kotlinx.html)
     dokkaPluginsClasspath(libs.freemarker)
@@ -35,6 +36,7 @@ dependencies {
             attribute(BUNDLING_ATTRIBUTE, project.objects.named(SHADOWED))
         }
     }
+    //endregion
 }
 
 /**

--- a/dokka-integration-tests/cli/build.gradle.kts
+++ b/dokka-integration-tests/cli/build.gradle.kts
@@ -1,79 +1,84 @@
 /*
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
+@file:Suppress("UnstableApiUsage")
 
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.gradle.api.attributes.Bundling.BUNDLING_ATTRIBUTE
+import org.gradle.api.attributes.Bundling.SHADOWED
 
 plugins {
-    id("dokkabuild.test-integration")
-    id("com.github.johnrengelman.shadow")
+    id("dokkabuild.kotlin-jvm")
+    id("dokkabuild.test-cli-dependencies")
+    `jvm-test-suite`
 }
 
 dependencies {
-    implementation(kotlin("test-junit5"))
-    implementation(libs.junit.jupiterApi)
-    implementation(projects.utilities)
-}
+    api(kotlin("test-junit5"))
+    api(libs.junit.jupiterApi)
+    api(projects.utilities)
 
-val cliPluginsClasspath: Configuration by configurations.creating {
-    description = "plugins/dependencies required to run CLI with base plugin"
-    attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage.JAVA_RUNTIME))
+    dokkaCli("org.jetbrains.dokka:runner-cli")
+
+    dokkaPluginsClasspath("org.jetbrains.dokka:plugin-base")
+    dokkaPluginsClasspath(libs.kotlinx.html)
+    dokkaPluginsClasspath(libs.freemarker)
+
+    val analysisDependency = dokkaBuild.integrationTestUseK2.map { useK2 ->
+        if (useK2) {
+            "org.jetbrains.dokka:analysis-kotlin-symbols"
+        } else {
+            "org.jetbrains.dokka:analysis-kotlin-descriptors"
+        }
     }
-
-    // we don't fetch transitive dependencies here to be able to control external dependencies explicitly
-    isTransitive = false
-}
-
-val cliClasspath: Configuration by configurations.creating {
-    description = "dependency on CLI JAR"
-    attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage.JAVA_RUNTIME))
-        attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling.SHADOWED))
-    }
-    // we should have single artifact here
-    isTransitive = false
-}
-
-dependencies {
-    cliClasspath("org.jetbrains.dokka:runner-cli")
-
-    cliPluginsClasspath("org.jetbrains.dokka:plugin-base")
-    // required dependencies of `plugin-base`
-    cliPluginsClasspath(libs.freemarker)
-    cliPluginsClasspath(libs.kotlinx.html)
-
-    val tryK2 = project.providers
-        .gradleProperty("org.jetbrains.dokka.experimental.tryK2")
-        .map(String::toBoolean)
-        .orNull ?: false
-
-    val analysisDependency = when {
-        tryK2 -> "org.jetbrains.dokka:analysis-kotlin-symbols"
-        else -> "org.jetbrains.dokka:analysis-kotlin-descriptors"
-    }
-
-    cliPluginsClasspath(analysisDependency) {
+    dokkaPluginsClasspath(analysisDependency) {
         attributes {
-            attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling.SHADOWED))
+            attribute(BUNDLING_ATTRIBUTE, project.objects.named(SHADOWED))
         }
     }
 }
 
-val cliPluginsShadowJar by tasks.registering(ShadowJar::class) {
-    archiveFileName.set("cli-plugins-${project.version}.jar")
-    configurations = listOf(cliPluginsClasspath)
+/**
+ * Provide files required for running Dokka CLI in a build cache friendly way.
+ */
+abstract class DokkaCliClasspathProvider : CommandLineArgumentProvider {
+    @get:Classpath
+    abstract val dokkaCli: RegularFileProperty
 
-    // service files are merged to make sure all Dokka plugins
-    // from the dependencies are loaded, and not just a single one.
-    mergeServiceFiles()
+    @get:Classpath
+    abstract val dokkaPluginsClasspath: ConfigurableFileCollection
+
+    override fun asArguments(): Iterable<String> = buildList {
+        add("-D" + "dokkaCliJarPath=" + dokkaCli.asFile.get().absolutePath)
+        add("-D" + "dokkaPluginsClasspath=" + dokkaPluginsClasspath.joinToString(";") { it.absolutePath })
+    }
 }
 
-tasks.integrationTest {
-    dependsOn(cliClasspath)
-    dependsOn(cliPluginsShadowJar)
 
-    inputs.dir(file("projects"))
-    environment("CLI_JAR_PATH", cliClasspath.singleFile)
-    environment("BASE_PLUGIN_JAR_PATH", cliPluginsShadowJar.get().archiveFile.get())
+testing {
+    suites {
+        withType<JvmTestSuite>().configureEach {
+            useJUnitJupiter()
+        }
+
+        register<JvmTestSuite>("integrationTest") {
+            dependencies {
+                implementation(project())
+            }
+
+            targets.configureEach {
+                testTask.configure {
+                    jvmArgumentProviders.add(
+                        objects.newInstance<DokkaCliClasspathProvider>().apply {
+                            dokkaCli = configurations.dokkaCliResolver.map { it.singleFile }
+                            dokkaPluginsClasspath.from(configurations.dokkaPluginsClasspathResolver)
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+tasks.check {
+    dependsOn(testing.suites)
 }

--- a/dokka-integration-tests/cli/src/integrationTest/kotlin/org/jetbrains/dokka/it/cli/CliIntegrationTest.kt
+++ b/dokka-integration-tests/cli/src/integrationTest/kotlin/org/jetbrains/dokka/it/cli/CliIntegrationTest.kt
@@ -1,13 +1,10 @@
 /*
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
-
 package org.jetbrains.dokka.it.cli
 
 import org.jetbrains.dokka.it.awaitProcessResult
 import java.io.File
-import java.io.PrintWriter
-import java.lang.IllegalStateException
 import kotlin.test.*
 
 class CliIntegrationTest : AbstractCliIntegrationTest() {
@@ -20,7 +17,11 @@ class CliIntegrationTest : AbstractCliIntegrationTest() {
 
     @Test
     fun runHelp() {
-        val process = ProcessBuilder("java", "-jar", cliJarFile.path, "-h")
+        val process = ProcessBuilder(
+            "java",
+            "-jar", dokkaCliJarPath,
+            "-h",
+        )
             .redirectErrorStream(true)
             .start()
 
@@ -34,9 +35,10 @@ class CliIntegrationTest : AbstractCliIntegrationTest() {
         val dokkaOutputDir = File(projectDir, "output")
         assertTrue(dokkaOutputDir.mkdirs())
         val process = ProcessBuilder(
-            "java", "-jar", cliJarFile.path,
+            "java",
+            "-jar", dokkaCliJarPath,
             "-outputDir", dokkaOutputDir.path,
-            "-pluginsClasspath", basePluginJarFile.path,
+            "-pluginsClasspath", dokkaPluginsClasspath,
             "-moduleName", "Basic Project",
             "-sourceSet",
             buildString {
@@ -48,6 +50,7 @@ class CliIntegrationTest : AbstractCliIntegrationTest() {
                 append(" -skipDeprecated")
             }
         )
+            .directory(projectDir)
             .redirectErrorStream(true)
             .start()
 
@@ -109,9 +112,10 @@ class CliIntegrationTest : AbstractCliIntegrationTest() {
         val dokkaOutputDir = File(projectDir, "output")
         assertTrue(dokkaOutputDir.mkdirs())
         val process = ProcessBuilder(
-            "java", "-jar", cliJarFile.path,
+            "java",
+            "-jar", dokkaCliJarPath,
             "-outputDir", dokkaOutputDir.path,
-            "-pluginsClasspath", basePluginJarFile.path,
+            "-pluginsClasspath", dokkaPluginsClasspath,
             "-moduleName", "Basic Project",
             "-failOnWarning",
             "-sourceSet",
@@ -137,9 +141,10 @@ class CliIntegrationTest : AbstractCliIntegrationTest() {
         val dokkaOutputDir = File(projectDir, "output")
         assertTrue(dokkaOutputDir.mkdirs())
         val process = ProcessBuilder(
-            "java", "-jar", cliJarFile.path,
+            "java",
+            "-jar", dokkaCliJarPath,
             "-outputDir", dokkaOutputDir.path,
-            "-pluginsClasspath", basePluginJarFile.path,
+            "-pluginsClasspath", dokkaPluginsClasspath,
             "-moduleName", "Basic Project",
             "-sourceSet",
             buildString {
@@ -167,10 +172,11 @@ class CliIntegrationTest : AbstractCliIntegrationTest() {
         val dokkaOutputDir = File(projectDir, "output")
         assertTrue(dokkaOutputDir.mkdirs())
         val process = ProcessBuilder(
-            "java", "-jar", cliJarFile.path,
+            "java",
+            "-jar", dokkaCliJarPath,
             "-outputDir", dokkaOutputDir.path,
             "-loggingLevel", "DEBUG",
-            "-pluginsClasspath", basePluginJarFile.path,
+            "-pluginsClasspath", dokkaPluginsClasspath,
             "-sourceSet",
             buildString {
                 append(" -src ${File(projectDir, "src").path}")
@@ -203,10 +209,11 @@ class CliIntegrationTest : AbstractCliIntegrationTest() {
         val dokkaOutputDir = File(projectDir, "output")
         assertTrue(dokkaOutputDir.mkdirs())
         val process = ProcessBuilder(
-            "java", "-jar", cliJarFile.path,
+            "java",
+            "-jar", dokkaCliJarPath,
             "-outputDir", dokkaOutputDir.path,
             "-loggingLevel", "WARN",
-            "-pluginsClasspath", basePluginJarFile.path,
+            "-pluginsClasspath", dokkaPluginsClasspath,
             "-sourceSet",
             buildString {
                 append(" -src ${File(projectDir, "src").path}")
@@ -225,9 +232,10 @@ class CliIntegrationTest : AbstractCliIntegrationTest() {
         val dokkaOutputDir = File(projectDir, "output")
         assertTrue(dokkaOutputDir.mkdirs())
         val process = ProcessBuilder(
-            "java", "-jar", cliJarFile.path,
+            "java",
+            "-jar", dokkaCliJarPath,
             "-outputDir", dokkaOutputDir.path,
-            "-pluginsClasspath", basePluginJarFile.path,
+            "-pluginsClasspath", dokkaPluginsClasspath,
             "-moduleName", "Basic Project",
             "-sourceSet",
             buildString {
@@ -266,20 +274,26 @@ class CliIntegrationTest : AbstractCliIntegrationTest() {
         )
     }
 
-
     @Test
     fun `should accept json as input configuration`() {
         val dokkaOutputDir = File(projectDir, "output")
         assertTrue(dokkaOutputDir.mkdirs())
-        val resourcePath = javaClass.getResource("/my-file.json")?.toURI() ?: throw IllegalStateException("No JSON found!")
-        val jsonPath = File(resourcePath).absolutePath
-        PrintWriter(jsonPath).run {
-            write(jsonBuilder(dokkaOutputDir.invariantSeparatorsPath, basePluginJarFile.invariantSeparatorsPath, File(projectDir, "src").invariantSeparatorsPath, reportUndocumented = true))
-            close()
-        }
+        val resourcePath =
+            javaClass.getResource("/my-file.json")?.toURI() ?: throw IllegalStateException("No JSON found!")
+        val jsonPath = File(resourcePath)
+        jsonPath.writeText(
+            jsonBuilder(
+                outputPath = dokkaOutputDir.invariantSeparatorsPath,
+                pluginsClasspath = dokkaPluginsClasspath,
+                projectPath = File(projectDir, "src").invariantSeparatorsPath,
+                reportUndocumented = true
+            )
+        )
 
         val process = ProcessBuilder(
-            "java", "-jar", cliJarFile.path, jsonPath
+            "java",
+            "-jar", dokkaCliJarPath,
+            jsonPath.absolutePath,
         ).redirectErrorStream(true).start()
 
         val result = process.awaitProcessResult()
@@ -304,29 +318,29 @@ class CliIntegrationTest : AbstractCliIntegrationTest() {
     }
 
     /**
-     * This test disables global `reportUndocumneted` property and set `reportUndocumented` via perPackageOptions to
+     * This test disables global `reportUndocumented` property and set `reportUndocumented` via `perPackageOptions` to
      * make sure that global settings apply to dokka context.
      */
     @Test
     fun `global settings should overwrite package options in configuration`() {
         val dokkaOutputDir = File(projectDir, "output")
         assertTrue(dokkaOutputDir.mkdirs())
-        val resourcePath = javaClass.getResource("/my-file.json")?.toURI() ?: throw IllegalStateException("No JSON found!")
-        val jsonPath = File(resourcePath).absolutePath
-        PrintWriter(jsonPath).run {
-            write(
-                jsonBuilder(
-                    outputPath = dokkaOutputDir.invariantSeparatorsPath,
-                    pluginsClasspath = basePluginJarFile.invariantSeparatorsPath,
-                    projectPath = File(projectDir, "src").invariantSeparatorsPath,
-                    globalSourceLinks = """
+        val resourcePath =
+            javaClass.getResource("/my-file.json")?.toURI() ?: throw IllegalStateException("No JSON found!")
+        val jsonPath = File(resourcePath)
+        jsonPath.writeText(
+            jsonBuilder(
+                outputPath = dokkaOutputDir.invariantSeparatorsPath,
+                pluginsClasspath = dokkaPluginsClasspath,
+                projectPath = File(projectDir, "src").invariantSeparatorsPath,
+                globalSourceLinks = """
                         {
                           "localDirectory": "/home/Vadim.Mishenev/dokka/examples/cli/src/main/kotlin",
                           "remoteUrl": "https://github.com/Kotlin/dokka/tree/master/examples/gradle/dokka-gradle-example/src/main/kotlin",
                           "remoteLineSuffix": "#L"
                         }
                     """.trimIndent(),
-                    globalExternalDocumentationLinks = """
+                globalExternalDocumentationLinks = """
                         {
                           "url": "https://docs.oracle.com/javase/8/docs/api/",
                           "packageListUrl": "https://docs.oracle.com/javase/8/docs/api/package-list"
@@ -336,7 +350,7 @@ class CliIntegrationTest : AbstractCliIntegrationTest() {
                           "packageListUrl": "https://kotlinlang.org/api/latest/jvm/stdlib/package-list"
                         }
                         """.trimIndent(),
-                    globalPerPackageOptions = """
+                globalPerPackageOptions = """
                         {
                           "matchingRegex": ".*",
                           "skipDeprecated": "true",
@@ -344,15 +358,17 @@ class CliIntegrationTest : AbstractCliIntegrationTest() {
                           "documentedVisibilities": ["PUBLIC", "PRIVATE", "PROTECTED", "INTERNAL", "PACKAGE"]
                         }
                     """.trimIndent(),
-                    reportUndocumented = false
-                ),
-            )
-            close()
-        }
+                reportUndocumented = false
+            ),
+        )
 
         val process = ProcessBuilder(
-            "java", "-jar", cliJarFile.path, jsonPath
-        ).redirectErrorStream(true).start()
+            "java",
+            "-jar", dokkaCliJarPath,
+            jsonPath.absolutePath,
+        )
+            .redirectErrorStream(true)
+            .start()
 
         val result = process.awaitProcessResult()
         assertEquals(0, result.exitCode, "Expected exitCode 0 (Success)")
@@ -376,7 +392,7 @@ class CliIntegrationTest : AbstractCliIntegrationTest() {
     }
 
     @Test
-    fun `relative paths in configuraiton should work`() {
+    fun `relative paths in configuration should work`() {
         val resourcePath =
             javaClass.getResource("/my-file.json")?.toURI() ?: throw IllegalStateException("No JSON found!")
         val jsonPath = File(resourcePath)
@@ -386,13 +402,15 @@ class CliIntegrationTest : AbstractCliIntegrationTest() {
         jsonPath.writeText(
             jsonBuilder(
                 outputPath = dokkaOutputDir.invariantSeparatorsPath,
-                pluginsClasspath = basePluginJarFile.absoluteFile.invariantSeparatorsPath,
+                pluginsClasspath = dokkaPluginsClasspath,
                 projectPath = "src", // relative path
             )
         )
 
         ProcessBuilder(
-            "java", "-jar", cliJarFile.absolutePath, jsonPath.absolutePath
+            "java",
+            "-jar", dokkaCliJarPath,
+            jsonPath.absolutePath
         ).directory(projectDir).redirectErrorStream(true).start().also { process ->
             val result = process.awaitProcessResult()
             assertEquals(0, result.exitCode, "Expected exitCode 0 (Success)")

--- a/dokka-integration-tests/cli/src/integrationTest/kotlin/org/jetbrains/dokka/it/cli/CliIntegrationTest.kt
+++ b/dokka-integration-tests/cli/src/integrationTest/kotlin/org/jetbrains/dokka/it/cli/CliIntegrationTest.kt
@@ -278,22 +278,21 @@ class CliIntegrationTest : AbstractCliIntegrationTest() {
     fun `should accept json as input configuration`() {
         val dokkaOutputDir = File(projectDir, "output")
         assertTrue(dokkaOutputDir.mkdirs())
-        val resourcePath =
-            javaClass.getResource("/my-file.json")?.toURI() ?: throw IllegalStateException("No JSON found!")
-        val jsonPath = File(resourcePath)
-        jsonPath.writeText(
-            jsonBuilder(
-                outputPath = dokkaOutputDir.invariantSeparatorsPath,
-                pluginsClasspath = dokkaPluginsClasspath,
-                projectPath = File(projectDir, "src").invariantSeparatorsPath,
-                reportUndocumented = true
+        val configJson = projectDir.resolve("dokka-config.json").apply {
+            writeText(
+                jsonBuilder(
+                    outputPath = dokkaOutputDir.invariantSeparatorsPath,
+                    pluginsClasspath = dokkaPluginsClasspath,
+                    projectPath = File(projectDir, "src").invariantSeparatorsPath,
+                    reportUndocumented = true
+                )
             )
-        )
+        }
 
         val process = ProcessBuilder(
             "java",
             "-jar", dokkaCliJarPath,
-            jsonPath.absolutePath,
+            configJson.absolutePath,
         ).redirectErrorStream(true).start()
 
         val result = process.awaitProcessResult()
@@ -325,47 +324,47 @@ class CliIntegrationTest : AbstractCliIntegrationTest() {
     fun `global settings should overwrite package options in configuration`() {
         val dokkaOutputDir = File(projectDir, "output")
         assertTrue(dokkaOutputDir.mkdirs())
-        val resourcePath =
-            javaClass.getResource("/my-file.json")?.toURI() ?: throw IllegalStateException("No JSON found!")
-        val jsonPath = File(resourcePath)
-        jsonPath.writeText(
-            jsonBuilder(
-                outputPath = dokkaOutputDir.invariantSeparatorsPath,
-                pluginsClasspath = dokkaPluginsClasspath,
-                projectPath = File(projectDir, "src").invariantSeparatorsPath,
-                globalSourceLinks = """
-                        {
-                          "localDirectory": "/home/Vadim.Mishenev/dokka/examples/cli/src/main/kotlin",
-                          "remoteUrl": "https://github.com/Kotlin/dokka/tree/master/examples/gradle/dokka-gradle-example/src/main/kotlin",
-                          "remoteLineSuffix": "#L"
-                        }
-                    """.trimIndent(),
-                globalExternalDocumentationLinks = """
-                        {
-                          "url": "https://docs.oracle.com/javase/8/docs/api/",
-                          "packageListUrl": "https://docs.oracle.com/javase/8/docs/api/package-list"
-                        },
-                        {
-                          "url": "https://kotlinlang.org/api/latest/jvm/stdlib/",
-                          "packageListUrl": "https://kotlinlang.org/api/latest/jvm/stdlib/package-list"
-                        }
+
+        val configJson = projectDir.resolve("dokka-config.json").apply {
+            writeText(
+                jsonBuilder(
+                    outputPath = dokkaOutputDir.invariantSeparatorsPath,
+                    pluginsClasspath = dokkaPluginsClasspath,
+                    projectPath = File(projectDir, "src").invariantSeparatorsPath,
+                    globalSourceLinks = """
+                            {
+                              "localDirectory": "/home/Vadim.Mishenev/dokka/examples/cli/src/main/kotlin",
+                              "remoteUrl": "https://github.com/Kotlin/dokka/tree/master/examples/gradle/dokka-gradle-example/src/main/kotlin",
+                              "remoteLineSuffix": "#L"
+                            }
                         """.trimIndent(),
-                globalPerPackageOptions = """
-                        {
-                          "matchingRegex": ".*",
-                          "skipDeprecated": "true",
-                          "reportUndocumented": "true", 
-                          "documentedVisibilities": ["PUBLIC", "PRIVATE", "PROTECTED", "INTERNAL", "PACKAGE"]
-                        }
-                    """.trimIndent(),
-                reportUndocumented = false
-            ),
-        )
+                    globalExternalDocumentationLinks = """
+                            {
+                              "url": "https://docs.oracle.com/javase/8/docs/api/",
+                              "packageListUrl": "https://docs.oracle.com/javase/8/docs/api/package-list"
+                            },
+                            {
+                              "url": "https://kotlinlang.org/api/latest/jvm/stdlib/",
+                              "packageListUrl": "https://kotlinlang.org/api/latest/jvm/stdlib/package-list"
+                            }
+                            """.trimIndent(),
+                    globalPerPackageOptions = """
+                            {
+                              "matchingRegex": ".*",
+                              "skipDeprecated": "true",
+                              "reportUndocumented": "true", 
+                              "documentedVisibilities": ["PUBLIC", "PRIVATE", "PROTECTED", "INTERNAL", "PACKAGE"]
+                            }
+                        """.trimIndent(),
+                    reportUndocumented = false
+                )
+            )
+        }
 
         val process = ProcessBuilder(
             "java",
             "-jar", dokkaCliJarPath,
-            jsonPath.absolutePath,
+            configJson.absolutePath,
         )
             .redirectErrorStream(true)
             .start()
@@ -393,24 +392,23 @@ class CliIntegrationTest : AbstractCliIntegrationTest() {
 
     @Test
     fun `relative paths in configuration should work`() {
-        val resourcePath =
-            javaClass.getResource("/my-file.json")?.toURI() ?: throw IllegalStateException("No JSON found!")
-        val jsonPath = File(resourcePath)
-
         val dokkaOutputDir = File(projectDir, "output-relative")
         assertTrue(dokkaOutputDir.mkdirs())
-        jsonPath.writeText(
-            jsonBuilder(
-                outputPath = dokkaOutputDir.invariantSeparatorsPath,
-                pluginsClasspath = dokkaPluginsClasspath,
-                projectPath = "src", // relative path
+
+        val configJson = projectDir.resolve("dokka-config.json").apply {
+            writeText(
+                jsonBuilder(
+                    outputPath = dokkaOutputDir.invariantSeparatorsPath,
+                    pluginsClasspath = dokkaPluginsClasspath,
+                    projectPath = "src", // relative path
+                )
             )
-        )
+        }
 
         ProcessBuilder(
             "java",
             "-jar", dokkaCliJarPath,
-            jsonPath.absolutePath
+            configJson.absolutePath
         ).directory(projectDir).redirectErrorStream(true).start().also { process ->
             val result = process.awaitProcessResult()
             assertEquals(0, result.exitCode, "Expected exitCode 0 (Success)")

--- a/dokka-integration-tests/cli/src/main/kotlin/org/jetbrains/dokka/it/cli/AbstractCliIntegrationTest.kt
+++ b/dokka-integration-tests/cli/src/main/kotlin/org/jetbrains/dokka/it/cli/AbstractCliIntegrationTest.kt
@@ -1,40 +1,15 @@
 /*
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
-
 package org.jetbrains.dokka.it.cli
 
 import org.jetbrains.dokka.it.AbstractIntegrationTest
-import java.io.File
-import kotlin.test.BeforeTest
-import kotlin.test.assertTrue
+import org.jetbrains.dokka.it.systemProperty
 
 public abstract class AbstractCliIntegrationTest : AbstractIntegrationTest() {
+    /** The Dokka CLI JAR. */
+    protected val dokkaCliJarPath: String by systemProperty()
 
-    protected val cliJarFile: File by lazy {
-        File(tempFolder, "dokka.jar")
-    }
-
-    protected val basePluginJarFile: File by lazy {
-        File(tempFolder, "base-plugin.jar")
-    }
-
-    @BeforeTest
-    public fun copyJarFiles() {
-        val cliJarPathEnvironmentKey = "CLI_JAR_PATH"
-        val cliJarFile = File(System.getenv(cliJarPathEnvironmentKey))
-        assertTrue(
-            cliJarFile.exists() && cliJarFile.isFile,
-            "Missing path to CLI jar System.getenv($cliJarPathEnvironmentKey)"
-        )
-        cliJarFile.copyTo(this.cliJarFile)
-
-        val basePluginPathEnvironmentKey = "BASE_PLUGIN_JAR_PATH"
-        val basePluginJarFile = File(System.getenv(basePluginPathEnvironmentKey))
-        assertTrue(
-            basePluginJarFile.exists() && basePluginJarFile.isFile,
-            "Missing path to base plugin jar System.getenv($basePluginPathEnvironmentKey)"
-        )
-        basePluginJarFile.copyTo(this.basePluginJarFile)
-    }
+    /** Classpath required for running the Dokka CLI, delimited by `;`. */
+    protected val dokkaPluginsClasspath: String by systemProperty()
 }

--- a/dokka-integration-tests/cli/src/main/kotlin/org/jetbrains/dokka/it/cli/jsonBuilder.kt
+++ b/dokka-integration-tests/cli/src/main/kotlin/org/jetbrains/dokka/it/cli/jsonBuilder.kt
@@ -4,21 +4,27 @@
 
 package org.jetbrains.dokka.it.cli
 
-fun jsonBuilder(
+import org.intellij.lang.annotations.Language
+
+@Language("JSON")
+public fun jsonBuilder(
     outputPath: String,
     pluginsClasspath: String,
     projectPath: String,
+    @Language("JSON", prefix = "[", suffix = "]")
     globalSourceLinks: String = "",
+    @Language("JSON", prefix = "[", suffix = "]")
     globalExternalDocumentationLinks: String = "",
+    @Language("JSON", prefix = "[", suffix = "]")
     globalPerPackageOptions: String = "",
-    reportUndocumented: Boolean = false
-
+    reportUndocumented: Boolean = false,
 ): String {
-   return """{
+    return """
+{
   "moduleName": "Dokka Example",
   "moduleVersion": null,
   "outputDir": "$outputPath",
-  "pluginsClasspath": ["$pluginsClasspath"],
+  "pluginsClasspath": [${pluginsClasspath.split(";").joinToString(",") { "\"$it\"" }}],
   "cacheRoot": null,
   "offlineMode": false,
   "sourceLinks": [$globalSourceLinks],

--- a/dokka-integration-tests/gradle/build.gradle.kts
+++ b/dokka-integration-tests/gradle/build.gradle.kts
@@ -271,7 +271,7 @@ val testAllExternalProjects by tasks.registering {
 
 val integrationTest by tasks.registering {
     description = "Lifecycle task for running integration tests"
-    // TODO - Refactor Maven and CLI integration tests to use Test Suites
+    // TODO KT-64200 - Refactor Maven and CLI integration tests to use Test Suites
     //      - Reimplement dokkabuild.test-integration.gradle.kts so that `integrationTest` is defined once there
     dependsOn(tasks.withType<Test>()) // all tests in this project are integration tests
 }

--- a/dokka-integration-tests/settings.gradle.kts
+++ b/dokka-integration-tests/settings.gradle.kts
@@ -42,7 +42,7 @@ dependencyResolutionManagement {
 includeBuild("../dokka-runners/runner-gradle-plugin-classic")
 includeBuild("../dokka-runners/runner-maven-plugin")
 includeBuild("../dokka-runners/runner-cli")
-includeBuild("../.") // depend on the the root project, so integration-tests can depend on the `dokka-subprojects/*` subprojects and their artifacts
+includeBuild("../.") // depend on the root project, so integration-tests can depend on projects in `dokka-subprojects/*`
 
 include(
     ":cli",

--- a/dokka-integration-tests/utilities/build.gradle.kts
+++ b/dokka-integration-tests/utilities/build.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
     // thus these dependencies are needed. Ideally, they should be removed.
     implementation(kotlin("test-junit5"))
 
-    implementation(libs.kotlinx.coroutines.core)
     implementation(libs.jsoup)
     implementation(libs.eclipse.jgit)
 }

--- a/dokka-integration-tests/utilities/src/main/kotlin/org/jetbrains/dokka/it/processUtils.kt
+++ b/dokka-integration-tests/utilities/src/main/kotlin/org/jetbrains/dokka/it/processUtils.kt
@@ -1,6 +1,7 @@
 /*
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
+
 package org.jetbrains.dokka.it
 
 import java.util.concurrent.TimeUnit
@@ -11,10 +12,11 @@ class ProcessResult(
 )
 
 fun Process.awaitProcessResult(): ProcessResult {
-    waitFor(60, TimeUnit.SECONDS)
+    val output = inputStream.bufferedReader().lineSequence()
+        .onEach { println(it) }
+        .joinToString("\n")
 
-    val output = inputStream.reader().readText()
-    println(output)
+    waitFor(60, TimeUnit.SECONDS)
 
     return ProcessResult(
         exitCode = exitValue(),

--- a/dokka-integration-tests/utilities/src/main/kotlin/org/jetbrains/dokka/it/systemProperties.kt
+++ b/dokka-integration-tests/utilities/src/main/kotlin/org/jetbrains/dokka/it/systemProperties.kt
@@ -11,6 +11,14 @@ import kotlin.properties.ReadOnlyProperty
  *
  * @see System.getProperty
  */
+fun systemProperty(): ReadOnlyProperty<Any?, String> =
+    systemProperty { it }
+
+/**
+ * Delegated accessor for a system property.
+ *
+ * @see System.getProperty
+ */
 fun <T> systemProperty(
     convert: (String) -> T
 ): ReadOnlyProperty<Any?, T> =

--- a/dokka-runners/runner-cli/src/test/kotlin/org/jetbrains/dokka/CliTest.kt
+++ b/dokka-runners/runner-cli/src/test/kotlin/org/jetbrains/dokka/CliTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-class CliIntegrationTest {
+class CliTest {
 
     @Test
     fun `should apply global settings to all source sets`() {

--- a/dokka-subprojects/plugin-base/build.gradle.kts
+++ b/dokka-subprojects/plugin-base/build.gradle.kts
@@ -55,11 +55,11 @@ dependencies {
     }
 }
 
-    // access the frontend files via the dependency on :plugins:base:frontend
-    val dokkaHtmlFrontendFiles: Provider<FileCollection> =
+// access the frontend files via the dependency on :plugins:base:frontend
+val dokkaHtmlFrontendFiles: Provider<FileCollection> =
     configurations.dokkaHtmlFrontendFiles.map { frontendFiles ->
-            frontendFiles.incoming.artifacts.artifactFiles
-        }
+        frontendFiles.incoming.artifacts.artifactFiles
+    }
 
 val prepareDokkaHtmlFrontendFiles by tasks.registering(Sync::class) {
     description = "copy Dokka Base frontend files into the resources directory"


### PR DESCRIPTION
Part of KT-64200

- Migrate the CLI integration tests away from the custom integration test convention (which is not build-cache compatible) to use JVM Test Suites.
- Remove shadowing, replace with passing in the JARs via system properties. (a custom CommandLineArgumentProvider is confusing and overly complicated, but it's required to satisfy Gradle input normalization, so that the build-cache can be re-used.)
- Simplify `processUtils.kt` - the coroutines logic isn't necessary since the entrypoint just used `runBlocking {}`.
- move `jsonBuilder.kt` test-util into `src/main`, since it's not a test
- Rename `CliIntegrationTest` to `CliTest` (it wasn't an integration test, and the name was confusing compared to the actual `CliIntegrationTest`)
- The JSON config tests a `.json` in the resources directory. I thought this was strange, so I changed it to use a new file created in the JUnit temporary directory.