### PR TITLE
Specify the kotlin-stdlib version for resolution

### DIFF
--- a/build-logic/src/main/kotlin/dokkabuild/utils/downloadKotlinStdlibJvmSources.kt
+++ b/build-logic/src/main/kotlin/dokkabuild/utils/downloadKotlinStdlibJvmSources.kt
@@ -29,7 +29,7 @@ fun downloadKotlinStdlibJvmSources(project: Project): Provider<File> {
     val kotlinStdlibJvmSources: Configuration by project.configurations.creating {
         description = "kotlin-stdlib JVM source code."
         declarable()
-        withDependencies {
+        defaultDependencies {
             add(project.dependencies.run { create(kotlin("stdlib")) })
         }
     }


### PR DESCRIPTION
The current approach doesn't work after changes in https://youtrack.jetbrains.com/issue/KT-73968

Dokka build is failing with the latest Kotlin dev build (2.2.0-dev-11137) that includes (https://github.com/JetBrains/kotlin/commit/431201fb526782706bd943a06813ef310dbdf3f0) 
The change also will be included in KGP `2.1.21`

```
* What went wrong:
  Could not determine the dependencies of task ':dokka-subprojects:plugin-base:downloadKotlinStdlibSources'.
  > Could not resolve all dependencies for configuration ':dokka-subprojects:plugin-base:kotlinStdlibJvmSourcesResolver'.
     > Could not find org.jetbrains.kotlin:kotlin-stdlib:.
       Required by:
           project :dokka-subprojects:plugin-base
  
  * Try:
  > Run with --debug option to get more log output.
  > Get more help at https://help.gradle.org/
  
  * Exception is:
  org.gradle.api.internal.tasks.TaskDependencyResolveException: Could not determine the dependencies of task ':dokka-subprojects:plugin-base:downloadKotlinStdlibSources'.
    at org.gradle.api.internal.tasks.CachingTaskDependencyResolveContext.getDependencies(CachingTaskDependencyResolveContext.java:70)

  Caused by: org.gradle.api.internal.artifacts.ivyservice.TypedResolveException: Could not resolve all dependencies for configuration ':dokka-subprojects:plugin-base:kotlinStdlibJvmSourcesResolver'.
    at org.gradle.api.internal.artifacts.ResolveExceptionMapper.mapFailure(ResolveExceptionMapper.java:68)

    ... 146 more
  Caused by: org.gradle.internal.resolve.ModuleVersionNotFoundException: Could not find org.jetbrains.kotlin:kotlin-stdlib:.
  Required by:
      project :dokka-subprojects:plugin-base
```