### PR TITLE
Significantly improves the performance when working with `PackageList`

### DIFF
--- a/dokka-subprojects/plugin-all-modules-page/src/main/kotlin/org/jetbrains/dokka/allModulesPage/AllModulesPageGeneration.kt
+++ b/dokka-subprojects/plugin-all-modules-page/src/main/kotlin/org/jetbrains/dokka/allModulesPage/AllModulesPageGeneration.kt
@@ -6,6 +6,7 @@ package org.jetbrains.dokka.allModulesPage
 
 import org.jetbrains.dokka.CoreExtensions
 import org.jetbrains.dokka.Timer
+import org.jetbrains.dokka.base.resolvers.shared.PackageList
 import org.jetbrains.dokka.generation.Generation
 import org.jetbrains.dokka.pages.RootPageNode
 import org.jetbrains.dokka.plugability.DokkaContext
@@ -21,7 +22,7 @@ public class AllModulesPageGeneration(private val context: DokkaContext) : Gener
     private val allModulesPagePlugin by lazy { context.plugin<AllModulesPagePlugin>() }
     private val templatingPlugin by lazy { context.plugin<TemplatingPlugin>() }
 
-    override fun Timer.generate() {
+    override fun Timer.generate(): Unit = try {
         report("Processing submodules")
         val generationContext = processSubmodules()
 
@@ -42,6 +43,8 @@ public class AllModulesPageGeneration(private val context: DokkaContext) : Gener
 
         report("Running post-actions")
         runPostActions()
+    } finally {
+        PackageList.clearCache()
     }
 
     override val generationName: String = "index page for project"

--- a/dokka-subprojects/plugin-base/api/plugin-base.api
+++ b/dokka-subprojects/plugin-base/api/plugin-base.api
@@ -853,6 +853,7 @@ public final class org/jetbrains/dokka/base/resolvers/shared/PackageList {
 }
 
 public final class org/jetbrains/dokka/base/resolvers/shared/PackageList$Companion {
+	public final fun clearCache ()V
 	public final fun load (Ljava/net/URL;IZ)Lorg/jetbrains/dokka/base/resolvers/shared/PackageList;
 	public static synthetic fun load$default (Lorg/jetbrains/dokka/base/resolvers/shared/PackageList$Companion;Ljava/net/URL;IZILjava/lang/Object;)Lorg/jetbrains/dokka/base/resolvers/shared/PackageList;
 }

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/generation/SingleModuleGeneration.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/generation/SingleModuleGeneration.kt
@@ -10,6 +10,7 @@ import org.jetbrains.dokka.DokkaConfiguration
 import org.jetbrains.dokka.DokkaException
 import org.jetbrains.dokka.Timer
 import org.jetbrains.dokka.base.DokkaBase
+import org.jetbrains.dokka.base.resolvers.shared.PackageList
 import org.jetbrains.dokka.generation.Generation
 import org.jetbrains.dokka.generation.exitGenerationGracefully
 import org.jetbrains.dokka.model.DModule
@@ -23,7 +24,7 @@ import org.jetbrains.dokka.utilities.report
 
 public class SingleModuleGeneration(private val context: DokkaContext) : Generation {
 
-    override fun Timer.generate() {
+    override fun Timer.generate(): Unit = try {
         report("Validity check")
         validityCheck(context)
 
@@ -56,6 +57,8 @@ public class SingleModuleGeneration(private val context: DokkaContext) : Generat
         runPostActions()
 
         reportAfterRendering()
+    } finally {
+        PackageList.clearCache()
     }
 
     override val generationName: String = "documentation for ${context.configuration.moduleName}"


### PR DESCRIPTION
While writing documentation inside [cryptography-kotlin](https://github.com/whyoleg/cryptography-kotlin) and checking Dokka's output, I was a bit surprised that running the `dokkaGenerateModuleHtml` task for some module with **just four files took 55 seconds**.

The module in question: [cryptography-serialization/pem](https://github.com/whyoleg/cryptography-kotlin/tree/daedb820faa364eddb7c3ac4920df6b2ae17ad33/cryptography-serialization/pem/src/commonMain/kotlin)

After a small profiling session, I found out that there is **no CPU work or memory allocations** happening most of the time after the documentable model is created.
That's how I found out that the threads are mostly **just waiting** somewhere in the `PackageList` code.
That was strange, as there are just two external documentation links added: stdlib and kotlinx-io.
So looks like we do a lot of requests there?
I think so, sometimes, I think that I could even hit rate-limiting on kotlinlang.org, or something like this, because all package lists were resolved with `Failed to download package-list from ...` and the task finished super fast :)

Using local package lists solves the issue, and the same task is now executed in **9 seconds**.

So I decided, why not cache them inside Dokka during execution? Results:

* pem module:
  * before: 55 seconds
  * after: **7.4 seconds** (~7 times faster)
* total Dokka tasks execution time across the whole project (12 modules, 5 of them have just 1 class)
  * before: 354 seconds (longest per module: 53)
  * after: **94 seconds (longest per module: 15)** (~4 times faster)

I've additionally checked kotlinx-io (only `okio` has additional to the stdlib package list):

* bytestring module: 36.5 vs 10.8 seconds (~3.5 times faster)
* core module: 37.7 vs 8.2 (~4.5 times faster)
* okio module: 33.9 vs 4.5 (~7.5 times faster)

So, on average, the speed up is `4 * package lists count` file :)
And, as by default, Dokka configures external links to the kotlin stdlib, does this mean that Dokka will now be **4 times faster**?

> Note: those tests, of course, are not fully representative, because they should be run in better isolation and with more iterations, but still, it's not just several percent % change, it's **hundreds % change!**

Regarding the PR itself, feel free to suggest another way to clean up that cache. As we use `PackageList.load` also during multi-module generation (with files), we still go through the cache.