### PR TITLE
Fix Configuring Custom Dokka Plugin

### DIFF
--- a/docs/topics/dokka-migration.md
+++ b/docs/topics/dokka-migration.md
@@ -104,6 +104,11 @@ options according to your project setup:
           customAssets.set(listOf("logo.png"))
           footerMessage.set("(c) Your Company")
       }
+      pluginConfiguration<YourCustomPlugin, YourCustomPluginConfiguration> {
+          stringProperty.set("bar")
+          booleanProperty.set(true)
+          fileListProperty.set(files("foo.txt", "bar.txt"))
+      }
   }
   ```
  
@@ -120,10 +125,19 @@ options according to your project setup:
               remoteLineSuffix.set("#L")
           }
       }
-      pluginsConfiguration.html {
-          customStyleSheets.from("styles.css")
-          customAssets.from("logo.png")
-          footerMessage.set("(c) Your Company")
+      pluginsConfiguration {
+          html {
+              customStyleSheets.from("styles.css")
+              customAssets.from("logo.png")
+              footerMessage.set("(c) Your Company")
+          }
+          pluginParameters("your.package.YourCustomPluginConfiguration") {
+              property("stringProperty", "bar")
+              property("booleanProperty", true)
+              files("fileListProperty") {
+                  from("foo.txt", "bar.txt")
+              }
+          }
       }
   }
   ```

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/formats/DokkaHtmlPlugin.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/formats/DokkaHtmlPlugin.kt
@@ -13,6 +13,7 @@ import org.gradle.kotlin.dsl.registerBinding
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.dokka.gradle.engine.plugins.DokkaHtmlPluginParameters
 import org.jetbrains.dokka.gradle.engine.plugins.DokkaHtmlPluginParameters.Companion.DOKKA_HTML_PARAMETERS_NAME
+import org.jetbrains.dokka.gradle.engine.plugins.DokkaPluginParametersBuilder
 import org.jetbrains.dokka.gradle.engine.plugins.DokkaVersioningPluginParameters
 import org.jetbrains.dokka.gradle.engine.plugins.DokkaVersioningPluginParameters.Companion.DOKKA_VERSIONING_PLUGIN_PARAMETERS_NAME
 import org.jetbrains.dokka.gradle.internal.DokkaInternalApi
@@ -35,10 +36,17 @@ constructor(
         HtmlModuleAggregationCheck(archives, providers)
 
     override fun DokkaFormatPluginContext.configure() {
+        registerCustomPluginConfigurationHelper()
         registerDokkaBasePluginConfiguration()
         registerDokkaVersioningPlugin()
         configureHtmlUrlLogging()
         configureModuleAggregation()
+    }
+
+    private fun DokkaFormatPluginContext.registerCustomPluginConfigurationHelper() {
+        with(dokkaExtension.pluginsConfiguration) {
+            registerBinding(DokkaPluginParametersBuilder::class, DokkaPluginParametersBuilder::class)
+        }
     }
 
     private fun DokkaFormatPluginContext.registerDokkaBasePluginConfiguration() {


### PR DESCRIPTION
Fixes #3869

- Register binding for `DokkaPluginParametersBuilder`
- Remove `@Internal` annotation on `jsonEncode()` for `DokkaPluginParametersBuilder` (see #3869)
- Annotate the getter for `DokkaPluginParametersBuilder.objects` instead of the field (the annotation only works for getters)
- Add missing functions for adding files, directories, and maps, which were implied but not present for `DokkaPluginParametersBuilder`
- remove overriden `DokkaPluginParametersBuilder.pluginFqn` property as it just caused issues
- Add documentation for configuring custom plugins in dokka-migration.md