### PR TITLE
[K2] Update Analysis API to 2.0.20-dev-4579 and replace the `Kt` prefix with `Ka`

### DIFF
--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/kdoc/ResolveKDocLink.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/kdoc/ResolveKDocLink.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiElement
 import org.jetbrains.dokka.analysis.kotlin.symbols.translators.getDRIFromSymbol
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.utilities.DokkaLogger
-import org.jetbrains.kotlin.analysis.api.KtAnalysisSession
+import org.jetbrains.kotlin.analysis.api.KaSession
 import org.jetbrains.kotlin.analysis.api.symbols.*
 import org.jetbrains.kotlin.idea.references.mainReference
 import org.jetbrains.kotlin.kdoc.psi.api.KDoc
@@ -35,7 +35,7 @@ internal inline fun DRI?.ifUnresolved(action: () -> Unit): DRI? = this ?: run {
  *
  * @return [DRI] or null if the [link] is unresolved
  */
-internal fun KtAnalysisSession.resolveKDocTextLinkToDRI(link: String, context: PsiElement? = null): DRI? {
+internal fun KaSession.resolveKDocTextLinkToDRI(link: String, context: PsiElement? = null): DRI? {
     val kDocLink = createKDocLink(link, context)
     return kDocLink?.let { resolveKDocLinkToDRI(it) }
 }
@@ -44,14 +44,14 @@ internal fun KtAnalysisSession.resolveKDocTextLinkToDRI(link: String, context: P
  * If the [link] is ambiguous, i.e. leads to more than one declaration,
  * it returns deterministically any declaration.
  *
- * @return [KtSymbol] or null if the [link] is unresolved
+ * @return [KaSymbol] or null if the [link] is unresolved
  */
-internal fun KtAnalysisSession.resolveKDocTextLinkToSymbol(link: String, context: PsiElement? = null): KtSymbol? {
+internal fun KaSession.resolveKDocTextLinkToSymbol(link: String, context: PsiElement? = null): KaSymbol? {
     val kDocLink = createKDocLink(link, context)
     return kDocLink?.let { resolveToSymbol(it) }
 }
 
-private fun KtAnalysisSession.createKDocLink(link: String, context: PsiElement? = null): KDocLink? {
+private fun KaSession.createKDocLink(link: String, context: PsiElement? = null): KDocLink? {
     val psiFactory = context?.let { KtPsiFactory.contextual(it) } ?: KtPsiFactory(this.useSiteModule.project)
     val kDoc = psiFactory.createComment(
         """
@@ -70,13 +70,13 @@ private fun KtAnalysisSession.createKDocLink(link: String, context: PsiElement? 
  *
  * @return [DRI] or null if the [link] is unresolved
  */
-internal fun KtAnalysisSession.resolveKDocLinkToDRI(link: KDocLink): DRI? {
+internal fun KaSession.resolveKDocLinkToDRI(link: KDocLink): DRI? {
     val linkedSymbol = resolveToSymbol(link)
     return if (linkedSymbol == null) null
     else getDRIFromSymbol(linkedSymbol)
 }
 
-private fun KtAnalysisSession.resolveToSymbol(kDocLink: KDocLink): KtSymbol? {
+private fun KaSession.resolveToSymbol(kDocLink: KDocLink): KaSymbol? {
     val lastNameSegment = kDocLink.children.filterIsInstance<KDocName>().lastOrNull()
     return lastNameSegment?.mainReference?.resolveToSymbols()?.sortedWith(linkCandidatesComparator)?.firstOrNull()
 }
@@ -86,12 +86,12 @@ private fun KtAnalysisSession.resolveToSymbol(kDocLink: KDocLink): KtSymbol? {
  *
  * TODO KT-64190
  */
-private var linkCandidatesComparator: Comparator<KtSymbol> = compareBy{
+private var linkCandidatesComparator: Comparator<KaSymbol> = compareBy{
     when(it) {
-        is KtClassifierSymbol -> 1
-        is KtPackageSymbol -> 2
-        is KtFunctionSymbol -> 3
-        is KtVariableSymbol-> 4
+        is KaClassifierSymbol -> 1
+        is KaPackageSymbol -> 2
+        is KaFunctionSymbol -> 3
+        is KaVariableSymbol-> 4
         else -> 5
     }
 }

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/kdoc/SyntheticKDocProvider.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/kdoc/SyntheticKDocProvider.kt
@@ -7,22 +7,22 @@ package org.jetbrains.dokka.analysis.kotlin.symbols.kdoc
 import org.jetbrains.dokka.analysis.kotlin.symbols.plugin.SymbolsAnalysisPlugin
 import org.jetbrains.dokka.analysis.markdown.jb.MarkdownParser
 import org.jetbrains.dokka.model.doc.DocumentationNode
-import org.jetbrains.kotlin.analysis.api.KtAnalysisSession
+import org.jetbrains.kotlin.analysis.api.KaSession
 import org.jetbrains.kotlin.analysis.api.symbols.*
-import org.jetbrains.kotlin.analysis.api.symbols.markers.KtPossibleMemberSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.markers.KaPossibleMemberSymbol
 import org.jetbrains.kotlin.builtins.StandardNames
 
 private const val ENUM_ENTRIES_TEMPLATE_PATH = "/dokka/docs/kdoc/EnumEntries.kt.template"
 private const val ENUM_VALUEOF_TEMPLATE_PATH = "/dokka/docs/kdoc/EnumValueOf.kt.template"
 private const val ENUM_VALUES_TEMPLATE_PATH = "/dokka/docs/kdoc/EnumValues.kt.template"
 
-internal fun KtAnalysisSession.hasGeneratedKDocDocumentation(symbol: KtSymbol): Boolean =
+internal fun KaSession.hasGeneratedKDocDocumentation(symbol: KaSymbol): Boolean =
     getDocumentationTemplatePath(symbol) != null
 
-private fun KtAnalysisSession.getDocumentationTemplatePath(symbol: KtSymbol): String? =
+private fun KaSession.getDocumentationTemplatePath(symbol: KaSymbol): String? =
     when (symbol) {
-        is KtPropertySymbol -> if (isEnumEntriesProperty(symbol)) ENUM_ENTRIES_TEMPLATE_PATH else null
-        is KtFunctionSymbol -> {
+        is KaPropertySymbol -> if (isEnumEntriesProperty(symbol)) ENUM_ENTRIES_TEMPLATE_PATH else null
+        is KaFunctionSymbol -> {
             when {
                 isEnumValuesMethod(symbol) -> ENUM_VALUES_TEMPLATE_PATH
                 isEnumValueOfMethod(symbol) -> ENUM_VALUEOF_TEMPLATE_PATH
@@ -33,25 +33,25 @@ private fun KtAnalysisSession.getDocumentationTemplatePath(symbol: KtSymbol): St
         else -> null
     }
 
-private fun KtAnalysisSession.isEnumSpecialMember(symbol: KtPossibleMemberSymbol): Boolean =
-    symbol.origin == KtSymbolOrigin.SOURCE_MEMBER_GENERATED
-            && (symbol.getContainingSymbol() as? KtClassOrObjectSymbol)?.classKind == KtClassKind.ENUM_CLASS
+private fun KaSession.isEnumSpecialMember(symbol: KaPossibleMemberSymbol): Boolean =
+    symbol.origin == KaSymbolOrigin.SOURCE_MEMBER_GENERATED
+            && (symbol.getContainingSymbol() as? KaClassOrObjectSymbol)?.classKind == KaClassKind.ENUM_CLASS
 
-private fun KtAnalysisSession.isEnumEntriesProperty(symbol: KtPropertySymbol): Boolean =
+private fun KaSession.isEnumEntriesProperty(symbol: KaPropertySymbol): Boolean =
     symbol.name == StandardNames.ENUM_ENTRIES && isEnumSpecialMember(symbol)
 
-private fun KtAnalysisSession.isEnumValuesMethod(symbol: KtFunctionSymbol): Boolean =
+private fun KaSession.isEnumValuesMethod(symbol: KaFunctionSymbol): Boolean =
     symbol.name == StandardNames.ENUM_VALUES && isEnumSpecialMember(symbol)
 
-private fun KtAnalysisSession.isEnumValueOfMethod(symbol: KtFunctionSymbol): Boolean =
+private fun KaSession.isEnumValueOfMethod(symbol: KaFunctionSymbol): Boolean =
     symbol.name == StandardNames.ENUM_VALUE_OF && isEnumSpecialMember(symbol)
 
-internal fun KtAnalysisSession.getGeneratedKDocDocumentationFrom(symbol: KtSymbol): DocumentationNode? {
+internal fun KaSession.getGeneratedKDocDocumentationFrom(symbol: KaSymbol): DocumentationNode? {
     val templatePath = getDocumentationTemplatePath(symbol) ?: return null
     return loadTemplate(templatePath)
 }
 
-private fun KtAnalysisSession.loadTemplate(filePath: String): DocumentationNode? {
+private fun KaSession.loadTemplate(filePath: String): DocumentationNode? {
     val kdoc = loadContent(filePath) ?: return null
     val externalDriProvider = { link: String ->
         resolveKDocTextLinkToDRI(link)

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/services/SymbolFullClassHierarchyBuilder.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/services/SymbolFullClassHierarchyBuilder.kt
@@ -11,7 +11,7 @@ import org.jetbrains.dokka.analysis.java.util.from
 import org.jetbrains.dokka.analysis.kotlin.symbols.translators.getDRIFromClassLike
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.model.*
-import org.jetbrains.kotlin.analysis.api.KtAnalysisSession
+import org.jetbrains.kotlin.analysis.api.KaSession
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.types.KtType
 import org.jetbrains.dokka.analysis.kotlin.internal.ClassHierarchy
@@ -36,7 +36,7 @@ internal class SymbolFullClassHierarchyBuilder(context: DokkaContext) : FullClas
         return map
     }
 
-    private fun KtAnalysisSession.collectSupertypesFromKtType(
+    private fun KaSession.collectSupertypesFromKtType(
         driWithKType: Pair<DRI, KtType>,
         supersMap: MutableMap<DRI, Supertypes>
     ) {
@@ -125,7 +125,7 @@ internal class SymbolFullClassHierarchyBuilder(context: DokkaContext) : FullClas
         return hierarchy
     }
 
-    private fun KtAnalysisSession.collectSupertypesWithKindFromKtType(
+    private fun KaSession.collectSupertypesWithKindFromKtType(
         typeTranslator: TypeTranslator,
         typeConstructorWithKindWithKType: Pair<TypeConstructorWithKind, KtType>,
         supersMap: MutableMap<DRI, SuperclassesWithKind>

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/services/SymbolSampleAnalysisEnvironment.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/services/SymbolSampleAnalysisEnvironment.kt
@@ -27,6 +27,7 @@ import org.jetbrains.dokka.plugability.query
 import org.jetbrains.dokka.plugability.querySingle
 import org.jetbrains.dokka.utilities.DokkaLogger
 import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolOrigin
 import org.jetbrains.kotlin.analysis.api.symbols.KtSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KtSymbolOrigin
 import org.jetbrains.kotlin.idea.KotlinLanguage
@@ -101,19 +102,20 @@ private class SymbolSampleAnalysisEnvironment(
     private inline fun <reified PSI : PsiElement> KtSymbol.kotlinAndJavaSourcePsiSafe(): PSI? {
         // TODO: support Java sources after KT-53669
         val sourcePsi = when (origin) {
-            KtSymbolOrigin.SOURCE -> this.psi
-            KtSymbolOrigin.JAVA -> this.psi
+            KaSymbolOrigin.SOURCE -> this.psi
+            KaSymbolOrigin.JAVA -> this.psi
 
-            KtSymbolOrigin.SOURCE_MEMBER_GENERATED -> null
-            KtSymbolOrigin.LIBRARY -> null
-            KtSymbolOrigin.SAM_CONSTRUCTOR -> null
-            KtSymbolOrigin.INTERSECTION_OVERRIDE -> null
-            KtSymbolOrigin.SUBSTITUTION_OVERRIDE -> null
-            KtSymbolOrigin.DELEGATED -> null
-            KtSymbolOrigin.JAVA_SYNTHETIC_PROPERTY -> null
-            KtSymbolOrigin.PROPERTY_BACKING_FIELD -> null
-            KtSymbolOrigin.PLUGIN -> null
-            KtSymbolOrigin.JS_DYNAMIC -> null
+            KaSymbolOrigin.SOURCE_MEMBER_GENERATED -> null
+            KaSymbolOrigin.LIBRARY -> null
+            KaSymbolOrigin.SAM_CONSTRUCTOR -> null
+            KaSymbolOrigin.INTERSECTION_OVERRIDE -> null
+            KaSymbolOrigin.SUBSTITUTION_OVERRIDE -> null
+            KaSymbolOrigin.DELEGATED -> null
+            KaSymbolOrigin.JAVA_SYNTHETIC_PROPERTY -> null
+            KaSymbolOrigin.PROPERTY_BACKING_FIELD -> null
+            KaSymbolOrigin.PLUGIN -> null
+            KaSymbolOrigin.JS_DYNAMIC -> null
+            KaSymbolOrigin.NATIVE_FORWARD_DECLARATION -> null
         }
 
         return sourcePsi as? PSI

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/TranslatorError.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/TranslatorError.kt
@@ -4,13 +4,13 @@
 
 package org.jetbrains.dokka.analysis.kotlin.symbols.translators
 
-import org.jetbrains.kotlin.analysis.api.KtAnalysisSession
-import org.jetbrains.kotlin.analysis.api.symbols.KtSymbol
-import org.jetbrains.kotlin.analysis.api.symbols.markers.KtNamedSymbol
+import org.jetbrains.kotlin.analysis.api.KaSession
+import org.jetbrains.kotlin.analysis.api.symbols.KaSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.markers.KaNamedSymbol
 
 internal class TranslatorError(message: String, cause: Throwable?) : IllegalStateException(message, cause)
 
-internal inline fun <R> KtAnalysisSession.withExceptionCatcher(symbol: KtSymbol, action: KtAnalysisSession.() -> R): R =
+internal inline fun <R> KaSession.withExceptionCatcher(symbol: KaSymbol, action: KaSession.() -> R): R =
     try {
         action()
     } catch (e: TranslatorError) {
@@ -27,7 +27,7 @@ internal inline fun <R> KtAnalysisSession.withExceptionCatcher(symbol: KtSymbol,
             "[$e]"
         }
         throw TranslatorError(
-            "Error in translating of symbol (${(symbol as? KtNamedSymbol)?.name}) $symbol in file: $file, $textRange",
+            "Error in translating of symbol (${(symbol as? KaNamedSymbol)?.name}) $symbol in file: $file, $textRange",
             e
         )
     }

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/TypeReferenceFactory.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/TypeReferenceFactory.kt
@@ -5,30 +5,30 @@
 package org.jetbrains.dokka.analysis.kotlin.symbols.translators
 
 import org.jetbrains.dokka.links.*
-import org.jetbrains.kotlin.analysis.api.KtAnalysisSession
-import org.jetbrains.kotlin.analysis.api.KtStarTypeProjection
-import org.jetbrains.kotlin.analysis.api.KtTypeArgumentWithVariance
-import org.jetbrains.kotlin.analysis.api.KtTypeProjection
+import org.jetbrains.kotlin.analysis.api.KaSession
+import org.jetbrains.kotlin.analysis.api.KaStarTypeProjection
+import org.jetbrains.kotlin.analysis.api.KaTypeArgumentWithVariance
+import org.jetbrains.kotlin.analysis.api.KaTypeProjection
 import org.jetbrains.kotlin.analysis.api.types.*
 
-internal fun KtAnalysisSession.getTypeReferenceFrom(type: KtType): TypeReference =
+internal fun KaSession.getTypeReferenceFrom(type: KaType): TypeReference =
     getTypeReferenceFromPossiblyRecursive(type, emptyList())
 
 
 // see `deep recursive typebound #1342` test
-private fun KtAnalysisSession.getTypeReferenceFromPossiblyRecursive(
-    type: KtType,
-    paramTrace: List<KtType>
+private fun KaSession.getTypeReferenceFromPossiblyRecursive(
+    type: KaType,
+    paramTrace: List<KaType>
 ): TypeReference {
-    if (type is KtTypeParameterType) {
-        // compare by symbol since, e.g. T? and T have the different KtType, but the same type parameter
-        paramTrace.indexOfFirst { it is KtTypeParameterType && type.symbol == it.symbol }
+    if (type is KaTypeParameterType) {
+        // compare by symbol since, e.g. T? and T have the different KaType, but the same type parameter
+        paramTrace.indexOfFirst { it is KaTypeParameterType && type.symbol == it.symbol }
             .takeIf { it >= 0 }
             ?.let { return RecursiveType(it) }
     }
 
     return when (type) {
-        is KtNonErrorClassType -> TypeConstructor(
+        is KaNonErrorClassType -> TypeConstructor(
             type.classId.asFqNameString(),
             type.ownTypeArguments.map {
                 getTypeReferenceFromTypeProjection(
@@ -38,7 +38,7 @@ private fun KtAnalysisSession.getTypeReferenceFromPossiblyRecursive(
             }
         )
 
-        is KtTypeParameterType -> {
+        is KaTypeParameterType -> {
             val upperBoundsOrNullableAny =
                 type.symbol.upperBounds.takeIf { it.isNotEmpty() } ?: listOf(this.builtinTypes.NULLABLE_ANY)
 
@@ -50,15 +50,15 @@ private fun KtAnalysisSession.getTypeReferenceFromPossiblyRecursive(
             })
         }
 
-        is KtClassErrorType -> TypeConstructor("$ERROR_CLASS_NAME $type", emptyList())
+        is KaClassErrorType -> TypeConstructor("$ERROR_CLASS_NAME $type", emptyList())
 
-        is KtDefinitelyNotNullType -> getTypeReferenceFromPossiblyRecursive(
+        is KaDefinitelyNotNullType -> getTypeReferenceFromPossiblyRecursive(
             type.original,
             paramTrace
         )
 
-        is KtDynamicType -> TypeConstructor("[dynamic]", emptyList())
-        is KtTypeErrorType -> TypeConstructor("$ERROR_CLASS_NAME $type", emptyList())
+        is KaDynamicType -> TypeConstructor("[dynamic]", emptyList())
+        is KaTypeErrorType -> TypeConstructor("$ERROR_CLASS_NAME $type", emptyList())
         // Non-denotable types, see https://kotlinlang.org/spec/type-system.html#type-kinds
 
         // By the definition [flexible types](https://kotlinlang.org/spec/type-system.html#flexible-types),
@@ -66,24 +66,24 @@ private fun KtAnalysisSession.getTypeReferenceFromPossiblyRecursive(
         // In Dokka K1, a lower bound is taken
         // For example, most Java types T in Kotlin are flexible (T..T?) or T!
         // see https://github.com/JetBrains/kotlin/blob/master/spec-docs/flexible-java-types.md (warn: it is not official spec)
-        is KtFlexibleType -> getTypeReferenceFromPossiblyRecursive(
+        is KaFlexibleType -> getTypeReferenceFromPossiblyRecursive(
             type.lowerBound,
             paramTrace
         )
-        is KtCapturedType -> throw NotImplementedError()
-        is KtIntegerLiteralType -> throw NotImplementedError()
-        is KtIntersectionType -> throw NotImplementedError()
+        is KaCapturedType -> throw NotImplementedError()
+        is KaIntegerLiteralType -> throw NotImplementedError()
+        is KaIntersectionType -> throw NotImplementedError()
     }.let {
         if (type.isMarkedNullable) Nullable(it) else it
     }
 
 }
 
-private fun KtAnalysisSession.getTypeReferenceFromTypeProjection(
-    typeProjection: KtTypeProjection,
-    paramTrace: List<KtType>
+private fun KaSession.getTypeReferenceFromTypeProjection(
+    typeProjection: KaTypeProjection,
+    paramTrace: List<KaType>
 ): TypeReference =
     when (typeProjection) {
-        is KtStarTypeProjection -> StarProjection
-        is KtTypeArgumentWithVariance -> getTypeReferenceFromPossiblyRecursive(typeProjection.type, paramTrace)
+        is KaStarTypeProjection -> StarProjection
+        is KaTypeArgumentWithVariance -> getTypeReferenceFromPossiblyRecursive(typeProjection.type, paramTrace)
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ kotlinx-bcv = "0.13.2"
 
 ## Analysis
 kotlin-compiler = "2.0.0"
-kotlin-compiler-k2 = "2.0.20-dev-3206"
+kotlin-compiler-k2 = "2.0.20-dev-4579"
 
 # MUST match the version of the intellij platform used in the kotlin compiler,
 # otherwise this will lead to different versions of psi API and implementations


### PR DESCRIPTION
More details are in [the breaking changes document](https://docs.google.com/document/d/1xy2Fwtns32SVWR8uUuh_cA92OcbLHHkz_cy8lJ8k0aU/edit#heading=h.utji327bt6bm). 

The change broke [our scheduled tests K2 ](https://teamcity.jetbrains.com/buildConfiguration/KotlinTools_Dokka_ScheduledDokkaTestsK2?mode=builds#all-projects)