### PR TITLE
Set `finalizeCoroutines` back to `true` and setup a test for metaspace leaks with DGPv2

### DIFF
--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaBasePlugin.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaBasePlugin.kt
@@ -170,7 +170,7 @@ constructor(
             enabled.convention(true)
             cacheRoot.convention(dokkaExtension.dokkaCacheDirectory)
             failOnWarning.convention(false)
-            finalizeCoroutines.convention(false)
+            finalizeCoroutines.convention(true)
             moduleName.convention(dokkaExtension.moduleName)
             moduleVersion.convention(dokkaExtension.moduleVersion)
             offlineMode.convention(false)

--- a/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/MemoryStressTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/MemoryStressTest.kt
@@ -64,6 +64,7 @@ private fun setupProject(
                 |  dokkaGeneratorIsolation.set(ProcessIsolation {
                 |      maxHeapSize.set("1g")
                 |      jvmArgs.add("-XX:MaxMetaspaceSize=$metaspaceMemory") // limit metaspace
+                |      jvmArgs.add("-XX:SoftRefLRUPolicyMSPerMB=10")
                 |  })
                 |}
                 |

--- a/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/MemoryStressTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/MemoryStressTest.kt
@@ -9,8 +9,8 @@ import org.jetbrains.dokka.gradle.utils.*
 import org.jetbrains.dokka.gradle.utils.projects.defaultKgpTestVersion
 
 class MemoryStressTest : FunSpec({
-    context("when subprojects have 10 modules and uses single worker") {
-        val project = setupProject(10)
+    context("when subprojects have 50 modules and uses single worker") {
+        val project = setupProject(50, "500m")
 
         test("generate HTML publication") {
             project.runner
@@ -31,7 +31,7 @@ class MemoryStressTest : FunSpec({
 
 private fun setupProject(
     numberOfProjects: Int,
-    metaspaceMemory: String = "500m"
+    metaspaceMemory: String
 ): GradleProjectTest = gradleKtsProjectTest("MemoryStressTest-$numberOfProjects") {
     val projectNames = List(numberOfProjects) { "subproject_$it" }
     settingsGradleKts += projectNames.joinToString("\n") { """include(":$it")""" }

--- a/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/MemoryStressTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/MemoryStressTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+package org.jetbrains.dokka.gradle
+
+import io.kotest.core.spec.style.FunSpec
+import org.jetbrains.dokka.gradle.internal.DokkaConstants
+import org.jetbrains.dokka.gradle.utils.*
+import org.jetbrains.dokka.gradle.utils.projects.defaultKgpTestVersion
+
+class MemoryStressTest : FunSpec({
+    context("when subprojects have 10 modules and uses single worker") {
+        val project = setupProject(10)
+
+        test("generate HTML publication") {
+            project.runner
+                .addArguments(
+                    ":dokkaGenerate",
+                    "--rerun-tasks",
+                    "--stacktrace",
+                    "--no-parallel",
+                    "--max-workers=1" // reuse single worker all the time to reproduce the issue
+                )
+                .forwardOutput()
+                .build {
+                    // ensure build completed
+                }
+        }
+    }
+})
+
+private fun setupProject(
+    numberOfProjects: Int,
+    metaspaceMemory: String = "500m"
+): GradleProjectTest = gradleKtsProjectTest("MemoryStressTest-$numberOfProjects") {
+    val projectNames = List(numberOfProjects) { "subproject_$it" }
+    settingsGradleKts += projectNames.joinToString("\n") { """include(":$it")""" }
+
+    buildGradleKts = """
+        |plugins {
+        |  // Must apply KGP in the root project ensure consistent classpath, 
+        |  // preventing issues like https://github.com/gradle/gradle/issues/17559 and https://github.com/gradle/gradle/issues/27218
+        |  kotlin("jvm") version "$defaultKgpTestVersion" apply false
+        |  id("org.jetbrains.dokka") version "${DokkaConstants.DOKKA_VERSION}"
+        |}
+        |
+        """.trimMargin()
+
+    buildGradleKts += projectNames.joinToString(
+        prefix = "dependencies {\n",
+        separator = "\n",
+        postfix = "\n}"
+    ) { """  dokka(project(":$it"))""" }
+
+    projectNames.forEach { projectName ->
+        dir(projectName) {
+            buildGradleKts = """
+                |plugins {
+                |  kotlin("jvm") version "$defaultKgpTestVersion"
+                |  id("org.jetbrains.dokka") version "${DokkaConstants.DOKKA_VERSION}"
+                |}
+                |
+                |dokka {
+                |  dokkaGeneratorIsolation.set(ProcessIsolation {
+                |      maxHeapSize.set("1g")
+                |      jvmArgs.add("-XX:MaxMetaspaceSize=$metaspaceMemory") // limit metaspace
+                |  })
+                |}
+                |
+                """.trimMargin()
+
+            createKotlinFile(
+                "src/main/kotlin/Hello.kt",
+                """
+                |package com.project.hello.${projectName}
+                |
+                |/** The Hello class */
+                |class Hello {
+                |    /** prints `Hello` to the console */  
+                |    fun sayHello() = println("Hello")
+                |}
+                |
+                """.trimMargin()
+            )
+        }
+    }
+}


### PR DESCRIPTION
Looks like we have an issue with metaspace memory, again...
But now, it's somewhere in workers' usage.

Reproduced with both 2.2 and 2.1. Not reproduced in 2.0.
I would say the cause could be #4182. Investigating.

New test added reproduces the issue locally - OOM fails after ±6 project generation:

```
> Task :subproject_0:dokkaGenerateModuleHtml
> Task :subproject_1:dokkaGenerateModuleHtml
> Task :subproject_2:dokkaGenerateModuleHtml
> Task :subproject_3:dokkaGenerateModuleHtml
> Task :subproject_4:dokkaGenerateModuleHtml
> Task :subproject_5:dokkaGenerateModuleHtml
> Task :subproject_6:dokkaGenerateModuleHtml

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "DefaultDispatcher-worker-1"
> Task :subproject_7:dokkaGenerateModuleHtml
Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "RMI TCP Connection(idle)"
Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "RMI TCP Connection(idle)"
Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "RMI TCP Connection(idle)"
```

After that, the project couldn't even recover, as the worker failed with OOM, and just stuck...

The reproducer is super simple: have N projects with a **single** worker reused all the time.