### PR TITLE
Don't add Android's `bootClasspath` to ALL source-sets in case android plugin is applied in KMP project

### DIFF
--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/adapters/AndroidAdapter.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/adapters/AndroidAdapter.kt
@@ -56,11 +56,6 @@ abstract class AndroidAdapter @Inject constructor(
         val androidExt = AndroidExtensionWrapper(project) ?: return
 
         dokkaExtension.dokkaSourceSets.configureEach {
-
-            classpath.from(
-                androidExt.bootClasspath()
-            )
-
             classpath.from(
                 analysisPlatform.map { analysisPlatform ->
                     when (analysisPlatform) {
@@ -186,6 +181,7 @@ private object AndroidClasspathCollector {
     ): FileCollection {
         val compilationClasspath = objects.fileCollection()
 
+        compilationClasspath.from(androidExt.bootClasspath())
         compilationClasspath.from({ androidExt.variantsCompileClasspath() })
 
         return compilationClasspath


### PR DESCRIPTION
This is not required, but because of this, even `commonMain` in a multiplatform project that has the `android` plugin applied will have `android.jar` in the classpath, and so it could theoretically resolve to declarations from there.
(spotted while writing a test for https://github.com/Kotlin/dokka/pull/4258)

@adam-enko, do you have any suggestions on how to test this?