### PR TITLE
GHA: Upload build reports on test failures

### DIFF
--- a/.github/workflows/tests-smoke.yml
+++ b/.github/workflows/tests-smoke.yml
@@ -34,3 +34,13 @@ jobs:
         run: >
           ./gradlew test --stacktrace --continue 
           "-Porg.jetbrains.dokka.javaToolchain.testLauncher=${{ env.JAVA_TEST_VERSION }}"
+      - name: Upload build reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-reports-${{ runner.os }}-${{ github.action }}-${{ github.run_id }}
+          path: |
+            **/build/reports/
+            **/*.hprof
+            **/*.log
+          if-no-files-found: ignore

--- a/.github/workflows/tests-thorough.yml
+++ b/.github/workflows/tests-thorough.yml
@@ -32,3 +32,13 @@ jobs:
         run: >
           ./gradlew test --stacktrace --continue
           "-Porg.jetbrains.dokka.javaToolchain.testLauncher=${{ matrix.javaVersion }}"
+      - name: Upload build reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+           name: build-reports-${{ runner.os }}-${{ github.action }}-${{ github.run_id }}
+           path: |
+              **/build/reports/
+              **/*.hprof
+              **/*.log
+           if-no-files-found: ignore


### PR DESCRIPTION
Let's upload the build reports, since the Build Scans aren't capturing issues with flaky tests.