### PR TITLE
Fix external documentation link default values

### DIFF
--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaBasePlugin.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaBasePlugin.kt
@@ -218,7 +218,7 @@ constructor(
                 }
 
                 maybeCreate("jdk") {
-                    enabled.convention(this@dss.enableJdkDocumentationLink)
+                    enabled.set(this@dss.enableJdkDocumentationLink)
                     url(this@dss.jdkVersion.map { jdkVersion ->
                         when {
                             jdkVersion < 11 -> "https://docs.oracle.com/javase/${jdkVersion}/docs/api/"
@@ -234,17 +234,17 @@ constructor(
                 }
 
                 maybeCreate("kotlinStdlib") {
-                    enabled.convention(this@dss.enableKotlinStdLibDocumentationLink)
+                    enabled.set(this@dss.enableKotlinStdLibDocumentationLink)
                     url("https://kotlinlang.org/api/latest/jvm/stdlib/")
                 }
 
                 maybeCreate("androidSdk") {
-                    enabled.convention(this@dss.enableAndroidDocumentationLink)
+                    enabled.set(this@dss.enableAndroidDocumentationLink)
                     url("https://developer.android.com/reference/kotlin/")
                 }
 
                 maybeCreate("androidX") {
-                    enabled.convention(this@dss.enableAndroidDocumentationLink)
+                    enabled.set(this@dss.enableAndroidDocumentationLink)
                     url("https://developer.android.com/reference/kotlin/")
                     packageListUrl("https://developer.android.com/reference/kotlin/androidx/package-list")
                 }

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/engine/parameters/DokkaSourceSetSpec.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/engine/parameters/DokkaSourceSetSpec.kt
@@ -310,9 +310,11 @@ constructor(
      * Whether to generate external documentation links for Android SDK API reference when
      * declarations from it are used.
      *
-     * Only relevant in Android projects, ignored otherwise.
+     * Only relevant in Android projects, and will be automatically disabled otherwise.
      *
-     * Default is `false`, meaning links will not be generated.
+     * The default value is automatically determined.
+     * If [analysisPlatform] is set to [KotlinPlatform.AndroidJVM], then the value will be `true`.
+     * Otherwise, the value defaults to `false`.
      *
      * @see externalDocumentationLinks
      */

--- a/dokka-runners/dokka-gradle-plugin/src/test/kotlin/DokkaPluginTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/test/kotlin/DokkaPluginTest.kt
@@ -83,6 +83,29 @@ class DokkaPluginTest : FunSpec({
                     gradleDocLink.packageListUrl.get()
                         .toString() shouldBe "https://docs.gradle.org/7.6.1/javadoc/package-list"
                 }
+
+                test("externalDocumentationLinks should be enabled by default") {
+                    val fooLink = testSourceSet.externalDocumentationLinks.create("foo")
+                    fooLink.enabled.orNull shouldBe true
+                }
+
+                test("kotlinStdlib externalDocumentationLink should be disabled when DokkaSourceSetSpec.enableKotlinStdLibDocumentationLink is disabled") {
+                    testSourceSet.enableKotlinStdLibDocumentationLink.set(false)
+                    val kotlinStdlib = testSourceSet.externalDocumentationLinks.getByName("kotlinStdlib")
+                    kotlinStdlib.enabled.orNull shouldBe false
+                }
+
+                context("Android externalDocumentationLinks should be disabled when DokkaSourceSetSpec.enableAndroidDocumentationLink is disabled") {
+                    testSourceSet.enableAndroidDocumentationLink.set(false)
+                    test("androidSdk") {
+                        val androidSdk = testSourceSet.externalDocumentationLinks.getByName("androidSdk")
+                        androidSdk.enabled.orNull shouldBe false
+                    }
+                    test("androidX") {
+                        val androidX = testSourceSet.externalDocumentationLinks.getByName("androidX")
+                        androidX.enabled.orNull shouldBe false
+                    }
+                }
             }
 
             context("perPackageOptions") {


### PR DESCRIPTION
Prevent the default value of `true` from overriding the specific values provided from the top level Dokka DSL.

[KT-70908](https://youtrack.jetbrains.com/issue/KT-70908/DGP-v2-passed-Android-package-lists-to-non-Android-projects)