### PR TITLE
Avoid configuration resolution error for v2 migration helper task

### DIFF
--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/DokkaClassicPlugin.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/DokkaClassicPlugin.kt
@@ -113,10 +113,13 @@ open class DokkaClassicPlugin : Plugin<Project> {
     }
 
     private fun Project.configureEachAbstractDokkaTask() {
-        tasks.withType<AbstractDokkaTask>().configureEach {
+        tasks.withType<AbstractDokkaTask>().configureEach task@{
             val formatClassifier = name.removePrefix("dokka").decapitalize()
             outputDirectory.convention(project.layout.buildDirectory.dir("dokka/$formatClassifier"))
             cacheRoot.convention(project.layout.dir(providers.provider { DokkaDefaults.cacheRoot }))
+
+            pluginsClasspath.from(this@task.plugins)
+            runtimeClasspath.from(this@task.runtime)
         }
     }
 

--- a/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/DokkaV1TaskDisabledTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/DokkaV1TaskDisabledTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+package org.jetbrains.dokka.gradle
+
+import io.kotest.core.spec.style.FunSpec
+import org.gradle.testkit.runner.TaskOutcome.SKIPPED
+import org.jetbrains.dokka.gradle.utils.addArguments
+import org.jetbrains.dokka.gradle.utils.build
+import org.jetbrains.dokka.gradle.utils.projects.initNoConfigMultiModuleProject
+import org.jetbrains.dokka.gradle.utils.shouldHaveRunTask
+
+class DokkaV1TaskDisabledTest : FunSpec({
+    context("given multi-module project") {
+
+        val project = initNoConfigMultiModuleProject {
+            gradleProperties {
+                dokka {
+                    pluginMode = "V2EnabledWithHelpers"
+                }
+            }
+        }
+
+        test("v1 tasks should be skipped when v2 is enabled") {
+            project.runner
+                .addArguments("dokkaHtml")
+                .build {
+                    shouldHaveRunTask(":subproject-one:dokkaHtml", SKIPPED)
+                    shouldHaveRunTask(":subproject-two:dokkaHtml", SKIPPED)
+                }
+        }
+    }
+})


### PR DESCRIPTION
Fix error when running `dokkaHtml` task when v2 migration helpers are enabled.

#### Summary

The problem:

- DGPv1 tasks contain automatic configuration for task inputs that cannot be disabled dynamically by V2.
- When v2 registered the migration helpers, it uses the same task types to prevent breaking changes in buildscripts.
- The task types automatically configured themselves using Configurations that v2 makes incompatible.


The solution:

- Update the v1 tasks to lazily configure the input values.

Fix [KT-72000](https://youtrack.jetbrains.com/issue/KT-72000)