### PR TITLE
Fix appending URI Path

### DIFF
--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/internal/uriUtils.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/internal/uriUtils.kt
@@ -8,5 +8,14 @@ import java.net.URI
 internal fun URI.appendPath(addition: String): URI {
     val currentPath = path.removeSuffix("/")
     val newPath = "$currentPath/$addition"
-    return resolve(newPath).normalize()
+
+    return URI(
+        /*    scheme = */ scheme,
+        /*  userInfo = */ userInfo,
+        /*      host = */ host,
+        /*      port = */ port,
+        /*      path = */ newPath,
+        /*     query = */ query,
+        /*  fragment = */ fragment,
+    ).normalize()
 }

--- a/dokka-runners/dokka-gradle-plugin/src/test/kotlin/internal/UriUtilsTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/test/kotlin/internal/UriUtilsTest.kt
@@ -1,16 +1,37 @@
 package internal
 
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.list
+import io.kotest.property.arbitrary.string
+import io.kotest.property.checkAll
 import org.jetbrains.dokka.gradle.internal.appendPath
 import java.net.URI
 
 class UriUtilsTest : FunSpec({
     test("appending path with space should be escaped") {
         val base = URI("http://localhost:8080/docs/")
-        val addition = "/Foo Bar/x/y/z/index.html"
+        val addition = "/Foo Bar/<x^y>z/#the%homepage.html"
 
         val result = base.appendPath(addition).toString()
-        result shouldBe "http://localhost:8080/docs/Foo%20Bar/x/y/z/index.html"
+        result shouldBe "http://localhost:8080/docs/Foo%20Bar/%3Cx%5Ey%3Ez/%23the%25homepage.html"
+    }
+
+    test("check any path can be appended to a URI without throwing exception") {
+        // generate strings to be/joined/into/a/path.
+        val pathElementsArb = Arb.list(
+            gen = Arb.string(minSize = 1, maxSize = 10),
+            range = 1..5,
+        )
+
+        checkAll(pathElementsArb) { pathElements ->
+            val path = pathElements.joinToString("/")
+            val base = URI("http://localhost:8080/docs/")
+            shouldNotThrowAny {
+                base.appendPath(path)
+            }
+        }
     }
 })

--- a/dokka-runners/dokka-gradle-plugin/src/test/kotlin/internal/UriUtilsTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/test/kotlin/internal/UriUtilsTest.kt
@@ -1,0 +1,16 @@
+package internal
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.jetbrains.dokka.gradle.internal.appendPath
+import java.net.URI
+
+class UriUtilsTest : FunSpec({
+    test("appending path with space should be escaped") {
+        val base = URI("http://localhost:8080/docs/")
+        val addition = "/Foo Bar/x/y/z/index.html"
+
+        val result = base.appendPath(addition).toString()
+        result shouldBe "http://localhost:8080/docs/Foo%20Bar/x/y/z/index.html"
+    }
+})


### PR DESCRIPTION
`URI#resolve(newPath)` doesn't escape spaces

Not escaping the space breaks logging the HTML URL logging task when the IntelliJ project name has a space.