### PR TITLE
Migrate to the latest AA (2.0.20-dev-5135) and IntelliJ Platform (233.13135.103)

### DIFF
--- a/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/parsers/DokkaPsiParser.kt
+++ b/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/parsers/DokkaPsiParser.kt
@@ -117,7 +117,7 @@ internal class DokkaPsiParser(
              */
             fun Array<PsiClassType>.getSuperTypesPsiClasses(): List<Pair<PsiClass, JavaClassKindTypes>> {
                 forEach { type ->
-                    (type as? PsiClassType)?.resolve()?.let {
+                    type.resolve()?.let {
                         val definedAt = DRI.from(it)
                         it.methods.forEach { method ->
                             val hash = method.hash
@@ -588,7 +588,7 @@ internal class DokkaPsiParser(
         type.isExtends -> Covariance(getBound(type.extendsBound))
         type.isSuper -> Contravariance(getBound(type.superBound))
         // If the type isn't explicitly bounded, it still has an implicit `extends Object` bound
-        type.extendsBound != PsiType.NULL -> Covariance(getBound(type.extendsBound))
+        type.extendsBound != PsiTypes.nullType() -> Covariance(getBound(type.extendsBound))
         else -> throw IllegalStateException("${type.presentableText} has incorrect bounds")
     }
 
@@ -782,12 +782,12 @@ internal class DokkaPsiParser(
     }
 
     private fun PsiLiteralExpression.toValue(): AnnotationParameterValue? = when (type) {
-        PsiType.INT -> (value as? Int)?.let { IntValue(it) }
-        PsiType.LONG -> (value as? Long)?.let { LongValue(it) }
-        PsiType.FLOAT -> (value as? Float)?.let { FloatValue(it) }
-        PsiType.DOUBLE -> (value as? Double)?.let { DoubleValue(it) }
-        PsiType.BOOLEAN -> (value as? Boolean)?.let { BooleanValue(it) }
-        PsiType.NULL -> NullValue
+        PsiTypes.intType() -> (value as? Int)?.let { IntValue(it) }
+        PsiTypes.longType() -> (value as? Long)?.let { LongValue(it) }
+        PsiTypes.floatType() -> (value as? Float)?.let { FloatValue(it) }
+        PsiTypes.doubleType() -> (value as? Double)?.let { DoubleValue(it) }
+        PsiTypes.booleanType() -> (value as? Boolean)?.let { BooleanValue(it) }
+        PsiTypes.nullType() -> NullValue
         else -> StringValue(text ?: "")
     }
 

--- a/dokka-subprojects/analysis-kotlin-descriptors-compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/AnalysisEnvironment.kt
+++ b/dokka-subprojects/analysis-kotlin-descriptors-compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/AnalysisEnvironment.kt
@@ -99,7 +99,7 @@ public class AnalysisEnvironment(
     private val configuration = CompilerConfiguration()
 
     init {
-        configuration.put(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, messageCollector)
+        configuration.put(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, messageCollector)
     }
 
     internal fun createCoreEnvironment(): KotlinCoreEnvironment {
@@ -319,7 +319,7 @@ public class AnalysisEnvironment(
                             )
                         }
                     } catch (e: Throwable) {
-                        configuration.getNotNull(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY)
+                        configuration.getNotNull(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY)
                             .report(CompilerMessageSeverity.WARNING, "Can not resolve KLIB. " + e.message)
                     }
                 }

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/kdoc/KDocProvider.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/kdoc/KDocProvider.kt
@@ -48,8 +48,8 @@ internal fun KaSession.getKDocDocumentationFrom(symbol: KaSymbol, logger: DokkaL
     val ktElement = symbol.psi
     val kdocLocation = ktElement?.containingFile?.name?.let {
         val name = when(symbol) {
-            is KaCallableSymbol -> symbol.callableIdIfNonLocal?.toString()
-            is KaClassOrObjectSymbol -> symbol.classIdIfNonLocal?.toString()
+            is KaCallableSymbol -> symbol.callableId?.toString()
+            is KaClassOrObjectSymbol -> symbol.classId?.toString()
             is KaNamedSymbol -> symbol.name.asString()
             else -> null
         }?.replace('/', '.') // replace to be compatible with K1

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/KotlinAnalysis.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/KotlinAnalysis.kt
@@ -11,8 +11,6 @@ import org.jetbrains.dokka.DokkaSourceSetID
 import org.jetbrains.dokka.Platform
 import org.jetbrains.dokka.utilities.DokkaLogger
 import org.jetbrains.kotlin.analysis.api.KtAnalysisApiInternals
-import org.jetbrains.kotlin.analysis.api.lifetime.KtLifetimeTokenProvider
-import org.jetbrains.kotlin.analysis.api.standalone.KtAlwaysAccessibleLifetimeTokenProvider
 import org.jetbrains.kotlin.analysis.api.standalone.buildStandaloneAnalysisAPISession
 import org.jetbrains.kotlin.analysis.project.structure.KtSourceModule
 import org.jetbrains.kotlin.analysis.project.structure.builder.KtModuleBuilder
@@ -72,8 +70,6 @@ internal fun createAnalysisSession(
         projectDisposable = projectDisposable,
         withPsiDeclarationFromBinaryModuleProvider = false
     ) {
-        registerProjectService(KtLifetimeTokenProvider::class.java, KtAlwaysAccessibleLifetimeTokenProvider())
-
         val sortedSourceSets = topologicalSortByDependantSourceSets(sourceSets, logger)
 
         val sourcesModuleBySourceSetId = mutableMapOf<DokkaSourceSetID, KtSourceModule>()

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/DefaultSymbolToDocumentableTranslator.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/DefaultSymbolToDocumentableTranslator.kt
@@ -419,8 +419,8 @@ internal class DokkaSymbolVisitor(
             .filterOutSyntheticJavaPropBackingField()
 
         fun List<KaFunctionSymbol>.filterOutSyntheticJavaPropAccessors() = filterNot { fn ->
-            if (fn.origin == KaSymbolOrigin.JAVA && fn.callableIdIfNonLocal != null)
-                syntheticJavaProperties.any { fn.callableIdIfNonLocal == it.javaGetterSymbol.callableIdIfNonLocal || fn.callableIdIfNonLocal == it.javaSetterSymbol?.callableIdIfNonLocal }
+            if (fn.origin == KaSymbolOrigin.JAVA && fn.callableId != null)
+                syntheticJavaProperties.any { fn.callableId == it.javaGetterSymbol.callableId || fn.callableId == it.javaSetterSymbol?.callableId }
             else false
         }
 
@@ -577,9 +577,9 @@ internal class DokkaSymbolVisitor(
         // it also covers @JvmName annotation
         val name = (if (isGetter) propertySymbol.javaGetterName else propertySymbol.javaSetterName)?.asString() ?: ""
 
-        // SyntheticJavaProperty has callableIdIfNonLocal, propertyAccessorSymbol.origin = JAVA_SYNTHETIC_PROPERTY
-        // For Kotlin properties callableIdIfNonLocal=null
-        val dri = if (propertyAccessorSymbol.callableIdIfNonLocal != null)
+        // SyntheticJavaProperty has callableId, propertyAccessorSymbol.origin = JAVA_SYNTHETIC_PROPERTY
+        // For Kotlin properties callableId=null
+        val dri = if (propertyAccessorSymbol.callableId != null)
             getDRIFromFunctionLike(propertyAccessorSymbol)
         else
             propertyDRI.copy(
@@ -629,7 +629,7 @@ internal class DokkaSymbolVisitor(
     private fun KaSession.visitConstructorSymbol(
         constructorSymbol: KaConstructorSymbol
     ): DFunction = withExceptionCatcher(constructorSymbol) {
-        val name = constructorSymbol.containingClassIdIfNonLocal?.shortClassName?.asString()
+        val name = constructorSymbol.containingClassId?.shortClassName?.asString()
             ?: throw IllegalStateException("Unknown containing class of constructor")
         val dri = createDRIWithOverridden(constructorSymbol).origin
         val isExpect = constructorSymbol.isExpect

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,14 +11,16 @@ kotlinx-serialization = "1.6.0"
 kotlinx-bcv = "0.13.2"
 
 ## Analysis
-kotlin-compiler = "2.0.0"
-kotlin-compiler-k2 = "2.0.20-dev-4579"
+# Version of compiler for analysis-descriptor is in sync with K2 because of updated intellij-platform in 2.0.20-dev-5055
+# can be changed to just 2.0.20 after release of Kotlin 2.0.20
+kotlin-compiler = "2.0.20-dev-5135"
+kotlin-compiler-k2 = "2.0.20-dev-5135"
 
 # MUST match the version of the intellij platform used in the kotlin compiler,
 # otherwise this will lead to different versions of psi API and implementations
 # on the classpath and will fail with hard to debug problems in runtime.
-# See: https://github.com/JetBrains/kotlin/blob/e6633d3d9214402fcf3585ae8c24213a4761cc8b/gradle/versions.properties#L1
-intellij-platform = "213.7172.53"
+# See: https://github.com/JetBrains/kotlin/blob/480b38f967493adf494b4e049cbe5ac1060d215f/gradle/versions.properties#L1
+intellij-platform = "233.13135.103"
 
 ## HTML
 jsoup = "1.16.1"


### PR DESCRIPTION
The latest AA built with the newer version of IntelliJ Platform so we need to update it. This transitively requires updating a kotlin-compiler version used for kotlin K1 analysis because we share java analysis between K1 and K2 kotlin analyses.