### PR TITLE
Migrate BTA versions and all `kotlin("...")` dependencies to version catalog for consistency

### DIFF
--- a/build-logic/src/main/kotlin/dokkabuild/utils/gradleKotlinCompatibility.kt
+++ b/build-logic/src/main/kotlin/dokkabuild/utils/gradleKotlinCompatibility.kt
@@ -6,6 +6,7 @@ package dokkabuild.utils
 
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.dokkaBuild
+import org.gradle.kotlin.dsl.libs
 import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
@@ -16,13 +17,15 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 fun Project.configureGradleKotlinCompatibility() {
     if (!dokkaBuild.enforceGradleKotlinCompatibility.get()) return
 
+    @OptIn(ExperimentalKotlinGradlePluginApi::class, ExperimentalBuildToolsApi::class)
     extensions.configure<KotlinJvmProjectExtension>("kotlin") {
-        @OptIn(ExperimentalKotlinGradlePluginApi::class, ExperimentalBuildToolsApi::class)
-        compilerVersion.set("2.0.21")
-        coreLibrariesVersion = "2.0.21"
+        val btaCompilerVersion = libs.versions.bta.kotlin.compiler
+        val btaLanguageVersion = libs.versions.bta.kotlin.language.map(KotlinVersion::fromVersion)
+        compilerVersion.set(btaCompilerVersion)
+        coreLibrariesVersion = btaCompilerVersion.get()
         compilerOptions {
-            languageVersion.set(KotlinVersion.fromVersion("1.4"))
-            apiVersion.set(KotlinVersion.fromVersion("1.4"))
+            languageVersion.set(btaLanguageVersion)
+            apiVersion.set(btaLanguageVersion)
             freeCompilerArgs.addAll(
                 "-Xsuppress-version-warnings",
                 // we need this flag to be able to use newer Analysis API versions

--- a/dokka-integration-tests/cli/build.gradle.kts
+++ b/dokka-integration-tests/cli/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 }
 
 dependencies {
-    api(kotlin("test-junit5"))
+    api(libs.kotlin.test.junit5)
     api(libs.junit.jupiterApi)
     api(projects.utilities)
 

--- a/dokka-integration-tests/gradle/build.gradle.kts
+++ b/dokka-integration-tests/gradle/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
 
     api(libs.jsoup)
 
-    api(kotlin("test-junit5"))
+    api(libs.kotlin.test.junit5)
     api(libs.junit.jupiterApi)
     api(libs.junit.jupiterParams)
     api(libs.kotest.assertionsCore)

--- a/dokka-integration-tests/maven/build.gradle.kts
+++ b/dokka-integration-tests/maven/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
 dependencies {
     api(projects.utilities)
 
-    api(kotlin("test-junit5"))
+    api(libs.kotlin.test.junit5)
     api(libs.junit.jupiterApi)
 
     val dokkaVersion = project.version.toString()

--- a/dokka-integration-tests/utilities/build.gradle.kts
+++ b/dokka-integration-tests/utilities/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 dependencies {
     // Classes from src rely on JUnit's @TempDir and Kotlin's @AfterTest,
     // thus these dependencies are needed. Ideally, they should be removed.
-    implementation(kotlin("test-junit5"))
+    implementation(libs.kotlin.test.junit5)
 
     implementation(libs.jsoup)
     implementation(libs.eclipse.jgit)

--- a/dokka-runners/dokka-gradle-plugin/build.gradle.kts
+++ b/dokka-runners/dokka-gradle-plugin/build.gradle.kts
@@ -153,7 +153,7 @@ testing.suites {
             implementation(libs.kotlinxSerialization.json)
 
             //region classic-plugin dependencies - delete these when src/classicMain is removed
-            implementation(project.dependencies.kotlin("test").toString())
+            implementation(libs.kotlin.test)
             implementation(libs.gradlePlugin.kotlin)
             implementation(libs.gradlePlugin.kotlin.klibCommonizerApi)
             implementation(libs.gradlePlugin.android)

--- a/dokka-runners/runner-cli/build.gradle.kts
+++ b/dokka-runners/runner-cli/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     implementation("org.jetbrains.dokka:dokka-core")
     implementation(libs.kotlinx.cli)
 
-    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlin.test)
 }
 
 tasks.shadowJar {

--- a/dokka-subprojects/analysis-kotlin-api/build.gradle.kts
+++ b/dokka-subprojects/analysis-kotlin-api/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
 
     testFixturesApi(projects.dokkaSubprojects.dokkaCore)
 
-    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlin.test)
 
     symbolsTestImplementation(project(path = ":dokka-subprojects:analysis-kotlin-symbols", configuration = "shadow"))
     descriptorsTestImplementation(

--- a/dokka-subprojects/analysis-kotlin-descriptors-compiler/build.gradle.kts
+++ b/dokka-subprojects/analysis-kotlin-descriptors-compiler/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     implementation(projects.dokkaSubprojects.analysisMarkdownJb)
     implementation(projects.dokkaSubprojects.analysisJavaPsi)
 
-    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlin.test)
     testImplementation(projects.dokkaSubprojects.coreContentMatcherTestUtils)
     testImplementation(projects.dokkaSubprojects.dokkaTestApi)
     testImplementation(projects.dokkaSubprojects.analysisKotlinApi)

--- a/dokka-subprojects/core-content-matcher-test-utils/build.gradle.kts
+++ b/dokka-subprojects/core-content-matcher-test-utils/build.gradle.kts
@@ -9,6 +9,6 @@ plugins {
 dependencies {
     implementation(projects.dokkaSubprojects.dokkaTestApi)
 
-    implementation(kotlin("reflect"))
-    implementation(kotlin("test"))
+    implementation(libs.kotlin.reflect)
+    implementation(libs.kotlin.test)
 }

--- a/dokka-subprojects/core-test-api/build.gradle.kts
+++ b/dokka-subprojects/core-test-api/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     api(projects.dokkaSubprojects.dokkaCore)
     // for assertions over `DokkaConfiguration/DokkaSourceSet`
     // it's compileOnly, so it should be able to handle both `junit` and `junit5`
-    compileOnly(kotlin("test"))
+    compileOnly(libs.kotlin.test)
 
-    implementation(kotlin("reflect"))
+    implementation(libs.kotlin.reflect)
 }

--- a/dokka-subprojects/core/build.gradle.kts
+++ b/dokka-subprojects/core/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 overridePublicationArtifactId("dokka-core")
 
 dependencies {
-    implementation(kotlin("reflect"))
+    implementation(libs.kotlin.reflect)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.jackson.kotlin)
     implementation(libs.jackson.xml)
@@ -22,7 +22,7 @@ dependencies {
         }
     }
 
-    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlin.test)
     testImplementation(projects.dokkaSubprojects.dokkaTestApi)
 }
 

--- a/dokka-subprojects/plugin-all-modules-page/build.gradle.kts
+++ b/dokka-subprojects/plugin-all-modules-page/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
 
     implementation(libs.kotlinx.html)
 
-    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlin.test)
     testImplementation(projects.dokkaSubprojects.pluginBase)
     testImplementation(projects.dokkaSubprojects.pluginBaseTestUtils)
     testImplementation(projects.dokkaSubprojects.pluginGfm)

--- a/dokka-subprojects/plugin-android-documentation/build.gradle.kts
+++ b/dokka-subprojects/plugin-android-documentation/build.gradle.kts
@@ -17,9 +17,9 @@ dependencies {
 
     implementation(projects.dokkaSubprojects.pluginBase)
 
-    implementation(kotlin("reflect"))
+    implementation(libs.kotlin.reflect)
 
-    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlin.test)
     testImplementation(projects.dokkaSubprojects.pluginBase)
     testImplementation(projects.dokkaSubprojects.dokkaTestApi)
 

--- a/dokka-subprojects/plugin-base-test-utils/build.gradle.kts
+++ b/dokka-subprojects/plugin-base-test-utils/build.gradle.kts
@@ -17,12 +17,12 @@ dependencies {
 
     api(projects.dokkaSubprojects.analysisKotlinApi)
 
-    implementation(kotlin("reflect"))
+    implementation(libs.kotlin.reflect)
     implementation(libs.jsoup)
 
-    implementation(kotlin("test"))
+    implementation(libs.kotlin.test)
     implementation(projects.dokkaSubprojects.dokkaTestApi)
 
-    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlin.test)
     testImplementation(projects.dokkaSubprojects.dokkaTestApi)
 }

--- a/dokka-subprojects/plugin-base/build.gradle.kts
+++ b/dokka-subprojects/plugin-base/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     implementation(projects.dokkaSubprojects.analysisMarkdownJb)
 
     // Other
-    implementation(kotlin("reflect"))
+    implementation(libs.kotlin.reflect)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.jsoup)
     implementation(libs.freemarker)
@@ -36,7 +36,7 @@ dependencies {
     }
 
     // Test only
-    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlin.test)
     testImplementation(libs.junit.jupiterParams)
 
     symbolsTestImplementation(project(path = ":dokka-subprojects:analysis-kotlin-symbols", configuration = "shadow"))

--- a/dokka-subprojects/plugin-gfm-template-processing/build.gradle.kts
+++ b/dokka-subprojects/plugin-gfm-template-processing/build.gradle.kts
@@ -19,9 +19,9 @@ dependencies {
     implementation(projects.dokkaSubprojects.pluginAllModulesPage)
     implementation(projects.dokkaSubprojects.pluginTemplating)
 
-    implementation(kotlin("reflect"))
+    implementation(libs.kotlin.reflect)
     implementation(libs.kotlinx.coroutines.core)
 
-    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlin.test)
     testImplementation(projects.dokkaSubprojects.dokkaTestApi)
 }

--- a/dokka-subprojects/plugin-gfm/build.gradle.kts
+++ b/dokka-subprojects/plugin-gfm/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
 
     implementation(projects.dokkaSubprojects.pluginBase)
 
-    implementation(kotlin("reflect"))
+    implementation(libs.kotlin.reflect)
     implementation(libs.jackson.kotlin)
     constraints {
         implementation(libs.jackson.databind) {
@@ -24,7 +24,7 @@ dependencies {
         }
     }
 
-    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlin.test)
     testImplementation(projects.dokkaSubprojects.pluginBase)
     testImplementation(projects.dokkaSubprojects.pluginBaseTestUtils)
     testImplementation(projects.dokkaSubprojects.dokkaTestApi)

--- a/dokka-subprojects/plugin-javadoc/build.gradle.kts
+++ b/dokka-subprojects/plugin-javadoc/build.gradle.kts
@@ -19,12 +19,12 @@ dependencies {
     implementation(projects.dokkaSubprojects.pluginBase)
     implementation(projects.dokkaSubprojects.pluginKotlinAsJava)
 
-    implementation(kotlin("reflect"))
+    implementation(libs.kotlin.reflect)
     implementation(libs.korlibs.template)
     implementation(libs.kotlinx.html)
     implementation(libs.kotlinx.coroutines.core)
 
-    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlin.test)
     symbolsTestImplementation(project(path = ":dokka-subprojects:analysis-kotlin-symbols", configuration = "shadow"))
     descriptorsTestImplementation(project(path = ":dokka-subprojects:analysis-kotlin-descriptors", configuration = "shadow"))
     testImplementation(projects.dokkaSubprojects.pluginBaseTestUtils)

--- a/dokka-subprojects/plugin-jekyll-template-processing/build.gradle.kts
+++ b/dokka-subprojects/plugin-jekyll-template-processing/build.gradle.kts
@@ -21,9 +21,9 @@ dependencies {
     implementation(projects.dokkaSubprojects.pluginGfm)
     implementation(projects.dokkaSubprojects.pluginGfmTemplateProcessing)
 
-    implementation(kotlin("reflect"))
+    implementation(libs.kotlin.reflect)
     implementation(libs.kotlinx.coroutines.core)
 
-    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlin.test)
     testImplementation(projects.dokkaSubprojects.dokkaTestApi)
 }

--- a/dokka-subprojects/plugin-jekyll/build.gradle.kts
+++ b/dokka-subprojects/plugin-jekyll/build.gradle.kts
@@ -17,8 +17,8 @@ dependencies {
     implementation(projects.dokkaSubprojects.pluginBase)
     implementation(projects.dokkaSubprojects.pluginGfm)
 
-    implementation(kotlin("reflect"))
+    implementation(libs.kotlin.reflect)
 
-    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlin.test)
     testImplementation(projects.dokkaSubprojects.dokkaTestApi)
 }

--- a/dokka-subprojects/plugin-kotlin-as-java/build.gradle.kts
+++ b/dokka-subprojects/plugin-kotlin-as-java/build.gradle.kts
@@ -18,9 +18,9 @@ dependencies {
 
     implementation(projects.dokkaSubprojects.pluginBase)
 
-    implementation(kotlin("reflect"))
+    implementation(libs.kotlin.reflect)
 
-    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlin.test)
     testImplementation(libs.jsoup)
     testImplementation(projects.dokkaSubprojects.pluginBase)
     symbolsTestImplementation(project(path = ":dokka-subprojects:analysis-kotlin-symbols", configuration = "shadow"))

--- a/dokka-subprojects/plugin-mathjax/build.gradle.kts
+++ b/dokka-subprojects/plugin-mathjax/build.gradle.kts
@@ -17,9 +17,9 @@ dependencies {
 
     implementation(projects.dokkaSubprojects.pluginBase)
 
-    implementation(kotlin("reflect"))
+    implementation(libs.kotlin.reflect)
 
-    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlin.test)
     testImplementation(libs.jsoup)
     testImplementation(projects.dokkaSubprojects.coreContentMatcherTestUtils)
     testImplementation(projects.dokkaSubprojects.dokkaTestApi)

--- a/dokka-subprojects/plugin-templating/build.gradle.kts
+++ b/dokka-subprojects/plugin-templating/build.gradle.kts
@@ -18,10 +18,10 @@ dependencies {
 
     implementation(projects.dokkaSubprojects.pluginBase)
 
-    implementation(kotlin("reflect"))
+    implementation(libs.kotlin.reflect)
     implementation(libs.kotlinx.coroutines.core)
 
-    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlin.test)
     testImplementation(libs.junit.jupiterParams)
 
     testImplementation(projects.dokkaSubprojects.pluginBaseTestUtils)

--- a/dokka-subprojects/plugin-versioning/build.gradle.kts
+++ b/dokka-subprojects/plugin-versioning/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     implementation(projects.dokkaSubprojects.pluginBase)
     implementation(projects.dokkaSubprojects.pluginTemplating)
 
-    implementation(kotlin("reflect"))
+    implementation(libs.kotlin.reflect)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.html)
     implementation(libs.apacheMaven.artifact)
@@ -28,6 +28,6 @@ dependencies {
         }
     }
 
-    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlin.test)
     testImplementation(projects.dokkaSubprojects.dokkaTestApi)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,12 @@
 [versions]
 
-# We use a different compiler version to compile modules and Gradle Plugin
-# to be able to use Kotlin Language/API version 1.4 to be compatible with Gradle 7.
-# The logic leaves in build-logic/src/main/kotlin/dokkabuild/utils/gradleKotlinCompatibility.kt
+# To be compatible with Gradle 7.x we need to compile modules and Gradle Plugin with Kotlin Language/API version 1.4.
+# For this we use Kotlin BTA (Build Tools API) with the custom compiler version of 2.0.21,
+# which is the latest Kotlin compiler version, which supports Kotlin Language/API version 1.4.
+# The logic lives in build-logic/src/main/kotlin/dokkabuild/utils/gradleKotlinCompatibility.kt
+bta-kotlin-compiler = "2.0.21"
+bta-kotlin-language = "1.4"
+
 gradlePlugin-kotlin = "2.1.21"
 # See: https://kotlinlang.org/docs/gradle-configure-project.html#apply-the-plugin
 gradlePlugin-android = "7.3.1"
@@ -68,6 +72,12 @@ kotest = "5.6.2"
 eclipse-jgit = "5.13.3.202401111512-r" # jgit 6.X requires Java 11 to run
 
 [libraries]
+
+# There should be no version in `kotlin-*` dependencies,
+# so that the version will be automatically provided by `coreLibrariesVersion` used in KGP
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect" }
+kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test" }
+kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5" }
 
 #### Kotlin Libs ####
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }


### PR DESCRIPTION
The PR is based on https://github.com/Kotlin/dokka/pull/4014