### PR TITLE
Fix links in nested class summary not resolved correctly

### DIFF
--- a/dokka-subprojects/plugin-javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/renderer/JavadocContentToTemplateMapTranslator.kt
+++ b/dokka-subprojects/plugin-javadoc/src/main/kotlin/org/jetbrains/dokka/javadoc/renderer/JavadocContentToTemplateMapTranslator.kt
@@ -139,7 +139,7 @@ internal class JavadocContentToTemplateMapTranslator(
                 "constructors" to node.constructors.map { templateMapForFunctionNode(it) },
                 "signature" to templateMapForSignatureNode(node.signature),
                 "methods" to templateMapForClasslikeMethods(node.methods),
-                "classlikeDocumentation" to htmlForContentNodes(node.description, node),
+                "classlikeDocumentation" to htmlForContentNodes(node.description, contextNode),
                 "entries" to node.entries.map { templateMapForEntryNode(it) },
                 "properties" to node.properties.map { templateMapForPropertyNode(it) },
                 "classlikes" to node.classlikes.map { templateMapForNestedClasslikeNode(it) },
@@ -249,7 +249,7 @@ internal class JavadocContentToTemplateMapTranslator(
                     contextNode.children.first { (it as? JavadocClasslikePageNode)?.dri?.first() == node.dri.first() },
                     contextNode
                 ).formatToEndWithHtml(),
-                "description" to htmlForContentNodes(node.description, node)
+                "description" to htmlForContentNodes(node.description, contextNode)
             )
         }
 


### PR DESCRIPTION
On one of our JavaDoc pages ([THEOplayerConfig.html](https://www.theoplayer.com/docs/theoplayer/v7/api-reference/android/com/theoplayer/android/api/THEOplayerConfig.html)), we noticed a broken link in the Nested Class Summary.

The Java source looks like this:
```java
package com.theoplayer.android.api;

/**
 * The THEOplayer Configuration API.
 */
public interface THEOplayerConfig {
    /**
     * The builder for {@link THEOplayerConfig}.
     */
    class Builder { }
}
```

The rendered HTML for the Nested Class Summary looks like this:
```html
<h3>Nested Class Summary</h3>
<div class="memberSummary">
    <table>
        <caption><span>Nested Classes</span><span class="tabEnd">&nbsp;</span></caption>
        <tr>
            <th class="colFirst" scope="col">Modifier and Type</th>
            <th class="colSecond" scope="col">Class</th>
            <th class="colLast" scope="col">Description</th>
        </tr>

        <tr class="altColor">
            <td class="colFirst"><code>public class</code></td>
            <th class="colSecond" scope="row"><code><a href="THEOplayerConfig.Builder.html">THEOplayerConfig.Builder</a></span></code>
            </th>
            <td class="colLast"><p>The builder for <a href=com/theoplayer/android/api/THEOplayerConfig.html>THEOplayerConfig</a>.</p></td>
        </tr>

    </table>
</div>
```
The link to `THEOplayerConfig` is rendered as:
```html
<a href=com/theoplayer/android/api/THEOplayerConfig.html>THEOplayerConfig</a>
```
However, the link should just point to the current page:
```html
<a href=THEOplayerConfig.html>THEOplayerConfig</a>
```

It turns out the JavaDoc renderer was passing the wrong `relative` node to `htmlForContentNodes()`. This PR fixes that, and now the link renders correctly. 😄