### PR TITLE
use `macos-latest` for `ui-showcase` build on CI

### DIFF
--- a/.github/workflows/preview-publish-ga.yml
+++ b/.github/workflows/preview-publish-ga.yml
@@ -26,12 +26,12 @@ jobs:
       - name: Document coroutines
         run: ./gradlew :dokka-integration-tests:gradle:testExternalProjectKotlinxCoroutines --stacktrace "-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=500m"
         env:
-          DOKKA_TEST_OUTPUT_PATH: /home/runner/work/dokka/coroutines
+          DOKKA_TEST_OUTPUT_PATH: ${{ github.workspace }}/dokka/coroutines
       - name: Copy files to GitHub Actions Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: dokka-coroutines
-          path: /home/runner/work/dokka/coroutines
+          path: ${{ github.workspace }}/dokka/coroutines
           retention-days: 7
 
   kotlinx-serialization:
@@ -52,12 +52,12 @@ jobs:
       - name: Document serialization
         run: ./gradlew :dokka-integration-tests:gradle:testExternalProjectKotlinxSerialization --stacktrace "-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=500m"
         env:
-          DOKKA_TEST_OUTPUT_PATH: /home/runner/work/dokka/serialization
+          DOKKA_TEST_OUTPUT_PATH: ${{ github.workspace }}/dokka/serialization
       - name: Copy files to GitHub Actions Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: dokka-serialization
-          path: /home/runner/work/dokka/serialization
+          path: ${{ github.workspace }}/dokka/serialization
           retention-days: 7
 
   biojava:
@@ -78,10 +78,10 @@ jobs:
       - name: Document biojava-core
         run: ./gradlew :dokka-integration-tests:maven:testExternalProjectBioJava --stacktrace
         env:
-          DOKKA_TEST_OUTPUT_PATH: /home/runner/work/dokka/biojava
+          DOKKA_TEST_OUTPUT_PATH: ${{ github.workspace }}/dokka/biojava
       - name: Copy files to GitHub Actions Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: dokka-biojava
-          path: /home/runner/work/dokka/biojava
+          path: ${{ github.workspace }}/dokka/biojava
           retention-days: 7

--- a/.github/workflows/preview-publish-web-s3.yml
+++ b/.github/workflows/preview-publish-web-s3.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Document coroutines
         run: ./gradlew :dokka-integration-tests:gradle:testExternalProjectKotlinxCoroutines --stacktrace "-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=500m"
         env:
-          DOKKA_TEST_OUTPUT_PATH: /home/runner/work/dokka/coroutines
+          DOKKA_TEST_OUTPUT_PATH: ${{ github.workspace }}/dokka/coroutines
       - name: Configure AWS credentials for S3 access
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -51,7 +51,7 @@ jobs:
       - name: Document serialization
         run: ./gradlew :dokka-integration-tests:gradle:testExternalProjectKotlinxSerialization --stacktrace "-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=500m"
         env:
-          DOKKA_TEST_OUTPUT_PATH: /home/runner/work/dokka/serialization
+          DOKKA_TEST_OUTPUT_PATH: ${{ github.workspace }}/dokka/serialization
       - name: Configure AWS credentials for S3 access
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -79,7 +79,7 @@ jobs:
       - name: Generate ui-showcase documentation
         run: ./gradlew :dokka-integration-tests:gradle:testUiShowcaseProject
         env:
-          DOKKA_TEST_OUTPUT_PATH: /home/runner/work/dokka/ui-showcase
+          DOKKA_TEST_OUTPUT_PATH: ${{ github.workspace }}/dokka/ui-showcase
       - name: Configure AWS credentials for S3 access
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -108,7 +108,7 @@ jobs:
       - name: Document biojava-core
         run: ./gradlew :dokka-integration-tests:maven:testExternalProjectBioJava --stacktrace
         env:
-          DOKKA_TEST_OUTPUT_PATH: /home/runner/work/dokka/biojava
+          DOKKA_TEST_OUTPUT_PATH: ${{ github.workspace }}/dokka/biojava
       - name: Configure AWS credentials for S3 access
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/preview-publish-web-s3.yml
+++ b/.github/workflows/preview-publish-web-s3.yml
@@ -64,7 +64,7 @@ jobs:
         run: echo https://dokka-snapshots.s3.eu-central-1.amazonaws.com/${{ env.branch-name }}/serialization/${GITHUB_SHA::7}/index.html
 
   ui-showcase:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     if: github.repository == 'Kotlin/dokka'
     steps:
       - name: Checkout dokka

--- a/dokka-integration-tests/gradle/src/testUiShowcaseProject/kotlin/UiShowcaseIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/testUiShowcaseProject/kotlin/UiShowcaseIntegrationTest.kt
@@ -6,6 +6,8 @@ package org.jetbrains.dokka.it.gradle
 
 import org.gradle.testkit.runner.TaskOutcome
 import org.jetbrains.dokka.it.TestOutputCopier
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 import java.io.File
@@ -13,6 +15,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
+@EnabledOnOs(OS.MAC, disabledReason = "Contains KMP code for macOS")
 class UiShowcaseIntegrationTest : AbstractGradleIntegrationTest(), TestOutputCopier {
     override val projectOutputLocation: File by lazy { File(projectDir, "build/dokka/htmlMultiModule") }
 


### PR DESCRIPTION
In https://github.com/Kotlin/dokka/pull/3662 test started to fail on ui-showcase module because of `ERROR CLASS`.
This was fixed in https://github.com/Kotlin/dokka/pull/3663 and everything was fine locally.
But on CI we were building `ui-showcase` on Linux - and so before #3662 there were no `macOS` specific declarations there.
So we need to build it on macOS.
Looks like we need to do the same on TC. @adam-enko could you help here? Is it possible to run only `UiShowcaseIntegrationTest` on TC on macOS? Other tests should work fine with linux runner.