### PR TITLE
Fix merging of implicit expect/actual with a single declaration

### DIFF
--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/translators/documentables/DefaultPageCreator.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/translators/documentables/DefaultPageCreator.kt
@@ -117,8 +117,7 @@ public open class DefaultPageCreator(
                     props.mergeClashingDocumentable().map(::pageForProperties)
         else
             classlikes.renameClashingDocumentable().map(::pageForClasslike) +
-                    functions.renameClashingDocumentable().map(::pageForFunction) +
-                    props.renameClashingDocumentable().mapNotNull(::pageForProperty)
+                    (functions + props).renameClashingDocumentable().mapNotNull(::pageForMember)
 
         return ClasslikePageNode(
             documentables.first().nameAfterClash(), contentForClasslikesAndEntries(documentables), dri, documentables,
@@ -158,8 +157,7 @@ public open class DefaultPageCreator(
                             entries.mergeClashingDocumentable().map(::pageForEnumEntries)
                 else
                     nestedClasslikes.renameClashingDocumentable().map(::pageForClasslike) +
-                            functions.renameClashingDocumentable().map(::pageForFunction) +
-                            props.renameClashingDocumentable().mapNotNull(::pageForProperty) +
+                            (functions + props).renameClashingDocumentable().mapNotNull(::pageForMember)  +
                             entries.renameClashingDocumentable().map(::pageForEnumEntry)
 
 
@@ -205,6 +203,12 @@ public open class DefaultPageCreator(
             }
         }
         return MemberPageNode(fs.first().nameAfterClash(), contentForMembers(fs), dri, fs)
+    }
+
+    private fun pageForMember(d: Documentable): MemberPageNode? = when (d) {
+        is DProperty -> pageForProperty(d)
+        is DFunction -> pageForFunction(d)
+        else -> throw IllegalStateException()
     }
 
     public open fun pageForProperty(p: DProperty): MemberPageNode? =

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/translators/documentables/DefaultPageCreator.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/translators/documentables/DefaultPageCreator.kt
@@ -174,22 +174,10 @@ public open class DefaultPageCreator(
 
     private fun <T : Documentable> List<T>.renameClashingDocumentable(): List<T> =
         groupBy { it.dri }.values.flatMap { elements ->
-            if (elements.size == 1 && !elements.single().hasClashingDriIdentifier()) elements else elements.mapNotNull { element ->
+            if (elements.size == 1) elements else elements.mapNotNull { element ->
                 element.renameClashingDocumentable()
             }
         }
-
-    private fun <T : Documentable> T.hasClashingDriIdentifier(): Boolean = when (this) {
-        is DClass -> extra[ClashingDriIdentifier] != null
-        is DObject -> extra[ClashingDriIdentifier] != null
-        is DAnnotation -> extra[ClashingDriIdentifier] != null
-        is DInterface -> extra[ClashingDriIdentifier] != null
-        is DEnum -> extra[ClashingDriIdentifier] != null
-        is DFunction -> extra[ClashingDriIdentifier] != null
-        is DProperty -> extra[ClashingDriIdentifier] != null
-        is DTypeAlias -> extra[ClashingDriIdentifier] != null
-        else -> false
-    }
 
     @Suppress("UNCHECKED_CAST")
     private fun <T : Documentable> T.renameClashingDocumentable(): T? = when (this) {

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/translators/documentables/DefaultPageCreator.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/translators/documentables/DefaultPageCreator.kt
@@ -174,10 +174,22 @@ public open class DefaultPageCreator(
 
     private fun <T : Documentable> List<T>.renameClashingDocumentable(): List<T> =
         groupBy { it.dri }.values.flatMap { elements ->
-            if (elements.size == 1) elements else elements.mapNotNull { element ->
+            if (elements.size == 1 && !elements.single().hasClashingDriIdentifier()) elements else elements.mapNotNull { element ->
                 element.renameClashingDocumentable()
             }
         }
+
+    private fun <T : Documentable> T.hasClashingDriIdentifier(): Boolean = when (this) {
+        is DClass -> extra[ClashingDriIdentifier] != null
+        is DObject -> extra[ClashingDriIdentifier] != null
+        is DAnnotation -> extra[ClashingDriIdentifier] != null
+        is DInterface -> extra[ClashingDriIdentifier] != null
+        is DEnum -> extra[ClashingDriIdentifier] != null
+        is DFunction -> extra[ClashingDriIdentifier] != null
+        is DProperty -> extra[ClashingDriIdentifier] != null
+        is DTypeAlias -> extra[ClashingDriIdentifier] != null
+        else -> false
+    }
 
     @Suppress("UNCHECKED_CAST")
     private fun <T : Documentable> T.renameClashingDocumentable(): T? = when (this) {

--- a/dokka-subprojects/plugin-base/src/test/kotlin/expectActuals/ExpectActualsTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/expectActuals/ExpectActualsTest.kt
@@ -6,8 +6,12 @@ package expectActuals
 
 import org.jetbrains.dokka.DokkaSourceSetID
 import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
+import org.jetbrains.dokka.model.DFunction
+import org.jetbrains.dokka.model.DProperty
+import org.jetbrains.dokka.model.dfs
 import org.jetbrains.dokka.model.withDescendants
 import org.jetbrains.dokka.pages.ClasslikePageNode
+import org.jetbrains.dokka.pages.MemberPageNode
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -433,6 +437,62 @@ class ExpectActualsTest : BaseAbstractTest() {
                     setOf("common", "jvm", "native"), function.sourceSets.map { it.sourceSetID.sourceSetName }.toSet()
                 )
             }
+        }
+    }
+
+    @Test
+    fun `should merge an implicit-expectActual function with a single property with #3685`() = testInline(
+        """
+        /src/common/test.kt
+        expect class Skiko
+
+        /src/jvm/test.kt
+        actual class Skiko actual constructor() {
+             val isShowing = false
+             override fun isShowing(): Boolean {
+                return false
+            }
+        }
+        
+        /src/native/test.kt
+        actual class Skiko actual constructor(){
+            fun isShowing(): Boolean {
+                return false
+            }
+        }
+        """.trimMargin(),
+        multiplatformConfiguration
+    ) {
+        renderingStage = { root, _ ->
+            val documentables = (root.dfs { it.name == "[jvm]isShowing" } as MemberPageNode).documentables
+            assertEquals(listOf(DFunction::class, DProperty::class), documentables.map { it::class })
+        }
+    }
+
+    @Test
+    fun `should merge an implicit-expectActual property with a single function with #3685`() = testInline(
+        """
+        /src/common/test.kt
+        expect class Skiko
+
+        /src/jvm/test.kt
+        actual class Skiko actual constructor() {
+             val isShowing = false
+             override fun isShowing(): Boolean {
+                return false
+            }
+        }
+        
+        /src/native/test.kt
+        actual class Skiko actual constructor(){
+            val isShowing = false
+        }
+        """.trimMargin(),
+        multiplatformConfiguration
+    ) {
+        renderingStage = { root, _ ->
+            val documentables = (root.dfs { it.name == "[jvm]isShowing" } as MemberPageNode).documentables
+            assertEquals(listOf(DFunction::class, DProperty::class), documentables.map { it::class })
         }
     }
 }

--- a/dokka-subprojects/plugin-base/src/test/kotlin/expectActuals/ExpectActualsTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/expectActuals/ExpectActualsTest.kt
@@ -449,7 +449,7 @@ class ExpectActualsTest : BaseAbstractTest() {
         /src/jvm/test.kt
         actual class Skiko actual constructor() {
              val isShowing = false
-             override fun isShowing(): Boolean {
+             fun isShowing(): Boolean {
                 return false
             }
         }
@@ -463,6 +463,10 @@ class ExpectActualsTest : BaseAbstractTest() {
         """.trimMargin(),
         multiplatformConfiguration
     ) {
+        pagesGenerationStage = { root ->
+            val cl = root.dfs { it.name == "Skiko" && it is ClasslikePageNode } ?: throw IllegalStateException()
+            assertEquals(2, cl.children.count { it.name == "[jvm]isShowing" })
+        }
         renderingStage = { root, _ ->
             val documentables = (root.dfs { it.name == "[jvm]isShowing" } as MemberPageNode).documentables
             assertEquals(listOf(DFunction::class, DProperty::class), documentables.map { it::class })
@@ -478,7 +482,7 @@ class ExpectActualsTest : BaseAbstractTest() {
         /src/jvm/test.kt
         actual class Skiko actual constructor() {
              val isShowing = false
-             override fun isShowing(): Boolean {
+             fun isShowing(): Boolean {
                 return false
             }
         }
@@ -490,6 +494,10 @@ class ExpectActualsTest : BaseAbstractTest() {
         """.trimMargin(),
         multiplatformConfiguration
     ) {
+        pagesGenerationStage = { root ->
+            val cl = root.dfs { it.name == "Skiko" && it is ClasslikePageNode } ?: throw IllegalStateException()
+            assertEquals(2, cl.children.count { it.name == "[jvm]isShowing" })
+        }
         renderingStage = { root, _ ->
             val documentables = (root.dfs { it.name == "[jvm]isShowing" } as MemberPageNode).documentables
             assertEquals(listOf(DFunction::class, DProperty::class), documentables.map { it::class })

--- a/dokka-subprojects/plugin-base/src/test/kotlin/expectActuals/ExpectActualsTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/expectActuals/ExpectActualsTest.kt
@@ -441,7 +441,7 @@ class ExpectActualsTest : BaseAbstractTest() {
     }
 
     @Test
-    fun `should merge an implicit-expectActual function with a single property with #3685`() = testInline(
+    fun `should merge an implicit-expectActual function with a single property #3685`() = testInline(
         """
         /src/common/test.kt
         expect class Skiko
@@ -474,7 +474,7 @@ class ExpectActualsTest : BaseAbstractTest() {
     }
 
     @Test
-    fun `should merge an implicit-expectActual property with a single function with #3685`() = testInline(
+    fun `should merge an implicit-expectActual property with a single function #3685`() = testInline(
         """
         /src/common/test.kt
         expect class Skiko


### PR DESCRIPTION
The main idea of this fix is that pages with implicit expect/actual declarations and a single declaration should have the same name since they are merged by `PageMerger` based on the page name. Before the fix, pages with the same DRI/path were unmerged, which caused an exception.