### PR TITLE
Fix read-only cache dir in DGP integration tests

### DIFF
--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleIntegrationTest.kt
@@ -154,11 +154,11 @@ abstract class AbstractGradleIntegrationTest : AbstractIntegrationTest() {
          *
          * See https://docs.gradle.org/8.9/userguide/dependency_resolution.html#sub:cache_copy
          *
-         * Note: Currently all Gradle versions store caches in `$GRADLE_USER_HOME/caches/modules-2`,
+         * Note: Currently all Gradle versions store caches in `$GRADLE_USER_HOME/caches/`,
          * but this might change. Check the docs.
          */
         private val hostGradleDependenciesCache: Path by lazy {
-            hostGradleUserHome.resolve("caches/modules-2")
+            hostGradleUserHome.resolve("caches")
         }
 
         /** file-based Maven repositories with Dokka dependencies */


### PR DESCRIPTION
The cache dir is set incorrectly, leading to this warning:

> Read-only cache is configured but the directory layout isn't expected. You must have a pre-populated modules-2 directory at ~/.gradle/caches/modules-2/modules-2 . Please follow the instructions at https://docs.gradle.org/7.6.2/userguide/dependency_resolution.html#sub:shared-readonly-cache

(Note the directory ends with `/modules-2/modules-2`. So `GRADLE_RO_DEP_CACHE` should be set to `$GRADLE_USER_HOME/caches`, not `$GRADLE_USER_HOME/caches/modules-2`)