### PR TITLE
Drop kotlinx.serialization compiler plugin as it's unnecessary

### DIFF
--- a/dokka-runners/dokka-gradle-plugin/api/dokka-gradle-plugin.api
+++ b/dokka-runners/dokka-gradle-plugin/api/dokka-gradle-plugin.api
@@ -254,21 +254,6 @@ public abstract class org/jetbrains/dokka/gradle/engine/parameters/DokkaGenerato
 	public abstract fun getSuppressObviousFunctions ()Lorg/gradle/api/provider/Property;
 }
 
-public final class org/jetbrains/dokka/gradle/engine/parameters/DokkaModuleDescriptionKxs$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field INSTANCE Lorg/jetbrains/dokka/gradle/engine/parameters/DokkaModuleDescriptionKxs$$serializer;
-	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jetbrains/dokka/gradle/engine/parameters/DokkaModuleDescriptionKxs;
-	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jetbrains/dokka/gradle/engine/parameters/DokkaModuleDescriptionKxs;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
-}
-
-public final class org/jetbrains/dokka/gradle/engine/parameters/DokkaModuleDescriptionKxs$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
 public abstract class org/jetbrains/dokka/gradle/engine/parameters/DokkaPackageOptionsSpec : java/io/Serializable, org/jetbrains/dokka/gradle/engine/parameters/HasConfigurableVisibilityModifiers {
 	public abstract fun getDocumentedVisibilities ()Lorg/gradle/api/provider/SetProperty;
 	public abstract fun getMatchingRegex ()Lorg/gradle/api/provider/Property;

--- a/dokka-runners/dokka-gradle-plugin/build.gradle.kts
+++ b/dokka-runners/dokka-gradle-plugin/build.gradle.kts
@@ -9,9 +9,6 @@ import dokkabuild.utils.skipTestFixturesPublications
 
 plugins {
     id("dokkabuild.gradle-plugin")
-
-    kotlin("plugin.serialization") version embeddedKotlinVersion
-
     `jvm-test-suite`
     `java-test-fixtures`
     id("dokkabuild.dev-maven-publish")

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/engine/parameters/DokkaModuleDescriptionKxs.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/engine/parameters/DokkaModuleDescriptionKxs.kt
@@ -3,7 +3,10 @@
  */
 package org.jetbrains.dokka.gradle.engine.parameters
 
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 import org.gradle.kotlin.dsl.java
 import org.jetbrains.dokka.DokkaConfiguration
 import org.jetbrains.dokka.gradle.internal.InternalDokkaGradlePluginApi
@@ -23,7 +26,6 @@ import org.jetbrains.dokka.gradle.internal.InternalDokkaGradlePluginApi
  * @see org.jetbrains.dokka.gradle.engine.parameters.DokkaModuleDescriptionKxs
  * @see org.jetbrains.dokka.DokkaModuleDescriptionImpl
  */
-@Serializable
 @InternalDokkaGradlePluginApi
 data class DokkaModuleDescriptionKxs(
     /** @see DokkaConfiguration.DokkaModuleDescription.name */
@@ -34,4 +36,20 @@ data class DokkaModuleDescriptionKxs(
     val moduleOutputDirName: String = "module",
     /** name of the sibling directory that contains the module includes */
     val moduleIncludesDirName: String = "includes",
-)
+) {
+    internal companion object {
+        fun toJsonObject(module: DokkaModuleDescriptionKxs): JsonObject = buildJsonObject {
+            put("name", module.name)
+            put("modulePath", module.modulePath)
+            put("moduleOutputDirName", module.moduleOutputDirName)
+            put("moduleIncludesDirName", module.moduleIncludesDirName)
+        }
+
+        fun fromJsonObject(obj: JsonObject): DokkaModuleDescriptionKxs = DokkaModuleDescriptionKxs(
+            name = obj["name"]!!.jsonPrimitive.content,
+            modulePath = obj["modulePath"]!!.jsonPrimitive.content,
+            moduleOutputDirName = obj["moduleOutputDirName"]!!.jsonPrimitive.content,
+            moduleIncludesDirName = obj["moduleIncludesDirName"]!!.jsonPrimitive.content,
+        )
+    }
+}

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/engine/parameters/DokkaModuleDescriptionKxs.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/engine/parameters/DokkaModuleDescriptionKxs.kt
@@ -33,11 +33,14 @@ data class DokkaModuleDescriptionKxs(
     /** @see org.jetbrains.dokka.gradle.DokkaExtension.modulePath */
     val modulePath: String,
     /** name of the sibling directory that contains the module output */
-    val moduleOutputDirName: String = "module",
+    val moduleOutputDirName: String = defaultModuleOutputDirName,
     /** name of the sibling directory that contains the module includes */
-    val moduleIncludesDirName: String = "includes",
+    val moduleIncludesDirName: String = defaultModuleIncludesDirName,
 ) {
     internal companion object {
+        private val defaultModuleOutputDirName = "module"
+        private val defaultModuleIncludesDirName = "includes"
+
         fun toJsonObject(module: DokkaModuleDescriptionKxs): JsonObject = buildJsonObject {
             put("name", module.name)
             put("modulePath", module.modulePath)
@@ -46,10 +49,14 @@ data class DokkaModuleDescriptionKxs(
         }
 
         fun fromJsonObject(obj: JsonObject): DokkaModuleDescriptionKxs = DokkaModuleDescriptionKxs(
-            name = obj["name"]!!.jsonPrimitive.content,
-            modulePath = obj["modulePath"]!!.jsonPrimitive.content,
-            moduleOutputDirName = obj["moduleOutputDirName"]!!.jsonPrimitive.content,
-            moduleIncludesDirName = obj["moduleIncludesDirName"]!!.jsonPrimitive.content,
+            name = obj.getString("name"),
+            modulePath = obj.getString("modulePath"),
+            moduleOutputDirName = obj.getString("moduleOutputDirName", defaultModuleOutputDirName),
+            moduleIncludesDirName = obj.getString("moduleIncludesDirName", defaultModuleIncludesDirName),
         )
+
+        private fun JsonObject.getString(key: String, defaultValue: String? = null): String {
+            return get(key)?.jsonPrimitive?.content ?: defaultValue ?: error("Missing required property '$key'")
+        }
     }
 }

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/engine/parameters/builders/DokkaParametersBuilder.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/engine/parameters/builders/DokkaParametersBuilder.kt
@@ -3,6 +3,7 @@
  */
 package org.jetbrains.dokka.gradle.engine.parameters.builders
 
+import kotlinx.serialization.json.JsonObject
 import org.gradle.api.Project
 import org.gradle.api.file.ArchiveOperations
 import org.gradle.api.file.FileCollection
@@ -96,9 +97,11 @@ internal class DokkaParametersBuilder(
                 }
 
                 val moduleDescriptor: DokkaModuleDescriptionKxs =
-                    DokkaBasePlugin.jsonMapper.decodeFromString(
-                        DokkaModuleDescriptionKxs.serializer(),
-                        moduleDescriptorJson.readText(),
+                    DokkaModuleDescriptionKxs.fromJsonObject(
+                        DokkaBasePlugin.jsonMapper.decodeFromString(
+                            JsonObject.serializer(),
+                            moduleDescriptorJson.readText(),
+                        )
                     )
 
                 val moduleOutputDirectory = moduleDir.resolve(moduleDescriptor.moduleOutputDirName)

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/tasks/DokkaGenerateModuleTask.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/tasks/DokkaGenerateModuleTask.kt
@@ -3,6 +3,7 @@
  */
 package org.jetbrains.dokka.gradle.tasks
 
+import kotlinx.serialization.json.JsonObject
 import org.gradle.api.file.ArchiveOperations
 import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.model.ObjectFactory
@@ -87,8 +88,8 @@ constructor(
 
         val encodedModuleDesc =
             DokkaBasePlugin.jsonMapper.encodeToString(
-                DokkaModuleDescriptionKxs.serializer(),
-                moduleDesc
+                JsonObject.serializer(),
+                DokkaModuleDescriptionKxs.toJsonObject(moduleDesc)
             )
 
         logger.info("encodedModuleDesc: $encodedModuleDesc".lines().joinToString(" "))

--- a/dokka-runners/dokka-gradle-plugin/src/test/kotlin/engine/parameters/DokkaModuleDescriptionKxsTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/test/kotlin/engine/parameters/DokkaModuleDescriptionKxsTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+package org.jetbrains.dokka.gradle.engine.parameters
+
+import kotlinx.serialization.json.*
+import kotlin.test.*
+
+class DokkaModuleDescriptionKxsTest {
+
+    @Test
+    fun testToJsonObject() {
+        val module = DokkaModuleDescriptionKxs(
+            name = "moduleName",
+            modulePath = "/path/to/module",
+            moduleOutputDirName = "outputDir",
+            moduleIncludesDirName = "includesDir"
+        )
+        val jsonObject = DokkaModuleDescriptionKxs.toJsonObject(module)
+
+        assertString("moduleName", jsonObject["name"])
+        assertString("/path/to/module", jsonObject["modulePath"])
+        assertString("outputDir", jsonObject["moduleOutputDirName"])
+        assertString("includesDir", jsonObject["moduleIncludesDirName"])
+    }
+
+    @Test
+    fun testFromJsonObject() {
+        val jsonObject = buildJsonObject {
+            put("name", "moduleName")
+            put("modulePath", "/path/to/module")
+            put("moduleOutputDirName", "outputDir")
+            put("moduleIncludesDirName", "includesDir")
+        }
+        val module = DokkaModuleDescriptionKxs.fromJsonObject(jsonObject)
+
+        assertEquals("moduleName", module.name)
+        assertEquals("/path/to/module", module.modulePath)
+        assertEquals("outputDir", module.moduleOutputDirName)
+        assertEquals("includesDir", module.moduleIncludesDirName)
+    }
+
+    @Test
+    fun testDefaultConstructorArguments() {
+        val jsonObject = buildJsonObject {
+            put("name", "defaultModule")
+            put("modulePath", "/default/path")
+        }
+        val module = DokkaModuleDescriptionKxs.fromJsonObject(jsonObject)
+
+        assertEquals("defaultModule", module.name)
+        assertEquals("/default/path", module.modulePath)
+
+        // those are default values coming from DokkaModuleDescriptionKxs Companion
+        assertEquals("module", module.moduleOutputDirName)
+        assertEquals("includes", module.moduleIncludesDirName)
+    }
+
+    private fun assertString(expected: String, actual: JsonElement?) {
+        assertNotNull(actual)
+        assertIs<JsonPrimitive>(actual)
+        assertTrue(actual.isString)
+        assertEquals(expected, actual.content)
+    }
+}


### PR DESCRIPTION
Extracted from https://github.com/Kotlin/dokka/pull/3898, required to be able to update to KGP 2.1.0
