### PR TITLE
Handle `InvocationTargetException` exception explicitly in `DokkaBootstrap`

### DIFF
--- a/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/dokkaBootstrapFactory.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/classicMain/kotlin/dokkaBootstrapFactory.kt
@@ -5,15 +5,15 @@
 package org.jetbrains.dokka.gradle
 
 import org.gradle.api.artifacts.Configuration
-import org.jetbrains.dokka.gradle.internal.DokkaBootstrap
 import org.jetbrains.dokka.DokkaBootstrap
+import org.jetbrains.dokka.gradle.internal.DokkaBootstrapProxy
 import kotlin.reflect.KClass
 
 
 @Deprecated(DOKKA_V1_DEPRECATION_MESSAGE)
 @Suppress("DeprecatedCallableAddReplaceWith")
 fun DokkaBootstrap(configuration: Configuration, bootstrapClass: KClass<out DokkaBootstrap>): DokkaBootstrap {
-    return DokkaBootstrap(
+    return DokkaBootstrapProxy(
         classpath = configuration.resolve(),
         bootstrapClass = bootstrapClass,
     )

--- a/dokka-runners/dokka-gradle-plugin/src/test/kotlin/internal/DokkaBootstrapProxyTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/test/kotlin/internal/DokkaBootstrapProxyTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014-2025 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package org.jetbrains.dokka.gradle.internal
+
+import org.jetbrains.dokka.DokkaBootstrap
+import java.util.function.BiConsumer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+// should be top-level
+private class FailingTestBootstrap : DokkaBootstrap {
+    override fun configure(serializedConfigurationJSON: String, logger: BiConsumer<String, String>) {
+        throw TestException("Test Exception Message: configure", Exception("Cause Exception Message: configure"))
+    }
+
+    override fun generate() {
+        throw TestException("Test Exception Message: generate", Exception("Cause Exception Message: generate"))
+    }
+}
+
+private class TestException(message: String, cause: Throwable?) : Exception(message, cause)
+
+class DokkaBootstrapProxyTest {
+    @Test
+    fun `exception thrown in DokkaBootstrap is not wrapped inside InvocationTargetException`() {
+        val proxy = DokkaBootstrapProxy(
+            FailingTestBootstrap::class.java.classLoader,
+            FailingTestBootstrap::class
+        )
+
+        assertFailsWith<TestException> {
+            proxy.configure("") { _, _ -> }
+        }.also { exception ->
+            assertEquals("Test Exception Message: configure", exception.message)
+            assertEquals("Cause Exception Message: configure", exception.cause?.message)
+        }
+        assertFailsWith<TestException> {
+            proxy.generate()
+        }.also { exception ->
+            assertEquals("Test Exception Message: generate", exception.message)
+            assertEquals("Cause Exception Message: generate", exception.cause?.message)
+        }
+    }
+}

--- a/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/DokkaGeneratorFailureTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/DokkaGeneratorFailureTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package org.jetbrains.dokka.gradle
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.string.shouldContain
+import org.jetbrains.dokka.gradle.internal.DokkaConstants.DOKKA_VERSION
+import org.jetbrains.dokka.gradle.utils.*
+
+class DokkaGeneratorFailureTest : FunSpec({
+    context("DokkaGenerator failure:") {
+        val project = gradleKtsProjectTest("dokka-generator-failure") {
+            buildGradleKts = """
+                |plugins {
+                |    kotlin("jvm") version embeddedKotlinVersion
+                |    id("org.jetbrains.dokka") version "$DOKKA_VERSION"
+                |}
+                |
+                |dokka {
+                |  dokkaSourceSets.configureEach {
+                |    suppress = false // to enable documentation for `test` source set
+                |    sourceRoots.from("src/shared/kotlin") // causes an error in Dokka generator checker
+                |  }
+                |}
+                |
+                """.trimMargin()
+
+            createKotlinFile("src/main/kotlin/Main.kt", "class Main")
+            createKotlinFile("src/test/kotlin/Test.kt", "class Test")
+            createKotlinFile("src/shared/kotlin/Shared.kt", "class Shared")
+        }
+
+        test("expect failure message from checkers to be shown by default") {
+            project.runner
+                .addArguments(
+                    ":dokkaGenerateModuleHtml",
+                    "--rerun",
+                )
+                .buildAndFail {
+                    output shouldContain "Pre-generation validity check failed"
+                    output shouldContain "Source sets 'java' and 'javaTest' have the common source roots"
+                }
+
+            project.runner
+                .addArguments(
+                    ":dokkaGeneratePublicationHtml",
+                    "--rerun",
+                )
+                .buildAndFail {
+                    output shouldContain "Pre-generation validity check failed"
+                    output shouldContain "Source sets 'java' and 'javaTest' have the common source roots"
+                }
+        }
+    }
+})


### PR DESCRIPTION
Handle `InvocationTargetException` exception explicitly in `DokkaBootstrap` to show better error messages in DGPv2, as Gradle will not show the cause of `InvocationTargetException` without `--stacktrace` flag

Fixes #4235