### PR TITLE
Fix merging expect-actual declarations

### DIFF
--- a/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/transformers/documentation/DefaultDocumentableMerger.kt
+++ b/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/transformers/documentation/DefaultDocumentableMerger.kt
@@ -116,6 +116,7 @@ public class DefaultDocumentableMerger(context: DokkaContext) : DocumentableMerg
                 listOf(actuals to actuals.flatMap { it.sourceSets }.toSet())
             } else expects.map { expect ->
                 val actualsForGivenExpect = actuals.filter { actual ->
+                    // [actual.sourceSets] can already be partially merged and contain more than one source set
                     actual.sourceSets.all {
                         dependencyInfo[it]
                         ?.contains(expect.expectPresentInSet!!)

--- a/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/transformers/documentation/DefaultDocumentableMerger.kt
+++ b/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/transformers/documentation/DefaultDocumentableMerger.kt
@@ -116,9 +116,11 @@ public class DefaultDocumentableMerger(context: DokkaContext) : DocumentableMerg
                 listOf(actuals to actuals.flatMap { it.sourceSets }.toSet())
             } else expects.map { expect ->
                 val actualsForGivenExpect = actuals.filter { actual ->
-                    dependencyInfo[actual.sourceSets.single()]
+                    actual.sourceSets.all {
+                        dependencyInfo[it]
                         ?.contains(expect.expectPresentInSet!!)
                         ?: throw IllegalStateException("Cannot resolve expect/actual relation for ${actual.name}")
+                    }
                 }
                 (listOf(expect) + actualsForGivenExpect) to actualsForGivenExpect.flatMap { it.sourceSets }.toSet()
             }


### PR DESCRIPTION
Fixes #3798

This bug appeared due to https://github.com/Kotlin/dokka/pull/3662
The merging order depends on the order of source sets. 
E.g. if we have the following order of source sets:` (expect, actual1, actual2)`. `DefaultDocumentableMerger` has a pairwise merger. So a declaration will be merged as follows:` (expect, actual1)`, then` (expect, actual1, actual2)`.

In the case of the original issue: the order of source sets `(actual1, actual2, expect)`.
Before https://github.com/Kotlin/dokka/pull/3662, it does not allow to merge actuals without an expect source set.
After that, we have a state when there is `(actual1, actual2)` that leads to an exception #3798. 



