### PR TITLE
Replace Potentially Scam Url from Readme projects using dokka [Needs Priority]

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Some libraries that use Dokka for their API reference documentation:
 
 * [kotlinx.coroutines](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/)
 * [Bitmovin](https://cdn.bitmovin.com/player/android/3/docs/index.html)
+* [Hexagon](https://hexagontk.com/stable/api/)
 * [Ktor](https://api.ktor.io/)
 * [OkHttp](https://square.github.io/okhttp/5.x/okhttp/okhttp3/)
 * [Gradle](https://docs.gradle.org/current/kotlin-dsl/index.html)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Some libraries that use Dokka for their API reference documentation:
 
 * [kotlinx.coroutines](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/)
 * [Bitmovin](https://cdn.bitmovin.com/player/android/3/docs/index.html)
-* [Hexagon](https://hexagonkt.com/api/index.html)
 * [Ktor](https://api.ktor.io/)
 * [OkHttp](https://square.github.io/okhttp/5.x/okhttp/okhttp3/)
 * [Gradle](https://docs.gradle.org/current/kotlin-dsl/index.html)


### PR DESCRIPTION
The url is wrong (the correct one https://hexagontk.com/stable/api/) and redirects to a scammy-like slots site. Corection: Hexagon still uses Dokka in its Api docs

Note that clicking on [Hexagon Old Url](https://hexagonkt.com/api/index.html) redirects to below image website
![Old Url redirecting to Site](https://github.com/user-attachments/assets/13b40a17-adf4-4bf8-81de-353f5e480b55)
![Actual correct api docs use dokka](https://github.com/user-attachments/assets/40aea734-bed7-4010-ae65-71d631d8a644)


