### PR TITLE
Add DefaultSymbolToDocumentableTranslator references in docs-developer

### DIFF
--- a/docs-developer/docs/developer_guide/architecture/data_model/documentable_model.md
+++ b/docs-developer/docs/developer_guide/architecture/data_model/documentable_model.md
@@ -11,7 +11,8 @@ By default, the documentables are created from:
 
 Code-wise, you can have a look at following classes:
 
-* `DefaultDescriptorToDocumentableTranslator` - responsible for Kotlin -> `Documentable` mapping
+* `DefaultDescriptorToDocumentableTranslator` - responsible for Kotlin's K1 -> `Documentable` mapping
+* `DefaultSymbolToDocumentableTranslator` - responsible for Kotlin's K2 -> `Documentable` mapping
 * `DefaultPsiToDocumentableTranslator` - responsible for Java -> `Documentable` mapping
 
 Upon creation, the documentable model represents a collection of trees, each with `DModule` as root.

--- a/docs-developer/docs/developer_guide/architecture/extension_points/core_extension_points.md
+++ b/docs-developer/docs/developer_guide/architecture/extension_points/core_extension_points.md
@@ -50,7 +50,7 @@ as long as you can map it to the [Documentable](../data_model/documentable_model
 
 For reference, see
 
-* `DefaultDescriptorToDocumentableTranslator` for Kotlin sources translation
+* `DefaultDescriptorToDocumentableTranslator` (K1) and `DefaultSymbolToDocumentableTranslator` (K2) for Kotlin sources translation
 * `DefaultPsiToDocumentableTranslator` for Java sources translation
 
 ## DocumentableMerger


### PR DESCRIPTION
Add a reference to `DefaultSymbolToDocumentableTranslator` in the documentation where `DefaultDescriptorToDocumentableTranslator` is mentioned.