### PR TITLE
Incorrect links being used for the Dokka plugins page

### DIFF
--- a/docs/topics/dokka-plugins.md
+++ b/docs/topics/dokka-plugins.md
@@ -268,11 +268,11 @@ Here are some notable Dokka plugins that you might find useful:
 
 | **Name**                                                                                                                           | **Description**                                                                                              |
 |------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
-| [Android documentation plugin](https://github.com/Kotlin/dokka/tree/%dokkaVersion%/dokka-subprojects/plugin-android-documentation) | Improves the documentation experience on Android                                                             |
-| [Versioning plugin](https://github.com/Kotlin/dokka/tree/%dokkaVersion%/dokka-subprojects/plugin-versioning)                       | Adds version selector and helps to organize documentation for different versions of your application/library |
+| [Android documentation plugin](https://github.com/Kotlin/dokka/tree/master/dokka-subprojects/plugin-android-documentation) | Improves the documentation experience on Android                                                             |
+| [Versioning plugin](https://github.com/Kotlin/dokka/tree/master/dokka-subprojects/plugin-versioning)                       | Adds version selector and helps to organize documentation for different versions of your application/library |
 | [MermaidJS HTML plugin](https://github.com/glureau/dokka-mermaid)                                                                  | Renders [MermaidJS](https://mermaid-js.github.io/mermaid/#/) diagrams and visualizations found in KDocs      |
-| [Mathjax HTML plugin](https://github.com/Kotlin/dokka/tree/%dokkaVersion%/dokka-subprojects/plugin-mathjax)                        | Pretty prints mathematics found in KDocs                                                                     |
-| [Kotlin as Java plugin](https://github.com/Kotlin/dokka/tree/%dokkaVersion%/dokka-subprojects/plugin-kotlin-as-java)              | Renders Kotlin signatures as seen from Java's perspective                                                    |
+| [Mathjax HTML plugin](https://github.com/Kotlin/dokka/tree/master/dokka-subprojects/plugin-mathjax)                        | Pretty prints mathematics found in KDocs                                                                     |
+| [Kotlin as Java plugin](https://github.com/Kotlin/dokka/tree/master/dokka-subprojects/plugin-kotlin-as-java)              | Renders Kotlin signatures as seen from Java's perspective                                                    |
 
 If you are a Dokka plugin author and would like to add your plugin to this list, get in touch with maintainers
 via [Slack](dokka-introduction.md#community) or [GitHub](https://github.com/Kotlin/dokka/).


### PR DESCRIPTION
It's as simple as that. I'm guessing that the default branch used to be the latest version, but that that's recently changed. I don't know more about this codebase, so this change might not make sense, if so, simply just tell me.

Have a wonderful day!