### PR TITLE
Increase default max heap of Worker to 2G

### DIFF
--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaBasePlugin.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaBasePlugin.kt
@@ -107,6 +107,7 @@ constructor(
 
         dokkaExtension.dokkaGeneratorIsolation.convention(
             dokkaExtension.ProcessIsolation {
+                maxHeapSize.convention("2g")
                 debug.convention(false)
                 jvmArgs.convention(
                     listOf(


### PR DESCRIPTION
[KT-73024](https://youtrack.jetbrains.com/issue/KT-73024/Increase-default-memory-of-DGP-worker-to-2G)