### PR TITLE
Rename `dokkaPublicationDirectory` to `basePublicationsDirectory`

### DIFF
--- a/docs/topics/dokka-migration.md
+++ b/docs/topics/dokka-migration.md
@@ -209,12 +209,12 @@ options according to your project setup:
     customAssets.from("example.png", "example2.png")
     ```
 
-* **Output directory:** Use the `dokka {}` block to specify a single output directory for all Dokka-generated documentation.
+* **Output directory:** Use the `dokka {}` block to specify the output directory for generated Dokka documentation.
 
     Previous configuration:
 
     ```kotlin
-    tasks.dokkaHtml{
+    tasks.dokkaHtml {
         dokkaSourceSets {
             configureEach {
                 outputDirectory.set(layout.buildDirectory.dir("dokkaDir"))
@@ -227,7 +227,9 @@ options according to your project setup:
 
     ```kotlin
     dokka {
-        dokkaPublicationDirectory.set(layout.buildDirectory.dir("dokkaDir"))
+        dokkaPublications.html {
+            outputDirectory.set(layout.buildDirectory.dir("dokkaDir"))
+        }
     }
     ```
 

--- a/docs/topics/dokka-migration.md
+++ b/docs/topics/dokka-migration.md
@@ -215,11 +215,7 @@ options according to your project setup:
 
     ```kotlin
     tasks.dokkaHtml {
-        dokkaSourceSets {
-            configureEach {
-                outputDirectory.set(layout.buildDirectory.dir("dokkaDir"))
-            }
-        }
+        outputDirectory.set(layout.buildDirectory.dir("dokkaDir"))
     }
     ```
 

--- a/dokka-runners/dokka-gradle-plugin/api/dokka-gradle-plugin.api
+++ b/dokka-runners/dokka-gradle-plugin/api/dokka-gradle-plugin.api
@@ -79,11 +79,12 @@ public abstract class org/jetbrains/dokka/gradle/DokkaExtension : java/io/Serial
 	public static synthetic fun ClassLoaderIsolation$default (Lorg/jetbrains/dokka/gradle/DokkaExtension;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/dokka/gradle/workers/WorkerIsolation$ClassLoader;
 	public final fun ProcessIsolation (Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/dokka/gradle/workers/WorkerIsolation$Process;
 	public static synthetic fun ProcessIsolation$default (Lorg/jetbrains/dokka/gradle/DokkaExtension;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/dokka/gradle/workers/WorkerIsolation$Process;
+	public abstract fun getBasePublicationsDirectory ()Lorg/gradle/api/file/DirectoryProperty;
 	public abstract fun getDokkaCacheDirectory ()Lorg/gradle/api/file/DirectoryProperty;
 	public abstract fun getDokkaEngineVersion ()Lorg/gradle/api/provider/Property;
 	public abstract fun getDokkaGeneratorIsolation ()Lorg/gradle/api/provider/Property;
 	public abstract fun getDokkaModuleDirectory ()Lorg/gradle/api/file/DirectoryProperty;
-	public abstract fun getDokkaPublicationDirectory ()Lorg/gradle/api/file/DirectoryProperty;
+	public final fun getDokkaPublicationDirectory ()Lorg/gradle/api/file/DirectoryProperty;
 	public final fun getDokkaPublications ()Lorg/gradle/api/NamedDomainObjectContainer;
 	public final fun getDokkaSourceSets ()Lorg/gradle/api/NamedDomainObjectContainer;
 	public abstract fun getModuleName ()Lorg/gradle/api/provider/Property;

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaBasePlugin.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaBasePlugin.kt
@@ -100,7 +100,7 @@ constructor(
             )
 
             sourceSetScopeDefault.convention(project.path)
-            dokkaPublicationDirectory.convention(layout.buildDirectory.dir("dokka"))
+            basePublicationsDirectory.convention(layout.buildDirectory.dir("dokka"))
             dokkaModuleDirectory.convention(layout.buildDirectory.dir("dokka-module"))
 //            @Suppress("DEPRECATION")
 //            dokkaConfigurationsDirectory.convention(layout.buildDirectory.dir("dokka-config"))
@@ -157,7 +157,7 @@ constructor(
             moduleName.convention(dokkaExtension.moduleName)
             moduleVersion.convention(dokkaExtension.moduleVersion)
             offlineMode.convention(false)
-            outputDirectory.convention(dokkaExtension.dokkaPublicationDirectory.dir(formatName))
+            outputDirectory.convention(dokkaExtension.basePublicationsDirectory.dir(formatName))
             moduleOutputDirectory.convention(dokkaExtension.dokkaModuleDirectory.dir(formatName))
             suppressInheritedMembers.convention(
                 @Suppress("DEPRECATION")

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaExtension.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaExtension.kt
@@ -31,8 +31,23 @@ constructor(
     internal val baseDependencyManager: BaseDependencyManager,
 ) : ExtensionAware, Serializable {
 
-    /** Directory into which [DokkaPublication]s will be produced */
-    abstract val dokkaPublicationDirectory: DirectoryProperty
+    /**
+     * Base directory into which all [DokkaPublication]s will be produced.
+     * By default, Dokka will generate all [DokkaPublication]s into a subdirectory inside [basePublicationsDirectory].
+     *
+     * To configure the output for a specific Publication, instead use [DokkaPublication.outputDirectory].
+     *
+     * #### Example
+     *
+     * Here we configure the output directory to be `./build/dokka-docs/`.
+     * Dokka will produce the HTML Publication into `./build/dokka-docs/html/`
+     * ```
+     * dokka {
+     *     basePublicationsDirectory.set(layout.buildDirectory.dir("dokka-docs"))
+     * }
+     * ```
+     */
+    abstract val basePublicationsDirectory: DirectoryProperty
 
     /**
      * Directory into which Dokka Modules will be produced.
@@ -179,6 +194,13 @@ constructor(
 
 
     //region deprecated properties
+    /** Deprecated. Use [basePublicationsDirectory] instead. */
+    // Deprecated in 2.0.0-Beta. Remove when Dokka 2.0.0 is released.
+    @Deprecated("Renamed to basePublicationsDirectory", ReplaceWith("basePublicationsDirectory"))
+    @Suppress("unused")
+    val dokkaPublicationDirectory: DirectoryProperty
+        get() = basePublicationsDirectory
+
     /**
      * ```
      * dokka {

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaExtension.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaExtension.kt
@@ -20,6 +20,7 @@ import org.jetbrains.dokka.gradle.workers.ClassLoaderIsolation
 import org.jetbrains.dokka.gradle.workers.ProcessIsolation
 import org.jetbrains.dokka.gradle.workers.WorkerIsolation
 import java.io.Serializable
+import kotlin.DeprecationLevel.ERROR
 
 /**
  * Configure the behaviour of the [DokkaBasePlugin].
@@ -196,7 +197,11 @@ constructor(
     //region deprecated properties
     /** Deprecated. Use [basePublicationsDirectory] instead. */
     // Deprecated in 2.0.0-Beta. Remove when Dokka 2.0.0 is released.
-    @Deprecated("Renamed to basePublicationsDirectory", ReplaceWith("basePublicationsDirectory"))
+    @Deprecated(
+        "Renamed to basePublicationsDirectory",
+        ReplaceWith("basePublicationsDirectory"),
+        level = ERROR,
+    )
     @Suppress("unused")
     val dokkaPublicationDirectory: DirectoryProperty
         get() = basePublicationsDirectory


### PR DESCRIPTION
Rename the property for clarity.

- `basePublicationsDirectory` controls the base output directory for all publications.


[Internal discussion](https://jetbrains.slack.com/archives/C02H0GSH474/p1728395235950729)