### PR TITLE
DGPv2: Tidy configurable options

### DIFF
--- a/dokka-runners/dokka-gradle-plugin/api/dokka-gradle-plugin.api
+++ b/dokka-runners/dokka-gradle-plugin/api/dokka-gradle-plugin.api
@@ -240,7 +240,6 @@ public final class org/jetbrains/dokka/gradle/SourceSetKotlinGistConfigurationKt
 
 public abstract class org/jetbrains/dokka/gradle/dokka/DokkaPublication : java/io/Serializable, org/gradle/api/Named, org/gradle/api/plugins/ExtensionAware {
 	public abstract fun getCacheRoot ()Lorg/gradle/api/file/DirectoryProperty;
-	public abstract fun getDelayTemplateSubstitution ()Lorg/gradle/api/provider/Property;
 	public abstract fun getEnabled ()Lorg/gradle/api/provider/Property;
 	public abstract fun getFailOnWarning ()Lorg/gradle/api/provider/Property;
 	public abstract fun getFinalizeCoroutines ()Lorg/gradle/api/provider/Property;

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaBasePlugin.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaBasePlugin.kt
@@ -153,7 +153,6 @@ constructor(
         dokkaExtension.dokkaPublications.all {
             enabled.convention(true)
             cacheRoot.convention(dokkaExtension.dokkaCacheDirectory)
-            delayTemplateSubstitution.convention(false)
             failOnWarning.convention(false)
             finalizeCoroutines.convention(false)
             moduleName.convention(dokkaExtension.moduleName)

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/dokka/DokkaPublication.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/dokka/DokkaPublication.kt
@@ -8,11 +8,8 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.*
-import org.gradle.api.tasks.PathSensitivity.RELATIVE
-import org.jetbrains.dokka.gradle.internal.DokkaPluginParametersContainer
 import org.jetbrains.dokka.gradle.internal.DokkaInternalApi
+import org.jetbrains.dokka.gradle.internal.DokkaPluginParametersContainer
 import org.jetbrains.dokka.gradle.internal.adding
 import java.io.Serializable
 import javax.inject.Inject
@@ -29,7 +26,6 @@ abstract class DokkaPublication
 @DokkaInternalApi
 @Inject
 constructor(
-    @get:Internal
     val formatName: String,
 
     /**
@@ -40,72 +36,31 @@ constructor(
 ) : Named, Serializable, ExtensionAware {
 
     /** Configurations for Dokka Generator Plugins. */
-    @get:Nested
     val pluginsConfiguration: DokkaPluginParametersContainer =
         extensions.adding("pluginsConfiguration", pluginsConfiguration)
 
-    @Internal
     override fun getName(): String = formatName
 
-    @get:Input
     abstract val enabled: Property<Boolean>
 
-    @get:Input
     abstract val moduleName: Property<String>
 
-    @get:Input
-    @get:Optional
     abstract val moduleVersion: Property<String>
 
-    @get:Internal
-    // marked as Internal because this task does not use the directory contents, only the location
     abstract val outputDir: DirectoryProperty
 
-    /**
-     * Because [outputDir] must be [Internal] (so Gradle doesn't check the directory contents),
-     * [outputDirPath] is required so Gradle can determine if the task is up-to-date.
-     */
-    @get:Input
-    // marked as an Input because a DokkaPublication is used to configure the appropriate Dokka Tasks
-    @DokkaInternalApi
-    protected val outputDirPath: Provider<String>
-        get() = outputDir.map { it.asFile.invariantSeparatorsPath }
-
-    @get:Internal
-    // Marked as Internal because this task does not use the directory contents, only the location.
-    // Note that `cacheRoot` is not used by Dokka, and will probably be deprecated.
     abstract val cacheRoot: DirectoryProperty
 
-    /**
-     * Because [cacheRoot] must be [Internal] (so Gradle doesn't check the directory contents),
-     * [cacheRootPath] is required so Gradle can determine if the task is up-to-date.
-     */
-    @get:Input
-    @get:Optional
-    @DokkaInternalApi
-    protected val cacheRootPath: Provider<String>
-        get() = cacheRoot.map { it.asFile.invariantSeparatorsPath }
-
-    @get:Input
     abstract val offlineMode: Property<Boolean>
 
-    @get:Input
     abstract val failOnWarning: Property<Boolean>
 
-    @get:Input
-    abstract val delayTemplateSubstitution: Property<Boolean>
-
-    @get:Input
     abstract val suppressObviousFunctions: Property<Boolean>
 
-    @get:InputFiles
-    @get:PathSensitive(RELATIVE)
     abstract val includes: ConfigurableFileCollection
 
-    @get:Input
     abstract val suppressInheritedMembers: Property<Boolean>
 
-    @get:Input
     // TODO probably not needed any more, since Dokka Generator now runs in an isolated JVM process
     abstract val finalizeCoroutines: Property<Boolean>
 }


### PR DESCRIPTION
- `delayTemplateSubstitution` is no longer used, it is configured automatically internally.
- `DokkaPublication` is not used as a task input, and so it does not need the Gradle task annotations. It also doesn't need the workarounds like `cacheRootPath` and `outputDirPath`.