### PR TITLE
Remove unused DGP utils

### DIFF
--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/internal/gradleUtils.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/internal/gradleUtils.kt
@@ -4,14 +4,9 @@
 package org.jetbrains.dokka.gradle.internal
 
 import org.gradle.api.*
-import org.gradle.api.artifacts.ArtifactView
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.ConfigurationContainer
-import org.gradle.api.artifacts.component.ComponentIdentifier
-import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.AttributeContainer
-import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.plugins.ExtensionContainer
@@ -113,13 +108,6 @@ internal operator fun GradleVersion.compareTo(version: String): Int =
     compareTo(GradleVersion.version(version))
 
 
-/** Only matches components that come from subprojects */
-internal object LocalProjectOnlyFilter : Spec<ComponentIdentifier> {
-    override fun isSatisfiedBy(element: ComponentIdentifier?): Boolean =
-        element is ProjectComponentIdentifier
-}
-
-
 /** Invert the result of a [Spec] predicate */
 internal operator fun <T> Spec<T>.not(): Spec<T> = Spec<T> { !this@not.isSatisfiedBy(it) }
 
@@ -143,44 +131,6 @@ internal fun <T> NamedDomainObjectContainer<T>.maybeCreate(
     name: String,
     configure: T.() -> Unit,
 ): T = maybeCreate(name).apply(configure)
-
-
-/**
- * Aggregate the incoming files from a [Configuration] (with name [named]) into [collector].
- *
- * Configurations that do not exist or cannot be
- * [resolved][org.gradle.api.artifacts.Configuration.isCanBeResolved]
- * will be ignored.
- *
- * @param[builtBy] An optional [TaskProvider], used to set [ConfigurableFileCollection.builtBy].
- * This should not typically be used, and is only necessary in rare cases where a Gradle Plugin is
- * misconfigured.
- */
-internal fun ConfigurationContainer.collectIncomingFiles(
-    named: String,
-    collector: ConfigurableFileCollection,
-    builtBy: TaskProvider<*>? = null,
-    artifactViewConfiguration: ArtifactView.ViewConfiguration.() -> Unit = {
-        // ignore failures: it's usually okay if fetching files is best-effort because
-        // maybe Dokka doesn't need _all_ dependencies
-        lenient(true)
-    },
-) {
-    val conf = findByName(named)
-    if (conf != null && conf.isCanBeResolved) {
-        val incomingFiles = conf.incoming
-            .artifactView(artifactViewConfiguration)
-            .artifacts
-            .resolvedArtifacts // using 'resolved' might help with triggering artifact transforms?
-            .map { artifacts -> artifacts.map { it.file } }
-
-        collector.from(incomingFiles)
-
-        if (builtBy != null) {
-            collector.builtBy(builtBy)
-        }
-    }
-}
 
 
 /**


### PR DESCRIPTION
These two utilities are no longer used. They can be removed to simplify the code.