### PR TITLE
Fix build-reports for thorough workflow

### DIFF
--- a/.github/workflows/tests-thorough.yml
+++ b/.github/workflows/tests-thorough.yml
@@ -36,7 +36,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-           name: build-reports-${{ runner.os }}-${{ github.action }}-${{ github.run_id }}
+           name: build-reports-${{ runner.os }}-${{ matrix.javaVersion }}-${{ github.action }}-${{ github.run_id }}
            path: |
               **/build/reports/
               **/*.hprof


### PR DESCRIPTION
extracted from https://github.com/Kotlin/dokka/pull/3808

The reason for this, that GA don't allow to create artefacts with the same name