### PR TITLE
DGP: Rename conflicting 'maybeCreate' helper function.

### DIFF
--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/gradleConfigurations.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/gradleConfigurations.kt
@@ -4,6 +4,7 @@
 
 package org.jetbrains.dokka.gradle
 
+import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
@@ -12,14 +13,14 @@ import org.gradle.kotlin.dsl.named
 import org.jetbrains.dokka.gradle.internal.PluginFeaturesService.Companion.pluginFeaturesService
 
 internal fun Project.maybeCreateDokkaDefaultPluginConfiguration(): Configuration {
-    return configurations.maybeCreate("dokkaPlugin") {
+    return configurations.findOrCreate("dokkaPlugin") {
         attributes.attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage.JAVA_RUNTIME))
         isCanBeConsumed = false
     }
 }
 
 internal fun Project.maybeCreateDokkaDefaultRuntimeConfiguration(): Configuration {
-    return configurations.maybeCreate("dokkaRuntime") {
+    return configurations.findOrCreate("dokkaRuntime") {
         attributes.attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage.JAVA_RUNTIME))
         isCanBeConsumed = false
     }
@@ -29,7 +30,7 @@ internal fun Project.maybeCreateDokkaPluginConfiguration(
     dokkaTaskName: String,
     additionalDependencies: Collection<Dependency> = emptySet()
 ): Configuration {
-    return project.configurations.maybeCreate("${dokkaTaskName}Plugin") {
+    return project.configurations.findOrCreate("${dokkaTaskName}Plugin") {
         extendsFrom(maybeCreateDokkaDefaultPluginConfiguration())
         attributes.attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage.JAVA_RUNTIME))
         isCanBeConsumed = false
@@ -46,7 +47,7 @@ internal fun Project.maybeCreateDokkaPluginConfiguration(
 }
 
 internal fun Project.maybeCreateDokkaRuntimeConfiguration(dokkaTaskName: String): Configuration {
-    return project.configurations.maybeCreate("${dokkaTaskName}Runtime") {
+    return project.configurations.findOrCreate("${dokkaTaskName}Runtime") {
         extendsFrom(maybeCreateDokkaDefaultRuntimeConfiguration())
         attributes.attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage.JAVA_RUNTIME))
         isCanBeConsumed = false
@@ -54,4 +55,8 @@ internal fun Project.maybeCreateDokkaRuntimeConfiguration(dokkaTaskName: String)
             add(project.dokkaArtifacts.dokkaCore)
         }
     }
+}
+
+private fun <T : Any> NamedDomainObjectContainer<T>.findOrCreate(name: String, configuration: T.() -> Unit): T {
+    return findByName(name) ?: create(name, configuration)
 }

--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/utils.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/utils.kt
@@ -4,7 +4,6 @@
 
 package org.jetbrains.dokka.gradle
 
-import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.UnknownDomainObjectException
 import org.gradle.kotlin.dsl.findByType
@@ -43,7 +42,3 @@ internal fun Project.isAndroidProject() = try {
 }
 
 internal fun KotlinTarget.isAndroidTarget() = this.platformType == KotlinPlatformType.androidJvm
-
-internal fun <T : Any> NamedDomainObjectContainer<T>.maybeCreate(name: String, configuration: T.() -> Unit): T {
-    return findByName(name) ?: create(name, configuration)
-}


### PR DESCRIPTION
DGPv1 and v2 both have a similar utility function: `fun <T> NamedDomainObjectContainer<T>.maybeCreate`. However, their behaviour is slightly different.

v1: maybe create the item, OR if it exists, configure it.
v2: maybe create the item, AND exist the new/existing item.

The only usage of v1's version was in the `gradleConfiguration.kt`, so this PR moves it and renames it to `findOrCreate()`, to avoid confusion.