### PR TITLE
Remove log4j coming from intellij dependencies

### DIFF
--- a/dokka-subprojects/analysis-java-psi/build.gradle.kts
+++ b/dokka-subprojects/analysis-java-psi/build.gradle.kts
@@ -10,14 +10,14 @@ dependencies {
     compileOnly(projects.dokkaSubprojects.dokkaCore)
     compileOnly(projects.dokkaSubprojects.analysisKotlinApi)
 
-    api(libs.intellij.java.psi.api)
+    // We exclude `log4j` as it's not used in our codebase,
+    // and we do override intellij logger with NOOP logger
+    // `log4j` dependency triggers errors by dependency vulnerability checkers
+    implementation(libs.intellij.java.psi.impl) {
+        exclude("org.jetbrains.intellij.deps", "log4j")
+    }
 
     implementation(projects.dokkaSubprojects.analysisMarkdownJb)
-
-    implementation(libs.intellij.java.psi.impl)
-    implementation(libs.intellij.platform.util.api)
-    implementation(libs.intellij.platform.util.rt)
-
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.jsoup)
 }

--- a/dokka-subprojects/analysis-kotlin-descriptors/build.gradle.kts
+++ b/dokka-subprojects/analysis-kotlin-descriptors/build.gradle.kts
@@ -13,11 +13,14 @@ plugins {
 overridePublicationArtifactId("analysis-kotlin-descriptors")
 
 dependencies {
-    // to override some interfaces (JvmAnnotationEnumFieldValue, JvmAnnotationConstantValue) from compiler since thet are empty there
+    // to override some interfaces (JvmAnnotationEnumFieldValue, JvmAnnotationConstantValue)
+    // from `kotlin-compiler`, since they are empty there
+    // this is a `hack` to include classes from `intellij-java-psi-api` in shadowJar
     // should be `api` since we already have it in :analysis-java-psi
-    api(libs.intellij.java.psi.api) {
-        isTransitive = false
-    }
+    // it's harder to do it in the same as with `fastutil`
+    // as several intellij dependencies share the same packages like `org.intellij.core`
+    api(libs.intellij.java.psi.api) { isTransitive = false }
+
     implementation(projects.dokkaSubprojects.analysisKotlinApi)
     implementation(projects.dokkaSubprojects.analysisKotlinDescriptorsCompiler)
     implementation(projects.dokkaSubprojects.analysisKotlinDescriptorsIde)

--- a/dokka-subprojects/analysis-kotlin-symbols/build.gradle.kts
+++ b/dokka-subprojects/analysis-kotlin-symbols/build.gradle.kts
@@ -15,40 +15,16 @@ overridePublicationArtifactId("analysis-kotlin-symbols")
 dependencies {
     compileOnly(projects.dokkaSubprojects.dokkaCore)
 
+    // this is a `hack` to include classes `intellij-java-psi-api` in shadowJar
+    // which are not present in `kotlin-compiler`
+    // should be `api` since we already have it in :analysis-java-psi
+    // it's harder to do it in the same as with `fastutil`
+    // as several intellij dependencies share the same packages like `org.intellij.core`
+    api(libs.intellij.java.psi.api) { isTransitive = false }
+
     implementation(projects.dokkaSubprojects.analysisKotlinApi)
     implementation(projects.dokkaSubprojects.analysisMarkdownJb)
     implementation(projects.dokkaSubprojects.analysisJavaPsi)
-
-
-    // ----------- IDE dependencies ----------------------------------------------------------------------------
-
-    listOf(
-        libs.intellij.platform.util.rt,
-        libs.intellij.platform.util.api,
-        libs.intellij.java.psi.api,
-        libs.intellij.java.psi.impl
-    ).forEach {
-        runtimeOnly(it) { isTransitive = false }
-    }
-
-    implementation(libs.intellij.java.psi.api) { isTransitive = false }
-
-
-    // TODO move to toml
-    listOf(
-        "com.jetbrains.intellij.platform:util-class-loader",
-        "com.jetbrains.intellij.platform:util-text-matching",
-        "com.jetbrains.intellij.platform:util-base",
-        "com.jetbrains.intellij.platform:util-xml-dom",
-        "com.jetbrains.intellij.platform:core-impl",
-        "com.jetbrains.intellij.platform:extensions",
-    ).forEach {
-        runtimeOnly("$it:213.7172.25") { isTransitive = false }
-    }
-
-    implementation("com.jetbrains.intellij.platform:core:213.7172.25") {
-        isTransitive = false
-    } // for Standalone prototype
 
     // ----------- Analysis dependencies ----------------------------------------------------------------------------
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -101,8 +101,6 @@ kotlin-symbol-light-classes = { module = "org.jetbrains.kotlin:symbol-light-clas
 #### Java analysis ####
 intellij-java-psi-api = { module = "com.jetbrains.intellij.java:java-psi", version.ref = "intellij-platform" }
 intellij-java-psi-impl = { module = "com.jetbrains.intellij.java:java-psi-impl", version.ref = "intellij-platform" }
-intellij-platform-util-api = { module = "com.jetbrains.intellij.platform:util", version.ref = "intellij-platform" }
-intellij-platform-util-rt = { module = "com.jetbrains.intellij.platform:util-rt", version.ref = "intellij-platform" }
 
 #### HTML ####
 jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }


### PR DESCRIPTION
Fixes #3508

Checked `shadowJar` contents before and after this change: the only difference is in the absence of `log4j` classes.
Note: we still include 2 classes from `log4j` - `Level` and `Priority` - they are coming from `kotlin-compiler` and don't trigger any dependency vulnerability checks.
We can drop those classes, and tests are working fine without them, but I've decided not to do this, as if they are used somehow in some situation, it will cause `No class found` exception.

Additionally, I've updated some comments and removed confusing dependencies which are not needed in `analysis-kotlin-symbols`, as they are coming from `analysis-java-psi` and `kotlin-compiler` anyway - no changes to those classes in final `shadowJar` have happened.
