### PR TITLE
Cache `packages` field, which is used by `DefaultExternalLocationProvider.resolve`

### DIFF
--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/resolvers/shared/PackageList.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/resolvers/shared/PackageList.kt
@@ -14,8 +14,7 @@ public data class PackageList(
     val locations: Map<String, String>,
     val url: URL
 ) {
-    val packages: Set<String>
-        get() = modules.values.flatten().toSet()
+    val packages: Set<String> by lazy { modules.values.flatten().toSet() }
 
     public fun moduleFor(packageName: String): Module? {
         return modules.asSequence()

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/resolvers/shared/PackageList.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/resolvers/shared/PackageList.kt
@@ -14,13 +14,20 @@ public data class PackageList(
     val locations: Map<String, String>,
     val url: URL
 ) {
-    val packages: Set<String> by lazy { modules.values.flatten().toSet() }
-
-    public fun moduleFor(packageName: String): Module? {
-        return modules.asSequence()
-            .filter { it.value.contains(packageName) }
-            .firstOrNull()?.key
+    private val moduleByPackage: Map<String, Module> by lazy {
+        mutableMapOf<String, Module>().apply {
+            modules.forEach { (module, packages) ->
+                packages.forEach { pkg ->
+                    // if multiple modules have the same package (split-package), store the first module.
+                    if (!containsKey(pkg)) put(pkg, module)
+                }
+            }
+        }
     }
+
+    val packages: Set<String> get() = moduleByPackage.keys
+
+    public fun moduleFor(packageName: String): Module? = moduleByPackage[packageName]
 
     public companion object {
         public const val PACKAGE_LIST_NAME: String = "package-list"


### PR DESCRIPTION
Found and tested on https://github.com/rjaros/kilua (results are reproducible even after several runs).
Reduces allocations inside [DefaultExternalLocationProvider.resolve](https://github.com/Kotlin/dokka/blob/d4d457d357627fd8100e4f0d47868020485996ec/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/resolvers/external/DefaultExternalLocationProvider.kt#L22) from 11 GB to 1 GB. Previously `packages` were recreated for each `resolve`.
The changes don't really affect kotlinx.io and kotlinx.coroutines.

For future: probably it might make sense to also cache results of `DefaultExternalLocationProvider.resolve`?
In this specific project there are a lot of references to `@Composable` annotation passing through this function call.