### PR TITLE
Publish previews for the ui-showcase test project

### DIFF
--- a/.github/workflows/preview-publish-web-s3.yml
+++ b/.github/workflows/preview-publish-web-s3.yml
@@ -63,6 +63,34 @@ jobs:
       - name: Print link
         run: echo https://dokka-snapshots.s3.eu-central-1.amazonaws.com/${{ env.branch-name }}/serialization/${GITHUB_SHA::7}/index.html
 
+  ui-showcase:
+    runs-on: ubuntu-latest
+    if: github.repository == 'Kotlin/dokka'
+    steps:
+      - name: Checkout dokka
+        uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 17
+      - uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-home-cache-cleanup: true
+      - name: Generate ui-showcase documentation
+        run: ./gradlew :dokka-integration-tests:gradle:testUiShowcaseProject
+        env:
+          DOKKA_TEST_OUTPUT_PATH: /home/runner/work/dokka/ui-showcase
+      - name: Configure AWS credentials for S3 access
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-central-1
+      - name: Copy files to dokka's S3 bucket
+        run: ./dokka-integration-tests/aws_sync.sh s3://${{ env.bucket-name }} ui-showcase ../ui-showcase
+      - name: Print link
+        run: echo https://dokka-snapshots.s3.eu-central-1.amazonaws.com/${{ env.branch-name }}/ui-showcase/${GITHUB_SHA::7}/index.html
+
   biojava:
     runs-on: ubuntu-latest
     if: github.repository == 'Kotlin/dokka'


### PR DESCRIPTION
Adds a GitHub Actions workflow that publishes the preview of the docs generated for the `ui-showcase` project to S3, similarly to how it's done for coroutines and serialization