### PR TITLE
Update Analysis API to 2.3.0-dev-5493

### DIFF
--- a/dokka-subprojects/plugin-base/src/test/kotlin/markdown/LinkTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/markdown/LinkTest.kt
@@ -930,11 +930,11 @@ class LinkTest : BaseAbstractTest() {
             |interface MyListWithNumber : List<Number>
             |
             |/**
-            | * 1 [List.foo] is resolved
-            | * 2 [MutableList.foo] is unresolved
-            | * 3 [MyListWithT.foo] is unresolved
-            | * 4 [MyListWithTNumberBound.foo] is unresolved in K2
-            | * 5 [MyListWithNumber.foo] is unresolved in K2
+            | * 1 [List.foo] 
+            | * 2 [MutableList.foo] is resolved only in K2, but unresolved in K1
+            | * 3 [MyListWithT.foo] is resolved only in K2, but unresolved in K1
+            | * 4 [MyListWithTNumberBound.foo]
+            | * 5 [MyListWithNumber.foo] 
             | */
             |fun usage() {}
         """.trimMargin(),
@@ -952,7 +952,11 @@ class LinkTest : BaseAbstractTest() {
                 )
                 assertEquals(
                     listOf(
-                        "List.foo" to fooDRI
+                        "List.foo" to fooDRI,
+                        "MutableList.foo" to fooDRI,
+                        "MyListWithT.foo" to fooDRI,
+                        "MyListWithTNumberBound.foo" to fooDRI,
+                        "MyListWithNumber.foo" to fooDRI,
                     ), module.getAllLinkDRIFrom("usage")
                 )
             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ javaDiffUtils = "4.12"
 
 ## Analysis
 kotlin-compiler = "2.2.0-dev-8822"
-kotlin-compiler-k2 = "2.3.0-dev-4019"
+kotlin-compiler-k2 = "2.3.0-dev-5493"
 
 # MUST match the version of the intellij platform used in the kotlin compiler,
 # otherwise this will lead to different versions of psi API and implementations


### PR DESCRIPTION
Fixes partially https://youtrack.jetbrains.com/issue/KT-76607: #3555
Also, 
 - https://youtrack.jetbrains.com/issue/KT-80178/Incorrect-modality-for-an-abstract-interface-function-with-a-redundant-open-modifier
  - https://youtrack.jetbrains.com/issue/KT-80234/Incorrect-value-of-isActual-for-the-implicitly-actual-constructor-of-annotation-class

