### PR TITLE
Update jackson to 2.15.3 which doesn't have known vulnerabilities

### DIFF
--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/TestedVersions.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/TestedVersions.kt
@@ -44,13 +44,9 @@ object TestedVersions {
             kotlinVersions = listOf("2.2.0", "2.1.21", "2.0.21"),
             androidGradlePluginVersions = listOf("8.3.0")
         ) + BuildVersions.permutations(
-            gradleVersions = listOf("7.4.2", *ifExhaustive("7.0")),
+            gradleVersions = listOf("7.6.3", *ifExhaustive("7.0")),
             kotlinVersions = listOf("1.7.20", "1.6.21", "1.5.31", "1.4.32"),
             androidGradlePluginVersions = listOf("7.2.0")
-        ) + BuildVersions.permutations(
-            gradleVersions = listOf("6.9", *ifExhaustive("6.1.1", "5.6.4")),
-            kotlinVersions = listOf("1.8.0", "1.7.0", "1.6.0", "1.5.0", "1.4.0"),
-            androidGradlePluginVersions = listOf("4.0.0", *ifExhaustive("3.6.3"))
         )
 
     // https://mvnrepository.com/artifact/org.jetbrains.kotlin-wrappers/kotlin-react

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,8 +40,8 @@ kotlinx-html = "0.9.1"
 jetbrains-markdown = "0.7.3"
 
 ## JSON
-jackson = "2.12.7" # jackson 2.13.X does not support kotlin language version 1.4, check before updating
-jacksonDatabind = "2.12.7.1" # fixes CVE-2022-42003
+# jackson 2.15.3 is the latest version, which works correctly with Kotlin API/Language 1.4 and Gradle 7.6.3+
+jackson = "2.15.3"
 
 ## Maven
 apacheMaven-core = "3.5.0"
@@ -136,7 +136,7 @@ jetbrains-markdown = { module = "org.jetbrains:markdown", version.ref = "jetbrai
 #### Jackson ####
 jackson-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 jackson-xml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml", version.ref = "jackson" }
-jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jacksonDatabind" }
+jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 
 #### Apache Maven ####
 apacheMaven-archiver = { module = "org.apache.maven:maven-archiver", version.ref = "apacheMaven-archiver" }


### PR DESCRIPTION
Fixes #4162 
Fixes #3194
Fixes #2572
Fixes #3657

Jackson 2.15.3 doesn't have known vulnerabilities (at the time this PR was created) and works fine for projects with Gradle 7.6.3+. Transitively from `jackson-dataformat-xml`, we now also have the `woodstox-core` dependency of version 6.5.1, which doesn't have vulnerabilities as well.

**So, strictly speaking, this PR drops support for Gradle 6.x.**

According to [Kotlin Gradle Plugin compatibility matrix](https://kotlinlang.org/docs/gradle-configure-project.html#apply-the-plugin), Gradle 7.6.3 is supported by KGP 2.1.0+ (earlier KGP versions support Gradle 6.x)

At the same time, DGPv2 will be enabled by default in Dokka 2.1.0, and according to [migration guide](https://kotlinlang.org/docs/dokka-migration.html#verify-supported-versions), it supports Gradle 7.6.x and Kotlin 1.9.x

WDYT?