### PR TITLE
Unhide DGPv2 migration guide

### DIFF
--- a/docs/dokka.tree
+++ b/docs/dokka.tree
@@ -6,7 +6,7 @@
 		<toc-element topic="dokka-get-started.md"/>
 		<toc-element toc-title="Run Dokka">
 			<toc-element topic="dokka-gradle.md"/>
-			<toc-element hidden="true" topic="dokka-migration.md"/>
+			<toc-element topic="dokka-migration.md"/>
 			<toc-element topic="dokka-maven.md"/>
 			<toc-element topic="dokka-cli.md"/>
 		</toc-element>


### PR DESCRIPTION
Now that DGPv2 has a beta release, we can display the migration guide.