### PR TITLE
Increase stress test metaspace size because of the increased AA requirements

### DIFF
--- a/dokka-integration-tests/gradle/src/testTemplateProjectTasksExecutionStress/kotlin/SequentialTasksExecutionStressTest.kt
+++ b/dokka-integration-tests/gradle/src/testTemplateProjectTasksExecutionStress/kotlin/SequentialTasksExecutionStressTest.kt
@@ -26,7 +26,7 @@ class SequentialTasksExecutionStressTest : AbstractGradleIntegrationTest() {
             "runTasks",
             "-Ptask_number=$iterations",
             jvmArgs = listOf(
-                "-Xmx1G", "-XX:MaxMetaspaceSize=500m",
+                "-Xmx1G", "-XX:MaxMetaspaceSize=600m",
                 "-XX:SoftRefLRUPolicyMSPerMB=10" // to free up the metaspace on JVM 8, see https://youtrack.jetbrains.com/issue/KT-55831/
             ),
             enableBuildCache = false,


### PR DESCRIPTION
Looks like after the last updates of AA in #4058 and/or #4052 AA requires a bit more meatspace memory and so our stress-test fails with K2 ([one](https://teamcity.jetbrains.com/buildConfiguration/KotlinTools_Dokka_DokkaIntegrationTestsK2/5059250), [two](https://teamcity.jetbrains.com/buildConfiguration/KotlinTools_Dokka_DokkaIntegrationTestsK2/5058216))

I've checked this test memory usage locally with K2, and I don't see any real problem with metaspace leaks.

Below are the graphs of non-heap memory usage of the test:

Before #4052 (https://github.com/Kotlin/dokka/commit/29849df76b4d7115ed509edeef6e0273d85c4be6):
<img width="452" alt="image" src="https://github.com/user-attachments/assets/8631fafd-5202-4cd2-a391-6edbc43b7f37" />
 
Before #4058 (https://github.com/Kotlin/dokka/commit/908a4459110b6888dbd31025f7af939b9196bca7):
<img width="455" alt="image" src="https://github.com/user-attachments/assets/509e2b00-738a-4b55-88ec-ed1529bff132" />

master (https://github.com/Kotlin/dokka/commit/3b20e70c6fce888bddf057cab290dd6e068e46bf) (**TEST FAILED BECAUSE OF OOM: METASPACE**):
<img width="459" alt="image" src="https://github.com/user-attachments/assets/ae2beb55-97a5-4787-8f2f-5a31b6a1d24d" />

with this PR and increased metaspace size:
<img width="456" alt="image" src="https://github.com/user-attachments/assets/b8301743-6eb8-46be-b155-d0a00d152f66" />
