### PR TITLE
Replace createTempDir with createTempDirectory

### DIFF
--- a/dokka-subprojects/analysis-kotlin-api/src/testFixtures/kotlin/org/jetbrains/dokka/analysis/test/api/util/FileUtils.kt
+++ b/dokka-subprojects/analysis-kotlin-api/src/testFixtures/kotlin/org/jetbrains/dokka/analysis/test/api/util/FileUtils.kt
@@ -7,6 +7,8 @@ package org.jetbrains.dokka.analysis.test.api.util
 import org.jetbrains.dokka.utilities.DokkaLogger
 import java.io.File
 import java.io.IOException
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.createTempDirectory
 
 /**
  * Converts a file path (like `org/jetbrains/dokka/test/File.kt`) to a fully qualified
@@ -27,8 +29,8 @@ internal fun filePathToPackageName(srcRelativeFilePath: String): String {
  * @throws IOException if the requested temporary directory could not be created or deleted once used.
  */
 internal fun <T> withTempDirectory(logger: DokkaLogger? = null, block: (tempDirectory: File) -> T): T {
-    @Suppress("DEPRECATION") // TODO migrate to kotlin.io.path.createTempDirectory with languageVersion >= 1.5
-    val tempDir = createTempDir()
+    @OptIn(ExperimentalPathApi::class)
+    val tempDir = createTempDirectory().toFile()
     try {
         logger?.debug("Created temporary directory $tempDir")
         return block(tempDir)

--- a/dokka-subprojects/analysis-kotlin-api/src/testFixtures/kotlin/org/jetbrains/dokka/analysis/test/api/util/FileUtils.kt
+++ b/dokka-subprojects/analysis-kotlin-api/src/testFixtures/kotlin/org/jetbrains/dokka/analysis/test/api/util/FileUtils.kt
@@ -7,8 +7,7 @@ package org.jetbrains.dokka.analysis.test.api.util
 import org.jetbrains.dokka.utilities.DokkaLogger
 import java.io.File
 import java.io.IOException
-import kotlin.io.path.ExperimentalPathApi
-import kotlin.io.path.createTempDirectory
+import java.nio.file.Files
 
 /**
  * Converts a file path (like `org/jetbrains/dokka/test/File.kt`) to a fully qualified
@@ -29,8 +28,7 @@ internal fun filePathToPackageName(srcRelativeFilePath: String): String {
  * @throws IOException if the requested temporary directory could not be created or deleted once used.
  */
 internal fun <T> withTempDirectory(logger: DokkaLogger? = null, block: (tempDirectory: File) -> T): T {
-    @OptIn(ExperimentalPathApi::class)
-    val tempDir = createTempDirectory().toFile()
+    val tempDir = Files.createTempDirectory("dokka-test").toFile()
     try {
         logger?.debug("Created temporary directory $tempDir")
         return block(tempDir)

--- a/dokka-subprojects/core-test-api/src/main/kotlin/org/jetbrains/dokka/testApi/testRunner/TestRunner.kt
+++ b/dokka-subprojects/core-test-api/src/main/kotlin/org/jetbrains/dokka/testApi/testRunner/TestRunner.kt
@@ -21,6 +21,7 @@ import java.nio.file.Files
 import java.nio.file.InvalidPathException
 import java.nio.file.Path
 import java.nio.file.Paths
+import kotlin.io.path.ExperimentalPathApi
 
 // TODO: take dokka configuration from file
 public abstract class AbstractTest<M : TestMethods, T : TestBuilder<M>, D : DokkaTestGenerator<M>>(
@@ -170,8 +171,8 @@ public abstract class AbstractTest<M : TestMethods, T : TestBuilder<M>, D : Dokk
         Files.write(file, content.toByteArray(charset))
     }
 
-    @Suppress("DEPRECATION") // TODO migrate to kotlin.io.path.createTempDirectory with languageVersion >= 1.5
-    private fun createTempDir(): File = kotlin.io.createTempDir()
+    @OptIn(ExperimentalPathApi::class)
+    private fun createTempDir(): File = kotlin.io.path.createTempDirectory().toFile()
 
     protected fun dokkaConfiguration(block: TestDokkaConfigurationBuilder.() -> Unit): DokkaConfigurationImpl =
         testApi.testRunner.dokkaConfiguration(block)

--- a/dokka-subprojects/core-test-api/src/main/kotlin/org/jetbrains/dokka/testApi/testRunner/TestRunner.kt
+++ b/dokka-subprojects/core-test-api/src/main/kotlin/org/jetbrains/dokka/testApi/testRunner/TestRunner.kt
@@ -21,7 +21,6 @@ import java.nio.file.Files
 import java.nio.file.InvalidPathException
 import java.nio.file.Path
 import java.nio.file.Paths
-import kotlin.io.path.ExperimentalPathApi
 
 // TODO: take dokka configuration from file
 public abstract class AbstractTest<M : TestMethods, T : TestBuilder<M>, D : DokkaTestGenerator<M>>(
@@ -171,8 +170,7 @@ public abstract class AbstractTest<M : TestMethods, T : TestBuilder<M>, D : Dokk
         Files.write(file, content.toByteArray(charset))
     }
 
-    @OptIn(ExperimentalPathApi::class)
-    private fun createTempDir(): File = kotlin.io.path.createTempDirectory().toFile()
+    private fun createTempDir(): File = Files.createTempDirectory("dokka-test").toFile()
 
     protected fun dokkaConfiguration(block: TestDokkaConfigurationBuilder.() -> Unit): DokkaConfigurationImpl =
         testApi.testRunner.dokkaConfiguration(block)


### PR DESCRIPTION
KUP start failing once `createTempDir` was deprecated with error (https://github.com/JetBrains/kotlin/commit/852ea9f86e76dc1442cdab05a222a2e945e7ea21).

