### PR TITLE
Update Gradle Properties types to be non-nullable

### DIFF
--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/engine/parameters/DokkaSourceSetSpec.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/engine/parameters/DokkaSourceSetSpec.kt
@@ -326,22 +326,24 @@ constructor(
      * used for setting up analysis and [`@sample`](https://kotlinlang.org/docs/kotlin-doc.html#sample-identifier)
      * environment.
      *
+     * This is an optional property.
      * By default, the latest language version available to Dokka's embedded compiler will be used.
      */
     @get:Input
     @get:Optional
-    abstract val languageVersion: Property<String?>
+    abstract val languageVersion: Property<String>
 
     /**
      * [Kotlin API version](https://kotlinlang.org/docs/compatibility-modes.html)
      * used for setting up analysis and [`@sample`](https://kotlinlang.org/docs/kotlin-doc.html#sample-identifier)
      * environment.
      *
+     * This is an optional property.
      * By default, it will be deduced from [languageVersion].
      */
     @get:Input
     @get:Optional
-    abstract val apiVersion: Property<String?>
+    abstract val apiVersion: Property<String>
 
     /**
      * JDK version to use when generating external documentation links for Java types.


### PR DESCRIPTION
Change languageVersion and apiVersion `Property<>`s to use non-nullable types, to be compatible with Gradle 9.

https://docs.gradle.org/9.0.0-milestone-9/userguide/upgrading_version_8.html#kotlin_dsl_now_uses_the_kotlin_language_version_2_1

Fix #4096