### PR TITLE
Run `check` task on CI

### DIFF
--- a/.github/workflows/tests-smoke.yml
+++ b/.github/workflows/tests-smoke.yml
@@ -32,7 +32,8 @@ jobs:
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - name: Run tests
         run: >
-          ./gradlew check --stacktrace --continue 
+          ./gradlew check --stacktrace --continue
+          "-Porg.jetbrains.dokka.integration_test.skip=true"
           "-Porg.jetbrains.dokka.javaToolchain.testLauncher=${{ env.JAVA_TEST_VERSION }}"
       - name: Upload build reports
         if: failure()

--- a/.github/workflows/tests-smoke.yml
+++ b/.github/workflows/tests-smoke.yml
@@ -32,7 +32,7 @@ jobs:
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - name: Run tests
         run: >
-          ./gradlew test --stacktrace --continue 
+          ./gradlew check --stacktrace --continue 
           "-Porg.jetbrains.dokka.javaToolchain.testLauncher=${{ env.JAVA_TEST_VERSION }}"
       - name: Upload build reports
         if: failure()

--- a/.github/workflows/tests-thorough.yml
+++ b/.github/workflows/tests-thorough.yml
@@ -30,7 +30,7 @@ jobs:
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - name: Run tests
         run: >
-          ./gradlew test --stacktrace --continue
+          ./gradlew check --stacktrace --continue
           "-Porg.jetbrains.dokka.javaToolchain.testLauncher=${{ matrix.javaVersion }}"
       - name: Upload build reports
         if: failure()

--- a/.github/workflows/tests-thorough.yml
+++ b/.github/workflows/tests-thorough.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Run tests
         run: >
           ./gradlew check --stacktrace --continue
+          "-Porg.jetbrains.dokka.integration_test.skip=true"
           "-Porg.jetbrains.dokka.javaToolchain.testLauncher=${{ matrix.javaVersion }}"
       - name: Upload build reports
         if: failure()

--- a/build-logic/src/main/kotlin/dokkabuild.test-integration.gradle.kts
+++ b/build-logic/src/main/kotlin/dokkabuild.test-integration.gradle.kts
@@ -22,6 +22,10 @@ val integrationTest by tasks.registering {
 }
 
 tasks.withType<Test>().configureEach {
+    onlyIf("property `org.jetbrains.dokka.integration_test.skip` != true") {
+        !dokkaBuild.integrationTestSkip.get()
+    }
+
     setForkEvery(1)
     maxHeapSize = "2G"
     dokkaBuild.integrationTestParallelism.orNull?.let { parallelism ->

--- a/build-logic/src/main/kotlin/dokkabuild.test-integration.gradle.kts
+++ b/build-logic/src/main/kotlin/dokkabuild.test-integration.gradle.kts
@@ -22,9 +22,8 @@ val integrationTest by tasks.registering {
 }
 
 tasks.withType<Test>().configureEach {
-    onlyIf("property `org.jetbrains.dokka.integration_test.skip` != true") {
-        !dokkaBuild.integrationTestSkip.get()
-    }
+    val integrationTestSkip = dokkaBuild.integrationTestSkip
+    onlyIf("property `org.jetbrains.dokka.integration_test.skip` != true") { !integrationTestSkip.get() }
 
     setForkEvery(1)
     maxHeapSize = "2G"

--- a/build-logic/src/main/kotlin/dokkabuild/DokkaBuildProperties.kt
+++ b/build-logic/src/main/kotlin/dokkabuild/DokkaBuildProperties.kt
@@ -67,6 +67,11 @@ abstract class DokkaBuildProperties @Inject constructor(
     val kotlinLanguageLevel: Provider<KotlinVersion> =
         dokkaProperty("kotlinLanguageLevel", KotlinVersion::fromVersion)
 
+    /** Allows skipping running of integration tests */
+    val integrationTestSkip: Provider<Boolean> =
+        dokkaProperty("integration_test.skip", String::toBoolean)
+            .orElse(false)
+
     /** Control [org.gradle.api.tasks.testing.Test.maxParallelForks] in integration tests. */
     val integrationTestParallelism: Provider<Int> =
         dokkaProperty("integration_test.parallelism", String::toInt)

--- a/dokka-integration-tests/gradle.properties
+++ b/dokka-integration-tests/gradle.properties
@@ -10,3 +10,7 @@ version=2.0.20-SNAPSHOT
 org.jetbrains.dokka.javaToolchain.mainCompiler=8
 org.jetbrains.dokka.javaToolchain.testLauncher=8
 org.jetbrains.dokka.integration_test.parallelism=2
+
+# !!! ATTENTION: do not commit this !!!
+# Uncomment next line to skip running Dokka integration tests
+#org.jetbrains.dokka.integration_test.skip=true

--- a/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/DokkaPluginFunctionalTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/DokkaPluginFunctionalTest.kt
@@ -134,7 +134,9 @@ class DokkaPluginFunctionalTest : FunSpec({
             }
     }
 
-    test("expect Dokka Plugin creates Dokka resolvable configurations") {
+    // TODO KT-71851 fix test failure on Windows
+    val isOsWindows = "win" in System.getProperty("os.name").lowercase()
+    test("expect Dokka Plugin creates Dokka resolvable configurations").config(enabled = !isOsWindows) {
         testProject.runner
             .addArguments("resolvableConfigurations", "--quiet")
             .build {


### PR DESCRIPTION
fixes https://github.com/Kotlin/dokka/issues/3805

Introduce a Gradle property to skip integration tests, which could be set on CI/locally to be able to run `check` task without running all integration tests.

If we will enable running integration tests unconditionally we will increase GA tests time from 10-15 minutes to more than an hour ([example](https://github.com/Kotlin/dokka/actions/runs/10918956278)).
Note: all tests are red in the above example because most of them failed with OOM or "not enough space" when downloading K/N toolchain for different version of Kotlin.
So enabling integration tests unconditionally on GA is not an option also for reasons other than "slow tests".

Note: running `check` on CI exposed issue with Windows and DGPv2 function tests. This should be fixed before the merging of this PR.
Additionally after the PR is merged we could change TC setup for `Dokka Tests` to also use `check` with `integration_test.skip=true` flag. Or even drop it, as it doesn't cover other OS like we have on GA.