### PR TITLE
Get information about expect/actual for properties in K2 via Analysis API and not via PSI

### DIFF
--- a/dokka-subprojects/analysis-kotlin-descriptors-compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/translator/DefaultDescriptorToDocumentableTranslator.kt
+++ b/dokka-subprojects/analysis-kotlin-descriptors-compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/translator/DefaultDescriptorToDocumentableTranslator.kt
@@ -740,8 +740,8 @@ private class DokkaDescriptorVisitor(
     ): DFunction {
         val dri = parent.copy(callable = Callable.from(descriptor))
         val isGetter = descriptor is PropertyGetterDescriptor
-        val isExpect = descriptor.isExpect
-        val isActual = descriptor.isActual
+        val isExpect = propertyDescriptor.isExpect
+        val isActual = propertyDescriptor.isActual
 
         suspend fun PropertyDescriptor.asParameter(parent: DRI) =
             DParameter(

--- a/dokka-subprojects/analysis-kotlin-descriptors-compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/translator/DefaultDescriptorToDocumentableTranslator.kt
+++ b/dokka-subprojects/analysis-kotlin-descriptors-compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/translator/DefaultDescriptorToDocumentableTranslator.kt
@@ -740,8 +740,6 @@ private class DokkaDescriptorVisitor(
     ): DFunction {
         val dri = parent.copy(callable = Callable.from(descriptor))
         val isGetter = descriptor is PropertyGetterDescriptor
-        val isExpect = propertyDescriptor.isExpect
-        val isActual = propertyDescriptor.isActual
 
         suspend fun PropertyDescriptor.asParameter(parent: DRI) =
             DParameter(
@@ -798,7 +796,7 @@ private class DokkaDescriptorVisitor(
                 type = descriptor.returnType!!.toBound(),
                 generics = generics.await(),
                 modifier = descriptor.modifier().toSourceSetDependent(),
-                expectPresentInSet = sourceSet.takeIf { isExpect },
+                expectPresentInSet = null,
                 receiver = descriptor.extensionReceiverParameter?.let {
                     visitReceiverParameterDescriptor(
                         it,
@@ -807,7 +805,7 @@ private class DokkaDescriptorVisitor(
                 },
                 sources = descriptor.createSources(),
                 sourceSets = setOf(sourceSet),
-                isExpectActual = (isExpect || isActual),
+                isExpectActual = false,
                 extra = PropertyContainer.withAll(
                     descriptor.additionalExtras().toSourceSetDependent().toAdditionalModifiers(),
                     descriptor.getAnnotations().toSourceSetDependent().toAnnotations(),

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/DefaultSymbolToDocumentableTranslator.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/DefaultSymbolToDocumentableTranslator.kt
@@ -476,14 +476,24 @@ internal class DokkaSymbolVisitor(
                 is KtKotlinPropertySymbol -> propertySymbol.isExpect to propertySymbol.isActual
                 is KtSyntheticJavaPropertySymbol -> false to false
             }
-            val generics = propertySymbol.typeParameters.mapIndexed { index, symbol ->
-                visitVariantTypeParameter(index, symbol, dri)
-            }
+            val generics =
+                propertySymbol.typeParameters.mapIndexed { index, symbol ->
+                    visitVariantTypeParameter(
+                        index,
+                        symbol,
+                        dri
+                    )
+                }
 
             return DProperty(
                 dri = dri,
                 name = propertySymbol.name.asString(),
-                receiver = propertySymbol.receiverParameter?.let { visitReceiverParameter(it, dri) },
+                receiver = propertySymbol.receiverParameter?.let {
+                    visitReceiverParameter(
+                        it,
+                        dri
+                    )
+                },
                 sources = propertySymbol.getSource(),
                 getter = propertySymbol.getter?.let { visitPropertyAccessor(it, propertySymbol, dri) },
                 setter = propertySymbol.setter?.let { visitPropertyAccessor(it, propertySymbol, dri) },
@@ -575,11 +585,6 @@ internal class DokkaSymbolVisitor(
         // for SyntheticJavaProperty
         val inheritedFrom = if(propertyAccessorSymbol.origin == KtSymbolOrigin.JAVA_SYNTHETIC_PROPERTY) dri.copy(callable = null) else null
 
-        val (isExpect, isActual) = when (propertySymbol) {
-            is KtKotlinPropertySymbol -> propertySymbol.isExpect to propertySymbol.isActual
-            is KtSyntheticJavaPropertySymbol -> false to false
-        }
-
         val generics = propertyAccessorSymbol.typeParameters.mapIndexed { index, symbol ->
             visitVariantTypeParameter(
                 index,
@@ -592,11 +597,16 @@ internal class DokkaSymbolVisitor(
             dri = dri,
             name = name,
             isConstructor = false,
-            receiver = propertyAccessorSymbol.receiverParameter?.let { visitReceiverParameter(it, dri) },
+            receiver = propertyAccessorSymbol.receiverParameter?.let {
+                visitReceiverParameter(
+                    it,
+                    dri
+                )
+            },
             parameters = propertyAccessorSymbol.valueParameters.mapIndexed { index, symbol ->
                 visitValueParameter(index, symbol, dri)
             },
-            expectPresentInSet = sourceSet.takeIf { isExpect },
+            expectPresentInSet = null,
             sources = propertyAccessorSymbol.getSource(),
             visibility = propertyAccessorSymbol.visibility.toDokkaVisibility().toSourceSetDependent(),
             generics = generics,
@@ -604,7 +614,7 @@ internal class DokkaSymbolVisitor(
             modifier = propertyAccessorSymbol.getDokkaModality().toSourceSetDependent(),
             type = toBoundFrom(propertyAccessorSymbol.returnType),
             sourceSets = setOf(sourceSet),
-            isExpectActual = (isExpect || isActual),
+            isExpectActual = false,
             extra = PropertyContainer.withAll(
                 propertyAccessorSymbol.additionalExtras()?.toSourceSetDependent()?.toAdditionalModifiers(),
                 inheritedFrom?.let { InheritedMember(it.toSourceSetDependent()) },

--- a/dokka-subprojects/plugin-base/src/test/kotlin/expectActuals/ExpectActualsTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/expectActuals/ExpectActualsTest.kt
@@ -69,9 +69,6 @@ class ExpectActualsTest : BaseAbstractTest() {
             val property = cls.properties.single { it.name == "property" }
             assertTrue(property.isExpectActual)
             assertEquals(commonSourceSetId, property.expectPresentInSet?.sourceSetID)
-            val getter = assertNotNull(property.getter)
-            assertTrue(getter.isExpectActual)
-            assertEquals(commonSourceSetId, getter.expectPresentInSet?.sourceSetID)
         }
     }
 


### PR DESCRIPTION
fixes #3360

After short investigation I found out that the issue is on our side - we had our own extension properties for `expect/actual` handling which were using just PSI information.
Accessors via Analysis API were added in https://youtrack.jetbrains.com/issue/KT-54846 (Fix in builds: 1.9.20-dev-7565).
There were no issues with functions, because `isExpect/isActual` were used there after update to Analysis API 1.9.20-* (because they were introduced as member properties and so they come before our extension properties during overload resolution). With properties the story is a bit different, because there is no `isExpect/isActual` for `KtPropertySymbol` which is used in our code, the exists only on `KtKotlinPropertySymbol`

So looks like upstream issue can be closed