### PR TITLE
Update Analysis API to 2.2.0-dev-8822

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,8 +15,8 @@ ktor = "2.3.11"
 javaDiffUtils = "4.12"
 
 ## Analysis
-kotlin-compiler = "2.2.0-dev-7826"
-kotlin-compiler-k2 = "2.2.0-dev-7826"
+kotlin-compiler = "2.2.0-dev-8822"
+kotlin-compiler-k2 = "2.2.0-dev-8822"
 
 # MUST match the version of the intellij platform used in the kotlin compiler,
 # otherwise this will lead to different versions of psi API and implementations


### PR DESCRIPTION
The AA 2.2.0-dev-8822  contains the fix of https://youtrack.jetbrains.com/issue/KT-74555


Presumably, the BCV plugin fails because `kotlinx-metadata-jvm` is unable to read Kotlin 2.2 metadata (e.g. see https://github.com/jetbrains/kotlin/commit/1a45888d50e0e8599d3763a5c21a888f34ff213f ). To avoid this, inline functions were copied.

