### PR TITLE
Remove Dokka debug config file from task outputs

### DIFF
--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/tasks/DokkaGenerateTask.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/tasks/DokkaGenerateTask.kt
@@ -98,11 +98,10 @@ constructor(
 
     /**
      * The [DokkaConfiguration] by Dokka Generator can be saved to a file for debugging purposes.
-     * To disable this behaviour set this property to `null`.
+     * To disable this behaviour use [Property.unsetConvention] to clear the default value.
      */
     @InternalDokkaGradlePluginApi
-    @get:Optional
-    @get:OutputFile
+    @get:Internal
     abstract val dokkaConfigurationJsonFile: RegularFileProperty
 
     /**

--- a/dokka-runners/dokka-gradle-plugin/src/testFixtures/kotlin/GradleTestKitUtils.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFixtures/kotlin/GradleTestKitUtils.kt
@@ -159,7 +159,7 @@ fun gradleKtsProjectTest(
 
     return gradleProjectTest(
         testProjectName = rootProjectNameValue,
-        baseDir = baseDir,
+        baseDir = baseDir.resolve(projectLocation),
     ) {
 
         settingsGradleKts = """

--- a/dokka-runners/dokka-gradle-plugin/src/testFixtures/kotlin/stringUtils.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFixtures/kotlin/stringUtils.kt
@@ -25,7 +25,7 @@ fun String.sortLines(separator: String = "\n") =
 
 
 /** Replace characters that don't match [isLetterOrDigit] with [replacement]. */
-internal fun String.replaceNonAlphaNumeric(
+fun String.replaceNonAlphaNumeric(
     replacement: String = "-"
 ): String =
     asIterable().joinToString("") { c ->

--- a/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/DumpDokkaConfigurationTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/DumpDokkaConfigurationTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+package org.jetbrains.dokka.gradle
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.test.TestScope
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.file.shouldExist
+import org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import org.jetbrains.dokka.gradle.internal.DokkaConstants.DOKKA_VERSION
+import org.jetbrains.dokka.gradle.utils.*
+import kotlin.io.path.invariantSeparatorsPathString
+import kotlin.io.path.name
+import kotlin.io.path.relativeToOrSelf
+
+class DumpDokkaConfigurationTest : FunSpec({
+
+    context("implicit task outputs should not contain Dokka config file") {
+
+        val project = initProject()
+
+        project.runner
+            .forwardOutput()
+            .addArguments(
+                ":clean",
+                ":syncDokkaOutput",
+                "--rerun",
+            )
+            .build {
+                test("expect syncDokkaOutput runs successfully") {
+                    shouldHaveTasksWithOutcome(
+                        ":syncDokkaOutput" to SUCCESS,
+                    )
+                }
+
+                test("verify sync task collects Dokka output files") {
+                    // Just a simple check to make sure that some files were copied, because testing the config
+                    // files don't exist could mean that nothing was copied and something else broke.
+                    project.file("build/tmp/syncDokkaOutput/module/module-descriptor.json")
+                        .toFile()
+                        .shouldExist()
+                    project.file("build/tmp/syncDokkaOutput/publication/index.html")
+                        .toFile()
+                        .shouldExist()
+                }
+
+                test("expect no Dokka config file in output") {
+                    project
+                        .dir("build/tmp/syncDokkaOutput")
+                        .findFiles { it.name == "dokka-configuration.json" }
+                        .map { it.relativeToOrSelf(project.projectDir).invariantSeparatorsPathString }
+                        .toList()
+                        .shouldBeEmpty()
+                }
+            }
+    }
+})
+
+private fun TestScope.initProject(
+    config: GradleProjectTest.() -> Unit = {},
+): GradleProjectTest {
+    val baseDirName = testCase.descriptor.ids()
+        .joinToString("/") { it.value.substringAfter("org.jetbrains.dokka.gradle.").replaceNonAlphaNumeric() }
+
+    return gradleKtsProjectTest(
+        projectLocation = baseDirName,
+        rootProjectName = "DumpDokkaConfigurationTest",
+    ) {
+        buildGradleKts = """
+            |plugins {
+            |    kotlin("jvm") version embeddedKotlinVersion
+            |    id("org.jetbrains.dokka") version "$DOKKA_VERSION"
+            |}
+            |
+            |val syncDokkaOutput by tasks.registering(Sync::class) {
+            |    // fetch the implicit output files of the DokkaGenerate tasks
+            |    from(tasks.dokkaGeneratePublicationHtml) {
+            |       into("publication")
+            |    }
+            |    from(tasks.dokkaGenerateModuleHtml) {
+            |       into("module")
+            |    }
+            |    into(temporaryDir)
+            |}
+            |
+            """.trimMargin()
+
+        createKotlinFile("src/main/kotlin/Foo.kt", "class Foo")
+
+        config()
+    }
+}


### PR DESCRIPTION
Dumping the Dokka config files is useful for debugging, but can interfere with task outputs.

Here we add a flag that disables the dumping the config file by default, but we enable it for our own tests.

Fix #3958