### PR TITLE
Fix publishing BioJava preview

### DIFF
--- a/.github/workflows/preview-publish-ga.yml
+++ b/.github/workflows/preview-publish-ga.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           gradle-home-cache-cleanup: true
       - name: Document biojava-core
-        run: ./gradlew :dokka-integration-tests:maven:integrationTest --tests org.jetbrains.dokka.it.maven.BiojavaIntegrationTest --stacktrace
+        run: ./gradlew :dokka-integration-tests:maven:testExternalProjectBioJava --stacktrace
         env:
           DOKKA_TEST_OUTPUT_PATH: /home/runner/work/dokka/biojava
       - name: Copy files to GitHub Actions Artifacts


### PR DESCRIPTION
Update the GitHub Action to use the new specific Gradle task for testing BioJava introduced in #3581.