### PR TITLE
Fix 'provider has no value' error when running DGP integration tests without ANDROID_HOME

### DIFF
--- a/dokka-integration-tests/gradle/build.gradle.kts
+++ b/dokka-integration-tests/gradle/build.gradle.kts
@@ -77,7 +77,9 @@ registerTestProjectSuite(
         testTask.configure {
             // Don't register ANDROID_HOME as a Task input, because the path is different on everyone's machine,
             // which means Gradle will never be able to cache the task.
-            environment("ANDROID_HOME", dokkaBuild.androidSdkDir.get().invariantSeparatorsPath)
+            dokkaBuild.androidSdkDir.orNull?.let { androidSdkDir ->
+                environment("ANDROID_HOME", androidSdkDir)
+            }
         }
     }
 }


### PR DESCRIPTION


Currently, if someone tries to run any Gradle Integration Test and they don't have ANDROID_HOME configured, then the Gradle build breaks because the SDK dir eagerly tries to fetch the value.

This change fixes this by only setting ANDROID_HOME in tests if possible. This allows running the integration tests, although the Android one will fail!