### PR TITLE
Migrate publication to new dev/test maven repositories

### DIFF
--- a/build-logic/src/main/kotlin/dokkabuild.publish-base.gradle.kts
+++ b/build-logic/src/main/kotlin/dokkabuild.publish-base.gradle.kts
@@ -23,7 +23,7 @@ publishing {
         }
         maven {
             name = "spaceDev"
-            url = uri("https://maven.pkg.jetbrains.space/kotlin/p/dokka/dev")
+            url = uri("https://packages.jetbrains.team/maven/p/kt/dokka-dev")
             credentials {
                 username = System.getenv("DOKKA_SPACE_PACKAGES_USER")
                 password = System.getenv("DOKKA_SPACE_PACKAGES_SECRET")
@@ -31,7 +31,7 @@ publishing {
         }
         maven {
             name = "spaceTest"
-            url = uri("https://maven.pkg.jetbrains.space/kotlin/p/dokka/test")
+            url = uri("https://packages.jetbrains.team/maven/p/kt/dokka-test")
             credentials {
                 username = System.getenv("DOKKA_SPACE_PACKAGES_USER")
                 password = System.getenv("DOKKA_SPACE_PACKAGES_SECRET")

--- a/build-logic/src/main/kotlin/dokkabuild.publish-base.gradle.kts
+++ b/build-logic/src/main/kotlin/dokkabuild.publish-base.gradle.kts
@@ -2,8 +2,6 @@
  * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-import java.net.URI
-
 plugins {
     id("dokkabuild.base")
     `maven-publish`
@@ -13,14 +11,6 @@ plugins {
 
 publishing {
     repositories {
-        maven {
-            name = "mavenCentral"
-            url = mavenCentralRepositoryUri()
-            credentials {
-                username = System.getenv("DOKKA_SONATYPE_USER")
-                password = System.getenv("DOKKA_SONATYPE_PASSWORD")
-            }
-        }
         maven {
             name = "spaceDev"
             url = uri("https://packages.jetbrains.team/maven/p/kt/dokka-dev")
@@ -67,22 +57,6 @@ publishing {
                 url.convention("https://github.com/Kotlin/dokka")
             }
         }
-    }
-}
-
-/**
- * Due to Gradle running publishing tasks in parallel, multiple staging repositories
- * can be created within a couple of seconds with all artifact files scattered throughout them.
- *
- * While Gradle's parallelism can be disabled, the simplest and most reliable option is
- * to just publish to a pre-defined staging repository.
- */
-fun mavenCentralRepositoryUri(): URI {
-    val repositoryId: String? = System.getenv("DOKKA_MVN_CENTRAL_REPOSITORY_ID")
-    return if (repositoryId.isNullOrBlank()) {
-        URI("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
-    } else {
-        URI("https://oss.sonatype.org/service/local/staging/deployByRepositoryId/$repositoryId")
     }
 }
 


### PR DESCRIPTION
The old ones (`maven.pkg.jetbrains.space`) are deprecated and will be removed in the future.

Dokka dev/test versions are available via redirector, and soon will also be migrated to redirect to the new maven repositories:
- https://redirector.kotlinlang.org/maven/dokka-dev - for dev builds
- https://redirector.kotlinlang.org/maven/dokka-test - for test builds