### PR TITLE
fix: made code samples runnable (#3535)

### DIFF
--- a/dokka-subprojects/plugin-base/src/main/resources/dokka/scripts/platform-content-handler.js
+++ b/dokka-subprojects/plugin-base/src/main/resources/dokka/scripts/platform-content-handler.js
@@ -104,6 +104,11 @@ const initPlayground = (theme) => {
 // As an alternative we could extract this samples-specific script to new js file but then we would handle dark mode in 2 separate files which is not ideal
 const samplesAreEnabled = () => {
     try {
+        if (typeof KotlinPlayground === 'undefined') {
+            // KotlinPlayground is exported universally as a global variable or as a module
+            // Due to possible interaction with other js scripts KotlinPlayground may not be accessible directly from `window`, so we need an additional check
+            KotlinPlayground = exports.KotlinPlayground;
+        }
         KotlinPlayground
         return true
     } catch (e) {


### PR DESCRIPTION
fixes the problem with runnable code snippets detected in #3535 and described in https://github.com/Kotlin/dokka/pull/3553