### PR TITLE
Enable Build Cache Push on GitHub CI

### DIFF
--- a/build-settings-logic/settings.gradle.kts
+++ b/build-settings-logic/settings.gradle.kts
@@ -126,7 +126,7 @@ val buildCacheLocalDirectory: Provider<String> =
     dokkaProperty("build.cache.local.directory")
 val buildCachePushEnabled: Provider<Boolean> =
     dokkaProperty("build.cache.push", String::toBoolean)
-        .orElse(buildingOnTeamCity)
+        .orElse(buildingOnCi)
 
 buildCache {
     local {

--- a/build-settings-logic/src/main/kotlin/dokkasettings.settings.gradle.kts
+++ b/build-settings-logic/src/main/kotlin/dokkasettings.settings.gradle.kts
@@ -93,7 +93,7 @@ val buildCacheLocalDirectory: Provider<String> =
     dokkaProperty("build.cache.local.directory")
 val buildCachePushEnabled: Provider<Boolean> =
     dokkaProperty("build.cache.push", String::toBoolean)
-        .orElse(buildingOnTeamCity)
+        .orElse(buildingOnCi)
 
 buildCache {
     local {


### PR DESCRIPTION
Now the Develocity credentials are set on GitHub CI we can enable pushing Build Cache. This will improve build performance.