### PR TITLE
Reduce SequentialTasksExecutionStressTest iterations from 100 to 50

### DIFF
--- a/dokka-integration-tests/gradle/src/testTemplateProjectTasksExecutionStress/kotlin/SequentialTasksExecutionStressTest.kt
+++ b/dokka-integration-tests/gradle/src/testTemplateProjectTasksExecutionStress/kotlin/SequentialTasksExecutionStressTest.kt
@@ -19,12 +19,14 @@ class SequentialTasksExecutionStressTest : AbstractGradleIntegrationTest() {
     @ParameterizedTest(name = "{0}")
     @ArgumentsSource(LatestTestedVersionsArgumentsProvider::class)
     fun execute(buildVersions: BuildVersions) {
+        val iterations = 50
+
         val result = createGradleRunner(
             buildVersions,
             "runTasks",
             "--info",
             "--stacktrace",
-            "-Ptask_number=100",
+            "-Ptask_number=$iterations",
             jvmArgs = listOf("-Xmx1G", "-XX:MaxMetaspaceSize=500m"),
             enableBuildCache = false,
         ).buildRelaxed()


### PR DESCRIPTION
This is a quick-fix to help improve the execution speed of the stress test (it currently takes ~15 minutes).

I've tried a few methods of introducing memory leaks, and all of them were caught after ~30 iterations, so 50 seems like a good number.

#3723 