### PR TITLE
Update Kotlin to 2.0.20-RC pre-release

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -12,6 +12,7 @@ pluginManagement {
         maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2") {
             name = "GradlePluginPortal-JBCache"
         }
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
     }
     includeBuild("../build-settings-logic")
 }
@@ -28,6 +29,7 @@ dependencyResolutionManagement {
         maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2") {
             name = "GradlePluginPortal-JBCache"
         }
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
     }
 
     versionCatalogs {

--- a/build-settings-logic/settings.gradle.kts
+++ b/build-settings-logic/settings.gradle.kts
@@ -14,6 +14,7 @@ pluginManagement {
         maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2") {
             name = "GradlePluginPortal-JBCache"
         }
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
     }
 }
 
@@ -27,6 +28,7 @@ dependencyResolutionManagement {
         maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2") {
             name = "GradlePluginPortal-JBCache"
         }
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
     }
 
     versionCatalogs {

--- a/dokka-integration-tests/gradle/projects/template.settings.gradle.kts
+++ b/dokka-integration-tests/gradle/projects/template.settings.gradle.kts
@@ -40,6 +40,7 @@ pluginManagement {
         mavenCentral()
         gradlePluginPortal()
         google()
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
     }
 }
 
@@ -57,6 +58,7 @@ dependencyResolutionManagement {
         }
         // Remove when Kotlin/Wasm is published into public Maven repository
         maven("https://maven.pkg.jetbrains.space/kotlin/p/wasm/experimental")
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
 
         // Declare the Node.js & Yarn download repositories - workaround for https://youtrack.jetbrains.com/issue/KT-51379
         exclusiveContent {

--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/TestedVersions.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/TestedVersions.kt
@@ -14,7 +14,7 @@ open class AllSupportedTestedVersionsArgumentsProvider : TestedVersionsArguments
 
 object TestedVersions {
 
-    val LATEST = BuildVersions("8.7", "2.0.20-RC-177")
+    val LATEST = BuildVersions("8.7", "2.0.20-Beta2")
 
     /**
      * All supported Gradle/Kotlin versions, including [LATEST]
@@ -41,7 +41,7 @@ object TestedVersions {
     val ANDROID =
         BuildVersions.permutations(
             gradleVersions = listOf("8.4"),
-            kotlinVersions = listOf("2.0.20-RC-177"),
+            kotlinVersions = listOf("2.0.20-Beta2"),
             androidGradlePluginVersions = listOf("8.3.0")
         ) + BuildVersions.permutations(
             gradleVersions = listOf("7.4.2", *ifExhaustive("7.0")),
@@ -68,6 +68,7 @@ object TestedVersions {
         "1.9.23" to "18.2.0-pre.682",
         "2.0.0" to "18.2.0-pre.726",
         "2.0.20-RC-177" to "18.3.1-pre.758",
+        "2.0.20-Beta2" to "18.3.1-pre.758",
     )
 }
 

--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/TestedVersions.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/TestedVersions.kt
@@ -14,7 +14,7 @@ open class AllSupportedTestedVersionsArgumentsProvider : TestedVersionsArguments
 
 object TestedVersions {
 
-    val LATEST = BuildVersions("8.7", "2.0.20-Beta2")
+    val LATEST = BuildVersions("8.7", "2.0.20-RC-177")
 
     /**
      * All supported Gradle/Kotlin versions, including [LATEST]
@@ -41,7 +41,7 @@ object TestedVersions {
     val ANDROID =
         BuildVersions.permutations(
             gradleVersions = listOf("8.4"),
-            kotlinVersions = listOf("2.0.20-Beta2"),
+            kotlinVersions = listOf("2.0.20-RC-177"),
             androidGradlePluginVersions = listOf("8.3.0")
         ) + BuildVersions.permutations(
             gradleVersions = listOf("7.4.2", *ifExhaustive("7.0")),
@@ -67,7 +67,7 @@ object TestedVersions {
         "1.9.10" to "18.2.0-pre.597",
         "1.9.23" to "18.2.0-pre.682",
         "2.0.0" to "18.2.0-pre.726",
-        "2.0.20-Beta2" to "18.3.1-pre.758",
+        "2.0.20-RC-177" to "18.3.1-pre.758",
     )
 }
 

--- a/dokka-integration-tests/maven/projects/it-maven/pom.xml
+++ b/dokka-integration-tests/maven/projects/it-maven/pom.xml
@@ -11,7 +11,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <kotlin.version>2.0.20-Beta2</kotlin.version>
+        <kotlin.version>2.0.20-RC-177</kotlin.version>
     </properties>
     <build>
         <plugins>

--- a/dokka-integration-tests/settings.gradle.kts
+++ b/dokka-integration-tests/settings.gradle.kts
@@ -11,6 +11,7 @@ pluginManagement {
     repositories {
         mavenCentral()
         gradlePluginPortal()
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
     }
 }
 
@@ -29,6 +30,7 @@ dependencyResolutionManagement {
         maven("https://cache-redirector.jetbrains.com/intellij-third-party-dependencies")
 
         mavenCentral()
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
     }
 
     versionCatalogs {

--- a/dokka-runners/runner-cli/settings.gradle.kts
+++ b/dokka-runners/runner-cli/settings.gradle.kts
@@ -11,6 +11,7 @@ pluginManagement {
     repositories {
         mavenCentral()
         gradlePluginPortal()
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
     }
 }
 
@@ -24,6 +25,7 @@ dependencyResolutionManagement {
     repositories {
         mavenCentral()
         google()
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
     }
 
     versionCatalogs {

--- a/dokka-runners/runner-gradle-plugin-classic/settings.gradle.kts
+++ b/dokka-runners/runner-gradle-plugin-classic/settings.gradle.kts
@@ -11,6 +11,7 @@ pluginManagement {
     repositories {
         mavenCentral()
         gradlePluginPortal()
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
     }
 }
 
@@ -24,6 +25,7 @@ dependencyResolutionManagement {
     repositories {
         mavenCentral()
         google()
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
     }
 
     versionCatalogs {

--- a/dokka-runners/runner-maven-plugin/settings.gradle.kts
+++ b/dokka-runners/runner-maven-plugin/settings.gradle.kts
@@ -11,6 +11,7 @@ pluginManagement {
     repositories {
         mavenCentral()
         gradlePluginPortal()
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
     }
 }
 
@@ -23,6 +24,7 @@ dependencyResolutionManagement {
     @Suppress("UnstableApiUsage")
     repositories {
         mavenCentral()
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
     }
 
     versionCatalogs {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 
-gradlePlugin-kotlin = "2.0.20-Beta2"
+gradlePlugin-kotlin = "2.0.20-RC-177"
 # See: https://kotlinlang.org/docs/gradle-configure-project.html#apply-the-plugin
 gradlePlugin-android = "7.1.3"
 gradlePlugin-dokka = "1.9.20"
@@ -11,7 +11,7 @@ kotlinx-serialization = "1.6.0"
 kotlinx-bcv = "0.13.2"
 
 ## Analysis
-kotlin-compiler = "2.0.20-Beta2"
+kotlin-compiler = "2.0.20-RC-177"
 kotlin-compiler-k2 = "2.0.20-dev-7572"
 
 # MUST match the version of the intellij platform used in the kotlin compiler,

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,7 @@ pluginManagement {
         maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2") {
             name = "GradlePluginPortal-JBCache"
         }
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
     }
 }
 
@@ -41,6 +42,8 @@ dependencyResolutionManagement {
         maven("https://cache-redirector.jetbrains.com/dl.google.com.android.maven2") {
             name = "Google-JBCache"
         }
+
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
 
         //region Declare the Node.js & Yarn download repositories
         // Required by Gradle Node plugin: https://github.com/node-gradle/gradle-node-plugin/blob/3.5.1/docs/faq.md#is-this-plugin-compatible-with-centralized-repositories-declaration


### PR DESCRIPTION
This PR exists purely to run CI checks with a pre-release version of 2.0.20-RC