### PR TITLE
Prettify file trees in docs

### DIFF
--- a/docs/topics/runners/dokka-gradle.md
+++ b/docs/topics/runners/dokka-gradle.md
@@ -142,13 +142,14 @@ By default, you can find ready-to-use documentation under `{parentProject}/build
 Given a project with the following structure:
 
 ```text
-parentProject
-    └── childProjectA
-        ├── demo
-            ├── ChildProjectAClass
-    └── childProjectB
-        ├── demo
-            ├── ChildProjectBClass
+.
+└── parentProject/
+    ├── childProjectA/
+    │   └── demo/
+    │       └── ChildProjectAClass
+    └── childProjectB/
+        └── demo/
+            └── ChildProjectBClass
 ```
 
 These pages are generated after running `dokkaHtmlMultiModule`:
@@ -179,13 +180,14 @@ build that contains all declarations from the subprojects.
 Given a project with the following structure:
 
 ```text
-parentProject
-    └── childProjectA
-        ├── demo
-            ├── ChildProjectAClass
-    └── childProjectB
-        ├── demo
-            ├── ChildProjectBClass
+.
+└── parentProject/
+    ├── childProjectA/
+    │   └── demo/
+    │       └── ChildProjectAClass
+    └── childProjectB/
+        └── demo/
+            └── ChildProjectBClass
 ```
 
 These pages are generated after running `dokkaHtmlCollector`:
@@ -306,15 +308,15 @@ Multiplatform:
 ```text
 .
 ├── build.gradle.kts
-└── src
-    └── commonMain
-        └── kotlin
-            └── Common.kt
-    └── jvmMain
-        └── kotlin
-            └── JvmUtils.kt
-    └── nativeMain
-        └── kotlin
+└── src/
+    ├── commonMain/
+    │   └── kotlin/
+    │       └── Common.kt
+    ├── jvmMain/
+    │   └── kotlin/
+    │       └── JvmUtils.kt
+    └── nativeMain/
+        └── kotlin/
             └── NativeUtils.kt
 ```
 
@@ -337,15 +339,15 @@ Multiplatform:
 ```text
 .
 ├── build.gradle
-└── src
-    └── commonMain
-        └── kotlin
-            └── Common.kt
-    └── jvmMain
-        └── kotlin
-            └── JvmUtils.kt
-    └── nativeMain
-        └── kotlin
+└── src/
+    ├── commonMain/
+    │   └── kotlin/
+    │       └── Common.kt
+    ├── jvmMain/
+    │   └── kotlin/
+    │       └── JvmUtils.kt
+    └── nativeMain/
+        └── kotlin/
             └── NativeUtils.kt
 ```
 
@@ -479,17 +481,17 @@ typically have the following structure:
 .
 ├── build.gradle.kts
 ├── settings.gradle.kts
-├── subproject-A
-    └── build.gradle.kts
-    └── src
-        └── main
-            └── kotlin
-                └── HelloFromA.kt
-├── subproject-B
-    └── build.gradle.kts
-    └── src
-        └── main
-            └── kotlin
+├── subproject-A/
+│   ├── build.gradle.kts
+│   └── src/
+│       └── main/
+│           └── kotlin/
+│               └── HelloFromA.kt
+└── subproject-B/
+    ├── build.gradle.kts
+    └── src/
+        └── main/
+            └── kotlin/
                 └── HelloFromB.kt
 ```
 
@@ -500,17 +502,17 @@ typically have the following structure:
 .
 ├── build.gradle
 ├── settings.gradle
-├── subproject-A
-    └── build.gradle
-    └── src
-        └── main
-            └── kotlin
-                └── HelloFromA.kt
-├── subproject-B
-    └── build.gradle
-    └── src
-        └── main
-            └── kotlin
+├── subproject-A/
+│   ├── build.gradle
+│   └── src/
+│       └── main/
+│           └── kotlin/
+│               └── HelloFromA.kt
+└── subproject-B/
+    ├── build.gradle
+    └── src/
+        └── main/
+            └── kotlin/
                 └── HelloFromB.kt
 ```
 

--- a/dokka-subprojects/plugin-versioning/README.md
+++ b/dokka-subprojects/plugin-versioning/README.md
@@ -118,10 +118,10 @@ Note that the directory passed to `olderVersionsDir` needs to follow a specific 
 ```text
 .
 └── olderVersionsDir
-    └── 1.7.10
-        ├── <dokka output>
+    ├── 1.7.10
+    │   └── <dokka output>
     └── 1.7.20
-        ├── <dokka output>
+        └── <dokka output>
 ...
 ```
 


### PR DESCRIPTION
Minor docs formatting update, so that the file trees look better. E.g. use `└` for the last file in a list instead of `├`.

I know these docs are probably going to be outdated soon, but the file trees not being pretty bugs me a little.


I used https://tree.nathanfriend.io/ to update the trees.