### PR TITLE
Use both macos targets in ui-showcase

### DIFF
--- a/dokka-integration-tests/gradle/projects/ui-showcase/kmp/build.gradle.kts
+++ b/dokka-integration-tests/gradle/projects/ui-showcase/kmp/build.gradle.kts
@@ -12,7 +12,11 @@ kotlin {
     jvm()
     linuxX64()
     macosX64()
+
+    // adding linuxArm64 and macosArm64 is a workaround for https://github.com/Kotlin/dokka/issues/3386
+    linuxArm64()
     macosArm64()
+
     js {
         nodejs()
     }

--- a/dokka-integration-tests/gradle/projects/ui-showcase/kmp/build.gradle.kts
+++ b/dokka-integration-tests/gradle/projects/ui-showcase/kmp/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
     jvm()
     linuxX64()
     macosX64()
+    macosArm64()
     js {
         nodejs()
     }

--- a/dokka-integration-tests/gradle/projects/ui-showcase/kmp/src/macosMain/kotlin/org/jetbrains/dokka/uitest/kmp/CInterop.kt
+++ b/dokka-integration-tests/gradle/projects/ui-showcase/kmp/src/macosMain/kotlin/org/jetbrains/dokka/uitest/kmp/CInterop.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+@file:Suppress("unused")
+
+package org.jetbrains.dokka.uitest.kmp
+
+import kotlinx.cinterop.CPointed
+import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.ExperimentalForeignApi
+
+/**
+ * Low-level MacOS function
+ */
+@OptIn(ExperimentalForeignApi::class)
+fun <T : CPointed> printPointerRawValue(pointer: CPointer<T>) {
+    println(pointer.rawValue)
+}

--- a/dokka-integration-tests/gradle/src/testUiShowcaseProject/kotlin/UiShowcaseIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/testUiShowcaseProject/kotlin/UiShowcaseIntegrationTest.kt
@@ -16,7 +16,6 @@ import kotlin.test.assertTrue
 class UiShowcaseIntegrationTest : AbstractGradleIntegrationTest(), TestOutputCopier {
     override val projectOutputLocation: File by lazy { File(projectDir, "build/dokka/htmlMultiModule") }
 
-    @OnlyDescriptors("CPointer is not resolved in K2")
     @ParameterizedTest(name = "{0}")
     @ArgumentsSource(LatestTestedVersionsArgumentsProvider::class)
     fun execute(buildVersions: BuildVersions) {


### PR DESCRIPTION
TL;DR;
This is needed because of the issue with rendering expect/actual. I would propose for now to just add `macosArm64` target and resolve underlying issue during implementation of https://github.com/Kotlin/dokka/issues/3386 for Dokka K2. We will anyway need to do something with such sourceSets.

In https://github.com/Kotlin/dokka/pull/3662 test started to fail on `ui-showcase` module because of `ERROR CLASS`.
Checking the page where the fail happened, I found that for some reason `ui-showcase` currently (on `master`) doesn't contain an actual declaration for `macos` sourceSet:
<img width="692" alt="image" src="https://github.com/Kotlin/dokka/assets/50462752/c34c3b73-ef03-4c08-b93a-bc73adc45403">
`asyncWithDelay` doesn't have `macos` tab, but `actual` declaration exists in sourceSet.

If we run the same test with the changes from https://github.com/Kotlin/dokka/pull/3662, `macos` tab is now appeared but shows `ERROR CLASS`:
<img width="827" alt="image" src="https://github.com/Kotlin/dokka/assets/50462752/38f956ee-e24d-4d1c-a4a1-86d57b1be466">
All other declarations of `asyncWithDelay` for other sourceSets look the same as before.

Also, other declarations (which don't depend on `coroutines`) like `getCurrentDate` which also has `expect/actual` defined in the same - work fine on `master` and `macos` tab exist:
<img width="665" alt="image" src="https://github.com/Kotlin/dokka/assets/50462752/a72f884c-6369-4b47-bd99-2afa61055ed5">

Most probably the issue is very similar to https://github.com/Kotlin/dokka/issues/3386 (even though problem described here reproducible on K1).

If we build `ui-showcase` with Dokka K2:
* on `master` - `linux` and `macos` are not shown at all for `asyncWithDelay`.
* with https://github.com/Kotlin/dokka/pull/3662 - all source sets are shown but both `linux` and `macos` will show `ERROR CLASS`
* if we add `macosArm64` target (as in this PR) - `macos` source set will be shown.


