### PR TITLE
Configure default documentedVisibilities for perPackageOptions

### DIFF
--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaBasePlugin.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaBasePlugin.kt
@@ -214,6 +214,7 @@ constructor(
                 suppress.convention(false)
                 skipDeprecated.convention(false)
                 reportUndocumented.convention(false)
+                documentedVisibilities.convention(listOf(VisibilityModifier.Public))
             }
 
             externalDocumentationLinks {

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/engine/parameters/DokkaPackageOptionsSpec.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/engine/parameters/DokkaPackageOptionsSpec.kt
@@ -1,9 +1,6 @@
 /*
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
-
-@file:Suppress("FunctionName")
-
 package org.jetbrains.dokka.gradle.engine.parameters
 
 import org.gradle.api.provider.Property

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/engine/parameters/DokkaPackageOptionsSpec.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/engine/parameters/DokkaPackageOptionsSpec.kt
@@ -1,8 +1,9 @@
-@file:Suppress("FunctionName")
-
 /*
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
+
+@file:Suppress("FunctionName")
+
 package org.jetbrains.dokka.gradle.engine.parameters
 
 import org.gradle.api.provider.Property
@@ -20,6 +21,7 @@ import java.io.Serializable
  * ```kotlin
  * tasks.dokkaHtml {
  *     dokkaSourceSets.configureEach {
+ *         // create a new perPackageOption
  *         perPackageOption {
  *             matchingRegex.set(".*internal.*")
  *             suppress.set(true)

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/engine/parameters/DokkaSourceSetSpec.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/engine/parameters/DokkaSourceSetSpec.kt
@@ -214,9 +214,11 @@ constructor(
     abstract val sourceLinks: DomainObjectSet<DokkaSourceLinkSpec>
 
     /**
-     * Allows to customize documentation generation options on a per-package basis.
+     * Allows customising documentation generation options on a per-package basis.
      *
-     * @see DokkaPackageOptionsSpec for details
+     * Use the [perPackageOptions] function to add a new item.
+     *
+     * @see DokkaPackageOptionsSpec
      */
     @get:Nested
     abstract val perPackageOptions: DomainObjectSet<DokkaPackageOptionsSpec>


### PR DESCRIPTION
Set `DokkaPackageOptionsSpec.documentedVisibilities` convention value to `Public`. 

This matches the existing behaviour in DGPv1 

https://github.com/Kotlin/dokka/blob/a3d5d43fa383141fae41bb88a1900e94e68c3fd7/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/GradlePackageOptionsBuilder.kt#L68-L71

Fix [KT-70872](https://youtrack.jetbrains.com/issue/KT-70872)