### PR TITLE
Update KotlinGradlePluginVersion.kt

### DIFF
--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/kotlin/KotlinGradlePluginVersion.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/kotlin/KotlinGradlePluginVersion.kt
@@ -19,16 +19,12 @@ internal fun Project.getKgpVersion(): KotlinGradlePluginVersion? = parseKotlinVe
  * or `1.8.20-dev-42` will be viewed as `1.8.20`.
  */
 internal fun parseKotlinVersion(fullVersionString: String): KotlinVersion? {
-    val versionParts = fullVersionString
-        .split(".", "-", limit = 4)
-        .takeIf { parts -> parts.size >= 3 && parts.subList(0, 3).all { it.isNumeric() } }
-        ?: return null
+    val versionParts = fullVersionString.split(".", limit = 3).map { it.takeWhile { char -> char.isDigit() } }
 
-    return KotlinVersion(
-        major = versionParts[0].toInt(),
-        minor = versionParts[1].toInt(),
-        patch = versionParts[2].toInt()
-    )
+    if (versionParts.size == 3 && versionParts.all { it.isNotEmpty() && it.all(Char::isDigit) }) {
+        val (major, minor, patch) = versionParts.map { it.toInt() }
+        return KotlinVersion(major, minor, patch)
+    }
+
+    return null
 }
-
-private fun String.isNumeric() = this.isNotEmpty() && this.all { it.isDigit() }


### PR DESCRIPTION
**Single Split Operation:** The split operation is now limited to 3 to directly get major, minor, and patch versions.

**Mapping with `takeWhile`:** This ensures that any suffixes are ignored while still allowing for clean extraction of numeric values.

**Destructuring Declaration:** Using destructuring to directly assign `major`, `minor`, and `patch` makes the code cleaner.

**Improved Numeric Check:** The numeric check is now integrated into the validation step for clarity.