### PR TITLE
[K1] Handle exception for recursive type aliases

### DIFF
--- a/dokka-subprojects/analysis-kotlin-descriptors-compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/translator/DefaultDescriptorToDocumentableTranslator.kt
+++ b/dokka-subprojects/analysis-kotlin-descriptors-compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/translator/DefaultDescriptorToDocumentableTranslator.kt
@@ -840,7 +840,9 @@ private class DokkaDescriptorVisitor(
     private suspend fun visitTypeAliasDescriptor(descriptor: TypeAliasDescriptor) =
         with(descriptor) {
             coroutineScope {
-                val defaultType = runCatching { defaultType }.getOrNull() // `defaultType` can throw an exception for a recursive typealias A = A
+                // `defaultType` can throw an exception for a recursive typealias A = A
+                // for more details see https://github.com/Kotlin/dokka/issues/3565
+                val defaultType = runCatching { defaultType }.getOrNull()
                 val generics = async { descriptor.declaredTypeParameters.parallelMap { it.toVariantTypeParameter() } }
                 val info = defaultType?.let {
                     buildAncestryInformation(it).copy(


### PR DESCRIPTION
Updated the `DefaultDescriptorToDocumentableTranslator` to avoid throwing an exception when encountering recursive type aliases. The changes ensure that the `defaultType` is safely accessed. Also, added a new test for this scenario to avoid regression in the future.