### PR TITLE
Enable Develocity test retry on CI

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -23,4 +23,6 @@ dependencies {
     // workaround for accessing version-catalog in convention plugins
     // https://github.com/gradle/gradle/issues/15383#issuecomment-779893192
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
+
+    implementation(libs.gradlePlugin.gradle.develocity)
 }

--- a/build-logic/src/main/kotlin/dokkabuild.base.gradle.kts
+++ b/build-logic/src/main/kotlin/dokkabuild.base.gradle.kts
@@ -13,7 +13,7 @@ plugins {
     base
 }
 
-extensions.create<DokkaBuildProperties>(
+val dokkaBuild = extensions.create<DokkaBuildProperties>(
     DokkaBuildProperties.EXTENSION_NAME,
     provider { project.version.toString() },
 )
@@ -22,4 +22,11 @@ tasks.withType<AbstractArchiveTask>().configureEach {
     // https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives
     isPreserveFileTimestamps = false
     isReproducibleFileOrder = true
+}
+
+tasks.withType<Test>().configureEach {
+    develocity.testRetry {
+        maxRetries = dokkaBuild.isCI.map { isCI -> if (isCI) 3 else 0 }
+        failOnPassedAfterRetry = true
+    }
 }


### PR DESCRIPTION
Enabling test retry will allow Develocity to identify flaky tests in a single build and across multiple builds.

https://docs.gradle.com/develocity/flaky-test-detection/