### PR TITLE
Support specifying custom folder name for older versions for versioning plugin

### DIFF
--- a/dokka-integration-tests/gradle/projects/it-multimodule-versioning-0/build.gradle
+++ b/dokka-integration-tests/gradle/projects/it-multimodule-versioning-0/build.gradle
@@ -16,18 +16,32 @@ subprojects {
     apply plugin: 'org.jetbrains.dokka'
 }
 
+def olderVersionsDirName = providers.gradleProperty("olderVersionsDirName").orNull
+
 dokkaHtmlMultiModule {
-    pluginsMapConfiguration.set(["org.jetbrains.dokka.versioning.VersioningPlugin": """{ "version": "1.2", "olderVersionsDir": "$projectDir/dokkas" }"""])
+    if (olderVersionsDirName == null) {
+        pluginsMapConfiguration.set(["org.jetbrains.dokka.versioning.VersioningPlugin": """{ "version": "1.2", "olderVersionsDir": "$projectDir/dokkas" }"""])
+    } else {
+        pluginsMapConfiguration.set(["org.jetbrains.dokka.versioning.VersioningPlugin": """{ "version": "1.2", "olderVersionsDir": "$projectDir/dokkas", "olderVersionsDirName": "$olderVersionsDirName" }"""])
+    }
 }
 
 tasks.register('dokkaHtmlMultiModuleBaseVersion', DokkaMultiModuleTask) {
     outputDirectory.set(file(projectDir.toPath().resolve("dokkas").resolve("1.0")))
-    pluginsMapConfiguration.set(["org.jetbrains.dokka.versioning.VersioningPlugin": """{ "version": "1.0" }"""])
+    if (olderVersionsDirName == null) {
+        pluginsMapConfiguration.set(["org.jetbrains.dokka.versioning.VersioningPlugin": """{ "version": "1.0" }"""])
+    } else {
+        pluginsMapConfiguration.set(["org.jetbrains.dokka.versioning.VersioningPlugin": """{ "version": "1.0", "olderVersionsDirName": "$olderVersionsDirName" }"""])
+    }
     addChildTasks([project(":first"), project(":second")], "dokkaHtmlPartial")
 }
 
 tasks.register('dokkaHtmlMultiModuleNextVersion', DokkaMultiModuleTask) {
     outputDirectory.set(file(projectDir.toPath().resolve("dokkas").resolve("1.1")))
-    pluginsMapConfiguration.set(["org.jetbrains.dokka.versioning.VersioningPlugin": """{ "version": "1.1", "olderVersionsDir": "$projectDir/dokkas" }"""])
+    if (olderVersionsDirName == null) {
+        pluginsMapConfiguration.set(["org.jetbrains.dokka.versioning.VersioningPlugin": """{ "version": "1.1", "olderVersionsDir": "$projectDir/dokkas" }"""])
+    } else {
+        pluginsMapConfiguration.set(["org.jetbrains.dokka.versioning.VersioningPlugin": """{ "version": "1.1", "olderVersionsDir": "$projectDir/dokkas", "olderVersionsDirName": "$olderVersionsDirName" }"""])
+    }
     addChildTasks([project(":first"), project(":second")], "dokkaHtmlPartial")
 }

--- a/dokka-subprojects/plugin-versioning/README.md
+++ b/dokka-subprojects/plugin-versioning/README.md
@@ -109,6 +109,7 @@ The table below contains all the possible configuration options for the versioni
 | `olderVersionsDir`                   | An optional path to a parent folder that contains other documentation versions. It requires a specific directory structure. For more information, see [Directory structure](#directory-structure).     |
 | `olderVersions`                      | An optional list of paths to other documentation versions. It must point to Dokka's outputs directly. This is useful if different versions can't all be in the same directory.                         |
 | `renderVersionsNavigationOnAllPages` | An optional boolean value indicating whether to render the navigation dropdown on all pages. Set to true by default.                                                                                   |
+| `olderVersionsDirName`               | An optional folder name where other documentation versions output will be placed. In case of empty string root folder will be used instead. Set to `older` by default.                                 |
 
 #### Directory structure
 
@@ -264,7 +265,7 @@ plugin to match versions and generate version navigation. If your previously gen
 file, you will need to re-generate documentation for such versions. Just adding the file will not work.
 
 The versioning plugin also bundles all other documentation versions that have been passed through `olderVersionsDir`
-and `olderVersions` configuration options by putting them inside the `older` directory.
+and `olderVersions` configuration options by putting them inside the directory passed through `olderVersionsDirName`.
 
 ## Usage example
 
@@ -281,8 +282,11 @@ The main idea behind it is the following:
 4. Once new documentation has been generated, it needs to be **copied** to somewhere accessible by the user.
    For example, GitHub pages or nginx static directories. It needs to be **copied**, not moved because Dokka will still
    need this version for future builds, otherwise there will be a gap in the archive.
-5. Once it has been safely copied, you can remove the `older` directory from the newly generated and archived version.
-   This helps reduce the overhead of each version bundling all previous versions, as these files are effectively duplicates.
+5. Once it has been safely copied,
+   you can remove the directory specified in `olderVersionsDirName`(`older` by default)
+   from the newly generated and archived version.
+   This helps reduce the overhead of each version bundling all previous versions,
+   as these files are effectively duplicates.
 
 ```kotlin
 import org.jetbrains.dokka.versioning.VersioningPlugin

--- a/dokka-subprojects/plugin-versioning/api/plugin-versioning.api
+++ b/dokka-subprojects/plugin-versioning/api/plugin-versioning.api
@@ -86,24 +86,27 @@ public final class org/jetbrains/dokka/versioning/VersioningConfiguration : org/
 	public static final field OLDER_VERSIONS_DIR Ljava/lang/String;
 	public static final field VERSIONS_FILE Ljava/lang/String;
 	public fun <init> ()V
-	public fun <init> (Ljava/io/File;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;)V
-	public synthetic fun <init> (Ljava/io/File;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/io/File;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/io/File;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/io/File;
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Ljava/util/List;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/Boolean;
-	public final fun copy (Ljava/io/File;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;)Lorg/jetbrains/dokka/versioning/VersioningConfiguration;
-	public static synthetic fun copy$default (Lorg/jetbrains/dokka/versioning/VersioningConfiguration;Ljava/io/File;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lorg/jetbrains/dokka/versioning/VersioningConfiguration;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/io/File;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;)Lorg/jetbrains/dokka/versioning/VersioningConfiguration;
+	public static synthetic fun copy$default (Lorg/jetbrains/dokka/versioning/VersioningConfiguration;Ljava/io/File;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/dokka/versioning/VersioningConfiguration;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getOlderVersions ()Ljava/util/List;
 	public final fun getOlderVersionsDir ()Ljava/io/File;
+	public final fun getOlderVersionsDirName ()Ljava/lang/String;
 	public final fun getRenderVersionsNavigationOnAllPages ()Ljava/lang/Boolean;
 	public final fun getVersion ()Ljava/lang/String;
 	public final fun getVersionsOrdering ()Ljava/util/List;
 	public fun hashCode ()I
 	public final fun setOlderVersions (Ljava/util/List;)V
 	public final fun setOlderVersionsDir (Ljava/io/File;)V
+	public final fun setOlderVersionsDirName (Ljava/lang/String;)V
 	public final fun setRenderVersionsNavigationOnAllPages (Ljava/lang/Boolean;)V
 	public final fun setVersion (Ljava/lang/String;)V
 	public final fun setVersionsOrdering (Ljava/util/List;)V
@@ -113,6 +116,7 @@ public final class org/jetbrains/dokka/versioning/VersioningConfiguration : org/
 public final class org/jetbrains/dokka/versioning/VersioningConfiguration$Companion {
 	public final fun getDefaultOlderVersions ()Ljava/util/List;
 	public final fun getDefaultOlderVersionsDir ()Ljava/io/File;
+	public final fun getDefaultOlderVersionsDirName ()Ljava/lang/String;
 	public final fun getDefaultRenderVersionsNavigationOnAllPages ()Z
 	public final fun getDefaultVersion ()Ljava/lang/String;
 	public final fun getDefaultVersionsOrdering ()Ljava/util/List;

--- a/dokka-subprojects/plugin-versioning/src/main/kotlin/org/jetbrains/dokka/versioning/VersioningConfiguration.kt
+++ b/dokka-subprojects/plugin-versioning/src/main/kotlin/org/jetbrains/dokka/versioning/VersioningConfiguration.kt
@@ -13,7 +13,8 @@ public data class VersioningConfiguration(
     var olderVersions: List<File>? = defaultOlderVersions,
     var versionsOrdering: List<String>? = defaultVersionsOrdering,
     var version: String? = defaultVersion,
-    var renderVersionsNavigationOnAllPages: Boolean? = defaultRenderVersionsNavigationOnAllPages
+    var renderVersionsNavigationOnAllPages: Boolean? = defaultRenderVersionsNavigationOnAllPages,
+    var olderVersionsDirName: String = defaultOlderVersionsDirName
 ) : ConfigurableBlock {
     internal fun versionFromConfigurationOrModule(dokkaContext: DokkaContext): String =
         version ?: dokkaContext.configuration.moduleVersion ?: "1.0"
@@ -31,7 +32,9 @@ public data class VersioningConfiguration(
         public val defaultVersionsOrdering: List<String>? = null
         public val defaultVersion: String? = null
         public val defaultRenderVersionsNavigationOnAllPages: Boolean = true
+        public val defaultOlderVersionsDirName: String = "older"
 
+        @Deprecated("Replaced with VersioningConfiguration.Companion.defaultOlderVersionsDirName and VersioningConfiguration.olderVersionsDirName")
         public const val OLDER_VERSIONS_DIR: String = "older"
         public const val VERSIONS_FILE: String = "version.json"
     }

--- a/dokka-subprojects/plugin-versioning/src/main/kotlin/org/jetbrains/dokka/versioning/VersioningStorage.kt
+++ b/dokka-subprojects/plugin-versioning/src/main/kotlin/org/jetbrains/dokka/versioning/VersioningStorage.kt
@@ -52,7 +52,13 @@ public class DefaultVersioningStorage(
 
     private fun getPreviousVersions(olderVersions: List<File>, output: File): Map<String, VersionDirs> =
         versionsFrom(olderVersions).associate { (key, srcDir) ->
-            key to VersionDirs(srcDir, output.resolve(VersioningConfiguration.OLDER_VERSIONS_DIR).resolve(key))
+            val olderVersionsDirName =
+                configuration?.olderVersionsDirName ?: VersioningConfiguration.defaultOlderVersionsDirName
+            val olderVersionsDir = when {
+                olderVersionsDirName.isBlank() -> output
+                else -> output.resolve(olderVersionsDirName)
+            }
+            key to VersionDirs(srcDir, olderVersionsDir.resolve(key))
         }
 
     private fun versionsFrom(olderVersions: List<File>) =


### PR DESCRIPTION
Fixes #3692 

* Introduce a new parameter `olderVersionsDirName` in `VersioningConfiguration` to customize the directory name for older versions HTMLs
* Add integration test with different folder names