### PR TITLE
Migrate to `redirector.kotlinlang.org`

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -6,9 +6,7 @@ rootProject.name = "build-logic"
 
 pluginManagement {
     repositories {
-        maven("https://cache-redirector.jetbrains.com/repo.maven.apache.org/maven2") {
-            name = "MavenCentral-JBCache"
-        }
+        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
         maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2") {
             name = "GradlePluginPortal-JBCache"
         }
@@ -19,12 +17,7 @@ pluginManagement {
 dependencyResolutionManagement {
     @Suppress("UnstableApiUsage")
     repositories {
-        maven("https://cache-redirector.jetbrains.com/repo.maven.apache.org/maven2") {
-            name = "MavenCentral-JBCache"
-        }
-        maven("https://cache-redirector.jetbrains.com/dl.google.com.android.maven2") {
-            name = "Google-JBCache"
-        }
+        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
         maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2") {
             name = "GradlePluginPortal-JBCache"
         }

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -6,7 +6,10 @@ rootProject.name = "build-logic"
 
 pluginManagement {
     repositories {
-        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
+        mavenCentral {
+            setUrl("https://cache-redirector.jetbrains.com/maven-central")
+            name = "MavenCentral-JBCache"
+        }
         maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2") {
             name = "GradlePluginPortal-JBCache"
         }
@@ -17,7 +20,10 @@ pluginManagement {
 dependencyResolutionManagement {
     @Suppress("UnstableApiUsage")
     repositories {
-        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
+        mavenCentral {
+            setUrl("https://cache-redirector.jetbrains.com/maven-central")
+            name = "MavenCentral-JBCache"
+        }
         maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2") {
             name = "GradlePluginPortal-JBCache"
         }

--- a/build-settings-logic/settings.gradle.kts
+++ b/build-settings-logic/settings.gradle.kts
@@ -8,9 +8,7 @@ rootProject.name = "build-settings-logic"
 
 pluginManagement {
     repositories {
-        maven("https://cache-redirector.jetbrains.com/repo.maven.apache.org/maven2") {
-            name = "MavenCentral-JBCache"
-        }
+        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
         maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2") {
             name = "GradlePluginPortal-JBCache"
         }
@@ -21,9 +19,7 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode = PREFER_SETTINGS
     repositories {
-        maven("https://cache-redirector.jetbrains.com/repo.maven.apache.org/maven2") {
-            name = "MavenCentral-JBCache"
-        }
+        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
         maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2") {
             name = "GradlePluginPortal-JBCache"
         }

--- a/build-settings-logic/settings.gradle.kts
+++ b/build-settings-logic/settings.gradle.kts
@@ -8,7 +8,10 @@ rootProject.name = "build-settings-logic"
 
 pluginManagement {
     repositories {
-        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
+        mavenCentral {
+            setUrl("https://cache-redirector.jetbrains.com/maven-central")
+            name = "MavenCentral-JBCache"
+        }
         maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2") {
             name = "GradlePluginPortal-JBCache"
         }
@@ -19,7 +22,10 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode = PREFER_SETTINGS
     repositories {
-        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
+        mavenCentral {
+            setUrl("https://cache-redirector.jetbrains.com/maven-central")
+            name = "MavenCentral-JBCache"
+        }
         maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2") {
             name = "GradlePluginPortal-JBCache"
         }

--- a/dokka-integration-tests/maven/src/main/kotlin/settingsXml.kt
+++ b/dokka-integration-tests/maven/src/main/kotlin/settingsXml.kt
@@ -20,7 +20,7 @@ fun createSettingsXml(): String {
 
     val mavenCentralRepo = Repository(
         id = "MavenCentral-JBCached",
-        url = "https://cache-redirector.jetbrains.com/repo.maven.apache.org/maven2",
+        url = "https://cache-redirector.jetbrains.com/maven-central",
     )
 
     val pluginRepos = buildList {

--- a/dokka-integration-tests/settings.gradle.kts
+++ b/dokka-integration-tests/settings.gradle.kts
@@ -9,7 +9,10 @@ pluginManagement {
     includeBuild("../build-settings-logic")
 
     repositories {
-        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
+        mavenCentral {
+            setUrl("https://cache-redirector.jetbrains.com/maven-central")
+            name = "MavenCentral-JBCache"
+        }
         maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2") {
             name = "GradlePluginPortal-JBCache"
         }
@@ -23,7 +26,10 @@ plugins {
 dependencyResolutionManagement {
     @Suppress("UnstableApiUsage")
     repositories {
-        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
+        mavenCentral {
+            setUrl("https://cache-redirector.jetbrains.com/maven-central")
+            name = "MavenCentral-JBCache"
+        }
     }
 
     versionCatalogs {

--- a/dokka-integration-tests/settings.gradle.kts
+++ b/dokka-integration-tests/settings.gradle.kts
@@ -9,8 +9,10 @@ pluginManagement {
     includeBuild("../build-settings-logic")
 
     repositories {
-        mavenCentral()
-        gradlePluginPortal()
+        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
+        maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2") {
+            name = "GradlePluginPortal-JBCache"
+        }
     }
 }
 
@@ -21,13 +23,7 @@ plugins {
 dependencyResolutionManagement {
     @Suppress("UnstableApiUsage")
     repositories {
-        maven("https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-ide")
-        maven("https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-ide-plugin-dependencies")
-
-        maven("https://cache-redirector.jetbrains.com/intellij-repository/releases")
-        maven("https://cache-redirector.jetbrains.com/intellij-third-party-dependencies")
-
-        mavenCentral()
+        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
     }
 
     versionCatalogs {

--- a/dokka-runners/dokka-gradle-plugin/settings.gradle.kts
+++ b/dokka-runners/dokka-gradle-plugin/settings.gradle.kts
@@ -9,8 +9,10 @@ pluginManagement {
     includeBuild("../../build-settings-logic")
 
     repositories {
-        mavenCentral()
-        gradlePluginPortal()
+        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
+        maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2") {
+            name = "GradlePluginPortal-JBCache"
+        }
     }
 }
 
@@ -21,8 +23,8 @@ plugins {
 dependencyResolutionManagement {
     @Suppress("UnstableApiUsage")
     repositories {
-        mavenCentral()
-        google()
+        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
+        google { setUrl("https://cache-redirector.jetbrains.com/dl.google.com/dl/android/maven2") }
     }
 
     versionCatalogs {

--- a/dokka-runners/dokka-gradle-plugin/settings.gradle.kts
+++ b/dokka-runners/dokka-gradle-plugin/settings.gradle.kts
@@ -30,7 +30,10 @@ dependencyResolutionManagement {
             setUrl("https://cache-redirector.jetbrains.com/maven-central")
             name = "MavenCentral-JBCache"
         }
-        google { setUrl("https://cache-redirector.jetbrains.com/dl.google.com/dl/android/maven2") }
+        google {
+            setUrl("https://cache-redirector.jetbrains.com/dl.google.com/dl/android/maven2")
+            name = "Google-JBCache"
+        }
     }
 
     versionCatalogs {

--- a/dokka-runners/dokka-gradle-plugin/settings.gradle.kts
+++ b/dokka-runners/dokka-gradle-plugin/settings.gradle.kts
@@ -9,7 +9,10 @@ pluginManagement {
     includeBuild("../../build-settings-logic")
 
     repositories {
-        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
+        mavenCentral {
+            setUrl("https://cache-redirector.jetbrains.com/maven-central")
+            name = "MavenCentral-JBCache"
+        }
         maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2") {
             name = "GradlePluginPortal-JBCache"
         }
@@ -23,7 +26,10 @@ plugins {
 dependencyResolutionManagement {
     @Suppress("UnstableApiUsage")
     repositories {
-        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
+        mavenCentral {
+            setUrl("https://cache-redirector.jetbrains.com/maven-central")
+            name = "MavenCentral-JBCache"
+        }
         google { setUrl("https://cache-redirector.jetbrains.com/dl.google.com/dl/android/maven2") }
     }
 

--- a/dokka-runners/runner-cli/settings.gradle.kts
+++ b/dokka-runners/runner-cli/settings.gradle.kts
@@ -9,7 +9,10 @@ pluginManagement {
     includeBuild("../../build-settings-logic")
 
     repositories {
-        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
+        mavenCentral {
+            setUrl("https://cache-redirector.jetbrains.com/maven-central")
+            name = "MavenCentral-JBCache"
+        }
         maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2") {
             name = "GradlePluginPortal-JBCache"
         }
@@ -23,7 +26,10 @@ plugins {
 dependencyResolutionManagement {
     @Suppress("UnstableApiUsage")
     repositories {
-        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
+        mavenCentral {
+            setUrl("https://cache-redirector.jetbrains.com/maven-central")
+            name = "MavenCentral-JBCache"
+        }
     }
 
     versionCatalogs {

--- a/dokka-runners/runner-cli/settings.gradle.kts
+++ b/dokka-runners/runner-cli/settings.gradle.kts
@@ -9,8 +9,10 @@ pluginManagement {
     includeBuild("../../build-settings-logic")
 
     repositories {
-        mavenCentral()
-        gradlePluginPortal()
+        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
+        maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2") {
+            name = "GradlePluginPortal-JBCache"
+        }
     }
 }
 
@@ -21,8 +23,7 @@ plugins {
 dependencyResolutionManagement {
     @Suppress("UnstableApiUsage")
     repositories {
-        mavenCentral()
-        google()
+        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
     }
 
     versionCatalogs {

--- a/dokka-runners/runner-maven-plugin/settings.gradle.kts
+++ b/dokka-runners/runner-maven-plugin/settings.gradle.kts
@@ -9,8 +9,10 @@ pluginManagement {
     includeBuild("../../build-settings-logic")
 
     repositories {
-        mavenCentral()
-        gradlePluginPortal()
+        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
+        maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2") {
+            name = "GradlePluginPortal-JBCache"
+        }
     }
 }
 
@@ -21,7 +23,7 @@ plugins {
 dependencyResolutionManagement {
     @Suppress("UnstableApiUsage")
     repositories {
-        mavenCentral()
+        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
     }
 
     versionCatalogs {

--- a/dokka-runners/runner-maven-plugin/settings.gradle.kts
+++ b/dokka-runners/runner-maven-plugin/settings.gradle.kts
@@ -9,7 +9,10 @@ pluginManagement {
     includeBuild("../../build-settings-logic")
 
     repositories {
-        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
+        mavenCentral {
+            setUrl("https://cache-redirector.jetbrains.com/maven-central")
+            name = "MavenCentral-JBCache"
+        }
         maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2") {
             name = "GradlePluginPortal-JBCache"
         }
@@ -23,7 +26,10 @@ plugins {
 dependencyResolutionManagement {
     @Suppress("UnstableApiUsage")
     repositories {
-        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
+        mavenCentral {
+            setUrl("https://cache-redirector.jetbrains.com/maven-central")
+            name = "MavenCentral-JBCache"
+        }
     }
 
     versionCatalogs {

--- a/dokka-runners/runner-maven-plugin/settings.xml
+++ b/dokka-runners/runner-maven-plugin/settings.xml
@@ -7,13 +7,13 @@
             <pluginRepositories>
                 <pluginRepository>
                     <id>MavenCentral-JBCached</id>
-                    <url>https://cache-redirector.jetbrains.com/repo.maven.apache.org/maven2</url>
+                    <url>https://cache-redirector.jetbrains.com/maven-central</url>
                 </pluginRepository>
             </pluginRepositories>
             <repositories>
                 <repository>
                     <id>MavenCentral-JBCached</id>
-                    <url>https://cache-redirector.jetbrains.com/repo.maven.apache.org/maven2</url>
+                    <url>https://cache-redirector.jetbrains.com/maven-central</url>
                 </repository>
             </repositories>
         </profile>
@@ -21,7 +21,7 @@
     <mirrors>
         <mirror>
             <id>MavenCentral-JBCached</id>
-            <url>https://cache-redirector.jetbrains.com/repo.maven.apache.org/maven2</url>
+            <url>https://cache-redirector.jetbrains.com/maven-central</url>
             <mirrorOf>central</mirrorOf>
         </mirror>
     </mirrors>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,9 +9,7 @@ pluginManagement {
     includeBuild("build-settings-logic")
 
     repositories {
-        maven("https://cache-redirector.jetbrains.com/repo.maven.apache.org/maven2") {
-            name = "MavenCentral-JBCache"
-        }
+        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
         maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2") {
             name = "GradlePluginPortal-JBCache"
         }
@@ -21,25 +19,16 @@ pluginManagement {
 dependencyResolutionManagement {
     @Suppress("UnstableApiUsage")
     repositories {
-        maven("https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-ide") {
-            name = "KotlinIde-JBCache"
-        }
-        maven("https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-ide-plugin-dependencies") {
-            name = "KotlinIdePluginDependencies-JBCache"
-        }
+        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
+
+        maven("https://redirector.kotlinlang.org/maven/kotlin-ide")
+        maven("https://redirector.kotlinlang.org/maven/kotlin-ide-plugin-dependencies")
 
         maven("https://cache-redirector.jetbrains.com/intellij-repository/releases") {
             name = "IjRepository-JBCache"
         }
         maven("https://cache-redirector.jetbrains.com/intellij-third-party-dependencies") {
             name = "IjThirdParty-JBCache"
-        }
-
-        maven("https://cache-redirector.jetbrains.com/repo.maven.apache.org/maven2") {
-            name = "MavenCentral-JBCache"
-        }
-        maven("https://cache-redirector.jetbrains.com/dl.google.com.android.maven2") {
-            name = "Google-JBCache"
         }
 
         //region Declare the Node.js & Yarn download repositories

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,8 +27,12 @@ dependencyResolutionManagement {
             name = "MavenCentral-JBCache"
         }
 
-        maven("https://redirector.kotlinlang.org/maven/kotlin-ide")
-        maven("https://redirector.kotlinlang.org/maven/kotlin-ide-plugin-dependencies")
+        maven("https://redirector.kotlinlang.org/maven/kotlin-ide") {
+            name = "KotlinIde-KRedirector"
+        }
+        maven("https://redirector.kotlinlang.org/maven/kotlin-ide-plugin-dependencies") {
+            name = "KotlinIdePluginDependencies-KRedirector"
+        }
 
         maven("https://cache-redirector.jetbrains.com/intellij-repository/releases") {
             name = "IjRepository-JBCache"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,7 +9,10 @@ pluginManagement {
     includeBuild("build-settings-logic")
 
     repositories {
-        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
+        mavenCentral {
+            setUrl("https://cache-redirector.jetbrains.com/maven-central")
+            name = "MavenCentral-JBCache"
+        }
         maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2") {
             name = "GradlePluginPortal-JBCache"
         }
@@ -19,7 +22,10 @@ pluginManagement {
 dependencyResolutionManagement {
     @Suppress("UnstableApiUsage")
     repositories {
-        mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
+        mavenCentral {
+            setUrl("https://cache-redirector.jetbrains.com/maven-central")
+            name = "MavenCentral-JBCache"
+        }
 
         maven("https://redirector.kotlinlang.org/maven/kotlin-ide")
         maven("https://redirector.kotlinlang.org/maven/kotlin-ide-plugin-dependencies")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,18 +27,11 @@ dependencyResolutionManagement {
             name = "MavenCentral-JBCache"
         }
 
-        maven("https://redirector.kotlinlang.org/maven/kotlin-ide") {
-            name = "KotlinIde-KRedirector"
-        }
-        maven("https://redirector.kotlinlang.org/maven/kotlin-ide-plugin-dependencies") {
-            name = "KotlinIdePluginDependencies-KRedirector"
-        }
-
         maven("https://cache-redirector.jetbrains.com/intellij-repository/releases") {
             name = "IjRepository-JBCache"
         }
-        maven("https://cache-redirector.jetbrains.com/intellij-third-party-dependencies") {
-            name = "IjThirdParty-JBCache"
+        maven("https://cache-redirector.jetbrains.com/intellij-dependencies") {
+            name = "IjDependencies-JBCache"
         }
 
         //region Declare the Node.js & Yarn download repositories

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,7 +42,7 @@ dependencyResolutionManagement {
         exclusiveContent {
             forRepository {
                 ivy("https://cache-redirector.jetbrains.com/nodejs.org/dist/") {
-                    name = "Node Distributions at $url"
+                    name = "Nodejs-JBCache"
                     patternLayout { artifact("v[revision]/[artifact](-v[revision]-[classifier]).[ext]") }
                     metadataSources { artifact() }
                     content { includeModule("org.nodejs", "node") }
@@ -54,7 +54,7 @@ dependencyResolutionManagement {
         exclusiveContent {
             forRepository {
                 ivy("https://cache-redirector.jetbrains.com/github.com/yarnpkg/yarn/releases/download") {
-                    name = "Yarn Distributions at $url"
+                    name = "Yarn-JBCache"
                     patternLayout { artifact("v[revision]/[artifact](-v[revision]).[ext]") }
                     metadataSources { artifact() }
                     content { includeModule("com.yarnpkg", "yarn") }


### PR DESCRIPTION
Additionally, align cache redirector usages to be similar to kotlin.git usages