### PR TITLE
[sample project] Added missing pluginApiPreviewAcknowledgement() override

### DIFF
--- a/examples/plugin/hide-internal-api/src/main/kotlin/org/example/dokka/plugin/HideInternalApiPlugin.kt
+++ b/examples/plugin/hide-internal-api/src/main/kotlin/org/example/dokka/plugin/HideInternalApiPlugin.kt
@@ -7,11 +7,16 @@ import org.jetbrains.dokka.model.Documentable
 import org.jetbrains.dokka.model.properties.WithExtraProperties
 import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.plugability.DokkaPlugin
+import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
+import org.jetbrains.dokka.plugability.PluginApiPreviewAcknowledgement
 
 class HideInternalApiPlugin : DokkaPlugin() {
     val myFilterExtension by extending {
         plugin<DokkaBase>().preMergeDocumentableTransformer providing ::HideInternalApiTransformer
     }
+
+    @OptIn(DokkaPluginApiPreview::class)
+    override fun pluginApiPreviewAcknowledgement() = PluginApiPreviewAcknowledgement
 }
 
 class HideInternalApiTransformer(context: DokkaContext) : SuppressedByConditionDocumentableFilterTransformer(context) {

--- a/examples/plugin/hide-internal-api/src/main/kotlin/org/example/dokka/plugin/HideInternalApiPlugin.kt
+++ b/examples/plugin/hide-internal-api/src/main/kotlin/org/example/dokka/plugin/HideInternalApiPlugin.kt
@@ -15,7 +15,7 @@ class HideInternalApiPlugin : DokkaPlugin() {
         plugin<DokkaBase>().preMergeDocumentableTransformer providing ::HideInternalApiTransformer
     }
 
-    @OptIn(DokkaPluginApiPreview::class)
+    @DokkaPluginApiPreview
     override fun pluginApiPreviewAcknowledgement() = PluginApiPreviewAcknowledgement
 }
 


### PR DESCRIPTION
Add the missing abstract function implementations for a successful build of the "hide-internal-api" sample project.

However, I noticed that the entire sample project is disabled in the IDE (by not including it in settings.gradle)

If you decide not to maintain the sample project anymore, you can just close this PR.