### PR TITLE
Fix parsing of `>` in code blocks

### DIFF
--- a/dokka-subprojects/plugin-base/src/test/kotlin/markdown/ParserTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/markdown/ParserTest.kt
@@ -18,7 +18,7 @@ import kotlin.test.assertTrue
 class ParserTest : KDocTest() {
 
     private fun parseMarkdownToDocNode(text: String) =
-        MarkdownParser( { null }, "").parseStringToDocNode(text)
+        MarkdownParser({ null }, "").parseStringToDocNode(text)
 
     @Test
     fun `Simple text`() {
@@ -715,7 +715,6 @@ class ParserTest : KDocTest() {
         executeTest(kdoc, expectedDocumentationNode)
     }
 
-    @Ignore //TODO: ATX_2 to ATX_6 and sometimes ATX_1 from jetbrains parser consumes white space. Need to handle it in their library
     @Test
     fun `All headers`() {
         val kdoc = """
@@ -901,7 +900,59 @@ class ParserTest : KDocTest() {
         executeTest(kdoc, expectedDocumentationNode)
     }
 
-    @Ignore //TODO: Again ATX_1 consumes white space
+    @Test
+    fun `Blockquote right after text`() {
+        val kdoc = """
+        | text
+        | > quote
+         """.trimMargin()
+
+        val expectedDocumentationNode = DocumentationNode(
+            listOf(
+                Description(
+                    CustomDocTag(
+                        listOf(
+                            P(listOf(Text("text"))),
+                            BlockQuote(listOf(P(listOf(Text("quote")))))
+                        ), name = MARKDOWN_ELEMENT_FILE_NAME
+                    )
+                )
+            )
+        )
+        executeTest(kdoc, expectedDocumentationNode)
+    }
+
+    @Test
+    fun `Blockquote right after text inside codeblock`() {
+        val kdoc = """
+        | ```md
+        | text
+        | > quote
+        | > quote
+        | ```
+         """.trimMargin()
+
+        val expectedDocumentationNode = DocumentationNode(
+            listOf(
+                Description(
+                    CustomDocTag(
+                        listOf(
+                            CodeBlock(
+                                listOf(
+                                    Text("text"), Br,
+                                    Text("> quote"), Br,
+                                    Text("> quote")
+                                ),
+                                params = mapOf("lang" to "md")
+                            ),
+                        ), name = MARKDOWN_ELEMENT_FILE_NAME
+                    )
+                )
+            )
+        )
+        executeTest(kdoc, expectedDocumentationNode)
+    }
+
     @Test
     fun `Blockquote nested with fancy text enhancement`() {
         val kdoc = """
@@ -928,7 +979,7 @@ class ParserTest : KDocTest() {
                                         listOf(
                                             Text("text "),
                                             B(listOf(Text("1"))),
-                                            Text("\ntext 2")
+                                            Text(" text 2")
                                         )
                                     ),
                                     BlockQuote(

--- a/dokka-subprojects/plugin-base/src/test/kotlin/markdown/ParserTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/markdown/ParserTest.kt
@@ -114,6 +114,39 @@ class ParserTest : KDocTest() {
     }
 
     @Test
+    fun `CodeBlock with angle brackets`() {
+        val kdoc = """
+        | Here is the code block:
+        | ```
+        | x > y
+        | and
+        | y < x
+        | ```
+        """.trimMargin()
+
+        val expectedDocumentationNode = DocumentationNode(
+            children = listOf(
+                Description(
+                    root = CustomDocTag(
+                        children = listOf(
+                            P(listOf(Text("Here is the code block:"))),
+                            CodeBlock(
+                                children = listOf(
+                                    Text("x > y"), Br,
+                                    Text("and"), Br,
+                                    Text("y < x")
+                                )
+                            )
+                        ),
+                        name = MARKDOWN_ELEMENT_FILE_NAME
+                    )
+                )
+            )
+        )
+        executeTest(kdoc, expectedDocumentationNode)
+    }
+
+    @Test
     fun `Multilined text`() {
         val kdoc = """
         | Text


### PR DESCRIPTION
Fixes #3775

Additionally, it could improve the performance (and memory pressure) of Markdown parsing a bit, as we don't create three `Regex`s anymore on each text processing

-----

Initially, I tested that code block and thought that the problem was inside `prism.js`, so we couldn't do anything.
But after additional checks, I was wrong, and the problem was inside our smart markdown parser, which had wrong regex replacements.
Specifically, `Regex(" >+ +")` was meant to replace only block quotes, like this one:
```
 > Blockquotes are very handy in email to emulate reply text.
 > This line is part of the same quote.
```
But in reality, it was replacing all `>` signs :)