### PR TITLE
[K2] Support generating documentation for stdlib

### DIFF
--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/InternalConfiguration.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/InternalConfiguration.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package org.jetbrains.dokka.analysis.kotlin.symbols.plugin
+
+// revisit in scope of https://github.com/Kotlin/dokka/issues/2776
+internal object InternalConfiguration {
+    private const val ALLOW_KOTLIN_PACKAGE_PROPERTY = "org.jetbrains.dokka.analysis.allowKotlinPackage"
+
+    /**
+     * Allow analysing code in the 'kotlin' package
+     *
+     * Default: false
+     *
+     * @see org.jetbrains.kotlin.config.AnalysisFlags.allowKotlinPackage
+     */
+    val allowKotlinPackage: Boolean
+        get() = getBooleanProperty(ALLOW_KOTLIN_PACKAGE_PROPERTY)
+
+    private fun getBooleanProperty(propertyName: String): Boolean {
+        return System.getProperty(propertyName) in setOf("1", "true")
+    }
+}

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/KotlinAnalysis.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/KotlinAnalysis.kt
@@ -49,6 +49,7 @@ internal fun getLanguageVersionSettings(
     return LanguageVersionSettingsImpl(
         languageVersion = languageVersion,
         apiVersion = apiVersion, analysisFlags = hashMapOf(
+            AnalysisFlags.allowKotlinPackage to InternalConfiguration.allowKotlinPackage,
             // special flag for Dokka
             // force to resolve light classes (lazily by default)
             AnalysisFlags.eagerResolveOfLightClasses to true

--- a/dokka-subprojects/plugin-base/src/test/kotlin/utils/systemProperties.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/utils/systemProperties.kt
@@ -14,6 +14,13 @@ internal fun withAllTypesPage(block: () -> Unit): Unit =
 internal fun withSinceKotlin(block: () -> Unit): Unit =
     DokkaBaseInternalConfiguration.withProperty(SHOULD_DISPLAY_SINCE_KOTLIN_SYS_PROP, "true", block)
 
+/**
+ * This property works only for K2
+ * Allow analysing code in the 'kotlin' package
+ */
+internal fun withAllowKotlinPackage(block: () -> Unit): Unit =
+    DokkaBaseInternalConfiguration.withProperty("org.jetbrains.dokka.analysis.allowKotlinPackage", "true", block)
+
 internal fun DokkaBaseInternalConfiguration.withProperty(propertyName: String, value: String, block: () -> Unit) {
     setProperty(propertyName, value)
     try {


### PR DESCRIPTION
StdLib should copy some source and sample files to avoid [#3701](https://github.com/Kotlin/dokka/issues/3701).
Also, generating documentation works well with the fix for https://youtrack.jetbrains.com/issue/KT-74740. However, to have the fix, Dokka needs to update AA - #3951, which is currently blocked.

