### PR TITLE
chore: frontend dev server to watch both ui kit and search

### DIFF
--- a/dokka-subprojects/plugin-base-frontend/package-lock.json
+++ b/dokka-subprojects/plugin-base-frontend/package-lock.json
@@ -25,7 +25,7 @@
         "react-dom": "^17.0.2",
         "ts-loader": "^9.2.6",
         "typescript": "^4.5.2",
-        "webpack": "^5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "^5.1.4"
       },
       "devDependencies": {
@@ -46,6 +46,7 @@
         "husky": "^9.0.11",
         "lint-staged": "^15.2.5",
         "mini-css-extract-plugin": "^2.4.5",
+        "npm-run-all": "^4.1.5",
         "postcss-loader": "^8.1.1",
         "postcss-scss": "^4.0.9",
         "prettier": "^3.3.0",
@@ -4097,6 +4098,18 @@
       ],
       "license": "MIT-0"
     },
+    "node_modules/@jetbrains/ring-ui/node_modules/extricate-loader": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/extricate-loader/-/extricate-loader-3.0.0.tgz",
+      "integrity": "sha512-Ts6BIh25xhFpeGaG0La345bYQdRXWv3ZvUwmJB6/QsXRywWrZmM1hGz8eZfQaBwy/HsmGOZevzGLesVtsrrmyg==",
+      "license": "Unlicense",
+      "dependencies": {
+        "loader-utils": "^1.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      }
+    },
     "node_modules/@jetbrains/ring-ui/node_modules/find-cache-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-4.0.0.tgz",
@@ -4134,6 +4147,32 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/@jetbrains/ring-ui/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/@jetbrains/ring-ui/node_modules/loader-utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
+      "license": "MIT",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/@jetbrains/ring-ui/node_modules/locate-path": {
       "version": "7.2.0",
@@ -5210,20 +5249,13 @@
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.0.tgz",
       "integrity": "sha512-gi6WQJ7cHRgZxtkQEoyHMppPjq9Kxo5Tjn2prSKDSmZrCz8TZ3jSRCeTJm+WoM+oB0WG37bRqLzaaU3q7JypGg==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
       }
     },
     "node_modules/@types/estree": {
@@ -9423,44 +9455,6 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
-    "node_modules/extricate-loader": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/extricate-loader/-/extricate-loader-3.0.0.tgz",
-      "integrity": "sha512-Ts6BIh25xhFpeGaG0La345bYQdRXWv3ZvUwmJB6/QsXRywWrZmM1hGz8eZfQaBwy/HsmGOZevzGLesVtsrrmyg==",
-      "license": "Unlicense",
-      "dependencies": {
-        "loader-utils": "^1.1.0"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0"
-      }
-    },
-    "node_modules/extricate-loader/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/extricate-loader/node_modules/loader-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-      "license": "MIT",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -11519,6 +11513,13 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "license": "MIT"
     },
+    "node_modules/json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -11715,6 +11716,46 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/load-json-file/node_modules/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/load-json-file/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/loader-runner": {
@@ -12443,6 +12484,15 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
       "license": "MIT"
+    },
+    "node_modules/memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10.0"
+      }
     },
     "node_modules/meow": {
       "version": "10.1.5",
@@ -13367,6 +13417,13 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT"
     },
+    "node_modules/nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/no-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
@@ -13439,6 +13496,200 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-all": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "chalk": "^2.4.1",
+        "cross-spawn": "^6.0.5",
+        "memorystream": "^0.3.1",
+        "minimatch": "^3.0.4",
+        "pidtree": "^0.3.0",
+        "read-pkg": "^3.0.0",
+        "shell-quote": "^1.6.1",
+        "string.prototype.padend": "^3.0.0"
+      },
+      "bin": {
+        "npm-run-all": "bin/npm-run-all/index.js",
+        "run-p": "bin/run-p/index.js",
+        "run-s": "bin/run-s/index.js"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/npm-run-all/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/pidtree": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
+      "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
       }
     },
     "node_modules/npm-run-path": {
@@ -17319,6 +17570,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/string.prototype.padend": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.6.tgz",
+      "integrity": "sha512-XZpspuSB7vJWhvJc9DLSlrXl1mcA2BdoY5jjnS135ydXqLoqhs96JjDtCkjJEQHvfqZIp9hBuBMgI589peyx9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/string.prototype.repeat": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
@@ -19051,12 +19321,11 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.93.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.93.0.tgz",
-      "integrity": "sha512-Y0m5oEY1LRuwly578VqluorkXbvXKh7U3rLoQCEO04M97ScRr44afGVkI0FQFsXzysk5OgFAxjZAb9rsGQVihA==",
+      "version": "5.94.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
+      "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
       "license": "MIT",
       "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.12.1",
         "@webassemblyjs/wasm-edit": "^1.12.1",
@@ -19065,7 +19334,7 @@
         "acorn-import-attributes": "^1.9.5",
         "browserslist": "^4.21.10",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.0",
+        "enhanced-resolve": "^5.17.1",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",

--- a/dokka-subprojects/plugin-base-frontend/package.json
+++ b/dokka-subprojects/plugin-base-frontend/package.json
@@ -14,11 +14,12 @@
     "build:ui-kit:minified": "webpack --config ./webpack.config-ui-kit.js --env minify=true",
     "build:ui-kit:unminified": "webpack --config ./webpack.config-ui-kit.js --env minify=false",
     "build": "webpack --mode=production --devtool source-map",
+    "watch": "webpack --mode=development --watch",
     "lint": "eslint . && npm run stylelint",
     "lint:fix": "eslint --fix --ext src/**/*.{ts,tsx,css,scss}",
     "prettier": "prettier --write 'src/**/*.{ts,tsx,css,scss}'",
     "stylelint": "stylelint --ignore-path .gitignore ./src/main/**/**/*.scss",
-    "start": "webpack-dev-server -d --history-api-fallback --inline --hot --colors --port 9010",
+    "start": "npm-run-all --parallel watch build:ui-kit:watch start:ui-kit",
     "prepare": "husky"
   },
   "babel": {
@@ -49,7 +50,7 @@
     "react-dom": "^17.0.2",
     "ts-loader": "^9.2.6",
     "typescript": "^4.5.2",
-    "webpack": "^5.89.0",
+    "webpack": "5.94.0",
     "webpack-cli": "^5.1.4"
   },
   "devDependencies": {
@@ -70,6 +71,7 @@
     "husky": "^9.0.11",
     "lint-staged": "^15.2.5",
     "mini-css-extract-plugin": "^2.4.5",
+    "npm-run-all": "^4.1.5",
     "postcss-loader": "^8.1.1",
     "postcss-scss": "^4.0.9",
     "prettier": "^3.3.0",

--- a/dokka-subprojects/plugin-base-frontend/webpack.config-ui-kit.js
+++ b/dokka-subprojects/plugin-base-frontend/webpack.config-ui-kit.js
@@ -6,7 +6,7 @@ const path = require('path');
 const WebpackShellPluginNext = require('webpack-shell-plugin-next');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 
-module.exports = (env, args) => {
+module.exports = (env) => {
   const isMinify = env.minify === 'true';
   return {
     watch: env.watch === 'true',
@@ -22,12 +22,6 @@ module.exports = (env, args) => {
           return !(/\.hot-update\.(js|json)$/.test(filePath) || /\.LICENSE\.txt$/.test(filePath));
         },
       },
-      watchFiles: {
-        paths: ['../../dokka-integration-tests/gradle/build/ui-showcase-result'],
-        options: {
-          ignored: ['../../dokka-integration-tests/gradle/build/ui-showcase-result/ui-kit']
-        }
-      }
     },
     entry: {
       entry: ['./src/main/ui-kit/index.ts'],
@@ -136,7 +130,7 @@ module.exports = (env, args) => {
       new WebpackShellPluginNext({
         onDoneWatch: {
           scripts: [
-            'echo "Done rebuild, coping files to dokka-integration-tests"',
+            'echo "[ui-kit] Done rebuild, coping files to dokka-integration-tests"',
             'cp -r ../plugin-base/src/main/resources/dokka/ui-kit ../../dokka-integration-tests/gradle/build/ui-showcase-result',
           ],
           blocking: false,

--- a/dokka-subprojects/plugin-base-frontend/webpack.config.js
+++ b/dokka-subprojects/plugin-base-frontend/webpack.config.js
@@ -67,8 +67,8 @@ const webpackConfig = (params, argv) => {
               onDoneWatch: {
                 scripts: [
                   'echo "[search] Done rebuild, coping files to dokka-integration-tests"',
-                  'cp -r ./dist/main.js ../../dokka-integration-tests/gradle/build/ui-showcase-result/scripts',
-                  'cp -r ./dist/main.css ../../dokka-integration-tests/gradle/build/ui-showcase-result/styles',
+                  'cp ./dist/main.js ../../dokka-integration-tests/gradle/build/ui-showcase-result/scripts',
+                  'cp ./dist/main.css ../../dokka-integration-tests/gradle/build/ui-showcase-result/styles',
                 ],
                 blocking: false,
                 parallel: true,

--- a/dokka-subprojects/plugin-base-frontend/webpack.config.js
+++ b/dokka-subprojects/plugin-base-frontend/webpack.config.js
@@ -2,82 +2,101 @@
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-const {join, resolve} = require('path');
+const { join, resolve } = require('path');
 
 const ringUiWebpackConfig = require('@jetbrains/ring-ui/webpack.config');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const TerserPlugin = require("terser-webpack-plugin");
+const WebpackShellPluginNext = require('webpack-shell-plugin-next');
+const TerserPlugin = require('terser-webpack-plugin');
 
 const pkgConfig = require('./package.json').config;
 
 const componentsPath = join(__dirname, pkgConfig.components);
 
-const webpackConfig = () => ({
-  entry: `${componentsPath}/root.tsx`,
-  resolve: {
-    mainFields: ['module', 'browser', 'main'],
-    extensions: ['.tsx', '.ts', '.js', '.svg'],
-    alias: {
-      react: resolve('./node_modules/react'),
-      'react-dom': resolve('./node_modules/react-dom'),
-      '@jetbrains/ring-ui': resolve('./node_modules/@jetbrains/ring-ui')
-    }
-  },
-  output: {
-    path: resolve(__dirname, pkgConfig.dist),
-    filename: '[name].js',
-    publicPath: '',
-    devtoolModuleFilenameTemplate: '/[absolute-resource-path]'
-  },
-  module: {
-    rules: [
-      ...ringUiWebpackConfig.config.module.rules,
-      {
-        test: /\.s[ac]ss$/i,
-        use: [
-          MiniCssExtractPlugin.loader,
-          'css-loader',
-          'sass-loader',
-        ],
-        include: componentsPath,
-        exclude: ringUiWebpackConfig.componentsPath,
+const webpackConfig = (params, argv) => {
+  const mode = argv.mode || 'development';
+  return {
+    entry: `${componentsPath}/root.tsx`,
+    resolve: {
+      mainFields: ['module', 'browser', 'main'],
+      extensions: ['.tsx', '.ts', '.js', '.svg'],
+      alias: {
+        react: resolve('./node_modules/react'),
+        'react-dom': resolve('./node_modules/react-dom'),
+        '@jetbrains/ring-ui': resolve('./node_modules/@jetbrains/ring-ui'),
       },
-      {
-        test: /\.tsx?$/,
-        use: [
-          {
-            loader: 'ts-loader',
-            options: {
-              transpileOnly: true
-            }
-          }
-        ]
-      },
-      {
-        test: /\.svg$/,
-        loader: require.resolve('svg-inline-loader'),
-        options: {removeSVGTagAttrs: false},
-        include: [require('@jetbrains/icons')]
-      }
-    ]
-  },
-  plugins: [
-    new MiniCssExtractPlugin({
-      // Options similar to the same options in webpackOptions.output
-      // both options are optional
-      filename: '[name].css',
-      chunkFilename: '[id].css',
-    }),
-  ],
-  optimization: {
+    },
+    module: {
+      rules: [
+        ...ringUiWebpackConfig.config.module.rules,
+        {
+          test: /\.s[ac]ss$/i,
+          use: [MiniCssExtractPlugin.loader, 'css-loader', 'sass-loader'],
+          include: componentsPath,
+          exclude: ringUiWebpackConfig.componentsPath,
+        },
+        {
+          test: /\.tsx?$/,
+          use: [
+            {
+              loader: 'ts-loader',
+              options: {
+                transpileOnly: true,
+              },
+            },
+          ],
+        },
+        {
+          test: /\.svg$/,
+          loader: require.resolve('svg-inline-loader'),
+          options: { removeSVGTagAttrs: false },
+          include: [require('@jetbrains/icons')],
+        },
+      ],
+    },
+    plugins: [
+      new MiniCssExtractPlugin({
+        // Options similar to the same options in webpackOptions.output
+        // both options are optional
+        filename: '[name].css',
+        chunkFilename: '[id].css',
+      }),
+      ...(mode === 'development'
+        ? [
+            new WebpackShellPluginNext({
+              onDoneWatch: {
+                scripts: [
+                  'echo "[search] Done rebuild, coping files to dokka-integration-tests"',
+                  'cp -r ./dist/main.js ../../dokka-integration-tests/gradle/build/ui-showcase-result/scripts',
+                  'cp -r ./dist/main.css ../../dokka-integration-tests/gradle/build/ui-showcase-result/styles',
+                ],
+                blocking: false,
+                parallel: true,
+              },
+            }),
+          ]
+        : []),
+    ],
+    optimization: {
       minimize: true,
-      minimizer: [new TerserPlugin({
-        extractComments: false,
-      })],
-  },
-  output: {
-    path: __dirname + '/dist/'
-  }
-});
+      minimizer: [
+        new TerserPlugin({
+          extractComments: false,
+          ...(mode === 'development'
+            ? {
+                terserOptions: {
+                  keep_classnames: true,
+                  keep_fnames: true,
+                },
+              }
+            : {}),
+        }),
+      ],
+    },
+    output: {
+      path: __dirname + '/dist/',
+    },
+  };
+};
 
 module.exports = webpackConfig;


### PR DESCRIPTION
1. Fixed problems with constant reloads of the devserver when running `npm run start:ui-kit`
2. Instead of running `npm run build:ui-kit` && `dokkabuild` && `npm run start:ui-kit` we now can run `dokkabuild` && `npm start`
3. Improved watcher will also watch the react module of UI with the search component
