### PR TITLE
Filter out JVM mapped methods

### DIFF
--- a/dokka-subprojects/plugin-base/api/plugin-base.api
+++ b/dokka-subprojects/plugin-base/api/plugin-base.api
@@ -67,6 +67,7 @@ public final class org/jetbrains/dokka/base/DokkaBase : org/jetbrains/dokka/plug
 	public final fun getInheritedEntriesVisbilityFilter ()Lorg/jetbrains/dokka/plugability/Extension;
 	public final fun getInheritorsExtractor ()Lorg/jetbrains/dokka/plugability/Extension;
 	public final fun getJavadocLocationProvider ()Lorg/jetbrains/dokka/plugability/Extension;
+	public final fun getJvmMappedMethodsFilter ()Lorg/jetbrains/dokka/plugability/Extension;
 	public final fun getKotlinAnalysis ()Lorg/jetbrains/dokka/plugability/ExtensionPoint;
 	public final fun getKotlinArrayDocumentableReplacer ()Lorg/jetbrains/dokka/plugability/Extension;
 	public final fun getKotlinSignatureProvider ()Lorg/jetbrains/dokka/plugability/Extension;
@@ -1197,6 +1198,11 @@ public final class org/jetbrains/dokka/base/transformers/documentables/Inheritor
 public final class org/jetbrains/dokka/base/transformers/documentables/InheritorsInfo$Companion : org/jetbrains/dokka/model/properties/ExtraProperty$Key {
 	public synthetic fun mergeStrategyFor (Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
 	public fun mergeStrategyFor (Lorg/jetbrains/dokka/base/transformers/documentables/InheritorsInfo;Lorg/jetbrains/dokka/base/transformers/documentables/InheritorsInfo;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
+}
+
+public final class org/jetbrains/dokka/base/transformers/documentables/JvmMappedMethodsDocumentableFilterTransformer : org/jetbrains/dokka/base/transformers/documentables/SuppressedByConditionDocumentableFilterTransformer {
+	public fun <init> (Lorg/jetbrains/dokka/plugability/DokkaContext;)V
+	public fun shouldBeSuppressed (Lorg/jetbrains/dokka/model/Documentable;)Z
 }
 
 public final class org/jetbrains/dokka/base/transformers/documentables/KotlinArrayDocumentableReplacerTransformer : org/jetbrains/dokka/base/transformers/documentables/DocumentableReplacerTransformer {

--- a/dokka-subprojects/plugin-base/api/plugin-base.api
+++ b/dokka-subprojects/plugin-base/api/plugin-base.api
@@ -1200,11 +1200,6 @@ public final class org/jetbrains/dokka/base/transformers/documentables/Inheritor
 	public fun mergeStrategyFor (Lorg/jetbrains/dokka/base/transformers/documentables/InheritorsInfo;Lorg/jetbrains/dokka/base/transformers/documentables/InheritorsInfo;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
 }
 
-public final class org/jetbrains/dokka/base/transformers/documentables/JvmMappedMethodsDocumentableFilterTransformer : org/jetbrains/dokka/base/transformers/documentables/SuppressedByConditionDocumentableFilterTransformer {
-	public fun <init> (Lorg/jetbrains/dokka/plugability/DokkaContext;)V
-	public fun shouldBeSuppressed (Lorg/jetbrains/dokka/model/Documentable;)Z
-}
-
 public final class org/jetbrains/dokka/base/transformers/documentables/KotlinArrayDocumentableReplacerTransformer : org/jetbrains/dokka/base/transformers/documentables/DocumentableReplacerTransformer {
 	public fun <init> (Lorg/jetbrains/dokka/plugability/DokkaContext;)V
 }

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/DokkaBase.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/DokkaBase.kt
@@ -83,6 +83,12 @@ public class DokkaBase : DokkaPlugin() {
         preMergeDocumentableTransformer providing ::SuppressTagDocumentableFilter
     }
 
+    public val jvmMappedMethodsFilter: Extension<PreMergeDocumentableTransformer, *, *> by extending {
+        preMergeDocumentableTransformer providing ::JvmMappedMethodsDocumentableFilterTransformer order {
+            before(kotlinArrayDocumentableReplacer)
+        }
+    }
+
     public val documentableVisibilityFilter: Extension<PreMergeDocumentableTransformer, *, *> by extending {
         preMergeDocumentableTransformer providing ::DocumentableVisibilityFilterTransformer
     }

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/transformers/documentables/JvmMappedMethodsDocumentableFilterTransformer.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/transformers/documentables/JvmMappedMethodsDocumentableFilterTransformer.kt
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package org.jetbrains.dokka.base.transformers.documentables
+
+import org.jetbrains.dokka.links.DRI
+import org.jetbrains.dokka.model.Annotations
+import org.jetbrains.dokka.model.DFunction
+import org.jetbrains.dokka.model.Documentable
+import org.jetbrains.dokka.model.StringValue
+import org.jetbrains.dokka.plugability.DokkaContext
+
+/**
+ *  Filter out methods  that come from [mapping to Java](https://kotlinlang.org/docs/java-interop.html#mapped-types)
+ *  since they have no available doc
+ *
+ *  Currently, a list of such methods is supported manually based on the compiler source
+ *  [here](https://github.com/JetBrains/kotlin/blob/0ef41d75b5901afea68a09cc3e762b52d8ce1e3c/core/compiler.common.jvm/src/org/jetbrains/kotlin/builtins/jvm/JvmBuiltInsSignatures.kt#L15).
+ *
+ * There are the 4 statuses (JDKMemberStatus) of mapped methods:
+ * - HIDDEN
+ * - VISIBLE
+ * - DROP
+ * - NOT_CONSIDERED in K1 / HIDDEN_IN_DECLARING_CLASS_ONLY in K2. See [DFunction.hasDeprecated]
+ * We want co cover the HIDDEN, VISIBLE, HIDDEN_IN_DECLARING_CLASS_ONLY statuses here.
+ *
+ *  TODO https://youtrack.jetbrains.com/issue/KT-69796/Analysis-API-Provide-a-way-to-detect-mapped-methods-from-JVM
+ */
+public class JvmMappedMethodsDocumentableFilterTransformer(context: DokkaContext) :
+    SuppressedByConditionDocumentableFilterTransformer(context) {
+
+    private fun inJavaLang(baseName: String, vararg signatures: String): Set<String> {
+        val packageAndClassNames = when (baseName) {
+            "CharSequence" -> "kotlin.CharSequence"
+            "Throwable" -> "kotlin.Throwable"
+            "Iterable" -> "kotlin.collections.Iterable"
+            "String" -> "kotlin.String"
+            "Enum" -> "kotlin.Enum"
+            "Double" -> "kotlin.Double"
+            "Float" -> "kotlin.Float"
+            "List" -> "kotlin.collections.list"
+            else -> throw IllegalStateException()
+        }
+        return signatures.map { "$packageAndClassNames.${it.substring(0, it.indexOf("("))}" }.toSet()
+    }
+
+    private fun inJavaUtil(baseName: String, vararg signatures: String): Set<String> {
+        val packageAndClassNames = when (baseName) {
+            "List" -> "kotlin.collections.List"
+            "MutableList" -> "kotlin.collections.MutableList"
+            "Iterator" -> "kotlin.collections.Iterator"
+            "Collection" -> "kotlin.collections.Collection"
+            "MutableCollection" -> "kotlin.collections.MutableCollection"
+            "Map" -> "kotlin.collections.Map"
+            "MutableMap" -> "kotlin.collections.MutableMap"
+            else -> throw IllegalStateException()
+        }
+        return if (packageAndClassNames == "kotlin.collections.Collection") { // hack for K1 since it can has  kotlin.collections.Set.spliterator instead of kotlin.collections.Collection.spliterator
+            signatures.map { "kotlin.collections.Collection.${it.substring(0, it.indexOf("("))}" }
+                .toSet() + signatures.map { "kotlin.collections.Set.${it.substring(0, it.indexOf("("))}" }
+                .toSet() + signatures.map { "kotlin.collections.List.${it.substring(0, it.indexOf("("))}" }.toSet()
+
+        } else signatures.map { "$packageAndClassNames.${it.substring(0, it.indexOf("("))}" }.toSet()
+    }
+
+    // this "grey" list does not exist in the compiler explicitly
+    // this was made manually
+    private val NOT_CONSIDER_METHOD_SIGNATURES: Set<String> = inJavaUtil(
+        "Collection", "toArray(Ljava/util/function/IntFunction;)[Ljava/lang/Object;"
+    )
+
+
+    // copy-pasted from [here](https://github.com/JetBrains/kotlin/blob/0ef41d75b5901afea68a09cc3e762b52d8ce1e3c/core/compiler.common.jvm/src/org/jetbrains/kotlin/builtins/jvm/JvmBuiltInsSignatures.kt#L15)
+    private val VISIBLE_METHOD_SIGNATURES: Set<String> = inJavaLang(
+        "CharSequence", "codePoints()Ljava/util/stream/IntStream;", "chars()Ljava/util/stream/IntStream;"
+    ) +
+
+            inJavaUtil(
+                "Iterator", "forEachRemaining(Ljava/util/function/Consumer;)V"
+            ) +
+
+            inJavaLang(
+                "Iterable", "forEach(Ljava/util/function/Consumer;)V", "spliterator()Ljava/util/Spliterator;"
+            ) +
+
+            inJavaLang(
+                "Throwable",
+                "setStackTrace([Ljava/lang/StackTraceElement;)V",
+                "fillInStackTrace()Ljava/lang/Throwable;",
+                "getLocalizedMessage()Ljava/lang/String;",
+                "printStackTrace()V",
+                "printStackTrace(Ljava/io/PrintStream;)V",
+                "printStackTrace(Ljava/io/PrintWriter;)V",
+                "getStackTrace()[Ljava/lang/StackTraceElement;",
+                "initCause(Ljava/lang/Throwable;)Ljava/lang/Throwable;",
+                "getSuppressed()[Ljava/lang/Throwable;",
+                "addSuppressed(Ljava/lang/Throwable;)V"
+            ) +
+
+            inJavaUtil(
+                "Collection",
+                "spliterator()Ljava/util/Spliterator;",
+                "parallelStream()Ljava/util/stream/Stream;",
+                "stream()Ljava/util/stream/Stream;",
+                "removeIf(Ljava/util/function/Predicate;)Z"
+            ) +
+
+            inJavaUtil(
+                "List",
+                "replaceAll(Ljava/util/function/UnaryOperator;)V",
+                // From JDK 21
+                "addFirst(Ljava/lang/Object;)V",
+                "addLast(Ljava/lang/Object;)V",
+                "removeFirst()Ljava/lang/Object;",
+                "removeLast()Ljava/lang/Object;",
+            ) +
+
+            inJavaUtil(
+                "Map",
+                "getOrDefault(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+                "forEach(Ljava/util/function/BiConsumer;)V",
+                "replaceAll(Ljava/util/function/BiFunction;)V",
+                "merge(Ljava/lang/Object;Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;",
+                "computeIfPresent(Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;",
+                "putIfAbsent(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+                "replace(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Z",
+                "replace(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+                "computeIfAbsent(Ljava/lang/Object;Ljava/util/function/Function;)Ljava/lang/Object;",
+                "compute(Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;"
+            )
+
+    // for mutable collections
+    private val MUTABLE_METHOD_SIGNATURES: Set<String> =
+        inJavaUtil("MutableCollection", "removeIf(Ljava/util/function/Predicate;)Z") +
+
+                inJavaUtil(
+                    "MutableList",
+                    "replaceAll(Ljava/util/function/UnaryOperator;)V",
+                    "sort(Ljava/util/Comparator;)V",
+                    "addFirst(Ljava/lang/Object;)V",
+                    "addLast(Ljava/lang/Object;)V",
+                    "removeFirst()Ljava/lang/Object;",
+                    "removeLast()Ljava/lang/Object;",
+                ) +
+
+                inJavaUtil(
+                    "MutableMap",
+                    "computeIfAbsent(Ljava/lang/Object;Ljava/util/function/Function;)Ljava/lang/Object;",
+                    "computeIfPresent(Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;",
+                    "compute(Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;",
+                    "merge(Ljava/lang/Object;Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;",
+                    "putIfAbsent(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+                    "remove(Ljava/lang/Object;Ljava/lang/Object;)Z",
+                    "replaceAll(Ljava/util/function/BiFunction;)V",
+                    "replace(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+                    "replace(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Z"
+                ) +
+                // In K1, [kotlin.CharSequence.codePoints] can be [kotlin.String.codePoints]
+                inJavaLang(
+                    "String", "codePoints()Ljava/util/stream/IntStream;", "chars()Ljava/util/stream/IntStream;"
+                )
+
+    private val DEPRECATED_LIST_METHODS: Set<String> = inJavaUtil(
+        "List",
+        "getFirst()Ljava/lang/Object;",
+        "getLast()Ljava/lang/Object;",
+    )
+
+
+    private val HIDDEN_METHOD_SIGNATURES: Set<String> =
+        inJavaUtil(
+            "List",
+            "sort(Ljava/util/Comparator;)V",
+            // From JDK 21
+            "reversed()Ljava/util/List;",
+        ) +
+
+                inJavaLang(
+                    "String",
+                    "codePointAt(I)I",
+                    "codePointBefore(I)I",
+                    "codePointCount(II)I",
+                    "compareToIgnoreCase(Ljava/lang/String;)I",
+                    "concat(Ljava/lang/String;)Ljava/lang/String;",
+                    "contains(Ljava/lang/CharSequence;)Z",
+                    "contentEquals(Ljava/lang/CharSequence;)Z",
+                    "contentEquals(Ljava/lang/StringBuffer;)Z",
+                    "endsWith(Ljava/lang/String;)Z",
+                    "equalsIgnoreCase(Ljava/lang/String;)Z",
+                    "getBytes()[B",
+                    "getBytes(II[BI)V",
+                    "getBytes(Ljava/lang/String;)[B",
+                    "getBytes(Ljava/nio/charset/Charset;)[B",
+                    "getChars(II[CI)V",
+                    "indexOf(I)I",
+                    "indexOf(II)I",
+                    "indexOf(Ljava/lang/String;)I",
+                    "indexOf(Ljava/lang/String;I)I",
+                    "intern()Ljava/lang/String;",
+                    "isEmpty()Z",
+                    "lastIndexOf(I)I",
+                    "lastIndexOf(II)I",
+                    "lastIndexOf(Ljava/lang/String;)I",
+                    "lastIndexOf(Ljava/lang/String;I)I",
+                    "matches(Ljava/lang/String;)Z",
+                    "offsetByCodePoints(II)I",
+                    "regionMatches(ILjava/lang/String;II)Z",
+                    "regionMatches(ZILjava/lang/String;II)Z",
+                    "replaceAll(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;",
+                    "replace(CC)Ljava/lang/String;",
+                    "replaceFirst(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;",
+                    "replace(Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Ljava/lang/String;",
+                    "split(Ljava/lang/String;I)[Ljava/lang/String;",
+                    "split(Ljava/lang/String;)[Ljava/lang/String;",
+                    "startsWith(Ljava/lang/String;I)Z",
+                    "startsWith(Ljava/lang/String;)Z",
+                    "substring(II)Ljava/lang/String;",
+                    "substring(I)Ljava/lang/String;",
+                    "toCharArray()[C",
+                    "toLowerCase()Ljava/lang/String;",
+                    "toLowerCase(Ljava/util/Locale;)Ljava/lang/String;",
+                    "toUpperCase()Ljava/lang/String;",
+                    "toUpperCase(Ljava/util/Locale;)Ljava/lang/String;",
+                    "trim()Ljava/lang/String;",
+                    "isBlank()Z",
+                    "lines()Ljava/util/stream/Stream;",
+                    "repeat(I)Ljava/lang/String;"
+                ) +
+
+                inJavaLang("Double", "isInfinite()Z", "isNaN()Z") + inJavaLang("Float", "isInfinite()Z", "isNaN()Z") +
+
+                inJavaLang("Enum", "getDeclaringClass()Ljava/lang/Class;", "finalize()V") + inJavaLang(
+            "CharSequence",
+            "isEmpty()Z"
+        )
+
+
+    private val deprecationAnnotationDRI = DRI("kotlin", "Deprecated")
+
+    /**
+     * KT-65438: In K1, such methods (e.g. translateEscapes, formatted... in java.lang.String) have the NOT_CONSIDERED status,
+     * that means they are available and have a deprecation annotation.
+     * In K2, they are unavailable for final classes + [NOT_CONSIDER_METHOD_SIGNATURES]
+     * @see NOT_CONSIDER_METHOD_SIGNATURES
+    */
+    private fun DFunction.hasDeprecated(): Boolean = this.extra[Annotations]?.directAnnotations?.any {
+        it.value.any {
+            it.dri == deprecationAnnotationDRI && it.params["message"] == StringValue("This member is not fully supported by Kotlin compiler, so it may be absent or have different signature in next major version")
+        }
+    } ?: false
+
+    override fun shouldBeSuppressed(d: Documentable): Boolean =
+        d is DFunction && (d.hasDeprecated() || d.dri.let { it.packageName + "." + it.classNames + "." + it.callable?.name }
+            .let {
+                it in VISIBLE_METHOD_SIGNATURES || it in MUTABLE_METHOD_SIGNATURES || it in DEPRECATED_LIST_METHODS || it in HIDDEN_METHOD_SIGNATURES || it in NOT_CONSIDER_METHOD_SIGNATURES
+            })
+}

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/transformers/documentables/JvmMappedMethodsDocumentableFilterTransformer.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/transformers/documentables/JvmMappedMethodsDocumentableFilterTransformer.kt
@@ -4,6 +4,7 @@
 
 package org.jetbrains.dokka.base.transformers.documentables
 
+import org.jetbrains.dokka.Platform
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.model.Annotations
 import org.jetbrains.dokka.model.DFunction
@@ -250,8 +251,11 @@ internal class JvmMappedMethodsDocumentableFilterTransformer(context: DokkaConte
         }
     } ?: false
 
+    // user case: stdlib
+    private fun DFunction.isOnlyInJVM() = sourceSets.all { it.analysisPlatform == Platform.jvm }
+
     override fun shouldBeSuppressed(d: Documentable): Boolean =
-        if (d is DFunction) {
+        if (d is DFunction && d.isOnlyInJVM()) {
             if (d.hasDeprecated())
                 true
             else {

--- a/dokka-subprojects/plugin-base/src/test/kotlin/transformers/JvmMappedMethodsFilterTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/transformers/JvmMappedMethodsFilterTest.kt
@@ -1,0 +1,315 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package transformers
+
+import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
+import org.jetbrains.dokka.model.DClasslike
+import org.jetbrains.dokka.model.DModule
+import org.jetbrains.dokka.model.dfs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class JvmMappedMethodsFilterTest : BaseAbstractTest() {
+    private val configuration = dokkaConfiguration {
+        sourceSets {
+            sourceSet {
+                sourceRoots = listOf("src")
+                analysisPlatform = "jvm"
+            }
+        }
+    }
+
+    fun List<DModule>.getMethodNamesFrom(classname: String): Set<String> {
+        val cl = this.mapNotNull { it.dfs { it.name == classname && it is DClasslike } }.first() as DClasslike
+        return cl.functions.map { it.name }.toSet()
+    }
+
+    @Test
+    fun `should filter out JVM mapped methods in CharSequence`() {
+        testInline(
+            """
+            |/src/MyCharSequence.kt
+            |interface MyCharSequence: CharSequence
+            """.trimIndent(), configuration
+        ) {
+            preMergeDocumentablesTransformationStage = { modules ->
+                assertEquals(
+                    setOf("subSequence", "get"),
+                    modules.getMethodNamesFrom("MyCharSequence")
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `should filter out JVM mapped methods in String`() {
+        // hacky test, String is final
+        testInline(
+            """
+            |/src/MyCharSequence.kt
+            |class MyString: String
+            """.trimIndent(), configuration
+        ) {
+            preMergeDocumentablesTransformationStage = { modules ->
+                assertEquals(
+                    setOf(
+                        "compareTo",
+                        "equals",
+                        "get",
+                        "plus",
+                        "subSequence",
+                        "toString"
+                    ),
+                    modules.getMethodNamesFrom("MyString")
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `should filter out JVM mapped methods in Collection and MutableCollection`() {
+        testInline(
+            """
+            |/src/MyList.kt
+            |interface MyCollection<T>: Collection<T>
+            |interface MyMutableCollection<T>: MutableCollection<T>
+            """.trimIndent(), configuration
+        ) {
+            preMergeDocumentablesTransformationStage = { modules ->
+
+                assertEquals(
+                    setOf(
+                        "contains",
+                        "containsAll",
+                        "isEmpty",
+                        "iterator",
+                    ),
+                    modules.getMethodNamesFrom("MyCollection")
+                )
+                assertEquals(
+                    setOf(
+                        "add",
+                        "addAll",
+                        "clear",
+                        "iterator",
+                        "remove",
+                        "removeAll",
+                        "retainAll",
+                        "isEmpty",
+                        "contains",
+                        "containsAll",
+                    ),
+                    modules.getMethodNamesFrom("MyMutableCollection")
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `should filter out JVM mapped methods in Set and MutableSet`() {
+        testInline(
+            """
+            |/src/MyList.kt
+            |interface MySet<T>: Set<T>
+            |interface MyMutableSet<T>: MutableSet<T>
+            """.trimIndent(), configuration
+        ) {
+            preMergeDocumentablesTransformationStage = { modules ->
+
+                assertEquals(
+                    setOf(
+                        "contains",
+                        "containsAll",
+                        "isEmpty",
+                        "iterator"
+                    ),
+                    modules.getMethodNamesFrom("MySet")
+                )
+                assertEquals(
+                    setOf(
+                        "add",
+                        "addAll",
+                        "clear",
+                        "contains",
+                        "containsAll",
+                        "isEmpty",
+                        "iterator",
+                        "remove",
+                        "removeAll",
+                        "retainAll",
+                    ),
+                    modules.getMethodNamesFrom("MyMutableSet")
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `should filter out JVM mapped methods in ListIterator and MutableListIterator`() {
+        testInline(
+            """
+            |/src/MyList.kt
+            |interface MyListIterator<T>: ListIterator<T>
+            |interface MyMutableListIterator<T>: MutableListIterator<T>
+            """.trimIndent(), configuration
+        ) {
+            preMergeDocumentablesTransformationStage = { modules ->
+
+                assertEquals(
+                    setOf(
+                        "hasNext",
+                        "hasPrevious",
+                        "next",
+                        "nextIndex",
+                        "previous",
+                        "previousIndex",
+                    ),
+                    modules.getMethodNamesFrom("MyListIterator")
+                )
+                assertEquals(
+                    setOf(
+                        "add",
+                        "hasNext",
+                        "hasPrevious",
+                        "next",
+                        "nextIndex",
+                        "previous",
+                        "previousIndex",
+                        "remove",
+                        "set",
+                    ),
+                    modules.getMethodNamesFrom("MyMutableListIterator")
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `should filter out JVM mapped methods in MutableIterator`() {
+        testInline(
+            """
+            |/src/MyList.kt
+            |interface MyIterator<T>: MutableIterator<T>
+            """.trimIndent(), configuration
+        ) {
+            preMergeDocumentablesTransformationStage = { modules ->
+                assertEquals(
+                    setOf(
+                        "hasNext",
+                        "next",
+                        "remove",
+                    ),
+                    modules.getMethodNamesFrom("MyIterator")
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `should filter out JVM mapped methods in List and MutableList`() {
+        testInline(
+            """
+            |/src/MyList.kt
+            |interface MyList<T>: List<T>
+            |interface MyMutableList<T>: MutableList<T>
+            """.trimIndent(), configuration
+        ) {
+            preMergeDocumentablesTransformationStage = { modules ->
+                assertEquals(
+                    setOf(
+                        "contains",
+                        "containsAll",
+                        "get",
+                        "indexOf",
+                        "isEmpty",
+                        "iterator",
+                        "lastIndexOf",
+                        "listIterator",
+                        "subList"
+                    ),
+                    modules.getMethodNamesFrom("MyList")
+                )
+                assertEquals(
+                    setOf(
+                        "add",
+                        "addAll",
+                        "clear",
+                        "contains",
+                        "containsAll",
+                        "get",
+                        "indexOf",
+                        "isEmpty",
+                        "iterator",
+                        "lastIndexOf",
+                        "listIterator",
+                        "remove",
+                        "removeAll",
+                        "removeAt",
+                        "retainAll",
+                        "set",
+                        "subList",
+                    ),
+                    modules.getMethodNamesFrom("MyMutableList")
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `should filter out JVM mapped methods in Throwable`() {
+        testInline(
+            """
+            |/src/MyThrowable.kt
+            |class MyThrowable: Throwable()
+            """.trimIndent(), configuration
+        ) {
+            preMergeDocumentablesTransformationStage = { modules ->
+                assertEquals(
+                    emptySet(),
+                    modules.getMethodNamesFrom("MyThrowable")
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `should filter out JVM mapped methods in MutableMap`() {
+        testInline(
+            """
+            |/src/MyMap.kt
+            |interface MyMap<K, V> : MutableMap<K, V>
+            """.trimIndent(), configuration
+        ) {
+            preMergeDocumentablesTransformationStage = { modules ->
+                assertEquals(
+                    setOf("clear", "containsKey", "containsValue", "get", "isEmpty", "put", "putAll"),
+                    modules.getMethodNamesFrom("MyMap"),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `should filter out JVM mapped methods in Iterable and MutableIterable`() {
+        testInline(
+            """
+            |/src/MyIterable.kt
+            |interface MyIterable<T> : Iterable<T>
+            |interface MyMutableIterable<T> : MutableIterable<T>
+            """.trimIndent(), configuration
+        ) {
+            preMergeDocumentablesTransformationStage = { modules ->
+                assertEquals(
+                    setOf("iterator"),
+                    modules.getMethodNamesFrom("MyIterable"),
+                )
+                assertEquals(
+                    setOf("iterator"),
+                    modules.getMethodNamesFrom("MyMutableIterable"),
+                )
+            }
+        }
+    }
+}

--- a/dokka-subprojects/plugin-base/src/test/kotlin/transformers/JvmMappedMethodsFilterTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/transformers/JvmMappedMethodsFilterTest.kt
@@ -44,31 +44,6 @@ class JvmMappedMethodsFilterTest : BaseAbstractTest() {
     }
 
     @Test
-    fun `should filter out JVM mapped methods in String`() {
-        // hacky test, String is final
-        testInline(
-            """
-            |/src/MyCharSequence.kt
-            |class MyString: String
-            """.trimIndent(), configuration
-        ) {
-            preMergeDocumentablesTransformationStage = { modules ->
-                assertEquals(
-                    setOf(
-                        "compareTo",
-                        "equals",
-                        "get",
-                        "plus",
-                        "subSequence",
-                        "toString"
-                    ),
-                    modules.getMethodNamesFrom("MyString")
-                )
-            }
-        }
-    }
-
-    @Test
     fun `should filter out JVM mapped methods in Collection and MutableCollection`() {
         testInline(
             """

--- a/dokka-subprojects/plugin-kotlin-as-java/api/plugin-kotlin-as-java.api
+++ b/dokka-subprojects/plugin-kotlin-as-java/api/plugin-kotlin-as-java.api
@@ -4,6 +4,7 @@ public final class org/jetbrains/dokka/kotlinAsJava/KotlinAsJavaPlugin : org/jet
 	public final fun getJvmNameTransformer ()Lorg/jetbrains/dokka/plugability/Extension;
 	public final fun getKotlinAsJavaDocumentableToPageTranslator ()Lorg/jetbrains/dokka/plugability/Extension;
 	public final fun getKotlinAsJavaDocumentableTransformer ()Lorg/jetbrains/dokka/plugability/Extension;
+	public final fun getSuppressJvmMappedMethodsFilter ()Lorg/jetbrains/dokka/plugability/Extension;
 }
 
 public final class org/jetbrains/dokka/kotlinAsJava/TransformToJavaKt {

--- a/dokka-subprojects/plugin-kotlin-as-java/src/main/kotlin/org/jetbrains/dokka/kotlinAsJava/KotlinAsJavaPlugin.kt
+++ b/dokka-subprojects/plugin-kotlin-as-java/src/main/kotlin/org/jetbrains/dokka/kotlinAsJava/KotlinAsJavaPlugin.kt
@@ -11,6 +11,7 @@ import org.jetbrains.dokka.kotlinAsJava.signatures.JavaSignatureProvider
 import org.jetbrains.dokka.kotlinAsJava.transformers.JvmNameDocumentableTransformer
 import org.jetbrains.dokka.kotlinAsJava.transformers.KotlinAsJavaDocumentableTransformer
 import org.jetbrains.dokka.kotlinAsJava.translators.KotlinAsJavaDocumentableToPageTranslator
+import org.jetbrains.dokka.model.DModule
 import org.jetbrains.dokka.plugability.DokkaPlugin
 import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
 import org.jetbrains.dokka.plugability.Extension
@@ -18,8 +19,19 @@ import org.jetbrains.dokka.plugability.PluginApiPreviewAcknowledgement
 import org.jetbrains.dokka.renderers.PostAction
 import org.jetbrains.dokka.transformers.documentation.DocumentableToPageTranslator
 import org.jetbrains.dokka.transformers.documentation.DocumentableTransformer
+import org.jetbrains.dokka.transformers.documentation.PreMergeDocumentableTransformer
 
 public class KotlinAsJavaPlugin : DokkaPlugin() {
+    private val dokkaBasePlugin: DokkaBase by lazy { plugin<DokkaBase>() }
+
+    public val suppressJvmMappedMethodsFilter: Extension<PreMergeDocumentableTransformer, *, *> by extending {
+        dokkaBasePlugin.preMergeDocumentableTransformer providing {
+            object : PreMergeDocumentableTransformer {
+                override fun invoke(modules: List<DModule>) = modules
+            }
+        } override dokkaBasePlugin.jvmMappedMethodsFilter
+    }
+
     public val kotlinAsJavaDocumentableTransformer: Extension<DocumentableTransformer, *, *> by extending {
         CoreExtensions.documentableTransformer with KotlinAsJavaDocumentableTransformer()
     }


### PR DESCRIPTION
This is a short-term solution for #3542 
The good news is that the generated documentation does not depend on a version of the JDK anymore 