### PR TITLE
IJ: Add YouTrack issue links for KT-# issues

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -7,6 +7,10 @@
           <option name="issueRegexp" value="#(\d+)" />
           <option name="linkRegexp" value="https://github.com/Kotlin/dokka/issues/$1" />
         </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="KT\-[1-9]\d*" />
+          <option name="linkRegexp" value="http://youtrack.jetbrains.com/issue/$0" />
+        </IssueNavigationLink>
       </list>
     </option>
   </component>


### PR DESCRIPTION
Tell IJ to make `KT-1234` clickable.

<img width="375" alt="image" src="https://github.com/user-attachments/assets/cbe0731a-d2c7-40a7-8373-8b9ad9b1f6bd">
