### PR TITLE
Update Develocity plugin to support "Resource usage observability in Build Scan"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,7 +57,7 @@ gradlePlugin-gradleNode = "7.0.1"
 ## Gradle Develocity
 # versions should be kept in sync with `build-settings-logic/settings.gradle.kts`
 gradlePlugin-gradle-customUserData = "2.0.2"
-gradlePlugin-gradle-develocity = "3.17.6"
+gradlePlugin-gradle-develocity = "3.18.2"
 gradlePlugin-gradle-foojayToolchains = "0.7.0"
 
 ## Test


### PR DESCRIPTION
It could be useful to investigate issues like this: https://github.com/Kotlin/dokka/actions/runs/10776209450/job/29882419601

Changelog: https://plugins.gradle.org/plugin/com.gradle.develocity

Note: it says "Compatible with scans.gradle.com and Develocity 2024.2 or later." - not sure which version is used on our Develocity server and how it will work if the version is lower so let's wait for https://github.com/Kotlin/dokka/pull/3790 merged