### PR TITLE
Fix OOM error caused by not cleaning AA sessions in tests

### DIFF
--- a/dokka-subprojects/analysis-kotlin-api/src/testFixtures/kotlin/org/jetbrains/dokka/analysis/test/api/TestProject.kt
+++ b/dokka-subprojects/analysis-kotlin-api/src/testFixtures/kotlin/org/jetbrains/dokka/analysis/test/api/TestProject.kt
@@ -122,9 +122,4 @@ fun TestProject.parse(logger: DokkaLogger = defaultAnalysisLogger): DModule = Te
 fun TestProject.useServices(
     logger: DokkaLogger = defaultAnalysisLogger,
     block: TestAnalysisServices.(context: TestAnalysisContext) -> Unit
-) {
-    withTempDirectory { tempDirectory ->
-        val (services, context) = TestProjectAnalyzer.analyze(this, tempDirectory, logger)
-        services.block(context)
-    }
-}
+): Unit = TestProjectAnalyzer.useServices(this, logger, block)


### PR DESCRIPTION
For the last month builds on `master` were RED because tests on macOS + JDK 8 failed with OOM when running `analysis-kotlin-api:testSymbols`.
After some investigation I found out that we don't dispose `KotlinAnalysis` session in test API there. When running Dokka in an ordinary way we do dispose them via post-actions.
This PR fixes this and now we run those post-actions also in test API.

Note: the same issue existed for both K2 and K1 tests, but K2 analysis (specifically standalone AA) just needs much more memory to do the same work as K1 and so OOM is not reproduced with K1
To compare, at the end of running tests with 512MB memory limit for problematic module:
* K2 analysis uses 99% of memory and runs for more than a minute
* K1 analysis uses 50% of memory and runs for 6 seconds
With this PR
* K2 analysis uses **up-to** 90% of memory (after that GC clears almost everything. up to ±10-15%) and runs for 9 seconds
* K1 analysis **still** uses 50% of memory and runs for 6 seconds
