### PR TITLE
Update `LogHtmlPublicationLinkTask` configuration to support Project Isolation

### DIFF
--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/formats/DokkaHtmlPlugin.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/formats/DokkaHtmlPlugin.kt
@@ -16,6 +16,7 @@ import org.jetbrains.dokka.gradle.dokka.plugins.DokkaHtmlPluginParameters.Compan
 import org.jetbrains.dokka.gradle.dokka.plugins.DokkaVersioningPluginParameters
 import org.jetbrains.dokka.gradle.dokka.plugins.DokkaVersioningPluginParameters.Companion.DOKKA_VERSIONING_PLUGIN_PARAMETERS_NAME
 import org.jetbrains.dokka.gradle.internal.DokkaInternalApi
+import org.jetbrains.dokka.gradle.internal.rootProjectName
 import org.jetbrains.dokka.gradle.internal.uppercaseFirstChar
 import org.jetbrains.dokka.gradle.tasks.DokkaGeneratePublicationTask
 import org.jetbrains.dokka.gradle.tasks.LogHtmlPublicationLinkTask
@@ -71,7 +72,7 @@ constructor(
             .flatMap { it.outputDirectory.file("index.html") }
 
         val indexHtmlPath = indexHtmlFile.map { indexHtml ->
-            val rootProjectName = project.rootProject.name
+            val rootProjectName = project.rootProjectName()
             val relativePath = indexHtml.asFile.relativeTo(project.rootDir)
             "${rootProjectName}/${relativePath.invariantSeparatorsPath}"
         }

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/internal/gradleUtils.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/internal/gradleUtils.kt
@@ -367,3 +367,23 @@ internal const val INTERNAL_CONF_NAME_TAG = "~internal"
 
 
 internal const val INTERNAL_CONF_DESCRIPTION_TAG = "[Internal Dokka Configuration]"
+
+
+/**
+ * Get the root project name.
+ *
+ * This function will try to be compatible with
+ * [Isolated Projects](https://docs.gradle.org/current/userguide/isolated_projects.html).
+ */
+internal fun Project.rootProjectName(): String {
+    return when {
+        CurrentGradleVersion >= "8.8" -> {
+            @Suppress("UnstableApiUsage")
+            isolated.rootProject.name
+        }
+
+        else -> {
+            rootProject.name
+        }
+    }
+}


### PR DESCRIPTION
Fetch the root project name in project-isolation compatible way, if possible.

Following up from https://github.com/Kotlin/dokka/pull/3788#discussion_r1750425419