### PR TITLE
DGPv2: Add noJdkLink/noStdlibLink/noAndroidSdkLink to help with migrating

### DIFF
--- a/dokka-runners/dokka-gradle-plugin/api/dokka-gradle-plugin.api
+++ b/dokka-runners/dokka-gradle-plugin/api/dokka-gradle-plugin.api
@@ -298,6 +298,9 @@ public abstract class org/jetbrains/dokka/gradle/engine/parameters/DokkaSourceSe
 	public abstract fun getJdkVersion ()Lorg/gradle/api/provider/Property;
 	public abstract fun getLanguageVersion ()Lorg/gradle/api/provider/Property;
 	public fun getName ()Ljava/lang/String;
+	public final fun getNoAndroidSdkLink ()Lorg/gradle/api/provider/Property;
+	public final fun getNoJdkLink ()Lorg/gradle/api/provider/Property;
+	public final fun getNoStdlibLink ()Lorg/gradle/api/provider/Property;
 	public abstract fun getPerPackageOptions ()Lorg/gradle/api/DomainObjectSet;
 	public abstract fun getReportUndocumented ()Lorg/gradle/api/provider/Property;
 	public abstract fun getSamples ()Lorg/gradle/api/file/ConfigurableFileCollection;

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/engine/parameters/DokkaSourceSetSpec.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/engine/parameters/DokkaSourceSetSpec.kt
@@ -9,6 +9,7 @@ import org.gradle.api.Named
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.model.ReplacedBy
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
@@ -378,4 +379,21 @@ constructor(
             }
         )
     }
+
+    //region deprecated properties
+    /** Renamed to [enableKotlinStdLibDocumentationLink]. */
+    @Deprecated("Renamed to enableKotlinStdLibDocumentationLink", ReplaceWith("enableKotlinStdLibDocumentationLink"))
+    @get:ReplacedBy("enableKotlinStdLibDocumentationLink")
+    val noStdlibLink: Property<Boolean> by ::enableKotlinStdLibDocumentationLink
+
+    /** Renamed to [enableJdkDocumentationLink]. */
+    @Deprecated("Renamed to enableJdkDocumentationLink", ReplaceWith("enableJdkDocumentationLink"))
+    @get:ReplacedBy("enableJdkDocumentationLink")
+    val noAndroidSdkLink: Property<Boolean> by ::enableAndroidDocumentationLink
+
+    /** Renamed to [enableAndroidDocumentationLink]. */
+    @Deprecated("Renamed to enableAndroidDocumentationLink", ReplaceWith("enableAndroidDocumentationLink"))
+    @get:ReplacedBy("enableAndroidDocumentationLink")
+    val noJdkLink: Property<Boolean> by ::enableJdkDocumentationLink
+    //endregion
 }

--- a/dokka-runners/dokka-gradle-plugin/src/test/kotlin/engine/parameters/DokkaSourceSetSpecTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/test/kotlin/engine/parameters/DokkaSourceSetSpecTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+package org.jetbrains.dokka.gradle.engine.parameters
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.dokka.gradle.utils.enableV2Plugin
+
+class DokkaSourceSetSpecTest : FunSpec({
+
+    val project = ProjectBuilder.builder().build()
+        .enableV2Plugin()
+
+    context("deprecations") {
+        val dss = project.createDokkaSourceSetSpec()
+
+        test("expect noStdlibLink === enableKotlinStdLibDocumentationLink") {
+            @Suppress("DEPRECATION")
+            dss.noStdlibLink shouldBeSameInstanceAs dss.enableKotlinStdLibDocumentationLink
+        }
+        test("expect noAndroidSdkLink === enableAndroidDocumentationLink") {
+            @Suppress("DEPRECATION")
+            dss.noAndroidSdkLink shouldBeSameInstanceAs dss.enableAndroidDocumentationLink
+        }
+        test("expect noJdkLink === enableJdkDocumentationLink") {
+            @Suppress("DEPRECATION")
+            dss.noJdkLink shouldBeSameInstanceAs dss.enableJdkDocumentationLink
+        }
+    }
+}) {
+
+    companion object {
+        private fun Project.createDokkaSourceSetSpec(
+            name: String = "main",
+            configure: DokkaSourceSetSpec.() -> Unit = {}
+        ): DokkaSourceSetSpec =
+            objects.newInstance(DokkaSourceSetSpec::class, name).apply(configure)
+    }
+}


### PR DESCRIPTION
Add noJdkLink/noStdlibLink/noAndroidSdkLink properties to help with migrating from DGPv1 to v2.

#2515
[KT-71758](https://youtrack.jetbrains.com/issue/KT-71758)