### PR TITLE
Fix S3 publication paths

### DIFF
--- a/.github/workflows/preview-publish-web-s3.yml
+++ b/.github/workflows/preview-publish-web-s3.yml
@@ -31,7 +31,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-central-1
       - name: Copy files to dokka's S3 bucket
-        run: ./dokka-integration-tests/aws_sync.sh s3://${{ env.bucket-name }} coroutines ../coroutines
+        run: ./dokka-integration-tests/aws_sync.sh s3://${{ env.bucket-name }} coroutines ${{ github.workspace }}/dokka/coroutines
       - name: Print link
         run: echo https://dokka-snapshots.s3.eu-central-1.amazonaws.com/${{ env.branch-name }}/coroutines/${GITHUB_SHA::7}/index.html
 
@@ -59,7 +59,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-central-1
       - name: Copy files to dokka's S3 bucket
-        run: ./dokka-integration-tests/aws_sync.sh s3://${{ env.bucket-name }} serialization ../serialization
+        run: ./dokka-integration-tests/aws_sync.sh s3://${{ env.bucket-name }} serialization ${{ github.workspace }}/dokka/serialization
       - name: Print link
         run: echo https://dokka-snapshots.s3.eu-central-1.amazonaws.com/${{ env.branch-name }}/serialization/${GITHUB_SHA::7}/index.html
 
@@ -87,7 +87,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-central-1
       - name: Copy files to dokka's S3 bucket
-        run: ./dokka-integration-tests/aws_sync.sh s3://${{ env.bucket-name }} ui-showcase ../ui-showcase
+        run: ./dokka-integration-tests/aws_sync.sh s3://${{ env.bucket-name }} ui-showcase ${{ github.workspace }}/dokka/ui-showcase
       - name: Print link
         run: echo https://dokka-snapshots.s3.eu-central-1.amazonaws.com/${{ env.branch-name }}/ui-showcase/${GITHUB_SHA::7}/index.html
 
@@ -116,6 +116,6 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-central-1
       - name: Copy files to dokka's S3 bucket
-        run: ./dokka-integration-tests/aws_sync.sh s3://${{ env.bucket-name }} biojava ../biojava
+        run: ./dokka-integration-tests/aws_sync.sh s3://${{ env.bucket-name }} biojava ${{ github.workspace }}/dokka/biojava
       - name: Print link
         run: echo https://dokka-snapshots.s3.eu-central-1.amazonaws.com/${{ env.branch-name }}/biojava/${GITHUB_SHA::7}/index.html

--- a/dokka-integration-tests/aws_sync.sh
+++ b/dokka-integration-tests/aws_sync.sh
@@ -33,6 +33,6 @@ done
 # Sync the new one
 commit_hash=$(git log -1 --format="%h")
 
-aws s3 sync "$project_path" "$s3_project_address$commit_hash/"
-
 echo "$commit_hash"
+
+aws s3 sync "$project_path" "$s3_project_address$commit_hash/"


### PR DESCRIPTION
After #3687 publication to S3, previews were broken because of wrong publication paths.
Bash script was logging `The user-provided path ../coroutines does not exist.` but finished successfully, so the error was unnoticed.
Both issues should be fixed now.