### PR TITLE
Kotlin 2.0.20-Beta1

### DIFF
--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/TestedVersions.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/TestedVersions.kt
@@ -14,7 +14,7 @@ open class AllSupportedTestedVersionsArgumentsProvider : TestedVersionsArguments
 
 object TestedVersions {
 
-    val LATEST = BuildVersions("8.7", "2.0.0")
+    val LATEST = BuildVersions("8.7", "2.0.20-Beta1")
 
     /**
      * All supported Gradle/Kotlin versions, including [LATEST]
@@ -41,7 +41,7 @@ object TestedVersions {
     val ANDROID =
         BuildVersions.permutations(
             gradleVersions = listOf("8.4"),
-            kotlinVersions = listOf("2.0.0"),
+            kotlinVersions = listOf("2.0.20-Beta1"),
             androidGradlePluginVersions = listOf("8.3.0")
         ) + BuildVersions.permutations(
             gradleVersions = listOf("7.4.2", *ifExhaustive("7.0")),
@@ -67,6 +67,7 @@ object TestedVersions {
         "1.9.10" to "18.2.0-pre.597",
         "1.9.23" to "18.2.0-pre.682",
         "2.0.0" to "18.2.0-pre.726",
+        "2.0.20-Beta1" to "18.3.1-pre.758",
     )
 }
 

--- a/dokka-integration-tests/maven/projects/it-maven/pom.xml
+++ b/dokka-integration-tests/maven/projects/it-maven/pom.xml
@@ -11,7 +11,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <kotlin.version>2.0.0</kotlin.version>
+        <kotlin.version>2.0.20-Beta1</kotlin.version>
     </properties>
     <build>
         <plugins>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 
-gradlePlugin-kotlin = "2.0.0"
+gradlePlugin-kotlin = "2.0.20-Beta1"
 # See: https://kotlinlang.org/docs/gradle-configure-project.html#apply-the-plugin
 gradlePlugin-android = "7.1.3"
 gradlePlugin-dokka = "1.9.20"


### PR DESCRIPTION
Note: `kotlin-compiler` version wasn't updated, as Beta1 doesn't contain IntelliJ platform update and so it should be updated when Beta2 will be released.