### PR TITLE
Simplify configuration of DokkaPublication output directories

### DIFF
--- a/dokka-runners/dokka-gradle-plugin/api/dokka-gradle-plugin.api
+++ b/dokka-runners/dokka-gradle-plugin/api/dokka-gradle-plugin.api
@@ -249,7 +249,7 @@ public abstract class org/jetbrains/dokka/gradle/dokka/DokkaPublication : java/i
 	public abstract fun getModuleVersion ()Lorg/gradle/api/provider/Property;
 	public fun getName ()Ljava/lang/String;
 	public abstract fun getOfflineMode ()Lorg/gradle/api/provider/Property;
-	public abstract fun getOutputDir ()Lorg/gradle/api/file/DirectoryProperty;
+	public abstract fun getOutputDirectory ()Lorg/gradle/api/file/DirectoryProperty;
 	public final fun getPluginsConfiguration ()Lorg/gradle/api/ExtensiblePolymorphicDomainObjectContainer;
 	public abstract fun getSuppressInheritedMembers ()Lorg/gradle/api/provider/Property;
 	public abstract fun getSuppressObviousFunctions ()Lorg/gradle/api/provider/Property;

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaBasePlugin.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaBasePlugin.kt
@@ -158,7 +158,8 @@ constructor(
             moduleName.convention(dokkaExtension.moduleName)
             moduleVersion.convention(dokkaExtension.moduleVersion)
             offlineMode.convention(false)
-            outputDir.convention(dokkaExtension.dokkaPublicationDirectory)
+            outputDirectory.convention(dokkaExtension.dokkaPublicationDirectory.dir(formatName))
+            moduleOutputDirectory.convention(dokkaExtension.dokkaModuleDirectory.dir(formatName))
             suppressInheritedMembers.convention(false)
             suppressObviousFunctions.convention(true)
         }

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/dokka/DokkaPublication.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/dokka/DokkaPublication.kt
@@ -47,7 +47,8 @@ constructor(
 
     abstract val moduleVersion: Property<String>
 
-    abstract val outputDir: DirectoryProperty
+    /** Output directory for the finished Dokka publication. */
+    abstract val outputDirectory: DirectoryProperty
 
     abstract val cacheRoot: DirectoryProperty
 
@@ -63,4 +64,7 @@ constructor(
 
     // TODO probably not needed any more, since Dokka Generator now runs in an isolated JVM process
     abstract val finalizeCoroutines: Property<Boolean>
+
+    /** Output directory for the partial Dokka module. */
+    internal abstract val moduleOutputDirectory: DirectoryProperty
 }

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/formats/DokkaFormatPlugin.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/formats/DokkaFormatPlugin.kt
@@ -86,7 +86,6 @@ abstract class DokkaFormatPlugin(
             val dokkaTasks = DokkaFormatTasks(
                 project = target,
                 publication = publication,
-                dokkaExtension = dokkaExtension,
                 formatDependencies = formatDependencies,
                 providers = providers,
             )

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/formats/DokkaFormatTasks.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/formats/DokkaFormatTasks.kt
@@ -7,7 +7,6 @@ import org.gradle.api.Project
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.register
-import org.jetbrains.dokka.gradle.DokkaExtension
 import org.jetbrains.dokka.gradle.dependencies.FormatDependenciesManager
 import org.jetbrains.dokka.gradle.dokka.DokkaPublication
 import org.jetbrains.dokka.gradle.internal.DokkaInternalApi
@@ -22,7 +21,6 @@ import org.jetbrains.dokka.gradle.tasks.TaskNames
 class DokkaFormatTasks(
     project: Project,
     private val publication: DokkaPublication,
-    private val dokkaExtension: DokkaExtension,
     private val formatDependencies: FormatDependenciesManager,
 
     private val providers: ProviderFactory,
@@ -60,7 +58,7 @@ class DokkaFormatTasks(
         ).configuring {
             description = "Executes the Dokka Generator, generating the $formatName publication"
 
-            outputDirectory.convention(dokkaExtension.dokkaPublicationDirectory.dir(formatName))
+            outputDirectory.convention(publication.outputDirectory)
 
             applyFormatSpecificConfiguration()
         }
@@ -72,7 +70,7 @@ class DokkaFormatTasks(
         ).configuring {
             description = "Executes the Dokka Generator, generating a $formatName module"
 
-            outputDirectory.convention(dokkaExtension.dokkaModuleDirectory.dir(formatName))
+            outputDirectory.convention(publication.moduleOutputDirectory)
 
             applyFormatSpecificConfiguration()
         }


### PR DESCRIPTION
- Rename `outputDir` to `outputDirectory` for consistency.
- Set the publication/module output dirs on a DokkaPublication, so that they are defined in a single place. This also makes it easier for users to configure the publication output, if desired.

Improves [KT-70880](https://youtrack.jetbrains.com/issue/KT-70880/DGP-v2-puts-output-in-the-html-subfolder-for-a-customized-output-directory)