### PR TITLE
Allow overriding a Dokka version in integration tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,16 @@ However, if you need to run all integration tests locally, you can use the `inte
 If you need to run a specific test locally, you can run it from your IDE or by calling the corresponding Gradle
 task (for example, `:dokka-integration-tests:gradle:testExternalProjectKotlinxCoroutines`).
 
+It's possible to run integration tests with a custom Dokka version published to 
+[MavenCentral](https://central.sonatype.com),
+[dev](https://maven.pkg.jetbrains.space/kotlin/p/dokka/dev) or
+[test](https://maven.pkg.jetbrains.space/kotlin/p/dokka/test) 
+via `org.jetbrains.dokka.integration_test.dokkaVersionOverride` Gradle property:
+
+```bash
+./gradlew :dokka-integration-tests:gradle:testExternalProjectKotlinxCoroutines -Porg.jetbrains.dokka.integration_test.dokkaVersionOverride=2.0.0-dev-329
+```
+
 ## Infrastructure
 
 ### Java version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ It's possible to run integration tests with a custom Dokka version published to
 [MavenCentral](https://central.sonatype.com),
 [dev](https://maven.pkg.jetbrains.space/kotlin/p/dokka/dev),
 [test](https://maven.pkg.jetbrains.space/kotlin/p/dokka/test) or
-`mavenLocal` (in this case the version should contain `-local-` suffix, f.e `2.0.0-local-reproducing-bug`) 
+`mavenLocal` 
 via `org.jetbrains.dokka.integration_test.dokkaVersionOverride` Gradle property:
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,10 +105,11 @@ However, if you need to run all integration tests locally, you can use the `inte
 If you need to run a specific test locally, you can run it from your IDE or by calling the corresponding Gradle
 task (for example, `:dokka-integration-tests:gradle:testExternalProjectKotlinxCoroutines`).
 
-It's possible to run integration tests with a custom Dokka version published to 
+It's possible to run integration tests with a custom Dokka version published to
 [MavenCentral](https://central.sonatype.com),
-[dev](https://maven.pkg.jetbrains.space/kotlin/p/dokka/dev) or
-[test](https://maven.pkg.jetbrains.space/kotlin/p/dokka/test) 
+[dev](https://maven.pkg.jetbrains.space/kotlin/p/dokka/dev),
+[test](https://maven.pkg.jetbrains.space/kotlin/p/dokka/test) or
+`mavenLocal` (in this case the version should contain `-local-` suffix, f.e `2.0.0-local-reproducing-bug`) 
 via `org.jetbrains.dokka.integration_test.dokkaVersionOverride` Gradle property:
 
 ```bash

--- a/build-logic/src/main/kotlin/dokkabuild/DokkaBuildProperties.kt
+++ b/build-logic/src/main/kotlin/dokkabuild/DokkaBuildProperties.kt
@@ -81,6 +81,10 @@ abstract class DokkaBuildProperties @Inject constructor(
         dokkaProperty("integration_test.useK2", String::toBoolean)
             .orElse(false)
 
+    /** Allows running integration tests with a custom Dokka version */
+    val integrationTestDokkaVersionOverride: Provider<String> =
+        dokkaProperty("integration_test.dokkaVersionOverride") { it }
+
     val androidSdkDir: Provider<File> =
         providers
             // first try finding a local.properties file in any parent directory

--- a/dokka-integration-tests/gradle/build.gradle.kts
+++ b/dokka-integration-tests/gradle/build.gradle.kts
@@ -94,6 +94,9 @@ tasks.withType<Test>().configureEach {
     }
 
     // environment() isn't Provider API compatible yet https://github.com/gradle/gradle/issues/11534
+    dokkaBuild.integrationTestDokkaVersionOverride.orNull?.let { versionOverride ->
+        environment("DOKKA_VERSION_OVERRIDE", versionOverride)
+    }
     dokkaBuild.integrationTestExhaustive.orNull?.let { exhaustive ->
         environment("isExhaustive", exhaustive)
     }

--- a/dokka-integration-tests/gradle/build.gradle.kts
+++ b/dokka-integration-tests/gradle/build.gradle.kts
@@ -95,7 +95,7 @@ tasks.withType<Test>().configureEach {
 
     // environment() isn't Provider API compatible yet https://github.com/gradle/gradle/issues/11534
     fun environmentProvider(name: String, provider: Provider<out Any>) {
-        inputs.property(name, provider)
+        inputs.property(name, provider).optional(true)
         provider.orNull?.let { environment(name, it) }
     }
 

--- a/dokka-integration-tests/gradle/build.gradle.kts
+++ b/dokka-integration-tests/gradle/build.gradle.kts
@@ -94,15 +94,14 @@ tasks.withType<Test>().configureEach {
     }
 
     // environment() isn't Provider API compatible yet https://github.com/gradle/gradle/issues/11534
-    dokkaBuild.integrationTestDokkaVersionOverride.orNull?.let { versionOverride ->
-        environment("DOKKA_VERSION_OVERRIDE", versionOverride)
+    fun environmentProvider(name: String, provider: Provider<out Any>) {
+        inputs.property(name, provider)
+        provider.orNull?.let { environment(name, it) }
     }
-    dokkaBuild.integrationTestExhaustive.orNull?.let { exhaustive ->
-        environment("isExhaustive", exhaustive)
-    }
-    dokkaBuild.androidSdkDir.orNull?.let { androidSdkDir ->
-        environment("ANDROID_HOME", androidSdkDir.invariantSeparatorsPath)
-    }
+
+    environmentProvider("DOKKA_VERSION_OVERRIDE", dokkaBuild.integrationTestDokkaVersionOverride)
+    environmentProvider("isExhaustive", dokkaBuild.integrationTestExhaustive)
+    environmentProvider("ANDROID_HOME", dokkaBuild.androidSdkDir.map { it.invariantSeparatorsPath })
 
     testLogging {
         exceptionFormat = FULL

--- a/dokka-integration-tests/gradle/projects/coroutines/coroutines.diff
+++ b/dokka-integration-tests/gradle/projects/coroutines/coroutines.diff
@@ -6,7 +6,7 @@ index e7d405e12..db5dcec66 100644
      }
 
      repositories {
-+        /* %{PROJECT_LOCAL_MAVEN_DIR}% */
++        /* %{DOKKA_IT_MAVEN_REPO}% */
          mavenCentral()
          maven { url "https://plugins.gradle.org/m2/" }
          CommunityProjectsBuild.addDevRepositoryIfEnabled(delegate, project)
@@ -54,7 +54,7 @@ index e7d405e12..db5dcec66 100644
  // Configure repositories
  allprojects {
      repositories {
-+        /* %{PROJECT_LOCAL_MAVEN_DIR}% */
++        /* %{DOKKA_IT_MAVEN_REPO}% */
          /*
           * google should be first in the repository list because some of the play services
           * transitive dependencies was removed from jcenter, thus breaking gradle dependency resolution
@@ -80,7 +80,7 @@ index ae54ad0f6..00963f5b2 100644
  val kotlinDevUrl = project.rootProject.properties["kotlin_repo_url"] as? String
 
  repositories {
-+    /* %{PROJECT_LOCAL_MAVEN_DIR}% */
++    /* %{DOKKA_IT_MAVEN_REPO}% */
      mavenCentral()
      if (cacheRedirectorEnabled) {
          maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2")
@@ -120,7 +120,7 @@ index c2e859f65..9cc749a1f 100644
  pluginManagement {
      val build_snapshot_train: String? by settings
      repositories {
-+        /* %{PROJECT_LOCAL_MAVEN_DIR}% */
++        /* %{DOKKA_IT_MAVEN_REPO}% */
          val cacheRedirectorEnabled = System.getenv("CACHE_REDIRECTOR")?.toBoolean() == true
          if (cacheRedirectorEnabled) {
              println("Redirecting repositories for buildSrc buildscript")
@@ -177,7 +177,7 @@ index 151c087fd..e4433c24f 100644
 
      repositories {
 -        maven { url "https://maven.pkg.jetbrains.space/kotlin/p/dokka/dev/" }
-+        /* %{PROJECT_LOCAL_MAVEN_DIR}% */
++        /* %{DOKKA_IT_MAVEN_REPO}% */
 +        //maven { url "https://maven.pkg.jetbrains.space/kotlin/p/dokka/dev/" }
          gradlePluginPortal()
      }

--- a/dokka-integration-tests/gradle/projects/serialization/serialization.diff
+++ b/dokka-integration-tests/gradle/projects/serialization/serialization.diff
@@ -7,7 +7,7 @@ index 73b566ae..e2af43bd 100644
 
      repositories {
 -        maven { url 'https://maven.pkg.jetbrains.space/kotlin/p/dokka/dev' }
-+        /* %{PROJECT_LOCAL_MAVEN_DIR}% */
++        /* %{DOKKA_IT_MAVEN_REPO}% */
 +        //maven { url 'https://maven.pkg.jetbrains.space/kotlin/p/dokka/dev' }
          // kotlin-dev with space redirector
          maven { url "https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/dev" }
@@ -61,7 +61,7 @@ index 73b566ae..e2af43bd 100644
          // Snapshot-specific
          repositories {
 -            mavenLocal()
-+            /* %{PROJECT_LOCAL_MAVEN_DIR}% */
++            /* %{DOKKA_IT_MAVEN_REPO}% */
 +            //mavenLocal()
              maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
          }
@@ -70,7 +70,7 @@ index 73b566ae..e2af43bd 100644
      }
 
      repositories {
-+        /* %{PROJECT_LOCAL_MAVEN_DIR}% */
++        /* %{DOKKA_IT_MAVEN_REPO}% */
          mavenCentral()
 -        maven { url 'https://maven.pkg.jetbrains.space/kotlin/p/dokka/dev' }
 +        //maven { url 'https://maven.pkg.jetbrains.space/kotlin/p/dokka/dev' }
@@ -92,7 +92,7 @@ index c999bcd2..98afdae7 100644
  }
 
  repositories {
-+    /* %{PROJECT_LOCAL_MAVEN_DIR}% */
++    /* %{DOKKA_IT_MAVEN_REPO}% */
      mavenCentral()
 -    mavenLocal()
 +    //mavenLocal()
@@ -143,7 +143,7 @@ index dda68347..119c321a 100644
 
      repositories {
 -        mavenLocal()
-+        /* %{PROJECT_LOCAL_MAVEN_DIR}% */
++        /* %{DOKKA_IT_MAVEN_REPO}% */
 +        //mavenLocal()
          mavenCentral()
          maven { url "https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/dev" }
@@ -153,7 +153,7 @@ index dda68347..119c321a 100644
 
  repositories {
 -    mavenLocal()
-+    /* %{PROJECT_LOCAL_MAVEN_DIR}% */
++    /* %{DOKKA_IT_MAVEN_REPO}% */
 +    //mavenLocal()
      mavenCentral()
      maven { url "https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/dev" }
@@ -166,7 +166,7 @@ index f8cb2d87..beebf995 100644
      }
 
      repositories {
-+        /* %{PROJECT_LOCAL_MAVEN_DIR}% */
++        /* %{DOKKA_IT_MAVEN_REPO}% */
          mavenCentral()
          maven { url 'https://plugins.gradle.org/m2/' }
          maven { url "https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/dev" }

--- a/dokka-integration-tests/gradle/projects/template.settings.gradle.kts
+++ b/dokka-integration-tests/gradle/projects/template.settings.gradle.kts
@@ -36,7 +36,7 @@ pluginManagement {
         }
     }
     repositories {
-        /* %{PROJECT_LOCAL_MAVEN_DIR}% */
+        /* %{DOKKA_IT_MAVEN_REPO}% */
         mavenCentral()
         gradlePluginPortal()
         google()
@@ -47,7 +47,7 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
     repositories {
-        /* %{PROJECT_LOCAL_MAVEN_DIR}% */
+        /* %{DOKKA_IT_MAVEN_REPO}% */
         mavenCentral()
         google()
         maven("https://maven.pkg.jetbrains.space/public/p/kotlinx-html/maven") {

--- a/dokka-integration-tests/gradle/projects/ui-showcase/README.md
+++ b/dokka-integration-tests/gradle/projects/ui-showcase/README.md
@@ -18,7 +18,7 @@ Dokka should be published in one of the following repositories:
 [MavenCentral](https://central.sonatype.com),
 [dev](https://maven.pkg.jetbrains.space/kotlin/p/dokka/dev),
 [test](https://maven.pkg.jetbrains.space/kotlin/p/dokka/test) or
-`mavenLocal` (in this case the version should contain `-local-` suffix, f.e `2.0.0-local-reproducing-bug`)
+`mavenLocal`
 
 ```bash
 export DOKKA_TEST_OUTPUT_PATH="build/ui-showcase-result"

--- a/dokka-integration-tests/gradle/projects/ui-showcase/README.md
+++ b/dokka-integration-tests/gradle/projects/ui-showcase/README.md
@@ -16,8 +16,9 @@ export DOKKA_TEST_OUTPUT_PATH="build/ui-showcase-result"
 
 Dokka should be published in one of the following repositories:
 [MavenCentral](https://central.sonatype.com),
-[dev](https://maven.pkg.jetbrains.space/kotlin/p/dokka/dev) or
-[test](https://maven.pkg.jetbrains.space/kotlin/p/dokka/test)
+[dev](https://maven.pkg.jetbrains.space/kotlin/p/dokka/dev),
+[test](https://maven.pkg.jetbrains.space/kotlin/p/dokka/test) or
+`mavenLocal` (in this case the version should contain `-local-` suffix, f.e `2.0.0-local-reproducing-bug`)
 
 ```bash
 export DOKKA_TEST_OUTPUT_PATH="build/ui-showcase-result"

--- a/dokka-integration-tests/gradle/projects/ui-showcase/README.md
+++ b/dokka-integration-tests/gradle/projects/ui-showcase/README.md
@@ -5,9 +5,21 @@ This is a Dokka test project for UI e2e tests.
 The goal is to have as much variety of UI elements in one project as possible, so that during refactorings
 we can compare the outputs between different versions of Dokka and make sure we didn't break any corner cases.
 
-### Run from root of the project
+### Run from the root of the project
 
 ```bash
 export DOKKA_TEST_OUTPUT_PATH="build/ui-showcase-result"
 ./gradlew :dokka-integration-tests:gradle:testUiShowcaseProject
+```
+
+### Run with the published Dokka version
+
+Dokka should be published in one of the following repositories:
+[MavenCentral](https://central.sonatype.com),
+[dev](https://maven.pkg.jetbrains.space/kotlin/p/dokka/dev) or
+[test](https://maven.pkg.jetbrains.space/kotlin/p/dokka/test)
+
+```bash
+export DOKKA_TEST_OUTPUT_PATH="build/ui-showcase-result"
+./gradlew :dokka-integration-tests:gradle:testUiShowcaseProject -Porg.jetbrains.dokka.integration_test.dokkaVersionOverride=2.0.0-dev-329
 ```

--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleIntegrationTest.kt
@@ -129,30 +129,15 @@ abstract class AbstractGradleIntegrationTest : AbstractIntegrationTest() {
 
         private val mavenRepositories: String by lazy {
             val reposSpecs = if (dokkaVersionOverride != null) {
+                println("Dokka version overridden with $dokkaVersionOverride")
                 // if `DOKKA_VERSION_OVERRIDE` environment variable is provided,
                 //  we allow running tests on a custom Dokka version from specific repositories
-                when {
-                    // release version like `2.0.0`
-                    !dokkaVersion.contains("-") -> "mavenCentral()"
-                    // locally published version for testing some bug like `2.0.0-local-reproducing-bug`
-                    dokkaVersion.contains("-local-") -> "mavenLocal()"
-                    // dev version like `2.0.0-dev-329`
-                    dokkaVersion.contains("-dev-") -> "maven(\"https://maven.pkg.jetbrains.space/kotlin/p/dokka/dev\")"
-                    // test version like `2.0.0-test-49477c44dfc58e2702f4c145ff41190b39d117fb`
-                    dokkaVersion.contains("-test-") -> "maven(\"https://maven.pkg.jetbrains.space/kotlin/p/dokka/test\")"
-                    else -> error(
-                        """
-                        Provided Dokka version override is not supported: $dokkaVersion.
-                        Supported versions are:
-                        - release versions like '2.0.0'
-                        - dev versions like `2.0.0-dev-329`
-                        - test versions like `2.0.0-test-49477c44dfc58e2702f4c145ff41190b39d117fb`
-                        - locally published (to mavenLocal) versions with `-local-` suffix like `2.0.0-local-reproducing-bug`
-                        """.trimIndent()
-                    )
-                }.also { repository ->
-                    println("Dokka version overridden with ${dokkaVersionOverride}. Using $repository for resolving Dokka")
-                }
+                """
+                maven("https://maven.pkg.jetbrains.space/kotlin/p/dokka/test"),
+                maven("https://maven.pkg.jetbrains.space/kotlin/p/dokka/dev"),
+                mavenCentral(),
+                mavenLocal()
+                """.trimIndent()
             } else {
                 // otherwise - use locally published versions via `devMavenPublish`
                 devMavenRepositories.withIndex().joinToString(",\n") { (i, repoPath) ->

--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleIntegrationTest.kt
@@ -184,7 +184,7 @@ abstract class AbstractGradleIntegrationTest : AbstractIntegrationTest() {
 
         fun File.updateProjectLocalMavenDir() {
 
-            val dokkaMavenRepoMarker = "/* %{PROJECT_LOCAL_MAVEN_DIR}% */"
+            val dokkaMavenRepoMarker = "/* %{DOKKA_IT_MAVEN_REPO}% */"
 
             // Exclusive repository containing local Dokka artifacts.
             // Must be compatible with both Groovy and Kotlin DSL.


### PR DESCRIPTION
An addition for https://github.com/Kotlin/dokka/pull/3583.

For UI showcase project, after PR is merged, it will be possible to run it like this:
```bash
./gradlew :dokka-integration-tests:gradle:testUiShowcaseProject -Porg.jetbrains.dokka.integration_test.dokkaVersionOverride=2.0.0-dev-329
```

It's also possible to add `org.jetbrains.dokka.integration_test.dokkaVersionOverride=2.0.0-dev-329` to `dokka-integration-tests/gradle.properties` (but, it's less recommended, as it could be unnoticed and affect tests behaviour)

Note: PR is based on master and not `ui-test-project` branch, so `testUiShowcaseProject` will be not available.

Note regarding implementation:
* it's easier to allow overriding version for all integration tests and not just for single `ui-showcase` project. Additionally it could be useful for reproducing bugs with older versions if needed via just property;
* it's possible to use `project.version` to override `DOKKA_VERSION` and then do the logic based on it - but it will cause rebuilding of all artefacts (because of `devMavenPublish`). It's possible to overcome this, but I didn't want to change a lot of code;
* additionally using `DOKKA_VERSION` for detecting some override could cause some unknown issues;
* so I've decided that separate property and separate env variable will be more safe, clear and `additive` change for this specific use case.