### PR TITLE
Fix constructor details to show description instead of brief in Javadoc

### DIFF
--- a/dokka-subprojects/plugin-javadoc/src/main/resources/views/class.korte
+++ b/dokka-subprojects/plugin-javadoc/src/main/resources/views/class.korte
@@ -249,7 +249,7 @@
                                     <li class="blockList">
                                         <h4>{{ constructor.name }}</h4>
                                         <pre>{{ constructor.name }}({{ constructor.inlineParameters|raw }})</pre>
-                                        <div class="block">{{ constructor.brief|raw}}</div>
+                                        <div class="block">{{ constructor.description|raw}}</div>
                                         {% if constructor.parameters.size != 0 && hasAnyDescription(constructor.parameters) %}
                                         <dl>
                                             <dt><span class="paramLabel">Parameters:</span></dt>

--- a/dokka-subprojects/plugin-javadoc/src/test/kotlin/org/jetbrains/dokka/javadoc/JavadocConstructorsTest.kt
+++ b/dokka-subprojects/plugin-javadoc/src/test/kotlin/org/jetbrains/dokka/javadoc/JavadocConstructorsTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package org.jetbrains.dokka.javadoc
+
+import org.jsoup.Jsoup
+import utils.TestOutputWriterPlugin
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class JavadocConstructorsTest : AbstractJavadocTemplateMapTest() {
+    @Test
+    fun `should render full constructor description in constructor details section`() {
+        val configuration = dokkaConfiguration {
+            sourceSets {
+                sourceSet {
+                    sourceRoots = listOf("src/main/kotlin")
+                    classpath = listOfNotNull(jvmStdlibPath)
+                }
+            }
+        }
+        val writerPlugin = TestOutputWriterPlugin()
+
+        testInline(
+            """
+            /src/main/kotlin/sample/TestConstructor.kt
+            package sample
+            /** 
+            * Documentation for TestConstructor 
+            *
+            * @constructor First line.
+            *
+            * Second line.
+            *
+            */
+            class TestConstructor
+            """,
+            configuration = configuration,
+            cleanupOutput = false,
+            pluginOverrides = listOf(writerPlugin, JavadocPlugin()),
+        ) {
+            renderingStage = { _, _ ->
+                val html = writerPlugin.writer.contents.getValue("sample/TestConstructor.html").let { Jsoup.parse(it) }
+                val constructorDetailDescription = html
+                    .select(".details")
+                    .select("section:first-child")
+                    .select("div.block")
+                    .text()
+                assertEquals("First line. Second line.", constructorDetailDescription)
+            }
+        }
+    }
+}


### PR DESCRIPTION
When generating Javadoc, the **Constructor Detail** section displays only the brief constructor description (i.e., the first sentence) instead of the full description. See line 252 in `class.korte`:

https://github.com/Kotlin/dokka/blob/540fe084aadac0edb333350210ee22ee9901a3de/dokka-subprojects/plugin-javadoc/src/main/resources/views/class.korte#L245-L264

[A similar issue for method details](https://github.com/Kotlin/dokka/issues/1407) was fixed [long time ago](https://github.com/Kotlin/dokka/commit/aeb2014eee704be377c06205d16f60562d2a8cf1#diff-bff61c124f11db527d3aaa3f9bd879c40b8a57bffec72087e1ecec7414d5bdddR273)  in version `1.4.0`.

This PR fixes the issue by replacing `constructor.brief` with `constructor.description`.