### PR TITLE
Reduce log level of test Gradle projects

### DIFF
--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleIntegrationTest.kt
@@ -110,7 +110,7 @@ abstract class AbstractGradleIntegrationTest : AbstractIntegrationTest() {
                         ERROR -> add("--error")
                     }
 
-                    add("-Pdokka.internal.gradle.dokkaGenerator.logLevelOverride=$dokkaLogLevel")
+                    add("-PdokkaGeneratorLogLevel=$dokkaLogLevel")
 
                     add("--stacktrace")
 

--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleIntegrationTest.kt
@@ -4,6 +4,8 @@
 
 package org.jetbrains.dokka.it.gradle
 
+import org.gradle.api.logging.LogLevel
+import org.gradle.api.logging.LogLevel.*
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.tooling.GradleConnectionException
@@ -42,7 +44,21 @@ abstract class AbstractGradleIntegrationTest : AbstractIntegrationTest() {
         buildVersions: BuildVersions,
         vararg arguments: String,
         jvmArgs: List<String> = listOf("-Xmx2G", "-XX:MaxMetaspaceSize=1G"),
-        enableBuildCache: Boolean = true,
+        enableBuildCache: Boolean? = true,
+        /**
+         * The log level that Gradle will use.
+         *
+         * Prefer using [LogLevel.LIFECYCLE] or above. Gradle TestKit stores logs in-memory, which makes the tests slow.
+         * See https://github.com/gradle/gradle/issues/23965
+         *
+         * Avoid using [LogLevel.DEBUG] - it is *very* noisy!
+         */
+        gradleLogLevel: LogLevel = LIFECYCLE,
+        /**
+         * The log level that Dokka Generator will use.
+         * Defaults to [gradleLogLevel], so that the Dokka logs are always produced.
+         */
+        dokkaLogLevel: LogLevel = gradleLogLevel,
     ): GradleRunner {
 
         // TODO quick hack to add `android { namespace }` on AGP 7+ (it's mandatory in 8+).
@@ -58,7 +74,7 @@ abstract class AbstractGradleIntegrationTest : AbstractIntegrationTest() {
                 |    namespace = "org.jetbrains.dokka.it.android"
                 |}
                 |
-            """.trimMargin()
+                """.trimMargin()
             )
         }
 
@@ -83,7 +99,24 @@ abstract class AbstractGradleIntegrationTest : AbstractIntegrationTest() {
             }
             .withArguments(
                 buildList {
-                    add(if (enableBuildCache) "--build-cache" else "--no-build-cache")
+
+                    when (gradleLogLevel) {
+                        // For the 'LogLevel to cli-option' mapping, see https://docs.gradle.org/8.9/userguide/logging.html#sec:choosing_a_log_level
+                        DEBUG -> add("--debug")
+                        INFO -> add("--info")
+                        LIFECYCLE -> {} // 'lifecycle' is the default and has no flag
+                        WARN -> add("--warn")
+                        QUIET -> add("--quiet")
+                        ERROR -> add("--error")
+                    }
+
+                    add("-Pdokka.internal.gradle.dokkaGenerator.logLevelOverride=$dokkaLogLevel")
+
+                    add("--stacktrace")
+
+                    if (enableBuildCache != null) {
+                        add(if (enableBuildCache) "--build-cache" else "--no-build-cache")
+                    }
 
                     add("-Pdokka_it_dokka_version=${dokkaVersion}")
                     add("-Pdokka_it_kotlin_version=${buildVersions.kotlinVersion}")
@@ -226,15 +259,10 @@ abstract class AbstractGradleIntegrationTest : AbstractIntegrationTest() {
     }
 }
 
-private fun GradleRunner.withJetBrainsCachedGradleVersion(version: GradleVersion): GradleRunner {
-    return withGradleDistribution(
-        URI.create(
-            "https://cache-redirector.jetbrains.com/" +
-                    "services.gradle.org/distributions/" +
-                    "gradle-${version.version}-bin.zip"
-        )
+private fun GradleRunner.withJetBrainsCachedGradleVersion(version: GradleVersion): GradleRunner =
+    withGradleDistribution(
+        URI("https://cache-redirector.jetbrains.com/services.gradle.org/distributions/gradle-${version.version}-bin.zip")
     )
-}
 
 private fun Throwable.withAllCauses(): Sequence<Throwable> {
     val root = this

--- a/dokka-integration-tests/gradle/src/testExternalProjectKotlinxCoroutines/kotlin/CoroutinesGradleIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/testExternalProjectKotlinxCoroutines/kotlin/CoroutinesGradleIntegrationTest.kt
@@ -53,7 +53,7 @@ class CoroutinesGradleIntegrationTest : AbstractGradleIntegrationTest(), TestOut
     fun execute(buildVersions: BuildVersions) {
         val result = createGradleRunner(
             buildVersions,
-            ":dokkaHtmlMultiModule", "-i", "-s",
+            ":dokkaHtmlMultiModule",
             jvmArgs = listOf(
                 "-Xmx2G",
                 "-XX:MaxMetaspaceSize=500m", // Intentionally small to verify that Dokka tasks do not cause leaks.

--- a/dokka-integration-tests/gradle/src/testExternalProjectKotlinxSerialization/kotlin/SerializationGradleIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/testExternalProjectKotlinxSerialization/kotlin/SerializationGradleIntegrationTest.kt
@@ -49,7 +49,7 @@ class SerializationGradleIntegrationTest : AbstractGradleIntegrationTest(), Test
     @ParameterizedTest(name = "{0}")
     @ArgumentsSource(SerializationBuildVersionsArgumentsProvider::class)
     fun execute(buildVersions: BuildVersions) {
-        val result = createGradleRunner(buildVersions, ":dokkaHtmlMultiModule", "-i", "-s").buildRelaxed()
+        val result = createGradleRunner(buildVersions, ":dokkaHtmlMultiModule").buildRelaxed()
 
         assertEquals(TaskOutcome.SUCCESS, assertNotNull(result.task(":dokkaHtmlMultiModule")).outcome)
 

--- a/dokka-integration-tests/gradle/src/testTemplateProjectAndroid/kotlin/Android0GradleIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/testTemplateProjectAndroid/kotlin/Android0GradleIntegrationTest.kt
@@ -41,7 +41,7 @@ class Android0GradleIntegrationTest : AbstractGradleIntegrationTest() {
     @ParameterizedTest(name = "{0}")
     @ArgumentsSource(AndroidTestedVersionsArgumentsProvider::class)
     fun execute(buildVersions: BuildVersions) {
-        val result = createGradleRunner(buildVersions, "dokkaHtml", "-i", "-s").buildRelaxed()
+        val result = createGradleRunner(buildVersions, "dokkaHtml").buildRelaxed()
         result.shouldHaveTask(":dokkaHtml").shouldHaveOutcome(SUCCESS, FROM_CACHE)
 
         val htmlOutputDir = File(projectDir, "build/dokka/html")

--- a/dokka-integration-tests/gradle/src/testTemplateProjectBasic/kotlin/BasicCachingIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/testTemplateProjectBasic/kotlin/BasicCachingIntegrationTest.kt
@@ -66,8 +66,6 @@ class BasicCachingIntegrationTest : AbstractGradleCachingIntegrationTest() {
             buildVersions,
             "clean",
             "dokkaHtml",
-            "-i",
-            "-s",
             "-Dorg.gradle.caching.debug=true",
             enableBuildCache = true,
         ).buildRelaxed()

--- a/dokka-integration-tests/gradle/src/testTemplateProjectBasic/kotlin/BasicGradleIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/testTemplateProjectBasic/kotlin/BasicGradleIntegrationTest.kt
@@ -28,8 +28,6 @@ class BasicGradleIntegrationTest : AbstractGradleIntegrationTest() {
             "dokkaJavadoc",
             "dokkaGfm",
             "dokkaJekyll",
-            "-i",
-            "-s"
         ).buildRelaxed()
 
         assertEquals(expectedOutcome, assertNotNull(result.task(":dokkaHtml")).outcome)

--- a/dokka-integration-tests/gradle/src/testTemplateProjectBasic/kotlin/GradleRelocatedCachingIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/testTemplateProjectBasic/kotlin/GradleRelocatedCachingIntegrationTest.kt
@@ -32,8 +32,6 @@ class GradleRelocatedCachingIntegrationTest : AbstractGradleCachingIntegrationTe
             buildVersions,
             "clean",
             "dokkaHtml",
-            "-i",
-            "-s",
             "-Dorg.gradle.caching.debug=true",
             enableBuildCache = true,
         ).withProjectDir(project).buildRelaxed()

--- a/dokka-integration-tests/gradle/src/testTemplateProjectBasicGroovy/kotlin/BasicGroovyIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/testTemplateProjectBasicGroovy/kotlin/BasicGroovyIntegrationTest.kt
@@ -22,8 +22,6 @@ class BasicGroovyIntegrationTest : AbstractGradleIntegrationTest() {
             "dokkaJavadoc",
             "dokkaGfm",
             "dokkaJekyll",
-            "-i",
-            "-s"
         ).buildRelaxed()
 
         result.shouldHaveTask(":dokkaHtml").shouldHaveOutcome(SUCCESS, FROM_CACHE)

--- a/dokka-integration-tests/gradle/src/testTemplateProjectCollector/kotlin/Collector0IntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/testTemplateProjectCollector/kotlin/Collector0IntegrationTest.kt
@@ -22,7 +22,6 @@ class Collector0IntegrationTest : AbstractGradleIntegrationTest() {
             ":moduleA:dokkaJavadocCollector",
             ":moduleA:dokkaGfmCollector",
             ":moduleA:dokkaJekyllCollector",
-            "-i", "-s"
         ).buildRelaxed()
 
         result.shouldHaveTask(":moduleA:dokkaHtmlCollector").shouldHaveOutcome(SUCCESS, FROM_CACHE)

--- a/dokka-integration-tests/gradle/src/testTemplateProjectConfiguration/kotlin/ConfigurationTest.kt
+++ b/dokka-integration-tests/gradle/src/testTemplateProjectConfiguration/kotlin/ConfigurationTest.kt
@@ -33,8 +33,6 @@ class ConfigurationTest : AbstractGradleIntegrationTest() {
     ) {
         val result = createGradleRunner(
             buildVersions,
-            "-info",
-            "-stacktrace",
             "-Preport_undocumented=true",
             "-Pfail_on_warning=true",
             "dokkaHtml"

--- a/dokka-integration-tests/gradle/src/testTemplateProjectJsIr/kotlin/JsIRGradleIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/testTemplateProjectJsIr/kotlin/JsIRGradleIntegrationTest.kt
@@ -35,8 +35,6 @@ class JsIRGradleIntegrationTest : AbstractGradleIntegrationTest() {
             buildVersions,
             "-Preact_version=$reactVersion",
             "dokkaHtml",
-            "-i",
-            "-s"
         ).buildRelaxed()
 
         result.shouldHaveTask(":dokkaHtml").shouldHaveOutcome(SUCCESS, FROM_CACHE)

--- a/dokka-integration-tests/gradle/src/testTemplateProjectMultimodule0/kotlin/MultiModule0IntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/testTemplateProjectMultimodule0/kotlin/MultiModule0IntegrationTest.kt
@@ -23,7 +23,6 @@ class MultiModule0IntegrationTest : AbstractGradleIntegrationTest() {
             ":moduleA:dokkaHtmlMultiModule",
             ":moduleA:dokkaGfmMultiModule",
             ":moduleA:dokkaJekyllMultiModule",
-            "-i", "-s"
         ).buildRelaxed()
 
         result.shouldHaveTask(":moduleA:dokkaHtmlMultiModule").shouldHaveOutcome(SUCCESS, FROM_CACHE)

--- a/dokka-integration-tests/gradle/src/testTemplateProjectMultimodule1/kotlin/MultiModule1IntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/testTemplateProjectMultimodule1/kotlin/MultiModule1IntegrationTest.kt
@@ -22,7 +22,6 @@ class MultiModule1IntegrationTest : AbstractGradleIntegrationTest() {
         val result = createGradleRunner(
             buildVersions,
             ":second:dokkaHtml",
-            "-i", "-s"
         ).buildRelaxed()
 
         result.shouldHaveTask(":second:dokkaHtml").shouldHaveOutcome(SUCCESS, FROM_CACHE)

--- a/dokka-integration-tests/gradle/src/testTemplateProjectMultimoduleInterModuleLinks/kotlin/MultiModuleInterModuleLinksIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/testTemplateProjectMultimoduleInterModuleLinks/kotlin/MultiModuleInterModuleLinksIntegrationTest.kt
@@ -8,7 +8,9 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 import java.io.File
-import kotlin.test.*
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 /**
  * The test aims to check links to declarations from a package that is in two different modules.
@@ -29,7 +31,6 @@ class MultiModuleInterModuleLinksIntegrationTest : AbstractGradleIntegrationTest
         val result = createGradleRunner(
             buildVersions,
             ":moduleA:dokkaHtmlMultiModule",
-            "-i", "-s"
         ).buildRelaxed()
 
         assertEquals(TaskOutcome.SUCCESS, assertNotNull(result.task(":moduleA:dokkaHtmlMultiModule")).outcome)

--- a/dokka-integration-tests/gradle/src/testTemplateProjectMultimoduleVersioning/kotlin/Versioning0IntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/testTemplateProjectMultimoduleVersioning/kotlin/Versioning0IntegrationTest.kt
@@ -26,7 +26,6 @@ class Versioning0IntegrationTest : AbstractGradleIntegrationTest() {
         val result = createGradleRunner(
             buildVersions,
             ":dokkaHtmlMultiModuleBaseVersion",
-            "-i", "-s"
         ).buildRelaxed()
 
         assertEquals(TaskOutcome.SUCCESS, assertNotNull(result.task(":dokkaHtmlMultiModuleBaseVersion")).outcome)
@@ -37,7 +36,6 @@ class Versioning0IntegrationTest : AbstractGradleIntegrationTest() {
             buildVersions,
             "clean",
             ":dokkaHtmlMultiModuleNextVersion",
-            "-i", "-s"
         ).buildRelaxed()
 
         assertEquals(TaskOutcome.SUCCESS, assertNotNull(result2.task(":dokkaHtmlMultiModuleNextVersion")).outcome)
@@ -48,7 +46,6 @@ class Versioning0IntegrationTest : AbstractGradleIntegrationTest() {
             buildVersions,
             "clean",
             ":dokkaHtmlMultiModule",
-            "-i", "-s"
         ).buildRelaxed()
 
         assertEquals(TaskOutcome.SUCCESS, assertNotNull(result3.task(":dokkaHtmlMultiModule")).outcome)
@@ -83,7 +80,6 @@ class Versioning0IntegrationTest : AbstractGradleIntegrationTest() {
         val result = createGradleRunner(
             buildVersions,
             ":dokkaHtmlMultiModuleBaseVersion",
-            "-i", "-s",
             "-PolderVersionsDirName=$olderVersionsDirName"
         ).buildRelaxed()
 
@@ -95,7 +91,6 @@ class Versioning0IntegrationTest : AbstractGradleIntegrationTest() {
             buildVersions,
             "clean",
             ":dokkaHtmlMultiModuleNextVersion",
-            "-i", "-s",
             "-PolderVersionsDirName=$olderVersionsDirName"
         ).buildRelaxed()
 
@@ -107,7 +102,6 @@ class Versioning0IntegrationTest : AbstractGradleIntegrationTest() {
             buildVersions,
             "clean",
             ":dokkaHtmlMultiModule",
-            "-i", "-s",
             "-PolderVersionsDirName=$olderVersionsDirName"
         ).buildRelaxed()
 
@@ -147,7 +141,6 @@ class Versioning0IntegrationTest : AbstractGradleIntegrationTest() {
         val result = createGradleRunner(
             buildVersions,
             ":dokkaHtmlMultiModuleBaseVersion",
-            "-i", "-s",
             "-PolderVersionsDirName=$olderVersionsDirName"
         ).buildRelaxed()
 
@@ -159,7 +152,6 @@ class Versioning0IntegrationTest : AbstractGradleIntegrationTest() {
             buildVersions,
             "clean",
             ":dokkaHtmlMultiModuleNextVersion",
-            "-i", "-s",
             "-PolderVersionsDirName=$olderVersionsDirName"
         ).buildRelaxed()
 
@@ -171,7 +163,6 @@ class Versioning0IntegrationTest : AbstractGradleIntegrationTest() {
             buildVersions,
             "clean",
             ":dokkaHtmlMultiModule",
-            "-i", "-s",
             "-PolderVersionsDirName=$olderVersionsDirName"
         ).buildRelaxed()
 

--- a/dokka-integration-tests/gradle/src/testTemplateProjectMultiplatform/kotlin/Multiplatform0GradleIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/testTemplateProjectMultiplatform/kotlin/Multiplatform0GradleIntegrationTest.kt
@@ -4,15 +4,11 @@
 
 package org.jetbrains.dokka.it.gradle
 
-import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.TaskOutcome.FROM_CACHE
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 import java.io.File
-import kotlin.test.BeforeTest
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class Multiplatform0GradleIntegrationTest : AbstractGradleIntegrationTest() {
@@ -26,13 +22,11 @@ class Multiplatform0GradleIntegrationTest : AbstractGradleIntegrationTest() {
             createGradleRunner(
                 buildVersions,
                 "dokkaHtml",
-                "-i",
-                "-s",
                 "-Pkotlin.mpp.enableGranularSourceSetsMetadata=true",
                 "-Pkotlin.native.enableDependencyPropagation=false"
             ).buildRelaxed()
         else
-            createGradleRunner(buildVersions, "dokkaHtml", "-i", "-s").buildRelaxed()
+            createGradleRunner(buildVersions, "dokkaHtml").buildRelaxed()
 
         result.shouldHaveTask(":dokkaHtml").shouldHaveOutcome(SUCCESS, FROM_CACHE)
 

--- a/dokka-integration-tests/gradle/src/testTemplateProjectTasksExecutionStress/kotlin/SequentialTasksExecutionStressTest.kt
+++ b/dokka-integration-tests/gradle/src/testTemplateProjectTasksExecutionStress/kotlin/SequentialTasksExecutionStressTest.kt
@@ -24,8 +24,6 @@ class SequentialTasksExecutionStressTest : AbstractGradleIntegrationTest() {
         val result = createGradleRunner(
             buildVersions,
             "runTasks",
-            "--info",
-            "--stacktrace",
             "-Ptask_number=$iterations",
             jvmArgs = listOf("-Xmx1G", "-XX:MaxMetaspaceSize=500m"),
             enableBuildCache = false,

--- a/dokka-integration-tests/gradle/src/testTemplateProjectWasmBasic/kotlin/WasmGradleIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/testTemplateProjectWasmBasic/kotlin/WasmGradleIntegrationTest.kt
@@ -29,7 +29,10 @@ class WasmGradleIntegrationTest : AbstractGradleIntegrationTest() {
     @ParameterizedTest(name = "{0}")
     @ArgumentsSource(WasmTestedVersionsArgumentsProvider::class)
     fun execute(buildVersions: BuildVersions) {
-        val result = createGradleRunner(buildVersions, "dokkaHtml", "-i", "-s").buildRelaxed()
+        val result = createGradleRunner(
+            buildVersions,
+            "dokkaHtml",
+        ).buildRelaxed()
         result.shouldHaveTask(":dokkaHtml").shouldHaveOutcome(SUCCESS, FROM_CACHE)
 
         val htmlOutputDir = File(projectDir, "build/dokka/html")

--- a/dokka-integration-tests/gradle/src/testTemplateProjectWasmJsWasiBasic/kotlin/WasmJsWasiGradleIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/testTemplateProjectWasmJsWasiBasic/kotlin/WasmJsWasiGradleIntegrationTest.kt
@@ -28,7 +28,7 @@ class WasmJsWasiGradleIntegrationTest : AbstractGradleIntegrationTest() {
     @ParameterizedTest(name = "{0}")
     @ArgumentsSource(WasmJsWasiTestedVersionsArgumentsProvider::class)
     fun execute(buildVersions: BuildVersions) {
-        val result = createGradleRunner(buildVersions, "dokkaHtml", "-i", "-s").buildRelaxed()
+        val result = createGradleRunner(buildVersions, "dokkaHtml").buildRelaxed()
         result.shouldHaveTask(":dokkaHtml").shouldHaveOutcome(SUCCESS, FROM_CACHE)
 
         val htmlOutputDir = File(projectDir, "build/dokka/html")

--- a/dokka-integration-tests/gradle/src/testUiShowcaseProject/kotlin/UiShowcaseIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/testUiShowcaseProject/kotlin/UiShowcaseIntegrationTest.kt
@@ -24,8 +24,6 @@ class UiShowcaseIntegrationTest : AbstractGradleIntegrationTest(), TestOutputCop
         val result = createGradleRunner(
             buildVersions,
             "dokkaHtmlMultiModule",
-            "-i",
-            "-s"
         ).buildRelaxed()
 
         result.shouldHaveTask(":dokkaHtmlMultiModule").shouldHaveOutcome(SUCCESS, FROM_CACHE)

--- a/dokka-runners/runner-gradle-plugin-classic/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/AbstractDokkaTask.kt
+++ b/dokka-runners/runner-gradle-plugin-classic/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/AbstractDokkaTask.kt
@@ -208,8 +208,8 @@ abstract class AbstractDokkaTask : DefaultTask() {
      *
      * Override the log level that [DokkaBootstrap] produces output logs. Intended for use in tests.
      */
-    private val dokkaGeneratorLogLevelOverride: Provider<LogLevel>
-        get() = providers.gradleProperty("dokka.internal.gradle.dokkaGenerator.logLevelOverride")
+    private val dokkaGeneratorLogLevel: Provider<LogLevel>
+        get() = providers.gradleProperty("org.jetbrains.dokka.internal.gradleLogLevel")
             .map { LogLevel.values().first { level -> level.name == it } }
 
     final override fun doFirst(action: Action<in Task>): Task = super.doFirst(action)
@@ -239,7 +239,7 @@ abstract class AbstractDokkaTask : DefaultTask() {
     private fun createProxyLogger(): BiConsumer<String, String> =
         object : BiConsumer<String, String> {
             private val overrideLogger: ((message: String) -> Unit)? =
-                when (dokkaGeneratorLogLevelOverride.orNull) {
+                when (dokkaGeneratorLogLevel.orNull) {
                     DEBUG -> logger::debug
                     INFO -> logger::info
                     LIFECYCLE -> logger::lifecycle

--- a/dokka-runners/runner-gradle-plugin-classic/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/AbstractDokkaTask.kt
+++ b/dokka-runners/runner-gradle-plugin-classic/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/AbstractDokkaTask.kt
@@ -210,7 +210,11 @@ abstract class AbstractDokkaTask : DefaultTask() {
      */
     private val dokkaGeneratorLogLevel: Provider<LogLevel>
         get() = providers.gradleProperty("org.jetbrains.dokka.internal.gradleLogLevel")
-            .map { LogLevel.values().first { level -> level.name == it } }
+            .flatMap {
+                providers.provider {
+                    LogLevel.values().firstOrNull { level -> level.name == it }
+                }
+            }
 
     final override fun doFirst(action: Action<in Task>): Task = super.doFirst(action)
 

--- a/dokka-runners/runner-gradle-plugin-classic/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/AbstractDokkaTask.kt
+++ b/dokka-runners/runner-gradle-plugin-classic/src/main/kotlin/org/jetbrains/dokka/gradle/tasks/AbstractDokkaTask.kt
@@ -12,10 +12,10 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.logging.LogLevel
+import org.gradle.api.logging.LogLevel.*
 import org.gradle.api.plugins.JavaBasePlugin
-import org.gradle.api.provider.ListProperty
-import org.gradle.api.provider.MapProperty
-import org.gradle.api.provider.Property
+import org.gradle.api.provider.*
 import org.gradle.api.tasks.*
 import org.gradle.kotlin.dsl.listProperty
 import org.gradle.kotlin.dsl.mapProperty
@@ -201,6 +201,17 @@ abstract class AbstractDokkaTask : DefaultTask() {
     @Classpath
     val runtime: Configuration = project.maybeCreateDokkaRuntimeConfiguration(name)
 
+    private val providers: ProviderFactory = project.providers
+
+    /**
+     * Internal Dokka Gradle Plugin only.
+     *
+     * Override the log level that [DokkaBootstrap] produces output logs. Intended for use in tests.
+     */
+    private val dokkaGeneratorLogLevelOverride: Provider<LogLevel>
+        get() = providers.gradleProperty("dokka.internal.gradle.dokkaGenerator.logLevelOverride")
+            .map { LogLevel.values().first { level -> level.name == it } }
+
     final override fun doFirst(action: Action<in Task>): Task = super.doFirst(action)
 
     final override fun doFirst(action: Closure<*>): Task = super.doFirst(action)
@@ -225,15 +236,36 @@ abstract class AbstractDokkaTask : DefaultTask() {
 
     internal abstract fun buildDokkaConfiguration(): DokkaConfigurationImpl
 
-    private fun createProxyLogger(): BiConsumer<String, String> = BiConsumer { level, message ->
-        when (level) {
-            "debug" -> logger.debug(message)
-            "info" -> logger.info(message)
-            "progress" -> logger.lifecycle(message)
-            "warn" -> logger.warn(message)
-            "error" -> logger.error(message)
+    private fun createProxyLogger(): BiConsumer<String, String> =
+        object : BiConsumer<String, String> {
+            private val overrideLogger: ((message: String) -> Unit)? =
+                when (dokkaGeneratorLogLevelOverride.orNull) {
+                    DEBUG -> logger::debug
+                    INFO -> logger::info
+                    LIFECYCLE -> logger::lifecycle
+                    WARN -> logger::warn
+                    QUIET -> logger::quiet
+                    ERROR -> logger::error
+                    null -> null
+                }
+
+            override fun accept(level: String, message: String) {
+                if (overrideLogger != null) {
+                    // when an override level is set, re-route all the messages
+                    overrideLogger.invoke(message)
+                } else {
+                    // otherwise, map the Dokka log level (org.jetbrains.dokka.utilities.LoggingLevel)
+                    // to an equivalent Gradle log level
+                    when (level) {
+                        "debug" -> logger.debug(message)
+                        "info" -> logger.info(message)
+                        "progress" -> logger.lifecycle(message)
+                        "warn" -> logger.warn(message)
+                        "error" -> logger.error(message)
+                    }
+                }
+            }
         }
-    }
 
     init {
         group = JavaBasePlugin.DOCUMENTATION_GROUP


### PR DESCRIPTION
### Motivation

Too many logs when using Gradle TestKit causes the tests to run slower. This is mainly because Gradle TestKit stores logs in-memory (see https://github.com/gradle/gradle/issues/23965).

Reducing the amount of logging would be beneficial for two reasons:

- The tests can run faster.
- The logs are not cluttered with unimportant messages from other Gradle tasks. We can focus on the Dokka Generator logs.

However, reducing the log level to 'lifecycle' would mean that the Dokka Generator logs would not be reported. To work around this, I added an internal flag that can override the default log level of Dokka Generator.

The result is that the tests run faster, and test results are easier to read and verify.

### Summary of changes

- Reduce the log-level of Gradle tests to 'lifecycle' by default (this can be overridden if necessary).
- Introduce an internal flag, `dokka.internal.gradle.dokkaGenerator.logLevelOverride`, in AbstractDokkaTask that can re-direct the logs of Dokka Generator to a specific level, independent from the Gradle log level.
- Correctly enable `--stacktrace` on all tests, and enable it by default for all tests.


^OSIP-355

### Depends on

- #3716 
