### PR TITLE
Deprecate DGPv1 types

### DIFF
--- a/dokka-integration-tests/README.md
+++ b/dokka-integration-tests/README.md
@@ -46,6 +46,11 @@ Here's how to update an external project:
    git diff > $pathToProjectInDokka/project.diff
    ```
 
+   Or, on macOS, copied to the clipboard:
+   ```shell
+   git diff | pbcopy
+   ```
+
 4. Check that the corresponding `GradleIntegrationTest` passes locally and push
 
 ### Example projects

--- a/dokka-integration-tests/gradle/projects/serialization/serialization.diff
+++ b/dokka-integration-tests/gradle/projects/serialization/serialization.diff
@@ -1,5 +1,5 @@
 diff --git a/build.gradle.kts b/build.gradle.kts
-index f2cfd853..028c590d 100644
+index f2cfd853..b74e188a 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -21,13 +21,13 @@ plugins {
@@ -26,7 +26,13 @@ index f2cfd853..028c590d 100644
          mavenCentral()
          maven("https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
      }
-@@ -143,7 +144,20 @@ tasks.withType<DokkaMultiModuleTask>().named("dokkaHtmlMultiModule") {
+@@ -138,12 +139,25 @@ tasks.register("dokka") {
+     dependsOn("dokkaHtmlMultiModule")
+ }
+
+-tasks.withType<DokkaMultiModuleTask>().named("dokkaHtmlMultiModule") {
++tasks.withType<@Suppress("DEPRECATION") DokkaMultiModuleTask>().named("dokkaHtmlMultiModule") {
+     pluginsMapConfiguration.put("org.jetbrains.dokka.base.DokkaBase", """{ "templatesDir": "${projectDir.toString().replace("\\", "/")}/dokka-templates" }""")
  }
 
  dependencies {
@@ -77,7 +83,7 @@ index 529b81c1..218558c2 100644
 
  kotlin {
 diff --git a/buildSrc/settings.gradle.kts b/buildSrc/settings.gradle.kts
-index b450fd5e..9f189439 100644
+index b450fd5e..927b34b9 100644
 --- a/buildSrc/settings.gradle.kts
 +++ b/buildSrc/settings.gradle.kts
 @@ -14,6 +14,7 @@ dependencyResolutionManagement {
@@ -88,11 +94,27 @@ index b450fd5e..9f189439 100644
          }
      }
  }
+@@ -48,4 +49,4 @@ fun overriddenKotlinVersion(): String? {
+         return trainVersion ?: trainVersionFile ?: throw IllegalArgumentException("\"kotlin_snapshot_version\" should be defined when building with snapshot compiler")
+     }
+     return null
+-}
+\ No newline at end of file
++}
 diff --git a/buildSrc/src/main/kotlin/dokka-conventions.gradle.kts b/buildSrc/src/main/kotlin/dokka-conventions.gradle.kts
-index d3013727..0c443aa4 100644
+index d3013727..b58ad96a 100644
 --- a/buildSrc/src/main/kotlin/dokka-conventions.gradle.kts
 +++ b/buildSrc/src/main/kotlin/dokka-conventions.gradle.kts
-@@ -15,7 +15,12 @@ plugins {
+@@ -2,6 +2,8 @@
+  * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+  */
+
++@file:Suppress("DEPRECATION")
++
+ import org.jetbrains.dokka.gradle.*
+ import java.net.URI
+
+@@ -15,7 +17,12 @@ plugins {
 
  val extens = extensions
  dependencies {
@@ -106,6 +128,39 @@ index d3013727..0c443aa4 100644
  }
 
  tasks.withType<DokkaTaskPartial>().named("dokkaHtmlPartial") {
+@@ -76,4 +83,4 @@ tasks.withType<DokkaTaskPartial>().named("dokkaHtmlPartial") {
+             }
+         }
+     }
+-}
+\ No newline at end of file
++}
+diff --git a/formats/json-io/build.gradle.kts b/formats/json-io/build.gradle.kts
+index 2effe4f2..0adb4f1e 100644
+--- a/formats/json-io/build.gradle.kts
++++ b/formats/json-io/build.gradle.kts
+@@ -33,7 +33,7 @@ kotlin {
+
+ project.configureJava9ModuleInfo()
+
+-tasks.named<DokkaTaskPartial>("dokkaHtmlPartial") {
++tasks.named<@Suppress("DEPRECATION") DokkaTaskPartial>("dokkaHtmlPartial") {
+     dokkaSourceSets {
+         configureEach {
+             externalDocumentationLink {
+diff --git a/formats/json-okio/build.gradle.kts b/formats/json-okio/build.gradle.kts
+index 93513985..42b93ac2 100644
+--- a/formats/json-okio/build.gradle.kts
++++ b/formats/json-okio/build.gradle.kts
+@@ -34,7 +34,7 @@ kotlin {
+
+ project.configureJava9ModuleInfo()
+
+-tasks.named<DokkaTaskPartial>("dokkaHtmlPartial") {
++tasks.named<@Suppress("DEPRECATION") DokkaTaskPartial>("dokkaHtmlPartial") {
+     dokkaSourceSets {
+         configureEach {
+             externalDocumentationLink {
 diff --git a/gradle/libs.versions.toml b/gradle/libs.versions.toml
 index 132a67b6..b851a68c 100644
 --- a/gradle/libs.versions.toml

--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/DokkaClassicPlugin.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/DokkaClassicPlugin.kt
@@ -11,12 +11,14 @@ import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
 import org.gradle.util.GradleVersion
 import org.jetbrains.dokka.DokkaDefaults
+import org.jetbrains.dokka.gradle.DOKKA_V1_DEPRECATION_MESSAGE
 
 /**
  * The OG Dokka Gradle Plugin. A.K.A. DGP Classic, or Dokka V1.
  *
  * This plugin is planned for removal, see https://youtrack.jetbrains.com/issue/KT-71027/Remove-Dokka-Gradle-Plugin-v1
  */
+@Deprecated(DOKKA_V1_DEPRECATION_MESSAGE)
 open class DokkaClassicPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         if (GradleVersion.version(project.gradle.gradleVersion) < GradleVersion.version("5.6")) {
@@ -63,11 +65,11 @@ open class DokkaClassicPlugin : Plugin<Project> {
         name: String,
         multiModuleTaskSupported: Boolean = true,
         allModulesPageAndTemplateProcessing: Dependency = project.dokkaArtifacts.allModulesPage,
-        configuration: AbstractDokkaTask.() -> Unit = {}
+        configuration: @Suppress("DEPRECATION") AbstractDokkaTask.() -> Unit = {}
     ) {
         project.maybeCreateDokkaPluginConfiguration(name)
         project.maybeCreateDokkaRuntimeConfiguration(name)
-        project.tasks.register<DokkaTask>(name) {
+        project.tasks.register<@Suppress("DEPRECATION") DokkaTask>(name) {
             configuration()
         }
 
@@ -75,7 +77,7 @@ open class DokkaClassicPlugin : Plugin<Project> {
             val partialName = "${name}Partial"
             project.maybeCreateDokkaPluginConfiguration(partialName)
             project.maybeCreateDokkaRuntimeConfiguration(partialName)
-            project.tasks.register<DokkaTaskPartial>(partialName) {
+            project.tasks.register<@Suppress("DEPRECATION") DokkaTaskPartial>(partialName) {
                 configuration()
             }
         }
@@ -86,7 +88,7 @@ open class DokkaClassicPlugin : Plugin<Project> {
                 project.maybeCreateDokkaPluginConfiguration(multiModuleName, setOf(allModulesPageAndTemplateProcessing))
                 project.maybeCreateDokkaRuntimeConfiguration(multiModuleName)
 
-                project.tasks.register<DokkaMultiModuleTask>(multiModuleName) {
+                project.tasks.register<@Suppress("DEPRECATION") DokkaMultiModuleTask>(multiModuleName) {
                     @Suppress("DEPRECATION")
                     addSubprojectChildTasks("${name}Partial")
                     configuration()
@@ -103,7 +105,7 @@ open class DokkaClassicPlugin : Plugin<Project> {
                 }
             }
 
-            project.tasks.register<DokkaCollectorTask>("${name}Collector") {
+            project.tasks.register<@Suppress("DEPRECATION") DokkaCollectorTask>("${name}Collector") {
                 @Suppress("DEPRECATION")
                 addSubprojectChildTasks(name)
                 description =
@@ -113,7 +115,7 @@ open class DokkaClassicPlugin : Plugin<Project> {
     }
 
     private fun Project.configureEachAbstractDokkaTask() {
-        tasks.withType<AbstractDokkaTask>().configureEach task@{
+        tasks.withType<@Suppress("DEPRECATION") AbstractDokkaTask>().configureEach task@{
             val formatClassifier = name.removePrefix("dokka").decapitalize()
             outputDirectory.convention(project.layout.buildDirectory.dir("dokka/$formatClassifier"))
             cacheRoot.convention(project.layout.dir(providers.provider { DokkaDefaults.cacheRoot }))
@@ -124,7 +126,7 @@ open class DokkaClassicPlugin : Plugin<Project> {
     }
 
     private fun Project.configureEachDokkaMultiModuleTask() {
-        tasks.withType<DokkaMultiModuleTask>().configureEach {
+        tasks.withType<@Suppress("DEPRECATION") DokkaMultiModuleTask>().configureEach {
             sourceChildOutputDirectories.from({ childDokkaTasks.map { it.outputDirectory } })
         }
     }

--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/DokkaMultiModuleFileLayout.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/DokkaMultiModuleFileLayout.kt
@@ -65,12 +65,6 @@ internal fun @Suppress("DEPRECATION") DokkaMultiModuleTask.targetChildOutputDire
 ): Provider<Directory> = fileLayout.get().targetChildOutputDirectory(this, child)
 
 
-//internal fun DokkaMultiModuleTask.copyChildOutputDirectories() {
-//    childDokkaTasks.forEach { child ->
-//        this.copyChildOutputDirectory(child)
-//    }
-//}
-
 internal fun @Suppress("DEPRECATION") DokkaMultiModuleTask.copyChildOutputDirectory(child: @Suppress("DEPRECATION") AbstractDokkaTask) {
     val targetChildOutputDirectory = project.file(fileLayout.get().targetChildOutputDirectory(this, child))
     val sourceChildOutputDirectory = child.outputDirectory.asFile.get()

--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/DokkaMultiModuleFileLayout.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/DokkaMultiModuleFileLayout.kt
@@ -7,15 +7,14 @@ package org.jetbrains.dokka.gradle
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 import org.jetbrains.dokka.DokkaException
-import org.jetbrains.dokka.gradle.DokkaMultiModuleFileLayout.CompactInParent
-import org.jetbrains.dokka.gradle.DokkaMultiModuleFileLayout.NoCopy
 import java.io.File
 
 /**
  * @see DokkaMultiModuleFileLayout.targetChildOutputDirectory
- * @see NoCopy
- * @see CompactInParent
+ * @see org.jetbrains.dokka.gradle.DokkaMultiModuleFileLayout.NoCopy
+ * @see org.jetbrains.dokka.gradle.DokkaMultiModuleFileLayout.CompactInParent
  */
+@Deprecated(DOKKA_V1_DEPRECATION_MESSAGE)
 fun interface DokkaMultiModuleFileLayout {
 
     /**
@@ -24,15 +23,19 @@ fun interface DokkaMultiModuleFileLayout {
      * @return The target output directory of the [child] dokka task referenced by [parent]. This should
      * be unique for all registered child tasks.
      */
-    fun targetChildOutputDirectory(parent: DokkaMultiModuleTask, child: AbstractDokkaTask): Provider<Directory>
+    fun targetChildOutputDirectory(
+        parent: @Suppress("DEPRECATION") DokkaMultiModuleTask,
+        child: @Suppress("DEPRECATION") AbstractDokkaTask
+    ): Provider<Directory>
 
     /**
      * Will link to the original [AbstractDokkaTask.outputDirectory]. This requires no copying of the output files.
      */
-    object NoCopy : DokkaMultiModuleFileLayout {
+    @Deprecated(DOKKA_V1_DEPRECATION_MESSAGE)
+    object NoCopy : @Suppress("DEPRECATION") DokkaMultiModuleFileLayout {
         override fun targetChildOutputDirectory(
-            parent: DokkaMultiModuleTask,
-            child: AbstractDokkaTask
+            parent: @Suppress("DEPRECATION") DokkaMultiModuleTask,
+            child: @Suppress("DEPRECATION") AbstractDokkaTask
         ): Provider<Directory> = child.outputDirectory
     }
 
@@ -43,10 +46,11 @@ fun interface DokkaMultiModuleFileLayout {
      * :parentProject:firstAncestor:secondAncestor will be be resolved to
      * {parent output directory}/firstAncestor/secondAncestor
      */
-    object CompactInParent : DokkaMultiModuleFileLayout {
+    @Deprecated(DOKKA_V1_DEPRECATION_MESSAGE)
+    object CompactInParent : @Suppress("DEPRECATION") DokkaMultiModuleFileLayout {
         override fun targetChildOutputDirectory(
-            parent: DokkaMultiModuleTask,
-            child: AbstractDokkaTask
+            parent: @Suppress("DEPRECATION") DokkaMultiModuleTask,
+            child: @Suppress("DEPRECATION") AbstractDokkaTask
         ): Provider<Directory> {
             val relativeProjectPath = parent.project.relativeProjectPath(child.project.path)
             val relativeFilePath = relativeProjectPath.replace(":", File.separator)
@@ -56,18 +60,18 @@ fun interface DokkaMultiModuleFileLayout {
     }
 }
 
-internal fun DokkaMultiModuleTask.targetChildOutputDirectory(
-    child: AbstractDokkaTask
+internal fun @Suppress("DEPRECATION") DokkaMultiModuleTask.targetChildOutputDirectory(
+    child: @Suppress("DEPRECATION") AbstractDokkaTask
 ): Provider<Directory> = fileLayout.get().targetChildOutputDirectory(this, child)
 
 
-internal fun DokkaMultiModuleTask.copyChildOutputDirectories() {
-    childDokkaTasks.forEach { child ->
-        this.copyChildOutputDirectory(child)
-    }
-}
+//internal fun DokkaMultiModuleTask.copyChildOutputDirectories() {
+//    childDokkaTasks.forEach { child ->
+//        this.copyChildOutputDirectory(child)
+//    }
+//}
 
-internal fun DokkaMultiModuleTask.copyChildOutputDirectory(child: AbstractDokkaTask) {
+internal fun @Suppress("DEPRECATION") DokkaMultiModuleTask.copyChildOutputDirectory(child: @Suppress("DEPRECATION") AbstractDokkaTask) {
     val targetChildOutputDirectory = project.file(fileLayout.get().targetChildOutputDirectory(this, child))
     val sourceChildOutputDirectory = child.outputDirectory.asFile.get()
 

--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/DokkaSourceSetMapper.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/DokkaSourceSetMapper.kt
@@ -8,32 +8,33 @@ import org.jetbrains.dokka.*
 import org.jetbrains.dokka.DokkaConfiguration.ExternalDocumentationLink
 import java.io.File
 
-internal fun GradleDokkaSourceSetBuilder.toDokkaSourceSetImpl(): DokkaSourceSetImpl = DokkaSourceSetImpl(
-    classpath = classpath.toList(),
-    displayName = displayNameOrDefault(),
-    sourceSetID = sourceSetID,
-    sourceRoots = sourceRoots.toSet(),
-    dependentSourceSets = dependentSourceSets.get().toSet(),
-    samples = samples.toSet(),
-    includes = includes.toSet(),
-    includeNonPublic = includeNonPublic.get(),
-    documentedVisibilities = documentedVisibilities.get(),
-    reportUndocumented = reportUndocumented.get(),
-    skipEmptyPackages = skipEmptyPackages.get(),
-    skipDeprecated = skipDeprecated.get(),
-    jdkVersion = jdkVersion.get(),
-    sourceLinks = sourceLinks.get().build().toSet(),
-    perPackageOptions = perPackageOptions.get().build(),
-    externalDocumentationLinks = externalDocumentationLinksWithDefaults(),
-    languageVersion = languageVersion.orNull,
-    apiVersion = apiVersion.orNull,
-    noStdlibLink = noStdlibLink.get(),
-    noJdkLink = noJdkLink.get(),
-    suppressedFiles = suppressedFilesWithDefaults(),
-    analysisPlatform = platform.get()
-)
+internal fun @Suppress("DEPRECATION") GradleDokkaSourceSetBuilder.toDokkaSourceSetImpl(): DokkaSourceSetImpl =
+    DokkaSourceSetImpl(
+        classpath = classpath.toList(),
+        displayName = displayNameOrDefault(),
+        sourceSetID = sourceSetID,
+        sourceRoots = sourceRoots.toSet(),
+        dependentSourceSets = dependentSourceSets.get().toSet(),
+        samples = samples.toSet(),
+        includes = includes.toSet(),
+        includeNonPublic = includeNonPublic.get(),
+        documentedVisibilities = documentedVisibilities.get(),
+        reportUndocumented = reportUndocumented.get(),
+        skipEmptyPackages = skipEmptyPackages.get(),
+        skipDeprecated = skipDeprecated.get(),
+        jdkVersion = jdkVersion.get(),
+        sourceLinks = sourceLinks.get().build().toSet(),
+        perPackageOptions = perPackageOptions.get().build(),
+        externalDocumentationLinks = externalDocumentationLinksWithDefaults(),
+        languageVersion = languageVersion.orNull,
+        apiVersion = apiVersion.orNull,
+        noStdlibLink = noStdlibLink.get(),
+        noJdkLink = noJdkLink.get(),
+        suppressedFiles = suppressedFilesWithDefaults(),
+        analysisPlatform = platform.get()
+    )
 
-private fun GradleDokkaSourceSetBuilder.displayNameOrDefault(): String {
+private fun @Suppress("DEPRECATION") GradleDokkaSourceSetBuilder.displayNameOrDefault(): String {
     displayName.orNull?.let { return it }
     if (name.endsWith("Main") && name != "Main") {
         return name.removeSuffix("Main")
@@ -42,7 +43,7 @@ private fun GradleDokkaSourceSetBuilder.displayNameOrDefault(): String {
     return name
 }
 
-private fun GradleDokkaSourceSetBuilder.externalDocumentationLinksWithDefaults(): Set<ExternalDocumentationLinkImpl> {
+private fun @Suppress("DEPRECATION") GradleDokkaSourceSetBuilder.externalDocumentationLinksWithDefaults(): Set<ExternalDocumentationLinkImpl> {
     return externalDocumentationLinks.get().build()
         .run {
             if (noJdkLink.get()) this
@@ -61,7 +62,7 @@ private fun GradleDokkaSourceSetBuilder.externalDocumentationLinksWithDefaults()
         .toSet()
 }
 
-private fun GradleDokkaSourceSetBuilder.suppressedFilesWithDefaults(): Set<File> {
+private fun @Suppress("DEPRECATION") GradleDokkaSourceSetBuilder.suppressedFilesWithDefaults(): Set<File> {
     val suppressedGeneratedFiles = if (suppressGeneratedFiles.get()) {
         val generatedRoot = project.layout.buildDirectory.dir("generated").get().asFile
         sourceRoots

--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/GradleDokkaSourceSetBuilder.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/GradleDokkaSourceSetBuilder.kt
@@ -44,6 +44,7 @@ import java.net.URL
  * }
  * ```
  */
+@Deprecated(DOKKA_V1_DEPRECATION_MESSAGE)
 open class GradleDokkaSourceSetBuilder(
     @Transient @get:Input val name: String,
     @Transient @get:Internal internal val project: Project,
@@ -188,8 +189,9 @@ open class GradleDokkaSourceSetBuilder(
      * Prefer using [sourceLink] action/closure for adding source links.
      */
     @Nested
-    val sourceLinks: SetProperty<GradleSourceLinkBuilder> = project.objects.setProperty<GradleSourceLinkBuilder>()
-        .convention(emptySet())
+    val sourceLinks: SetProperty<@Suppress("DEPRECATION") GradleSourceLinkBuilder> =
+        project.objects.setProperty<@Suppress("DEPRECATION") GradleSourceLinkBuilder>()
+            .convention(emptySet())
 
     /**
      * Allows to customize documentation generation options on a per-package basis.
@@ -197,8 +199,8 @@ open class GradleDokkaSourceSetBuilder(
      * @see GradlePackageOptionsBuilder for details
      */
     @Nested
-    val perPackageOptions: ListProperty<GradlePackageOptionsBuilder> =
-        project.objects.listProperty<GradlePackageOptionsBuilder>()
+    val perPackageOptions: ListProperty<@Suppress("DEPRECATION") GradlePackageOptionsBuilder> =
+        project.objects.listProperty<@Suppress("DEPRECATION") GradlePackageOptionsBuilder>()
             .convention(emptyList())
 
     /**
@@ -207,8 +209,8 @@ open class GradleDokkaSourceSetBuilder(
      * Prefer using [externalDocumentationLink] action/closure for adding links.
      */
     @Nested
-    val externalDocumentationLinks: SetProperty<GradleExternalDocumentationLinkBuilder> =
-        project.objects.setProperty<GradleExternalDocumentationLinkBuilder>()
+    val externalDocumentationLinks: SetProperty<@Suppress("DEPRECATION") GradleExternalDocumentationLinkBuilder> =
+        project.objects.setProperty<@Suppress("DEPRECATION") GradleExternalDocumentationLinkBuilder>()
             .convention(emptySet())
 
     /**
@@ -356,7 +358,7 @@ open class GradleDokkaSourceSetBuilder(
     /**
      * Convenient override to **append** source sets to [dependentSourceSets]
      */
-    fun dependsOn(sourceSet: GradleDokkaSourceSetBuilder) {
+    fun dependsOn(sourceSet: @Suppress("DEPRECATION") GradleDokkaSourceSetBuilder) {
         dependsOn(sourceSet.sourceSetID)
     }
 
@@ -411,8 +413,8 @@ open class GradleDokkaSourceSetBuilder(
      *
      * @see [GradleSourceLinkBuilder] for details.
      */
-    fun sourceLink(action: Action<in GradleSourceLinkBuilder>) {
-        val sourceLink = GradleSourceLinkBuilder(project)
+    fun sourceLink(action: Action<in @Suppress("DEPRECATION") GradleSourceLinkBuilder>) {
+        val sourceLink = @Suppress("DEPRECATION") GradleSourceLinkBuilder(project)
         action.execute(sourceLink)
         sourceLinks.add(sourceLink)
     }
@@ -433,8 +435,8 @@ open class GradleDokkaSourceSetBuilder(
      *
      * @see [GradlePackageOptionsBuilder] for details.
      */
-    fun perPackageOption(action: Action<in GradlePackageOptionsBuilder>) {
-        val option = GradlePackageOptionsBuilder(project)
+    fun perPackageOption(action: Action<in @Suppress("DEPRECATION") GradlePackageOptionsBuilder>) {
+        val option = @Suppress("DEPRECATION") GradlePackageOptionsBuilder(project)
         action.execute(option)
         perPackageOptions.add(option)
     }
@@ -455,8 +457,8 @@ open class GradleDokkaSourceSetBuilder(
      *
      * See [GradleExternalDocumentationLinkBuilder] for details.
      */
-    fun externalDocumentationLink(action: Action<in GradleExternalDocumentationLinkBuilder>) {
-        val link = GradleExternalDocumentationLinkBuilder(project)
+    fun externalDocumentationLink(action: Action<in @Suppress("DEPRECATION") GradleExternalDocumentationLinkBuilder>) {
+        val link = @Suppress("DEPRECATION") GradleExternalDocumentationLinkBuilder(project)
         action.execute(link)
         externalDocumentationLinks.add(link)
     }
@@ -473,7 +475,7 @@ open class GradleDokkaSourceSetBuilder(
      */
     fun externalDocumentationLink(url: URL, packageListUrl: URL? = null) {
         externalDocumentationLinks.add(
-            GradleExternalDocumentationLinkBuilder(project).apply {
+            @Suppress("DEPRECATION") GradleExternalDocumentationLinkBuilder(project).apply {
                 this.url.convention(url)
                 if (packageListUrl != null) {
                     this.packageListUrl.convention(packageListUrl)

--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/GradleDokkaSourceSetBuilderExtensions.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/GradleDokkaSourceSetBuilderExtensions.kt
@@ -9,28 +9,32 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 /**
  * Convenient override to **append** source sets to [GradleDokkaSourceSetBuilder.dependentSourceSets]
  */
-fun GradleDokkaSourceSetBuilder.dependsOn(sourceSet: KotlinSourceSet) {
+@Deprecated(DOKKA_V1_DEPRECATION_MESSAGE)
+fun @Suppress("DEPRECATION") GradleDokkaSourceSetBuilder.dependsOn(sourceSet: KotlinSourceSet) {
     dependsOn(DokkaSourceSetID(sourceSet.name))
 }
 
 /**
  * Convenient override to **append** source sets to [GradleDokkaSourceSetBuilder.dependentSourceSets]
  */
-fun GradleDokkaSourceSetBuilder.dependsOn(@Suppress("DEPRECATION") sourceSet: com.android.build.gradle.api.AndroidSourceSet) {
+@Deprecated(DOKKA_V1_DEPRECATION_MESSAGE)
+fun @Suppress("DEPRECATION") GradleDokkaSourceSetBuilder.dependsOn(@Suppress("DEPRECATION") sourceSet: com.android.build.gradle.api.AndroidSourceSet) {
     dependsOn(DokkaSourceSetID(sourceSet.name))
 }
 
 /**
  * Convenient override to **append** source sets to [GradleDokkaSourceSetBuilder.dependentSourceSets]
  */
-fun GradleDokkaSourceSetBuilder.dependsOn(@Suppress("UnstableApiUsage") sourceSet: com.android.build.api.dsl.AndroidSourceSet) {
+@Deprecated(DOKKA_V1_DEPRECATION_MESSAGE)
+fun @Suppress("DEPRECATION") GradleDokkaSourceSetBuilder.dependsOn(@Suppress("UnstableApiUsage") sourceSet: com.android.build.api.dsl.AndroidSourceSet) {
     dependsOn(DokkaSourceSetID(sourceSet.name))
 }
 
 /**
  * Extension allowing configuration of Dokka source sets via Kotlin Gradle plugin source sets.
  */
-fun GradleDokkaSourceSetBuilder.kotlinSourceSet(kotlinSourceSet: KotlinSourceSet) {
+@Deprecated(DOKKA_V1_DEPRECATION_MESSAGE)
+fun @Suppress("DEPRECATION") GradleDokkaSourceSetBuilder.kotlinSourceSet(kotlinSourceSet: KotlinSourceSet) {
+    @Suppress("DEPRECATION")
     configureWithKotlinSourceSet(kotlinSourceSet)
 }
-

--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/GradleDokkaSourceSetBuilderFactory.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/GradleDokkaSourceSetBuilderFactory.kt
@@ -7,6 +7,10 @@ package org.jetbrains.dokka.gradle
 import org.gradle.api.NamedDomainObjectFactory
 
 @Suppress("ObjectLiteralToLambda") // Will fail at runtime in Gradle versions <= 6.6
-fun AbstractDokkaTask.gradleDokkaSourceSetBuilderFactory(): NamedDomainObjectFactory<GradleDokkaSourceSetBuilder> =
-    NamedDomainObjectFactory { name -> GradleDokkaSourceSetBuilder(name, project, DokkaSourceSetIdFactory()) }
-
+@Deprecated(DOKKA_V1_DEPRECATION_MESSAGE)
+fun @Suppress("DEPRECATION") AbstractDokkaTask.gradleDokkaSourceSetBuilderFactory()
+        : NamedDomainObjectFactory<@Suppress("DEPRECATION") GradleDokkaSourceSetBuilder> =
+    NamedDomainObjectFactory { name ->
+        @Suppress("DEPRECATION")
+        GradleDokkaSourceSetBuilder(name, project, DokkaSourceSetIdFactory())
+    }

--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/GradleExternalDocumentationLinkBuilder.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/GradleExternalDocumentationLinkBuilder.kt
@@ -37,6 +37,7 @@ import java.net.URL
  * }
  * ```
  */
+@Deprecated(DOKKA_V1_DEPRECATION_MESSAGE)
 class GradleExternalDocumentationLinkBuilder(
     @Transient @get:Internal internal val project: Project
 ) : DokkaConfigurationBuilder<ExternalDocumentationLinkImpl> {

--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/GradlePackageOptionsBuilder.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/GradlePackageOptionsBuilder.kt
@@ -33,6 +33,7 @@ import org.jetbrains.dokka.PackageOptionsImpl
  * }
  * ```
  */
+@Deprecated(DOKKA_V1_DEPRECATION_MESSAGE)
 class GradlePackageOptionsBuilder(
     @Transient @get:Internal internal val project: Project
 ) : DokkaConfigurationBuilder<PackageOptionsImpl> {

--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/GradleSourceLinkBuilder.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/GradleSourceLinkBuilder.kt
@@ -31,6 +31,7 @@ import java.net.URL
  * }
  * ```
  */
+@Deprecated(DOKKA_V1_DEPRECATION_MESSAGE)
 class GradleSourceLinkBuilder(
     @Transient @get:Internal internal val project: Project
 ) : DokkaConfigurationBuilder<SourceLinkDefinitionImpl> {

--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/checkChildDokkaTasksIsNotEmpty.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/checkChildDokkaTasksIsNotEmpty.kt
@@ -6,7 +6,7 @@ package org.jetbrains.dokka.gradle
 
 import org.jetbrains.dokka.DokkaException
 
-internal fun AbstractDokkaParentTask.checkChildDokkaTasksIsNotEmpty() {
+internal fun @Suppress("DEPRECATION") AbstractDokkaParentTask.checkChildDokkaTasksIsNotEmpty() {
     if (childDokkaTaskPaths.isEmpty()) {
         throw DokkaException(
             """

--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/checkDependentSourceSets.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/checkDependentSourceSets.kt
@@ -6,11 +6,11 @@ package org.jetbrains.dokka.gradle
 
 import org.jetbrains.dokka.DokkaSourceSetID
 
-internal fun checkSourceSetDependencies(sourceSets: List<GradleDokkaSourceSetBuilder>) {
+internal fun checkSourceSetDependencies(sourceSets: List<@Suppress("DEPRECATION") GradleDokkaSourceSetBuilder>) {
     checkSourceSetDependencies(sourceSets.associateBy { it.sourceSetID })
 }
 
-private fun checkSourceSetDependencies(sourceSets: Map<DokkaSourceSetID, GradleDokkaSourceSetBuilder>) {
+private fun checkSourceSetDependencies(sourceSets: Map<DokkaSourceSetID, @Suppress("DEPRECATION") GradleDokkaSourceSetBuilder>) {
     sourceSets.values.forEach { sourceSet ->
         sourceSet.dependentSourceSets.get().forEach { dependentSourceSetID ->
             val dependentSourceSet = requireNotNull(sourceSets[dependentSourceSetID]) {

--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/dokkaBootstrapFactory.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/dokkaBootstrapFactory.kt
@@ -18,10 +18,11 @@ internal fun DokkaBootstrap(classpath: Set<File>, bootstrapClass: KClass<out Dok
 
     val runtimeClassloaderBootstrapClass = runtimeClassLoader.loadClass(bootstrapClass.qualifiedName)
     val runtimeClassloaderBootstrapInstance = runtimeClassloaderBootstrapClass.constructors.first().newInstance()
-    return automagicTypedProxy(DokkaClassicPlugin::class.java.classLoader, runtimeClassloaderBootstrapInstance)
+    return automagicTypedProxy(@Suppress("DEPRECATION") DokkaClassicPlugin::class.java.classLoader, runtimeClassloaderBootstrapInstance)
 }
 
-@Deprecated("Internal Dokka API.")
+@Deprecated(DOKKA_V1_DEPRECATION_MESSAGE)
+@Suppress("DeprecatedCallableAddReplaceWith")
 fun DokkaBootstrap(configuration: Configuration, bootstrapClass: KClass<out DokkaBootstrap>): DokkaBootstrap {
     return DokkaBootstrap(
         classpath = configuration.resolve(),

--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/internal/AbstractDokkaTaskExtensions.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/internal/AbstractDokkaTaskExtensions.kt
@@ -6,19 +6,20 @@ package org.jetbrains.dokka.gradle.internal
 
 import org.jetbrains.dokka.DokkaConfiguration
 import org.jetbrains.dokka.InternalDokkaApi
-import org.jetbrains.dokka.gradle.AbstractDokkaTask
+import org.jetbrains.dokka.gradle.DOKKA_V1_DEPRECATION_MESSAGE
 import org.jetbrains.dokka.toCompactJsonString
 import org.jetbrains.dokka.toPrettyJsonString
 
 /**
- * Serializes [DokkaConfiguration] of this [AbstractDokkaTask] as json
+ * Serializes [DokkaConfiguration] of this [org.jetbrains.dokka.gradle.AbstractDokkaTask] as json
  *
  * Should be used for short-term debugging only, no guarantees are given for the support of this API.
  *
  * Better alternative should be introduced as part of [#2873](https://github.com/Kotlin/dokka/issues/2873).
  */
 @InternalDokkaApi
-fun AbstractDokkaTask.buildJsonConfiguration(prettyPrint: Boolean = true): String {
+@Deprecated(DOKKA_V1_DEPRECATION_MESSAGE)
+fun @Suppress("DEPRECATION") org.jetbrains.dokka.gradle.AbstractDokkaTask.buildJsonConfiguration(prettyPrint: Boolean = true): String {
     val configuration = this.buildDokkaConfiguration()
     return if (prettyPrint) {
         configuration.toPrettyJsonString()

--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/kotlin/KotlinNativeDistributionAccessor.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/kotlin/KotlinNativeDistributionAccessor.kt
@@ -2,10 +2,10 @@
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-@file:Suppress("INVISIBLE_REFERENCE")
 package org.jetbrains.dokka.gradle.kotlin
 
 import org.gradle.api.Project
+import org.jetbrains.dokka.gradle.DOKKA_V1_DEPRECATION_MESSAGE
 import org.jetbrains.kotlin.commonizer.KonanDistribution
 import org.jetbrains.kotlin.commonizer.platformLibsDir
 import org.jetbrains.kotlin.commonizer.stdlib
@@ -23,6 +23,7 @@ import java.io.File
  *
  * It should not be used with Kotlin versions later than 1.9
  */
+@Deprecated(DOKKA_V1_DEPRECATION_MESSAGE)
 internal class KotlinNativeDistributionAccessor(
   project: Project
 ) {

--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/kotlin/kotlinClasspathUtils.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/kotlin/kotlinClasspathUtils.kt
@@ -55,7 +55,8 @@ private fun KotlinCompilation.newCompileClasspathOf(project: Project): FileColle
         if (this is AbstractKotlinNativeCompilation) {
             val excludePlatformFiles = project.classpathProperty("excludeKonanPlatformDependencyFiles", default = false)
             if (!excludePlatformFiles) {
-                val kotlinNativeDistributionAccessor = KotlinNativeDistributionAccessor(project)
+                val kotlinNativeDistributionAccessor =
+                    @Suppress("DEPRECATION") KotlinNativeDistributionAccessor(project)
                 result.from(kotlinNativeDistributionAccessor.stdlibDir)
                 result.from(kotlinNativeDistributionAccessor.platformDependencies(konanTarget))
             }

--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/sourceSetKotlinGistConfiguration.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/sourceSetKotlinGistConfiguration.kt
@@ -9,11 +9,12 @@ import org.jetbrains.dokka.gradle.kotlin.KotlinSourceSetGist
 import org.jetbrains.dokka.gradle.kotlin.gistOf
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 
-fun GradleDokkaSourceSetBuilder.configureWithKotlinSourceSet(sourceSet: KotlinSourceSet) {
+@Deprecated(DOKKA_V1_DEPRECATION_MESSAGE)
+fun @Suppress("DEPRECATION") GradleDokkaSourceSetBuilder.configureWithKotlinSourceSet(sourceSet: KotlinSourceSet) {
     configureWithKotlinSourceSetGist(project.gistOf(sourceSet))
 }
 
-internal fun GradleDokkaSourceSetBuilder.configureWithKotlinSourceSetGist(sourceSet: KotlinSourceSetGist) {
+internal fun @Suppress("DEPRECATION") GradleDokkaSourceSetBuilder.configureWithKotlinSourceSetGist(sourceSet: KotlinSourceSetGist) {
     val dependentSourceSetIds = sourceSet.dependentSourceSetNames.map { sourceSetNames ->
         sourceSetNames.map { sourceSetName -> DokkaSourceSetID(sourceSetName) }
     }

--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/tasks/AbstractDokkaLeafTask.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/tasks/AbstractDokkaLeafTask.kt
@@ -14,14 +14,19 @@ import org.gradle.kotlin.dsl.container
 import org.gradle.work.DisableCachingByDefault
 
 @DisableCachingByDefault(because = "Abstract super-class, not to be instantiated directly")
-abstract class AbstractDokkaLeafTask : AbstractDokkaTask() {
+@Deprecated(DOKKA_V1_DEPRECATION_MESSAGE)
+abstract class AbstractDokkaLeafTask : @Suppress("DEPRECATION") AbstractDokkaTask() {
 
     @get:Internal
-    val dokkaSourceSets: NamedDomainObjectContainer<GradleDokkaSourceSetBuilder> =
-        project.container(GradleDokkaSourceSetBuilder::class, gradleDokkaSourceSetBuilderFactory()).also { container ->
+    val dokkaSourceSets: NamedDomainObjectContainer<@Suppress("DEPRECATION") GradleDokkaSourceSetBuilder> =
+        project.container(
+            @Suppress("DEPRECATION") GradleDokkaSourceSetBuilder::class,
+            @Suppress("DEPRECATION") gradleDokkaSourceSetBuilderFactory(),
+        ).also { container ->
             DslObject(this).extensions.add("dokkaSourceSets", container)
             project.kotlinOrNull?.sourceSets?.all sourceSet@{
                 container.register(name) {
+                    @Suppress("DEPRECATION")
                     configureWithKotlinSourceSet(this@sourceSet)
                 }
             }
@@ -33,7 +38,7 @@ abstract class AbstractDokkaLeafTask : AbstractDokkaTask() {
      * as task dependency graph.
      */
     @get:Nested
-    protected val unsuppressedSourceSets: List<GradleDokkaSourceSetBuilder>
+    protected val unsuppressedSourceSets: List<@Suppress("DEPRECATION") GradleDokkaSourceSetBuilder>
         get() = dokkaSourceSets
             .toList()
             .also(::checkSourceSetDependencies)

--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/tasks/AbstractDokkaParentTask.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/tasks/AbstractDokkaParentTask.kt
@@ -2,7 +2,7 @@
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-@file:Suppress("PackageDirectoryMismatch")
+@file:Suppress("PackageDirectoryMismatch", "DeprecatedCallableAddReplaceWith")
 
 package org.jetbrains.dokka.gradle
 
@@ -20,16 +20,16 @@ private const val DEPRECATION_MESSAGE = """
     don't apply the Dokka plugin for it, or disable individual project tasks using the Gradle API .
 """
 
-@Suppress("DEPRECATION")
 @DisableCachingByDefault(because = "Abstract super-class, not to be instantiated directly")
-abstract class AbstractDokkaParentTask : AbstractDokkaTask() {
+@Deprecated(DOKKA_V1_DEPRECATION_MESSAGE)
+abstract class AbstractDokkaParentTask : @Suppress("DEPRECATION") AbstractDokkaTask() {
 
     @get:Internal
     internal var childDokkaTaskPaths: Set<String> = emptySet()
         private set
 
     @get:Nested
-    internal val childDokkaTasks: Set<AbstractDokkaTask>
+    internal val childDokkaTasks: Set<@Suppress("DEPRECATION") AbstractDokkaTask>
         get() = childDokkaTaskPaths
             .mapNotNull { path -> project.tasks.findByPath(path) }
             .map(::checkIsAbstractDokkaTask)
@@ -37,12 +37,12 @@ abstract class AbstractDokkaParentTask : AbstractDokkaTask() {
 
     /* By task reference */
     @Deprecated(message = DEPRECATION_MESSAGE, level = DeprecationLevel.WARNING)
-    fun addChildTask(task: AbstractDokkaTask) {
+    fun addChildTask(task: @Suppress("DEPRECATION") AbstractDokkaTask) {
         childDokkaTaskPaths = childDokkaTaskPaths + task.path
     }
 
     @Deprecated(message = DEPRECATION_MESSAGE, level = DeprecationLevel.WARNING)
-    fun removeChildTask(task: AbstractDokkaTask) {
+    fun removeChildTask(task:@Suppress("DEPRECATION")  AbstractDokkaTask) {
         childDokkaTaskPaths = childDokkaTaskPaths - task.path
     }
 
@@ -61,6 +61,7 @@ abstract class AbstractDokkaParentTask : AbstractDokkaTask() {
     @Deprecated(message = DEPRECATION_MESSAGE, level = DeprecationLevel.WARNING)
     fun addChildTasks(projects: Iterable<Project>, childTasksName: String) {
         projects.forEach { project ->
+            @Suppress("DEPRECATION")
             addChildTask(project.absoluteProjectPath(childTasksName))
         }
     }
@@ -68,17 +69,20 @@ abstract class AbstractDokkaParentTask : AbstractDokkaTask() {
     @Deprecated(message = DEPRECATION_MESSAGE, level = DeprecationLevel.WARNING)
     fun removeChildTasks(projects: Iterable<Project>, childTasksName: String) {
         projects.forEach { project ->
+            @Suppress("DEPRECATION")
             removeChildTask(project.absoluteProjectPath(childTasksName))
         }
     }
 
     @Deprecated(message = DEPRECATION_MESSAGE, level = DeprecationLevel.WARNING)
     fun addSubprojectChildTasks(childTasksName: String) {
+        @Suppress("DEPRECATION")
         addChildTasks(project.subprojects, childTasksName)
     }
 
     @Deprecated(message = DEPRECATION_MESSAGE, level = DeprecationLevel.WARNING)
     fun removeSubprojectChildTasks(childTasksName: String) {
+        @Suppress("DEPRECATION")
         removeChildTasks(project.subprojects, childTasksName)
     }
 
@@ -91,16 +95,19 @@ abstract class AbstractDokkaParentTask : AbstractDokkaTask() {
 
     @Deprecated(message = DEPRECATION_MESSAGE, level = DeprecationLevel.WARNING)
     fun removeChildTasks(projects: Iterable<Project>) {
-        projects.forEach { project -> removeChildTasks(project) }
+        projects.forEach { project ->
+            @Suppress("DEPRECATION")
+            removeChildTasks(project)
+        }
     }
 
-    private fun checkIsAbstractDokkaTask(task: Task): AbstractDokkaTask {
-        if (task is AbstractDokkaTask) {
+    private fun checkIsAbstractDokkaTask(task: Task): @Suppress("DEPRECATION") AbstractDokkaTask {
+        if (task is @kotlin.Suppress("DEPRECATION") AbstractDokkaTask) {
             return task
         }
         throw IllegalArgumentException(
-            "Only tasks of type ${AbstractDokkaTask::class.java.name} can be added as child for " +
-                    "${AbstractDokkaParentTask::class.java.name} tasks.\n" +
+            "Only tasks of type ${@Suppress("DEPRECATION") AbstractDokkaTask::class.java.name} can be added as child for " +
+                    "${@Suppress("DEPRECATION") AbstractDokkaParentTask::class.java.name} tasks.\n" +
                     "Found task ${task.path} of type ${task::class.java.name} added to $path"
         )
     }

--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/tasks/AbstractDokkaTask.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/tasks/AbstractDokkaTask.kt
@@ -32,6 +32,7 @@ import java.util.function.BiConsumer
 import kotlin.reflect.full.createInstance
 
 @DisableCachingByDefault(because = "Abstract super-class, not to be instantiated directly")
+@Deprecated(DOKKA_V1_DEPRECATION_MESSAGE)
 abstract class AbstractDokkaTask : DefaultTask() {
 
     /**

--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/tasks/DokkaCollectorTask.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/tasks/DokkaCollectorTask.kt
@@ -10,7 +10,8 @@ import org.gradle.api.tasks.CacheableTask
 import org.jetbrains.dokka.DokkaConfigurationImpl
 
 @CacheableTask
-abstract class DokkaCollectorTask : AbstractDokkaParentTask() {
+@Deprecated(DOKKA_V1_DEPRECATION_MESSAGE)
+abstract class DokkaCollectorTask : @Suppress("DEPRECATION") AbstractDokkaParentTask() {
 
     override fun generateDocumentation() {
         checkChildDokkaTasksIsNotEmpty()

--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/tasks/DokkaMultiModuleTask.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/tasks/DokkaMultiModuleTask.kt
@@ -19,12 +19,13 @@ import java.io.File
 
 @Suppress("unused") // Shall provide source compatibility if possible
 @Deprecated("Use 'DokkaMultiModuleTask' instead", ReplaceWith("DokkaMultiModuleTask"), DeprecationLevel.ERROR)
-typealias DokkaMultimoduleTask = DokkaMultiModuleTask
+typealias DokkaMultimoduleTask = @Suppress("DEPRECATION") DokkaMultiModuleTask
 
 private typealias TaskPath = String
 
 @CacheableTask
-abstract class DokkaMultiModuleTask : AbstractDokkaParentTask() {
+@Deprecated(DOKKA_V1_DEPRECATION_MESSAGE)
+abstract class DokkaMultiModuleTask : @Suppress("DEPRECATION") AbstractDokkaParentTask() {
 
     /**
      * List of Markdown files that contain
@@ -58,8 +59,9 @@ abstract class DokkaMultiModuleTask : AbstractDokkaParentTask() {
     abstract val includes: ConfigurableFileCollection
 
     @Internal
-    val fileLayout: Property<DokkaMultiModuleFileLayout> = project.objects.property<DokkaMultiModuleFileLayout>()
-        .convention(DokkaMultiModuleFileLayout.CompactInParent)
+    val fileLayout: Property<@Suppress("DEPRECATION") DokkaMultiModuleFileLayout> =
+        project.objects.property<@Suppress("DEPRECATION") DokkaMultiModuleFileLayout>()
+            .convention(@Suppress("DEPRECATION") DokkaMultiModuleFileLayout.CompactInParent)
 
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
@@ -72,7 +74,7 @@ abstract class DokkaMultiModuleTask : AbstractDokkaParentTask() {
 
     @get:Input
     internal val childDokkaTaskIncludes: Map<TaskPath, Set<File>>
-        get() = childDokkaTasks.filterIsInstance<DokkaTaskPartial>().associate { task ->
+        get() = childDokkaTasks.filterIsInstance<@Suppress("DEPRECATION") DokkaTaskPartial>().associate { task ->
             task.path to task.dokkaSourceSets.flatMap { it.includes }.toSet()
         }
 

--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/tasks/DokkaTask.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/tasks/DokkaTask.kt
@@ -11,7 +11,8 @@ import org.jetbrains.dokka.DokkaConfigurationImpl
 import org.jetbrains.dokka.build
 
 @CacheableTask
-abstract class DokkaTask : AbstractDokkaLeafTask() {
+@Deprecated(DOKKA_V1_DEPRECATION_MESSAGE)
+abstract class DokkaTask : @Suppress("DEPRECATION") AbstractDokkaLeafTask() {
     override fun buildDokkaConfiguration(): DokkaConfigurationImpl =
         DokkaConfigurationImpl(
             moduleName = moduleName.get(),

--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/tasks/DokkaTaskPartial.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/tasks/DokkaTaskPartial.kt
@@ -11,7 +11,8 @@ import org.jetbrains.dokka.DokkaConfigurationImpl
 import org.jetbrains.dokka.build
 
 @CacheableTask
-abstract class DokkaTaskPartial : AbstractDokkaLeafTask() {
+@Deprecated(DOKKA_V1_DEPRECATION_MESSAGE)
+abstract class DokkaTaskPartial : @Suppress("DEPRECATION") AbstractDokkaLeafTask() {
 
     override fun buildDokkaConfiguration(): DokkaConfigurationImpl {
         return DokkaConfigurationImpl(

--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/utils.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/utils.kt
@@ -42,3 +42,6 @@ internal fun Project.isAndroidProject() = try {
 }
 
 internal fun KotlinTarget.isAndroidTarget() = this.platformType == KotlinPlatformType.androidJvm
+
+internal const val DOKKA_V1_DEPRECATION_MESSAGE =
+    "Dokka Gradle plugin V1 mode is deprecated, and scheduled to be removed in Dokka v2.2.0. Migrate to v2 mode https://kotl.in/dokka-gradle-migration"

--- a/dokka-runners/dokka-gradle-plugin/src/classicTest/kotlin/AndroidAutoConfigurationTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicTest/kotlin/AndroidAutoConfigurationTest.kt
@@ -2,6 +2,8 @@
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
+@file:Suppress("DEPRECATION")
+
 package org.jetbrains.dokka.gradle
 
 import com.android.build.gradle.LibraryExtension

--- a/dokka-runners/dokka-gradle-plugin/src/classicTest/kotlin/ConfigureWithKotlinSourceSetGistTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicTest/kotlin/ConfigureWithKotlinSourceSetGistTest.kt
@@ -2,6 +2,8 @@
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
+@file:Suppress("DEPRECATION")
+
 package org.jetbrains.dokka.gradle
 
 import org.gradle.api.artifacts.FileCollectionDependency

--- a/dokka-runners/dokka-gradle-plugin/src/classicTest/kotlin/DokkaClassicPluginApplyTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicTest/kotlin/DokkaClassicPluginApplyTest.kt
@@ -2,6 +2,8 @@
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
+@file:Suppress("DEPRECATION")
+
 package org.jetbrains.dokka.gradle
 
 import org.gradle.api.plugins.JavaBasePlugin

--- a/dokka-runners/dokka-gradle-plugin/src/classicTest/kotlin/DokkaConfigurationJsonTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicTest/kotlin/DokkaConfigurationJsonTest.kt
@@ -24,7 +24,7 @@ class DokkaConfigurationJsonTest {
     fun `DokkaTask configuration toJsonString then parseJson`() {
         val project = ProjectBuilder.builder().build()
         project.plugins.apply("org.jetbrains.dokka")
-        val dokkaTask = project.tasks.withType<DokkaTask>().first()
+        val dokkaTask = project.tasks.withType<@Suppress("DEPRECATION")DokkaTask>().first()
         dokkaTask.plugins.withDependencies_ { clear() }
         dokkaTask.apply {
             this.failOnWarning.set(true)

--- a/dokka-runners/dokka-gradle-plugin/src/classicTest/kotlin/DokkaConfigurationSerializableTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicTest/kotlin/DokkaConfigurationSerializableTest.kt
@@ -25,7 +25,7 @@ class DokkaConfigurationSerializableTest {
     fun `DokkaTask configuration write to file then parse`(@TempDir tempDirectory: File) {
         val project = ProjectBuilder.builder().build()
         project.plugins.apply("org.jetbrains.dokka")
-        val dokkaTask = project.tasks.withType<DokkaTask>().first()
+        val dokkaTask = project.tasks.withType<@Suppress("DEPRECATION")DokkaTask>().first()
         dokkaTask.plugins.withDependencies_ { clear() }
         dokkaTask.apply {
             this.failOnWarning.set(true)

--- a/dokka-runners/dokka-gradle-plugin/src/classicTest/kotlin/DokkaMultiModuleFileLayoutTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicTest/kotlin/DokkaMultiModuleFileLayoutTest.kt
@@ -2,6 +2,8 @@
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
+@file:Suppress("DEPRECATION")
+
 package org.jetbrains.dokka.gradle
 
 import org.gradle.kotlin.dsl.create

--- a/dokka-runners/dokka-gradle-plugin/src/classicTest/kotlin/GradleDokkaSourceSetBuilder.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicTest/kotlin/GradleDokkaSourceSetBuilder.kt
@@ -2,6 +2,8 @@
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
+@file:Suppress("DEPRECATION")
+
 package org.jetbrains.dokka.gradle
 
 import org.gradle.api.Project

--- a/dokka-runners/dokka-gradle-plugin/src/classicTest/kotlin/GradleDokkaSourceSetBuilderTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicTest/kotlin/GradleDokkaSourceSetBuilderTest.kt
@@ -2,6 +2,8 @@
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
+@file:Suppress("DEPRECATION")
+
 package org.jetbrains.dokka.gradle
 
 import com.android.build.gradle.internal.api.DefaultAndroidSourceSet

--- a/dokka-runners/dokka-gradle-plugin/src/classicTest/kotlin/KotlinDslDokkaTaskConfigurationTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicTest/kotlin/KotlinDslDokkaTaskConfigurationTest.kt
@@ -2,6 +2,8 @@
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
+@file:Suppress("DEPRECATION")
+
 package org.jetbrains.dokka.gradle
 
 import org.gradle.kotlin.dsl.withType

--- a/dokka-runners/dokka-gradle-plugin/src/classicTest/kotlin/tasks/DokkaCollectorTaskTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicTest/kotlin/tasks/DokkaCollectorTaskTest.kt
@@ -2,6 +2,8 @@
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
+@file:Suppress("DEPRECATION")
+
 package org.jetbrains.dokka.gradle.tasks
 
 import org.gradle.kotlin.dsl.create

--- a/dokka-runners/dokka-gradle-plugin/src/classicTest/kotlin/tasks/DokkaTaskTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicTest/kotlin/tasks/DokkaTaskTest.kt
@@ -2,7 +2,7 @@
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-@file:Suppress("PackageDirectoryMismatch")
+@file:Suppress("PackageDirectoryMismatch", "DEPRECATION")
 
 package org.jetbrains.dokka.gradle
 

--- a/dokka-runners/dokka-gradle-plugin/src/classicTest/kotlin/utils/samWithReceiverWorkarounds.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicTest/kotlin/utils/samWithReceiverWorkarounds.kt
@@ -2,6 +2,8 @@
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
+@file:Suppress("DEPRECATION")
+
 package org.jetbrains.dokka.gradle.utils
 
 import org.gradle.api.DomainObjectCollection

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaPlugin.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaPlugin.kt
@@ -11,7 +11,6 @@ import org.jetbrains.dokka.gradle.internal.InternalDokkaGradlePluginApi
 import org.jetbrains.dokka.gradle.internal.PluginFeaturesService.Companion.pluginFeaturesService
 import org.jetbrains.dokka.gradle.internal.addV2MigrationHelpers
 import javax.inject.Inject
-import org.jetbrains.dokka.gradle.DokkaClassicPlugin as ClassicDokkaPlugin
 
 /**
  * Dokka Gradle Plugin.
@@ -33,7 +32,7 @@ constructor() : Plugin<Project> {
     }
 
     private fun applyV1(project: Project) {
-        project.pluginManager.apply(ClassicDokkaPlugin::class)
+        project.pluginManager.apply(@Suppress("DEPRECATION") DokkaClassicPlugin::class)
     }
 
     private fun applyV2(project: Project) {

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/internal/v2MigrationUtils.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/internal/v2MigrationUtils.kt
@@ -33,7 +33,7 @@ internal fun addV2MigrationHelpers(
 }
 
 private fun configureDokkaTaskConventions(project: Project) {
-    project.tasks.withType<AbstractDokkaTask>().configureEach {
+    project.tasks.withType<@Suppress("DEPRECATION") AbstractDokkaTask>().configureEach {
         // The DGPv1 tasks are only present to prevent buildscripts with references to them from breaking.
         // The tasks are non-operable and should be hidden, to help nudge users to the DGPv2 tasks.
         // Setting tasks with group null will hide it when running `gradle tasks`,
@@ -84,7 +84,7 @@ private fun setupDokkaTasks(
         project.configurations.createDokkaRuntimeConfiguration(taskName = baseTaskName)
     }
 
-    project.tasks.register<DokkaTask>(baseTaskName) {
+    project.tasks.register<@Suppress("DEPRECATION") DokkaTask>(baseTaskName) {
         description = "$taskDesc Generates documentation in '$format' format."
     }
 
@@ -92,7 +92,7 @@ private fun setupDokkaTasks(
         val partialName = "${baseTaskName}Partial"
         project.configurations.createDokkaPluginConfiguration(taskName = partialName)
         project.configurations.createDokkaRuntimeConfiguration(taskName = partialName)
-        project.tasks.register<DokkaTaskPartial>(partialName) {
+        project.tasks.register<@Suppress("DEPRECATION") DokkaTaskPartial>(partialName) {
             description = "$taskDesc Generates documentation in '$format' format."
         }
     }
@@ -103,13 +103,13 @@ private fun setupDokkaTasks(
             project.configurations.createDokkaPluginConfiguration(taskName = multiModuleName)
             project.configurations.createDokkaRuntimeConfiguration(taskName = multiModuleName)
 
-            project.tasks.register<DokkaMultiModuleTask>(multiModuleName) {
+            project.tasks.register<@Suppress("DEPRECATION") DokkaMultiModuleTask>(multiModuleName) {
                 description =
                     "$taskDesc Runs all subprojects '$name' tasks and generates $format module navigation page."
             }
         }
 
-        project.tasks.register<DokkaCollectorTask>("${baseTaskName}Collector") {
+        project.tasks.register<@Suppress("DEPRECATION") DokkaCollectorTask>("${baseTaskName}Collector") {
             description =
                 "$taskDesc Generates documentation merging all subprojects '$baseTaskName' tasks into one virtual module."
         }


### PR DESCRIPTION
Deprecate all DGPv1 mode public APIs. This will help users migrating to v2 DGPv2 to clean up leftover DGPv1 code.

Added `@Suppress("DEPRECATION")` to internal usages of the deprecated types to avoid noisy warnings. I made the suppressions as targeted as possible, to avoid accidental suppression from Gradle types.

fix #4098