### PR TITLE
Run integration tests with Kotlin 2.1.0

### DIFF
--- a/dokka-integration-tests/gradle/projects/it-multiplatform-0/src/commonMain/kotlin/it/mpp0/ExpectedClass.kt
+++ b/dokka-integration-tests/gradle/projects/it-multiplatform-0/src/commonMain/kotlin/it/mpp0/ExpectedClass.kt
@@ -3,3 +3,7 @@ package it.mpp0
 expect class ExpectedClass {
     val platform: String
 }
+
+expect class ExpectedClass2 {
+    val platform: String
+}

--- a/dokka-integration-tests/gradle/projects/it-multiplatform-0/src/desktopMain/kotlin/it/mpp0/ExpectedClass.kt
+++ b/dokka-integration-tests/gradle/projects/it-multiplatform-0/src/desktopMain/kotlin/it/mpp0/ExpectedClass.kt
@@ -1,5 +1,0 @@
-package it.mpp0
-
-actual class ExpectedClass {
-    actual val platform: String = "linux"
-}

--- a/dokka-integration-tests/gradle/projects/it-multiplatform-0/src/desktopMain/kotlin/it/mpp0/ExpectedClass2.kt
+++ b/dokka-integration-tests/gradle/projects/it-multiplatform-0/src/desktopMain/kotlin/it/mpp0/ExpectedClass2.kt
@@ -1,0 +1,5 @@
+package it.mpp0
+
+actual class ExpectedClass2 {
+    actual val platform: String = "desktop"
+}

--- a/dokka-integration-tests/gradle/projects/it-multiplatform-0/src/jsMain/kotlin/it/mpp0/ExpectedClass.kt
+++ b/dokka-integration-tests/gradle/projects/it-multiplatform-0/src/jsMain/kotlin/it/mpp0/ExpectedClass.kt
@@ -3,3 +3,7 @@ package it.mpp0
 actual class ExpectedClass {
     actual val platform: String = "js"
 }
+
+actual class ExpectedClass2 {
+    actual val platform: String = "js"
+}

--- a/dokka-integration-tests/gradle/projects/it-multiplatform-0/src/jvmMain/kotlin/it/mpp0/ExpectedClass.kt
+++ b/dokka-integration-tests/gradle/projects/it-multiplatform-0/src/jvmMain/kotlin/it/mpp0/ExpectedClass.kt
@@ -9,3 +9,7 @@ actual class ExpectedClass {
     fun jvmOnlyFunction() = Unit
 
 }
+
+actual class ExpectedClass2 {
+    actual val platform: String = "jvm"
+}

--- a/dokka-integration-tests/gradle/projects/it-multiplatform-0/src/linuxMain/kotlin/it/mpp0/CPointerExtension.kt
+++ b/dokka-integration-tests/gradle/projects/it-multiplatform-0/src/linuxMain/kotlin/it/mpp0/CPointerExtension.kt
@@ -6,6 +6,6 @@ import kotlinx.cinterop.CPointer
 /**
  * Will print the raw value
  */
-fun CPointer<CPointed>.customExtension() {
+fun CPointer<CPointed>.customExtension2() {
     println(this.rawValue)
 }

--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/TestedVersions.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/TestedVersions.kt
@@ -14,7 +14,7 @@ open class AllSupportedTestedVersionsArgumentsProvider : TestedVersionsArguments
 
 object TestedVersions {
 
-    val LATEST = BuildVersions("8.7", "2.0.20")
+    val LATEST = BuildVersions("8.10.2", "2.1.0")
 
     /**
      * All supported Gradle/Kotlin versions, including [LATEST]
@@ -24,10 +24,10 @@ object TestedVersions {
     val ALL_SUPPORTED =
         BuildVersions.permutations(
             gradleVersions = listOf("7.6.2"),
-            kotlinVersions = listOf("1.9.23", "1.8.20", "1.7.20", "1.6.21", "1.5.31"),
+            kotlinVersions = listOf("2.0.21", "1.9.23", "1.8.20", "1.7.20", "1.6.21", "1.5.31"),
         ) + BuildVersions.permutations(
             gradleVersions = listOf(*ifExhaustive("7.0", "6.1.1")),
-            kotlinVersions = listOf(*ifExhaustive( "1.8.0", "1.7.0", "1.6.0", "1.5.0"))
+            kotlinVersions = listOf(*ifExhaustive("1.8.0", "1.7.0", "1.6.0", "1.5.0"))
         ) + LATEST
 
     /**
@@ -41,7 +41,7 @@ object TestedVersions {
     val ANDROID =
         BuildVersions.permutations(
             gradleVersions = listOf("8.4"),
-            kotlinVersions = listOf("2.0.20"),
+            kotlinVersions = listOf("2.1.0", "2.0.21"),
             androidGradlePluginVersions = listOf("8.3.0")
         ) + BuildVersions.permutations(
             gradleVersions = listOf("7.4.2", *ifExhaustive("7.0")),
@@ -67,7 +67,8 @@ object TestedVersions {
         "1.9.10" to "18.2.0-pre.597",
         "1.9.23" to "18.2.0-pre.682",
         "2.0.0" to "18.2.0-pre.726",
-        "2.0.20" to "18.3.1-pre.758",
+        "2.0.21" to "18.3.1-pre.758",
+        "2.1.0" to "18.3.1-pre.818",
     )
 }
 

--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/junit/TestedVersionsSource.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/junit/TestedVersionsSource.kt
@@ -45,6 +45,7 @@ fun interface TestedVersionsSource<T : TestedVersions> {
         private val allKgpVersions: List<String> = listOf(
             "1.9.25",
             "2.0.21",
+            "2.1.0",
         )
 
         /**


### PR DESCRIPTION
related to https://github.com/Kotlin/dokka/pull/3859#discussion_r1802881712

Note: Dokka itself is still compiled with 2.0.20

commit https://github.com/Kotlin/dokka/pull/3865/commits/282eb2b93bdc58152cea503de167579001243e3c makes project used in test compilable - previously there were redeclaration of the same symbols in `desktopMain` and `linuxMain`/`macosMain` source-sets