### PR TITLE
HTML rendering memory allocations optimisation

### DIFF
--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/renderers/FileWriter.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/renderers/FileWriter.kt
@@ -29,7 +29,7 @@ public class FileWriter(
             val dir = Paths.get(root.absolutePath, path.dropLastWhile { it != '/' }).toFile()
             withContext(Dispatchers.IO) {
                 dir.mkdirsOrFail()
-                Files.write(Paths.get(root.absolutePath, "$path$ext"), text.lines())
+                Paths.get(root.absolutePath, "$path$ext").toFile().writeText(text)
             }
         } catch (e: Throwable) {
             context.logger.error("Failed to write $this. ${e.message}")

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/renderers/html/HtmlRenderer.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/renderers/html/HtmlRenderer.kt
@@ -947,9 +947,10 @@ public open class HtmlRenderer(
         }
 
     // same as createHTML but creates StringBuilder of default size instead of using StringBuilder with 32kb size (default)
-    // it's useful for cases with "embedded html" f.e source-set-dependent content
+    // it's useful for cases with "embedded html" f.e source-set-dependent content.
+    // capacity of the StringBuilder was selected after experiments based on generating documentation for kotlin-stdlib
     private fun createSmallHTML(prettyPrint: Boolean = true, xhtmlCompatible: Boolean = false): TagConsumer<String> =
-        HTMLStreamBuilder(StringBuilder(), prettyPrint, xhtmlCompatible)
+        HTMLStreamBuilder(StringBuilder(256), prettyPrint, xhtmlCompatible)
             .onFinalizeMap { sb, _ -> sb.toString() }
             .delayed()
 

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/renderers/html/HtmlRenderer.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/renderers/html/HtmlRenderer.kt
@@ -347,18 +347,18 @@ public open class HtmlRenderer(
                 val distinct =
                     groupDivergentInstancesWithSourceSet(it.value, it.key, pageContext,
                         beforeTransformer = { instance, _, sourceSet ->
-                            createSmallHTML(prettyPrint = false).prepareForTemplates().div {
-                                instance.before?.let { before ->
+                            instance.before?.let { before ->
+                                createSmallHTML(prettyPrint = false).prepareForTemplates().div {
                                     buildContentNode(before, pageContext, sourceSet)
-                                }
-                            }.stripDiv()
+                                }.stripDiv()
+                            } ?: ""
                         },
                         afterTransformer = { instance, _, sourceSet ->
-                            createSmallHTML(prettyPrint = false).prepareForTemplates().div {
-                                instance.after?.let { after ->
+                            instance.after?.let { after ->
+                                createSmallHTML(prettyPrint = false).prepareForTemplates().div {
                                     buildContentNode(after, pageContext, sourceSet)
-                                }
-                            }.stripDiv()
+                                }.stripDiv()
+                            } ?: ""
                         })
 
                 val isPageWithOverloadedMembers = pageContext is MemberPage && pageContext.documentables().size > 1

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/renderers/html/innerTemplating/DefaultTemplateModelFactory.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/renderers/html/innerTemplating/DefaultTemplateModelFactory.kt
@@ -7,6 +7,7 @@ package org.jetbrains.dokka.base.renderers.html.innerTemplating
 import freemarker.core.Environment
 import freemarker.template.*
 import kotlinx.html.*
+import kotlinx.html.stream.appendHTML
 import kotlinx.html.stream.createHTML
 import org.jetbrains.dokka.DokkaConfiguration
 import org.jetbrains.dokka.base.DokkaBase
@@ -102,10 +103,9 @@ public class DefaultTemplateModelFactory(
     private val String.isAbsolute: Boolean
         get() = URI(this).isAbsolute
 
-    private fun Appendable.resourcesForPage(pathToRoot: String, resources: List<String>): Unit =
-        resources.forEach { resource ->
-
-            val resourceHtml = with(createHTML()) {
+    private fun Appendable.resourcesForPage(pathToRoot: String, resources: List<String>) {
+        with(appendHTML()) {
+            resources.forEach { resource ->
                 when {
 
                     resource.URIExtension == "css" ->
@@ -126,13 +126,10 @@ public class DefaultTemplateModelFactory(
                         }
 
                     resource.isImage() -> link(href = if (resource.isAbsolute) resource else "$pathToRoot$resource")
-                    else -> null
                 }
             }
-            if (resourceHtml != null) {
-                append(resourceHtml)
-            }
         }
+    }
 
 }
 


### PR DESCRIPTION
Overall the main idea of the changes is to reduce usage of `createHTML` which by default create `StringBuilder` of 32KB size and in most cases it needs much less, specifically in source-set-dependent content and during resource links embedding.

Those optimisations were found during investigation of stdlib docs build ([internal discussion](https://jetbrains.slack.com/archives/C02H0GSH474/p1726159162133729))