### PR TITLE
Test with KGP 2.1.0-RC

### DIFF
--- a/build-logic/src/main/kotlin/dokkabuild.gradle-plugin.gradle.kts
+++ b/build-logic/src/main/kotlin/dokkabuild.gradle-plugin.gradle.kts
@@ -3,6 +3,7 @@
  */
 
 import dokkabuild.utils.excludeGradleEmbeddedDependencies
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
@@ -12,10 +13,13 @@ plugins {
 }
 
 kotlin {
+    @OptIn(ExperimentalKotlinGradlePluginApi::class)
+    compilerVersion = libs.versions.gradlePlugin.kotlin.compiler
+    @Suppress("DEPRECATION", "DEPRECATION_ERROR")
     compilerOptions {
         // Must use Kotlin 1.4 to support Gradle 7
-        languageVersion = @Suppress("DEPRECATION") KotlinVersion.KOTLIN_1_4
-        apiVersion = @Suppress("DEPRECATION") KotlinVersion.KOTLIN_1_4
+        languageVersion = KotlinVersion.KOTLIN_1_4
+        apiVersion = KotlinVersion.KOTLIN_1_4
     }
 }
 

--- a/build-logic/src/main/kotlin/dokkabuild.gradle-plugin.gradle.kts
+++ b/build-logic/src/main/kotlin/dokkabuild.gradle-plugin.gradle.kts
@@ -3,6 +3,7 @@
  */
 
 import dokkabuild.utils.excludeGradleEmbeddedDependencies
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
@@ -13,7 +14,7 @@ plugins {
 }
 
 kotlin {
-    @OptIn(ExperimentalKotlinGradlePluginApi::class)
+    @OptIn(ExperimentalBuildToolsApi::class, ExperimentalKotlinGradlePluginApi::class)
     compilerVersion = libs.versions.gradlePlugin.kotlin.compiler
     @Suppress("DEPRECATION", "DEPRECATION_ERROR")
     compilerOptions {

--- a/build-logic/src/main/kotlin/dokkabuild.kotlin-jvm.gradle.kts
+++ b/build-logic/src/main/kotlin/dokkabuild.kotlin-jvm.gradle.kts
@@ -2,6 +2,8 @@
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+
 plugins {
     id("dokkabuild.java")
     kotlin("jvm")
@@ -11,6 +13,11 @@ val rootProjectsWithoutDependencyOnDokkaCore = listOf("dokka-integration-tests")
 
 kotlin {
     explicitApi()
+
+    if (dokkaBuild.kotlinLanguageLevel.isPresent) {
+        @OptIn(ExperimentalKotlinGradlePluginApi::class)
+        compilerVersion = libs.versions.gradlePlugin.kotlin.compiler
+    }
     compilerOptions {
         allWarningsAsErrors = true
         languageVersion = dokkaBuild.kotlinLanguageLevel

--- a/build-logic/src/main/kotlin/dokkabuild.kotlin-jvm.gradle.kts
+++ b/build-logic/src/main/kotlin/dokkabuild.kotlin-jvm.gradle.kts
@@ -2,6 +2,7 @@
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 
 plugins {
@@ -15,7 +16,7 @@ kotlin {
     explicitApi()
 
     if (dokkaBuild.kotlinLanguageLevel.isPresent) {
-        @OptIn(ExperimentalKotlinGradlePluginApi::class)
+        @OptIn(ExperimentalBuildToolsApi::class, ExperimentalKotlinGradlePluginApi::class)
         compilerVersion = libs.versions.gradlePlugin.kotlin.compiler
     }
     compilerOptions {

--- a/dokka-integration-tests/gradle/projects/template.settings.gradle.kts
+++ b/dokka-integration-tests/gradle/projects/template.settings.gradle.kts
@@ -37,7 +37,6 @@ pluginManagement {
     }
     repositories {
         /* %{DOKKA_IT_MAVEN_REPO}% */
-        maven("https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
         mavenCentral()
         gradlePluginPortal()
         google()
@@ -49,7 +48,6 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
     repositories {
         /* %{DOKKA_IT_MAVEN_REPO}% */
-        maven("https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
         mavenCentral()
         google()
         maven("https://maven.pkg.jetbrains.space/public/p/kotlinx-html/maven") {

--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleIntegrationTest.kt
@@ -227,6 +227,7 @@ abstract class AbstractGradleIntegrationTest : AbstractIntegrationTest() {
 
             /* language=kts */
             """
+            |maven { setUrl("https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/dev") }
             |exclusiveContent {
             |    forRepositories(
             |      $reposSpecs

--- a/dokka-runners/dokka-gradle-plugin/api/dokka-gradle-plugin.api
+++ b/dokka-runners/dokka-gradle-plugin/api/dokka-gradle-plugin.api
@@ -254,21 +254,6 @@ public abstract class org/jetbrains/dokka/gradle/engine/parameters/DokkaGenerato
 	public abstract fun getSuppressObviousFunctions ()Lorg/gradle/api/provider/Property;
 }
 
-public final class org/jetbrains/dokka/gradle/engine/parameters/DokkaModuleDescriptionKxs$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field INSTANCE Lorg/jetbrains/dokka/gradle/engine/parameters/DokkaModuleDescriptionKxs$$serializer;
-	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jetbrains/dokka/gradle/engine/parameters/DokkaModuleDescriptionKxs;
-	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jetbrains/dokka/gradle/engine/parameters/DokkaModuleDescriptionKxs;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
-}
-
-public final class org/jetbrains/dokka/gradle/engine/parameters/DokkaModuleDescriptionKxs$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
 public abstract class org/jetbrains/dokka/gradle/engine/parameters/DokkaPackageOptionsSpec : java/io/Serializable, org/jetbrains/dokka/gradle/engine/parameters/HasConfigurableVisibilityModifiers {
 	public abstract fun getDocumentedVisibilities ()Lorg/gradle/api/provider/SetProperty;
 	public abstract fun getMatchingRegex ()Lorg/gradle/api/provider/Property;

--- a/dokka-runners/dokka-gradle-plugin/build.gradle.kts
+++ b/dokka-runners/dokka-gradle-plugin/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 
     // fails with back-end exception no matter which version is used
     // probably related to the fact that we use `kotlin.compiler.runViaBuildToolsApi`
-    kotlin("plugin.serialization") version embeddedKotlinVersion // doesn't work
+//    kotlin("plugin.serialization") version embeddedKotlinVersion // doesn't work
 //    kotlin("plugin.serialization") version "2.0.20" // doesn't work
 //    kotlin("plugin.serialization") version "2.1.0-RC-330" // doesn't work
 

--- a/dokka-runners/dokka-gradle-plugin/build.gradle.kts
+++ b/dokka-runners/dokka-gradle-plugin/build.gradle.kts
@@ -10,7 +10,11 @@ import dokkabuild.utils.skipTestFixturesPublications
 plugins {
     id("dokkabuild.gradle-plugin")
 
-    kotlin("plugin.serialization") version embeddedKotlinVersion
+    // fails with back-end exception no matter which version is used
+    // probably related to the fact that we use `kotlin.compiler.runViaBuildToolsApi`
+    kotlin("plugin.serialization") version embeddedKotlinVersion // doesn't work
+//    kotlin("plugin.serialization") version "2.0.20" // doesn't work
+//    kotlin("plugin.serialization") version "2.1.0-RC-330" // doesn't work
 
     `jvm-test-suite`
     `java-test-fixtures`

--- a/dokka-runners/dokka-gradle-plugin/gradle.properties
+++ b/dokka-runners/dokka-gradle-plugin/gradle.properties
@@ -9,6 +9,7 @@ version=2.0.20-SNAPSHOT
 org.jetbrains.dokka.javaToolchain.mainCompiler=8
 org.jetbrains.dokka.javaToolchain.testLauncher=8
 org.jetbrains.dokka.kotlinLanguageLevel=1.4
+kotlin.compiler.runViaBuildToolsApi=true
 
 # Gradle settings
 org.gradle.jvmargs=-Dfile.encoding=UTF-8

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/engine/parameters/DokkaModuleDescriptionKxs.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/engine/parameters/DokkaModuleDescriptionKxs.kt
@@ -3,7 +3,10 @@
  */
 package org.jetbrains.dokka.gradle.engine.parameters
 
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 import org.gradle.kotlin.dsl.java
 import org.jetbrains.dokka.DokkaConfiguration
 import org.jetbrains.dokka.gradle.internal.InternalDokkaGradlePluginApi
@@ -23,7 +26,6 @@ import org.jetbrains.dokka.gradle.internal.InternalDokkaGradlePluginApi
  * @see org.jetbrains.dokka.gradle.engine.parameters.DokkaModuleDescriptionKxs
  * @see org.jetbrains.dokka.DokkaModuleDescriptionImpl
  */
-@Serializable
 @InternalDokkaGradlePluginApi
 data class DokkaModuleDescriptionKxs(
     /** @see DokkaConfiguration.DokkaModuleDescription.name */
@@ -34,4 +36,20 @@ data class DokkaModuleDescriptionKxs(
     val moduleOutputDirName: String = "module",
     /** name of the sibling directory that contains the module includes */
     val moduleIncludesDirName: String = "includes",
-)
+) {
+    internal companion object {
+        fun toJsonObject(module: DokkaModuleDescriptionKxs): JsonObject = buildJsonObject {
+            put("name", module.name)
+            put("modulePath", module.modulePath)
+            put("moduleOutputDirName", module.moduleOutputDirName)
+            put("moduleIncludesDirName", module.moduleIncludesDirName)
+        }
+
+        fun fromJsonObject(obj: JsonObject): DokkaModuleDescriptionKxs = DokkaModuleDescriptionKxs(
+            name = obj["name"]!!.jsonPrimitive.content,
+            modulePath = obj["modulePath"]!!.jsonPrimitive.content,
+            moduleOutputDirName = obj["moduleOutputDirName"]!!.jsonPrimitive.content,
+            moduleIncludesDirName = obj["moduleIncludesDirName"]!!.jsonPrimitive.content,
+        )
+    }
+}

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/engine/parameters/builders/DokkaParametersBuilder.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/engine/parameters/builders/DokkaParametersBuilder.kt
@@ -3,6 +3,7 @@
  */
 package org.jetbrains.dokka.gradle.engine.parameters.builders
 
+import kotlinx.serialization.json.JsonObject
 import org.gradle.api.Project
 import org.gradle.api.file.ArchiveOperations
 import org.gradle.api.file.FileCollection
@@ -96,9 +97,11 @@ internal class DokkaParametersBuilder(
                 }
 
                 val moduleDescriptor: DokkaModuleDescriptionKxs =
-                    DokkaBasePlugin.jsonMapper.decodeFromString(
-                        DokkaModuleDescriptionKxs.serializer(),
-                        moduleDescriptorJson.readText(),
+                    DokkaModuleDescriptionKxs.fromJsonObject(
+                        DokkaBasePlugin.jsonMapper.decodeFromString(
+                            JsonObject.serializer(),
+                            moduleDescriptorJson.readText(),
+                        )
                     )
 
                 val moduleOutputDirectory = moduleDir.resolve(moduleDescriptor.moduleOutputDirName)

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/tasks/DokkaGenerateModuleTask.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/tasks/DokkaGenerateModuleTask.kt
@@ -3,6 +3,7 @@
  */
 package org.jetbrains.dokka.gradle.tasks
 
+import kotlinx.serialization.json.JsonObject
 import org.gradle.api.file.ArchiveOperations
 import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.model.ObjectFactory
@@ -87,8 +88,8 @@ constructor(
 
         val encodedModuleDesc =
             DokkaBasePlugin.jsonMapper.encodeToString(
-                DokkaModuleDescriptionKxs.serializer(),
-                moduleDesc
+                JsonObject.serializer(),
+                DokkaModuleDescriptionKxs.toJsonObject(moduleDesc)
             )
 
         logger.info("encodedModuleDesc: $encodedModuleDesc".lines().joinToString(" "))

--- a/dokka-runners/dokka-gradle-plugin/src/testFixtures/kotlin/GradleTestKitUtils.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFixtures/kotlin/GradleTestKitUtils.kt
@@ -205,7 +205,6 @@ class GradleProjectTest(
                 |pluginManagement {
                 |  repositories {
                 |${dokkaTestRepo.prependIndent("    ")}
-                |    maven("https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
                 |    mavenCentral()
                 |    gradlePluginPortal()
                 |  }
@@ -215,7 +214,6 @@ class GradleProjectTest(
                 |dependencyResolutionManagement {
                 |  repositories {
                 |${dokkaTestRepo.prependIndent("    ")}
-                |    maven("https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
                 |    mavenCentral()
                 |  }
                 |}
@@ -250,6 +248,7 @@ class GradleProjectTest(
             }
 
             """
+            |maven("https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
             |exclusiveContent {
             |    forRepositories(
             |      $reposSpecs

--- a/dokka-runners/runner-cli/gradle.properties
+++ b/dokka-runners/runner-cli/gradle.properties
@@ -9,3 +9,4 @@ version=2.0.20-SNAPSHOT
 org.jetbrains.dokka.javaToolchain.mainCompiler=8
 org.jetbrains.dokka.javaToolchain.testLauncher=8
 org.jetbrains.dokka.kotlinLanguageLevel=1.4
+kotlin.compiler.runViaBuildToolsApi=true

--- a/dokka-runners/runner-maven-plugin/gradle.properties
+++ b/dokka-runners/runner-maven-plugin/gradle.properties
@@ -7,3 +7,4 @@ version=2.0.20-SNAPSHOT
 org.jetbrains.dokka.javaToolchain.mainCompiler=8
 org.jetbrains.dokka.javaToolchain.testLauncher=8
 org.jetbrains.dokka.kotlinLanguageLevel=1.4
+kotlin.compiler.runViaBuildToolsApi=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,7 @@ version=2.0.20-SNAPSHOT
 org.jetbrains.dokka.javaToolchain.mainCompiler=8
 org.jetbrains.dokka.javaToolchain.testLauncher=8
 org.jetbrains.dokka.kotlinLanguageLevel=1.4
+kotlin.compiler.runViaBuildToolsApi=true
 
 # Code style
 kotlin.code.style=official

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,9 @@
 [versions]
 
 gradlePlugin-kotlin = "2.0.20"
+# We use a different compiler version to use Kotlin Language/API version 1.4 to compile modules
+# to be able to be compatible with Gradle 7.
+gradlePlugin-kotlin-compiler = "2.0.20"
 # See: https://kotlinlang.org/docs/gradle-configure-project.html#apply-the-plugin
 gradlePlugin-android = "7.1.3"
 gradlePlugin-dokka = "1.9.20"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 
-gradlePlugin-kotlin = "2.0.20"
+gradlePlugin-kotlin = "2.1.0-RC-330"
 # We use a different compiler version to use Kotlin Language/API version 1.4 to compile modules
 # to be able to be compatible with Gradle 7.
 gradlePlugin-kotlin-compiler = "2.0.20"


### PR DESCRIPTION
compilation is failing with:
```
[KOTLIN] e: org.jetbrains.kotlin.backend.common.CompilationException: Back-end: Please report this problem https://kotl.in/issue
dokka/dokka-runners/dokka-gradle-plugin/src/main/kotlin/engine/parameters/DokkaModuleDescriptionKxs.kt:26:1
Problem with `@Serializable
@DokkaInternalApi
data class DokkaModuleDescriptionKxs
...
Details: kotlinx.serialization compiler plugin internal error: unable to transform declaration, see cause
...
Caused by: java.lang.NoSuchMethodError: 'org.jetbrains.kotlin.ir.expressions.impl.IrWhenImpl org.jetbrains.kotlin.ir.builders.ExpressionHelpersKt.irIfThen$default(org.jetbrains.kotlin.ir.builders.IrBuilderWithScope, org.jetbrains.kotlin.ir.types.IrType, org.jetbrains.kotlin.ir.expressions.IrExpression, org.jetbrains.kotlin.ir.expressions.IrExpression, org.jetbrains.kotlin.ir.expressions.IrStatementOrigin, int, java.lang.Object)'
...
```

Probably there is some issue with kotlinx.serialization compiler plugin usage when using `kotlin.compiler.runViaBuildToolsApi`.
KGP version = 2.1.0-RC-330
Kotlin compiler version used to compile code = 2.0.20
I've tried to set all different versions of kotlinx.serialization plugins, but none of them work.


Not sure where the issue comes from, but probably the easiest way will be to drop `kotlinx.serialization` usage from DGPv2 so that there will be less moving parts :)
It's possible to replace it:
1. or with just runtime `kotlinx.serialization` usage via `JsonObject`
2. or `kotlinx.serialization` can be fully dropped as it's used only for [single class](https://github.com/Kotlin/dokka/blob/e3dc412e9185564a49ecc639a7291b0596abc0a0/dokka-runners/dokka-gradle-plugin/src/main/kotlin/engine/parameters/DokkaModuleDescriptionKxs.kt#L28) which could be easily replaced with just a txt file with 4 lines :)

Note: last commit adds a workaround: https://github.com/Kotlin/dokka/pull/3898/commits/d43e162bdbe4bfd05338b679ada91b28385604c1

with applied workaround, there are several failed DGPv2 functional tests