### PR TITLE
Use cache-redirector for Maven plugin build

### DIFF
--- a/build-logic/src/main/kotlin/dokkabuild.setup-maven-cli.gradle.kts
+++ b/build-logic/src/main/kotlin/dokkabuild.setup-maven-cli.gradle.kts
@@ -113,4 +113,5 @@ tasks.withType<MvnExec>().configureEach {
     workDirectory.convention(layout.dir(provider { temporaryDir }))
     showErrors.convention(true)
     batchMode.convention(true)
+    settingsXml.convention(layout.projectDirectory.file("settings.xml"))
 }

--- a/build-logic/src/main/kotlin/dokkabuild/tasks/MvnExec.kt
+++ b/build-logic/src/main/kotlin/dokkabuild/tasks/MvnExec.kt
@@ -55,6 +55,17 @@ constructor(
     @get:PathSensitive(NONE)
     abstract val mvnCli: RegularFileProperty
 
+    /**
+     * Optional Maven `settings.xml` file.
+     *
+     * When `mvn` is invoked, it will be set using the `--settings` argument.
+     */
+    @get:InputFile
+    @get:PathSensitive(NONE)
+    @get:NormalizeLineEndings
+    @get:Optional
+    abstract val settingsXml: RegularFileProperty
+
     @get:Input
     abstract val arguments: ListProperty<String>
 
@@ -82,6 +93,10 @@ constructor(
             addAll(arguments.get())
             if (showErrors.orNull == true) add("--errors")
             if (batchMode.orNull == true) add("--batch-mode")
+            if (settingsXml.isPresent) {
+                add("--settings")
+                add(settingsXml.get().asFile.invariantSeparatorsPath)
+            }
         }
 
         exec.exec {

--- a/dokka-runners/runner-maven-plugin/settings.xml
+++ b/dokka-runners/runner-maven-plugin/settings.xml
@@ -1,0 +1,31 @@
+<!-- Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license. -->
+
+<settings>
+    <profiles>
+        <profile>
+            <id>dokka-build</id>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>MavenCentral-JBCached</id>
+                    <url>https://cache-redirector.jetbrains.com/repo.maven.apache.org/maven2</url>
+                </pluginRepository>
+            </pluginRepositories>
+            <repositories>
+                <repository>
+                    <id>MavenCentral-JBCached</id>
+                    <url>https://cache-redirector.jetbrains.com/repo.maven.apache.org/maven2</url>
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
+    <mirrors>
+        <mirror>
+            <id>MavenCentral-JBCached</id>
+            <url>https://cache-redirector.jetbrains.com/repo.maven.apache.org/maven2</url>
+            <mirrorOf>central</mirrorOf>
+        </mirror>
+    </mirrors>
+    <activeProfiles>
+        <activeProfile>dokka-build</activeProfile>
+    </activeProfiles>
+</settings>


### PR DESCRIPTION
Currently the Dokka Maven Plugin does not use the JetBrains cache-redirector for builds. This PR adds a `settings.xml` that is used in all MvnExec tasks.

Part of [KT-64200](https://youtrack.jetbrains.com/issue/KT-64200), follow up to #3650.

(For external readers: the JetBrains cache-redirector is intended to improve TeamCity performance, and is not intended for external use.)