### PR TITLE
Fix some Javadoc links with generic parameters

### DIFF
--- a/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/util/PsiCommentsUtils.kt
+++ b/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/util/PsiCommentsUtils.kt
@@ -44,6 +44,10 @@ internal fun PsiElement.referenceElementOrSelf(): PsiElement? =
 
 internal fun PsiDocTag.linkElement(): PsiElement? =
     dataElements.firstOrNull {
+        /**
+         * * According to the [com.intellij.java.syntax.parser.JavaDocParser],
+         * no other node is expected here for the reference (link)
+         */
         it.node.elementType == JavaDocElementType.DOC_REFERENCE_HOLDER ||
                 it.node.elementType == JavaDocElementType.DOC_METHOD_OR_FIELD_REF
     }

--- a/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/util/PsiCommentsUtils.kt
+++ b/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/util/PsiCommentsUtils.kt
@@ -7,7 +7,6 @@ package org.jetbrains.dokka.analysis.java.util
 import com.intellij.psi.JavaDocTokenType
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiJavaCodeReferenceElement
-import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.impl.source.tree.JavaDocElementType
 import com.intellij.psi.javadoc.PsiDocComment
 import com.intellij.psi.javadoc.PsiDocTag
@@ -44,7 +43,10 @@ internal fun PsiElement.referenceElementOrSelf(): PsiElement? =
     } else this
 
 internal fun PsiDocTag.linkElement(): PsiElement? =
-    valueElement ?: dataElements.firstOrNull { it !is PsiWhiteSpace }
+    dataElements.firstOrNull {
+        it.node.elementType == JavaDocElementType.DOC_REFERENCE_HOLDER ||
+                it.node.elementType == JavaDocElementType.DOC_METHOD_OR_FIELD_REF
+    }
 
 internal fun PsiElement.defaultLabel() = children.firstOrNull {
     it is PsiDocToken && it.text.isNotBlank() && !it.isSharpToken()


### PR DESCRIPTION
In K1, we register IDE's service `JavadocManager`, we could do the same in K2:
`registerProjectService(JavadocManager::class.java, JavadocManagerImpl(project))`
However, it seems unnecessary, since the link is unresolved in K1 as well.


