### PR TITLE
[K2] Replace workaround for `tailrec` modifier

### DIFF
--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/DefaultSymbolToDocumentableTranslator.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/DefaultSymbolToDocumentableTranslator.kt
@@ -941,7 +941,7 @@ internal class DokkaSymbolVisitor(
         ExtraModifiers.KotlinOnlyModifiers.Suspend.takeIf { isSuspend },
         ExtraModifiers.KotlinOnlyModifiers.Operator.takeIf { isOperator },
 //ExtraModifiers.JavaOnlyModifiers.Static.takeIf { isJvmStaticInObjectOrClassOrInterface() },
-        ExtraModifiers.KotlinOnlyModifiers.TailRec.takeIf { (psi as? KtNamedFunction)?.hasModifier(KtTokens.TAILREC_KEYWORD) == true },
+        ExtraModifiers.KotlinOnlyModifiers.TailRec.takeIf { isTailRec },
         ExtraModifiers.KotlinOnlyModifiers.External.takeIf { isExternal },
         ExtraModifiers.KotlinOnlyModifiers.Override.takeIf { isOverride }
     ).toSet().takeUnless { it.isEmpty() }


### PR DESCRIPTION
After https://youtrack.jetbrains.com/issue/KT-60483/Analysis-API-add-isTailrec-property-to-KtFunctionSymbol