### PR TITLE
Do not filter out accessors of synthetic properties

### DIFF
--- a/dokka-integration-tests/gradle/projects/it-android-kotlin-jvm-builtin/expectedData/html/it-android/it.android/-integration-test-activity/index.html
+++ b/dokka-integration-tests/gradle/projects/it-android-kotlin-jvm-builtin/expectedData/html/it-android/it.android/-integration-test-activity/index.html
@@ -2342,6 +2342,216 @@
               </div>
             </div>
           </div>
+<a data-name="-2108225789%2FFunctions%2F1404203640" anchor-label="getActionBar" id="-2108225789%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-2108225789%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Action</span><wbr></wbr><span><span>Bar</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-2108225789%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-2108225789%2FFunctions%2F1404203640"><span class="token function">getActionBar</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/app/ActionBar.html">ActionBar</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1526237776%2FFunctions%2F1404203640" anchor-label="getApplication" id="1526237776%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1526237776%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span><span>Application</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1526237776%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#1526237776%2FFunctions%2F1404203640"><span class="token function">getApplication</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/app/Application.html">Application</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="720574270%2FFunctions%2F1404203640" anchor-label="getApplicationContext" id="720574270%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#720574270%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Application</span><wbr></wbr><span><span>Context</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="720574270%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#720574270%2FFunctions%2F1404203640"><span class="token function">getApplicationContext</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/Context.html">Context</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="875309695%2FFunctions%2F1404203640" anchor-label="getApplicationInfo" id="875309695%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#875309695%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Application</span><wbr></wbr><span><span>Info</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="875309695%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#875309695%2FFunctions%2F1404203640"><span class="token function">getApplicationInfo</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/pm/ApplicationInfo.html">ApplicationInfo</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1028304091%2FFunctions%2F1404203640" anchor-label="getAssets" id="-1028304091%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1028304091%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span><span>Assets</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1028304091%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1028304091%2FFunctions%2F1404203640"><span class="token function">getAssets</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/res/AssetManager.html">AssetManager</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="745115299%2FFunctions%2F1404203640" anchor-label="getAttributionSource" id="745115299%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#745115299%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Attribution</span><wbr></wbr><span><span>Source</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="745115299%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#745115299%2FFunctions%2F1404203640"><span class="token function">getAttributionSource</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/AttributionSource.html">AttributionSource</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-2059689374%2FFunctions%2F1404203640" anchor-label="getAttributionTag" id="-2059689374%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-2059689374%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Attribution</span><wbr></wbr><span><span>Tag</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-2059689374%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-2059689374%2FFunctions%2F1404203640"><span class="token function">getAttributionTag</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1836627711%2FFunctions%2F1404203640" anchor-label="getBaseContext" id="1836627711%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1836627711%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Base</span><wbr></wbr><span><span>Context</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1836627711%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1836627711%2FFunctions%2F1404203640"><span class="token function">getBaseContext</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/Context.html">Context</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-803358382%2FFunctions%2F1404203640" anchor-label="getCacheDir" id="-803358382%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-803358382%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Cache</span><wbr></wbr><span><span>Dir</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-803358382%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-803358382%2FFunctions%2F1404203640"><span class="token function">getCacheDir</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-2093832307%2FFunctions%2F1404203640" anchor-label="getCallingActivity" id="-2093832307%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-2093832307%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Calling</span><wbr></wbr><span><span>Activity</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-2093832307%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-2093832307%2FFunctions%2F1404203640"><span class="token function">getCallingActivity</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/ComponentName.html">ComponentName</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1745389992%2FFunctions%2F1404203640" anchor-label="getCallingPackage" id="-1745389992%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1745389992%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Calling</span><wbr></wbr><span><span>Package</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1745389992%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1745389992%2FFunctions%2F1404203640"><span class="token function">getCallingPackage</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1601610448%2FFunctions%2F1404203640" anchor-label="getChangingConfigurations" id="-1601610448%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1601610448%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Changing</span><wbr></wbr><span><span>Configurations</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1601610448%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1601610448%2FFunctions%2F1404203640"><span class="token function">getChangingConfigurations</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1242041746%2FFunctions%2F1404203640" anchor-label="getClassLoader" id="1242041746%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1242041746%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Class</span><wbr></wbr><span><span>Loader</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1242041746%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1242041746%2FFunctions%2F1404203640"><span class="token function">getClassLoader</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/ClassLoader.html">ClassLoader</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1138511077%2FFunctions%2F1404203640" anchor-label="getCodeCacheDir" id="1138511077%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1138511077%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Code</span><wbr></wbr><span>Cache</span><wbr></wbr><span><span>Dir</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1138511077%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1138511077%2FFunctions%2F1404203640"><span class="token function">getCodeCacheDir</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="1123824824%2FFunctions%2F1404203640" anchor-label="getColor" id="1123824824%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
           <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
             <div class="main-subrow keyValue ">
@@ -2372,6 +2582,81 @@
               </div>
             </div>
           </div>
+<a data-name="-1710268232%2FFunctions%2F1404203640" anchor-label="getComponentName" id="-1710268232%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1710268232%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Component</span><wbr></wbr><span><span>Name</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1710268232%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1710268232%2FFunctions%2F1404203640"><span class="token function">getComponentName</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/ComponentName.html">ComponentName</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1924753378%2FFunctions%2F1404203640" anchor-label="getContentResolver" id="-1924753378%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1924753378%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Content</span><wbr></wbr><span><span>Resolver</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1924753378%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1924753378%2FFunctions%2F1404203640"><span class="token function">getContentResolver</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/ContentResolver.html">ContentResolver</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="261968391%2FFunctions%2F1404203640" anchor-label="getContentScene" id="261968391%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#261968391%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Content</span><wbr></wbr><span><span>Scene</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="261968391%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#261968391%2FFunctions%2F1404203640"><span class="token function">getContentScene</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/transition/Scene.html">Scene</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1914863227%2FFunctions%2F1404203640" anchor-label="getContentTransitionManager" id="1914863227%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1914863227%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Content</span><wbr></wbr><span>Transition</span><wbr></wbr><span><span>Manager</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1914863227%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1914863227%2FFunctions%2F1404203640"><span class="token function">getContentTransitionManager</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/transition/TransitionManager.html">TransitionManager</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1699869637%2FFunctions%2F1404203640" anchor-label="getCurrentFocus" id="-1699869637%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1699869637%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Current</span><wbr></wbr><span><span>Focus</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1699869637%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1699869637%2FFunctions%2F1404203640"><span class="token function">getCurrentFocus</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/view/View.html">View</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="1055464536%2FFunctions%2F1404203640" anchor-label="getDatabasePath" id="1055464536%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
           <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
             <div class="main-subrow keyValue ">
@@ -2383,6 +2668,36 @@
               <div>
                 <div class="title">
                   <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1055464536%2FFunctions%2F1404203640"><span class="token function">getDatabasePath</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">name<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></span></span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="666732474%2FFunctions%2F1404203640" anchor-label="getDataDir" id="666732474%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#666732474%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Data</span><wbr></wbr><span><span>Dir</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="666732474%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#666732474%2FFunctions%2F1404203640"><span class="token function">getDataDir</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1783008893%2FFunctions%2F1404203640" anchor-label="getDelegate" id="1783008893%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1783008893%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span><span>Delegate</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1783008893%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1783008893%2FFunctions%2F1404203640"><span class="token function">getDelegate</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/appcompat/app/AppCompatDelegate.html">AppCompatDelegate</a></div></div></div>
                 </div>
               </div>
             </div>
@@ -2402,6 +2717,21 @@
               </div>
             </div>
           </div>
+<a data-name="488073307%2FFunctions%2F1404203640" anchor-label="getDisplay" id="488073307%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#488073307%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span><span>Display</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="488073307%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#488073307%2FFunctions%2F1404203640"><span class="token function">getDisplay</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/view/Display.html">Display</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="-816782443%2FFunctions%2F1404203640" anchor-label="getDrawable" id="-816782443%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
           <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
             <div class="main-subrow keyValue ">
@@ -2413,6 +2743,51 @@
               <div>
                 <div class="title">
                   <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#-816782443%2FFunctions%2F1404203640"><span class="token function">getDrawable</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">id<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/graphics/drawable/Drawable.html">Drawable</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-921690152%2FFunctions%2F1404203640" anchor-label="getDrawerToggleDelegate" id="-921690152%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-921690152%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Drawer</span><wbr></wbr><span>Toggle</span><wbr></wbr><span><span>Delegate</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-921690152%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-921690152%2FFunctions%2F1404203640"><span class="token function">getDrawerToggleDelegate</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/appcompat/app/ActionBarDrawerToggle.Delegate.html">ActionBarDrawerToggle.Delegate</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="544398023%2FFunctions%2F1404203640" anchor-label="getExternalCacheDir" id="544398023%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#544398023%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>External</span><wbr></wbr><span>Cache</span><wbr></wbr><span><span>Dir</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="544398023%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#544398023%2FFunctions%2F1404203640"><span class="token function">getExternalCacheDir</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1262724320%2FFunctions%2F1404203640" anchor-label="getExternalCacheDirs" id="1262724320%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1262724320%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>External</span><wbr></wbr><span>Cache</span><wbr></wbr><span><span>Dirs</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1262724320%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1262724320%2FFunctions%2F1404203640"><span class="token function">getExternalCacheDirs</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-array/index.html">Array</a><span class="token operator">&lt;</span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a><span class="token operator">&gt;</span></div></div></div>
                 </div>
               </div>
             </div>
@@ -2447,6 +2822,21 @@
               </div>
             </div>
           </div>
+<a data-name="1078368190%2FFunctions%2F1404203640" anchor-label="getExternalMediaDirs" id="1078368190%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1078368190%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>External</span><wbr></wbr><span>Media</span><wbr></wbr><span><span>Dirs</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1078368190%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1078368190%2FFunctions%2F1404203640"><span class="token function">getExternalMediaDirs</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-array/index.html">Array</a><span class="token operator">&lt;</span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a><span class="token operator">&gt;</span></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="2147131388%2FFunctions%2F1404203640" anchor-label="getExtraData" id="2147131388%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
           <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
             <div class="main-subrow keyValue ">
@@ -2458,6 +2848,21 @@
               <div>
                 <div class="title">
                   <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><span class="token operator">&lt;</span><a href="index.html#2147131388%2FFunctions%2F1404203640">T</a><span class="token operator"> : </span><a href="https://developer.android.com/reference/kotlin/androidx/core/app/ComponentActivity.ExtraData.html">ComponentActivity.ExtraData</a><span class="token operator">&gt; </span><a href="index.html#2147131388%2FFunctions%2F1404203640"><span class="token function">getExtraData</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">extraDataClass<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/Class.html">Class</a><span class="token operator">&lt;</span><a href="index.html#2147131388%2FFunctions%2F1404203640">T</a><span class="token operator">&gt;</span></span></span><span class="token punctuation">)</span><span class="token operator">: </span><a href="index.html#2147131388%2FFunctions%2F1404203640">T</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-2018610489%2FFunctions%2F1404203640" anchor-label="getFilesDir" id="-2018610489%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-2018610489%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Files</span><wbr></wbr><span><span>Dir</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-2018610489%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-2018610489%2FFunctions%2F1404203640"><span class="token function">getFilesDir</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a></div></div></div>
                 </div>
               </div>
             </div>
@@ -2477,6 +2882,396 @@
               </div>
             </div>
           </div>
+<a data-name="1444016003%2FFunctions%2F1404203640" anchor-label="getFragmentManager" id="1444016003%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1444016003%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Fragment</span><wbr></wbr><span><span>Manager</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1444016003%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1444016003%2FFunctions%2F1404203640"><span class="token function">getFragmentManager</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/app/FragmentManager.html">FragmentManager</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1000759074%2FFunctions%2F1404203640" anchor-label="getIntent" id="-1000759074%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1000759074%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span><span>Intent</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1000759074%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1000759074%2FFunctions%2F1404203640"><span class="token function">getIntent</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/Intent.html">Intent</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1865555744%2FFunctions%2F1404203640" anchor-label="getLastCustomNonConfigurationInstance" id="1865555744%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1865555744%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Last</span><wbr></wbr><span>Custom</span><wbr></wbr><span>Non</span><wbr></wbr><span>Configuration</span><wbr></wbr><span><span>Instance</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1865555744%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1865555744%2FFunctions%2F1404203640"><span class="token function">getLastCustomNonConfigurationInstance</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-any/index.html">Any</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-977658074%2FFunctions%2F1404203640" anchor-label="getLastNonConfigurationInstance" id="-977658074%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-977658074%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Last</span><wbr></wbr><span>Non</span><wbr></wbr><span>Configuration</span><wbr></wbr><span><span>Instance</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-977658074%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-977658074%2FFunctions%2F1404203640"><span class="token function">getLastNonConfigurationInstance</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-any/index.html">Any</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-755744763%2FFunctions%2F1404203640" anchor-label="getLayoutInflater" id="-755744763%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-755744763%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Layout</span><wbr></wbr><span><span>Inflater</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-755744763%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-755744763%2FFunctions%2F1404203640"><span class="token function">getLayoutInflater</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/view/LayoutInflater.html">LayoutInflater</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-363549909%2FFunctions%2F1404203640" anchor-label="getLifecycle" id="-363549909%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-363549909%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span><span>Lifecycle</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-363549909%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-363549909%2FFunctions%2F1404203640"><span class="token function">getLifecycle</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/lifecycle/Lifecycle.html">Lifecycle</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="2145988102%2FFunctions%2F1404203640" anchor-label="getLoaderManager" id="2145988102%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#2145988102%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Loader</span><wbr></wbr><span><span>Manager</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="2145988102%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#2145988102%2FFunctions%2F1404203640"><span class="token function">getLoaderManager</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/app/LoaderManager.html">LoaderManager</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-376937214%2FFunctions%2F1404203640" anchor-label="getLocalClassName" id="-376937214%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-376937214%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Local</span><wbr></wbr><span>Class</span><wbr></wbr><span><span>Name</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-376937214%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-376937214%2FFunctions%2F1404203640"><span class="token function">getLocalClassName</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1205639281%2FFunctions%2F1404203640" anchor-label="getMainExecutor" id="1205639281%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1205639281%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Main</span><wbr></wbr><span><span>Executor</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1205639281%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1205639281%2FFunctions%2F1404203640"><span class="token function">getMainExecutor</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/util/concurrent/Executor.html">Executor</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="400244339%2FFunctions%2F1404203640" anchor-label="getMainLooper" id="400244339%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#400244339%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Main</span><wbr></wbr><span><span>Looper</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="400244339%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#400244339%2FFunctions%2F1404203640"><span class="token function">getMainLooper</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/os/Looper.html">Looper</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1704478464%2FFunctions%2F1404203640" anchor-label="getMaxNumPictureInPictureActions" id="-1704478464%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1704478464%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Max</span><wbr></wbr><span>Num</span><wbr></wbr><span>Picture</span><wbr></wbr><span>In</span><wbr></wbr><span>Picture</span><wbr></wbr><span><span>Actions</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1704478464%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1704478464%2FFunctions%2F1404203640"><span class="token function">getMaxNumPictureInPictureActions</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1703977600%2FFunctions%2F1404203640" anchor-label="getMediaController" id="-1703977600%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1703977600%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Media</span><wbr></wbr><span><span>Controller</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1703977600%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#-1703977600%2FFunctions%2F1404203640"><span class="token function">getMediaController</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/media/session/MediaController.html">MediaController</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="13623128%2FFunctions%2F1404203640" anchor-label="getMenuInflater" id="13623128%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#13623128%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Menu</span><wbr></wbr><span><span>Inflater</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="13623128%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#13623128%2FFunctions%2F1404203640"><span class="token function">getMenuInflater</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/view/MenuInflater.html">MenuInflater</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1811406884%2FFunctions%2F1404203640" anchor-label="getNoBackupFilesDir" id="1811406884%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1811406884%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>No</span><wbr></wbr><span>Backup</span><wbr></wbr><span>Files</span><wbr></wbr><span><span>Dir</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1811406884%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1811406884%2FFunctions%2F1404203640"><span class="token function">getNoBackupFilesDir</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="252787007%2FFunctions%2F1404203640" anchor-label="getObbDir" id="252787007%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#252787007%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Obb</span><wbr></wbr><span><span>Dir</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="252787007%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#252787007%2FFunctions%2F1404203640"><span class="token function">getObbDir</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="812717416%2FFunctions%2F1404203640" anchor-label="getObbDirs" id="812717416%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#812717416%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Obb</span><wbr></wbr><span><span>Dirs</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="812717416%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#812717416%2FFunctions%2F1404203640"><span class="token function">getObbDirs</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-array/index.html">Array</a><span class="token operator">&lt;</span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a><span class="token operator">&gt;</span></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1524217389%2FFunctions%2F1404203640" anchor-label="getOnBackInvokedDispatcher" id="-1524217389%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1524217389%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>On</span><wbr></wbr><span>Back</span><wbr></wbr><span>Invoked</span><wbr></wbr><span><span>Dispatcher</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1524217389%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1524217389%2FFunctions%2F1404203640"><span class="token function">getOnBackInvokedDispatcher</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/window/OnBackInvokedDispatcher.html">OnBackInvokedDispatcher</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1039536402%2FFunctions%2F1404203640" anchor-label="getOnBackPressedDispatcher" id="1039536402%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1039536402%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>On</span><wbr></wbr><span>Back</span><wbr></wbr><span>Pressed</span><wbr></wbr><span><span>Dispatcher</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1039536402%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#1039536402%2FFunctions%2F1404203640"><span class="token function">getOnBackPressedDispatcher</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/activity/OnBackPressedDispatcher.html">OnBackPressedDispatcher</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-814243443%2FFunctions%2F1404203640" anchor-label="getOpPackageName" id="-814243443%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-814243443%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Op</span><wbr></wbr><span>Package</span><wbr></wbr><span><span>Name</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-814243443%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-814243443%2FFunctions%2F1404203640"><span class="token function">getOpPackageName</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1681869883%2FFunctions%2F1404203640" anchor-label="getPackageCodePath" id="-1681869883%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1681869883%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Package</span><wbr></wbr><span>Code</span><wbr></wbr><span><span>Path</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1681869883%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1681869883%2FFunctions%2F1404203640"><span class="token function">getPackageCodePath</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="224992758%2FFunctions%2F1404203640" anchor-label="getPackageManager" id="224992758%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#224992758%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Package</span><wbr></wbr><span><span>Manager</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="224992758%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#224992758%2FFunctions%2F1404203640"><span class="token function">getPackageManager</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/pm/PackageManager.html">PackageManager</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1158183924%2FFunctions%2F1404203640" anchor-label="getPackageName" id="-1158183924%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1158183924%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Package</span><wbr></wbr><span><span>Name</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1158183924%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1158183924%2FFunctions%2F1404203640"><span class="token function">getPackageName</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="512700484%2FFunctions%2F1404203640" anchor-label="getPackageResourcePath" id="512700484%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#512700484%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Package</span><wbr></wbr><span>Resource</span><wbr></wbr><span><span>Path</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="512700484%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#512700484%2FFunctions%2F1404203640"><span class="token function">getPackageResourcePath</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-417920553%2FFunctions%2F1404203640" anchor-label="getParams" id="-417920553%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-417920553%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span><span>Params</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-417920553%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-417920553%2FFunctions%2F1404203640"><span class="token function">getParams</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/ContextParams.html">ContextParams</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-78472560%2FFunctions%2F1404203640" anchor-label="getParent" id="-78472560%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-78472560%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span><span>Parent</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-78472560%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#-78472560%2FFunctions%2F1404203640"><span class="token function">getParent</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/app/Activity.html">Activity</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1492932869%2FFunctions%2F1404203640" anchor-label="getParentActivityIntent" id="1492932869%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1492932869%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Parent</span><wbr></wbr><span>Activity</span><wbr></wbr><span><span>Intent</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1492932869%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1492932869%2FFunctions%2F1404203640"><span class="token function">getParentActivityIntent</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/Intent.html">Intent</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="-761855413%2FFunctions%2F1404203640" anchor-label="getPreferences" id="-761855413%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
           <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
             <div class="main-subrow keyValue ">
@@ -2488,6 +3283,81 @@
               <div>
                 <div class="title">
                   <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-761855413%2FFunctions%2F1404203640"><span class="token function">getPreferences</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">mode<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/SharedPreferences.html">SharedPreferences</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-581473925%2FFunctions%2F1404203640" anchor-label="getReferrer" id="-581473925%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-581473925%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span><span>Referrer</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-581473925%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-581473925%2FFunctions%2F1404203640"><span class="token function">getReferrer</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/net/Uri.html">Uri</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1038606840%2FFunctions%2F1404203640" anchor-label="getRequestedOrientation" id="1038606840%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1038606840%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Requested</span><wbr></wbr><span><span>Orientation</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1038606840%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1038606840%2FFunctions%2F1404203640"><span class="token function">getRequestedOrientation</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-404044493%2FFunctions%2F1404203640" anchor-label="getResources" id="-404044493%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-404044493%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span><span>Resources</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-404044493%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-404044493%2FFunctions%2F1404203640"><span class="token function">getResources</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/res/Resources.html">Resources</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="2075539550%2FFunctions%2F1404203640" anchor-label="getSavedStateRegistry" id="2075539550%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#2075539550%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Saved</span><wbr></wbr><span>State</span><wbr></wbr><span><span>Registry</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="2075539550%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#2075539550%2FFunctions%2F1404203640"><span class="token function">getSavedStateRegistry</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/savedstate/SavedStateRegistry.html">SavedStateRegistry</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-630770%2FFunctions%2F1404203640" anchor-label="getSearchEvent" id="-630770%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-630770%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Search</span><wbr></wbr><span><span>Event</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-630770%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#-630770%2FFunctions%2F1404203640"><span class="token function">getSearchEvent</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/view/SearchEvent.html">SearchEvent</a></div></div></div>
                 </div>
               </div>
             </div>
@@ -2507,6 +3377,21 @@
               </div>
             </div>
           </div>
+<a data-name="-382132249%2FFunctions%2F1404203640" anchor-label="getSplashScreen" id="-382132249%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-382132249%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Splash</span><wbr></wbr><span><span>Screen</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-382132249%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#-382132249%2FFunctions%2F1404203640"><span class="token function">getSplashScreen</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/window/SplashScreen.html">SplashScreen</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="-1235756924%2FFunctions%2F1404203640" anchor-label="getString" id="-1235756924%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
           <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
             <div class="main-subrow keyValue ">
@@ -2518,6 +3403,66 @@
               <div>
                 <div class="title">
                   <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#55471304%2FFunctions%2F1404203640"><span class="token function">getString</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">resId<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></div><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#-285648560%2FFunctions%2F1404203640"><span class="token function">getString</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">resId<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a><span class="token punctuation">, </span></span><span class="parameter "><span class="token keyword">vararg </span>formatArgs<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-array/index.html">Array</a><span class="token operator">&lt;</span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-any/index.html">Any</a><span class="token operator">&gt;</span></span></span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="993354804%2FFunctions%2F1404203640" anchor-label="getSupportActionBar" id="993354804%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#993354804%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Support</span><wbr></wbr><span>Action</span><wbr></wbr><span><span>Bar</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="993354804%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#993354804%2FFunctions%2F1404203640"><span class="token function">getSupportActionBar</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/appcompat/app/ActionBar.html">ActionBar</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="396613922%2FFunctions%2F1404203640" anchor-label="getSupportFragmentManager" id="396613922%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#396613922%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Support</span><wbr></wbr><span>Fragment</span><wbr></wbr><span><span>Manager</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="396613922%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#396613922%2FFunctions%2F1404203640"><span class="token function">getSupportFragmentManager</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/fragment/app/FragmentManager.html">FragmentManager</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="97973093%2FFunctions%2F1404203640" anchor-label="getSupportLoaderManager" id="97973093%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#97973093%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Support</span><wbr></wbr><span>Loader</span><wbr></wbr><span><span>Manager</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="97973093%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#97973093%2FFunctions%2F1404203640"><span class="token function">getSupportLoaderManager</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/loader/app/LoaderManager.html">LoaderManager</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="192054068%2FFunctions%2F1404203640" anchor-label="getSupportParentActivityIntent" id="192054068%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#192054068%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Support</span><wbr></wbr><span>Parent</span><wbr></wbr><span>Activity</span><wbr></wbr><span><span>Intent</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="192054068%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#192054068%2FFunctions%2F1404203640"><span class="token function">getSupportParentActivityIntent</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/Intent.html">Intent</a></div></div></div>
                 </div>
               </div>
             </div>
@@ -2552,6 +3497,21 @@
               </div>
             </div>
           </div>
+<a data-name="-1226887558%2FFunctions%2F1404203640" anchor-label="getTaskId" id="-1226887558%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1226887558%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Task</span><wbr></wbr><span><span>Id</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1226887558%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1226887558%2FFunctions%2F1404203640"><span class="token function">getTaskId</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="635200548%2FFunctions%2F1404203640" anchor-label="getText" id="635200548%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
           <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
             <div class="main-subrow keyValue ">
@@ -2563,6 +3523,171 @@
               <div>
                 <div class="title">
                   <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#635200548%2FFunctions%2F1404203640"><span class="token function">getText</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">resId<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/CharSequence.html">CharSequence</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="945814313%2FFunctions%2F1404203640" anchor-label="getTheme" id="945814313%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#945814313%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span><span>Theme</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="945814313%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#945814313%2FFunctions%2F1404203640"><span class="token function">getTheme</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/res/Resources.Theme.html">Resources.Theme</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="671976584%2FFunctions%2F1404203640" anchor-label="getTitle" id="671976584%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#671976584%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span><span>Title</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="671976584%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#671976584%2FFunctions%2F1404203640"><span class="token function">getTitle</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/CharSequence.html">CharSequence</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-815012881%2FFunctions%2F1404203640" anchor-label="getTitleColor" id="-815012881%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-815012881%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Title</span><wbr></wbr><span><span>Color</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-815012881%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#-815012881%2FFunctions%2F1404203640"><span class="token function">getTitleColor</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-123874808%2FFunctions%2F1404203640" anchor-label="getViewModelStore" id="-123874808%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-123874808%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>View</span><wbr></wbr><span>Model</span><wbr></wbr><span><span>Store</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-123874808%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-123874808%2FFunctions%2F1404203640"><span class="token function">getViewModelStore</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/lifecycle/ViewModelStore.html">ViewModelStore</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="819156245%2FFunctions%2F1404203640" anchor-label="getVoiceInteractor" id="819156245%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#819156245%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Voice</span><wbr></wbr><span><span>Interactor</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="819156245%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#819156245%2FFunctions%2F1404203640"><span class="token function">getVoiceInteractor</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/app/VoiceInteractor.html">VoiceInteractor</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="714135997%2FFunctions%2F1404203640" anchor-label="getVolumeControlStream" id="714135997%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#714135997%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Volume</span><wbr></wbr><span>Control</span><wbr></wbr><span><span>Stream</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="714135997%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#714135997%2FFunctions%2F1404203640"><span class="token function">getVolumeControlStream</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-721579237%2FFunctions%2F1404203640" anchor-label="getWallpaper" id="-721579237%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-721579237%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span><span>Wallpaper</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-721579237%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-721579237%2FFunctions%2F1404203640"><span class="token function">getWallpaper</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/graphics/drawable/Drawable.html">Drawable</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-662155776%2FFunctions%2F1404203640" anchor-label="getWallpaperDesiredMinimumHeight" id="-662155776%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-662155776%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Wallpaper</span><wbr></wbr><span>Desired</span><wbr></wbr><span>Minimum</span><wbr></wbr><span><span>Height</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-662155776%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-662155776%2FFunctions%2F1404203640"><span class="token function">getWallpaperDesiredMinimumHeight</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="295343597%2FFunctions%2F1404203640" anchor-label="getWallpaperDesiredMinimumWidth" id="295343597%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#295343597%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Wallpaper</span><wbr></wbr><span>Desired</span><wbr></wbr><span>Minimum</span><wbr></wbr><span><span>Width</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="295343597%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#295343597%2FFunctions%2F1404203640"><span class="token function">getWallpaperDesiredMinimumWidth</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1004659210%2FFunctions%2F1404203640" anchor-label="getWindow" id="1004659210%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1004659210%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span><span>Window</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1004659210%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1004659210%2FFunctions%2F1404203640"><span class="token function">getWindow</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/view/Window.html">Window</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-130996765%2FFunctions%2F1404203640" anchor-label="getWindowManager" id="-130996765%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-130996765%2FFunctions%2F1404203640"><span>get</span><wbr></wbr><span>Window</span><wbr></wbr><span><span>Manager</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-130996765%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-130996765%2FFunctions%2F1404203640"><span class="token function">getWindowManager</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/view/WindowManager.html">WindowManager</a></div></div></div>
                 </div>
               </div>
             </div>
@@ -2608,6 +3733,246 @@
               <div>
                 <div class="title">
                   <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1946521782%2FFunctions%2F1404203640"><span class="token function">invalidateOptionsMenu</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1073823551%2FFunctions%2F1404203640" anchor-label="isActivityTransitionRunning" id="1073823551%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1073823551%2FFunctions%2F1404203640"><span>is</span><wbr></wbr><span>Activity</span><wbr></wbr><span>Transition</span><wbr></wbr><span><span>Running</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1073823551%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1073823551%2FFunctions%2F1404203640"><span class="token function">isActivityTransitionRunning</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1931207062%2FFunctions%2F1404203640" anchor-label="isChangingConfigurations" id="1931207062%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1931207062%2FFunctions%2F1404203640"><span>is</span><wbr></wbr><span>Changing</span><wbr></wbr><span><span>Configurations</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1931207062%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1931207062%2FFunctions%2F1404203640"><span class="token function">isChangingConfigurations</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1947658526%2FFunctions%2F1404203640" anchor-label="isChild" id="1947658526%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1947658526%2FFunctions%2F1404203640"><span>is</span><wbr></wbr><span><span>Child</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1947658526%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#1947658526%2FFunctions%2F1404203640"><span class="token function">isChild</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-423188415%2FFunctions%2F1404203640" anchor-label="isDestroyed" id="-423188415%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-423188415%2FFunctions%2F1404203640"><span>is</span><wbr></wbr><span><span>Destroyed</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-423188415%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-423188415%2FFunctions%2F1404203640"><span class="token function">isDestroyed</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1565618010%2FFunctions%2F1404203640" anchor-label="isDeviceProtectedStorage" id="1565618010%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1565618010%2FFunctions%2F1404203640"><span>is</span><wbr></wbr><span>Device</span><wbr></wbr><span>Protected</span><wbr></wbr><span><span>Storage</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1565618010%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1565618010%2FFunctions%2F1404203640"><span class="token function">isDeviceProtectedStorage</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1522152277%2FFunctions%2F1404203640" anchor-label="isFinishing" id="-1522152277%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1522152277%2FFunctions%2F1404203640"><span>is</span><wbr></wbr><span><span>Finishing</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1522152277%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1522152277%2FFunctions%2F1404203640"><span class="token function">isFinishing</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="80260575%2FFunctions%2F1404203640" anchor-label="isImmersive" id="80260575%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#80260575%2FFunctions%2F1404203640"><span>is</span><wbr></wbr><span><span>Immersive</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="80260575%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#80260575%2FFunctions%2F1404203640"><span class="token function">isImmersive</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="49252659%2FFunctions%2F1404203640" anchor-label="isInMultiWindowMode" id="49252659%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#49252659%2FFunctions%2F1404203640"><span>is</span><wbr></wbr><span>In</span><wbr></wbr><span>Multi</span><wbr></wbr><span>Window</span><wbr></wbr><span><span>Mode</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="49252659%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#49252659%2FFunctions%2F1404203640"><span class="token function">isInMultiWindowMode</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1297157635%2FFunctions%2F1404203640" anchor-label="isInPictureInPictureMode" id="-1297157635%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1297157635%2FFunctions%2F1404203640"><span>is</span><wbr></wbr><span>In</span><wbr></wbr><span>Picture</span><wbr></wbr><span>In</span><wbr></wbr><span>Picture</span><wbr></wbr><span><span>Mode</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1297157635%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1297157635%2FFunctions%2F1404203640"><span class="token function">isInPictureInPictureMode</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="386928344%2FFunctions%2F1404203640" anchor-label="isLaunchedFromBubble" id="386928344%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#386928344%2FFunctions%2F1404203640"><span>is</span><wbr></wbr><span>Launched</span><wbr></wbr><span>From</span><wbr></wbr><span><span>Bubble</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="386928344%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#386928344%2FFunctions%2F1404203640"><span class="token function">isLaunchedFromBubble</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1903895843%2FFunctions%2F1404203640" anchor-label="isLocalVoiceInteractionSupported" id="-1903895843%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1903895843%2FFunctions%2F1404203640"><span>is</span><wbr></wbr><span>Local</span><wbr></wbr><span>Voice</span><wbr></wbr><span>Interaction</span><wbr></wbr><span><span>Supported</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1903895843%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1903895843%2FFunctions%2F1404203640"><span class="token function">isLocalVoiceInteractionSupported</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1776278686%2FFunctions%2F1404203640" anchor-label="isRestricted" id="-1776278686%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1776278686%2FFunctions%2F1404203640"><span>is</span><wbr></wbr><span><span>Restricted</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1776278686%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1776278686%2FFunctions%2F1404203640"><span class="token function">isRestricted</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="2027112825%2FFunctions%2F1404203640" anchor-label="isTaskRoot" id="2027112825%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#2027112825%2FFunctions%2F1404203640"><span>is</span><wbr></wbr><span>Task</span><wbr></wbr><span><span>Root</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="2027112825%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#2027112825%2FFunctions%2F1404203640"><span class="token function">isTaskRoot</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="2131014658%2FFunctions%2F1404203640" anchor-label="isUiContext" id="2131014658%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#2131014658%2FFunctions%2F1404203640"><span>is</span><wbr></wbr><span>Ui</span><wbr></wbr><span><span>Context</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="2131014658%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#2131014658%2FFunctions%2F1404203640"><span class="token function">isUiContext</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1356218592%2FFunctions%2F1404203640" anchor-label="isVoiceInteraction" id="-1356218592%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1356218592%2FFunctions%2F1404203640"><span>is</span><wbr></wbr><span>Voice</span><wbr></wbr><span><span>Interaction</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1356218592%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1356218592%2FFunctions%2F1404203640"><span class="token function">isVoiceInteraction</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1896831266%2FFunctions%2F1404203640" anchor-label="isVoiceInteractionRoot" id="-1896831266%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1896831266%2FFunctions%2F1404203640"><span>is</span><wbr></wbr><span>Voice</span><wbr></wbr><span>Interaction</span><wbr></wbr><span><span>Root</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1896831266%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1896831266%2FFunctions%2F1404203640"><span class="token function">isVoiceInteractionRoot</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
                 </div>
               </div>
             </div>
@@ -4427,6 +5792,21 @@
               </div>
             </div>
           </div>
+<a data-name="376493809%2FFunctions%2F1404203640" anchor-label="setContentTransitionManager" id="376493809%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#376493809%2FFunctions%2F1404203640"><span>set</span><wbr></wbr><span>Content</span><wbr></wbr><span>Transition</span><wbr></wbr><span><span>Manager</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="376493809%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#376493809%2FFunctions%2F1404203640"><span class="token function">setContentTransitionManager</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">tm<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/transition/TransitionManager.html">TransitionManager</a></span></span><span class="token punctuation">)</span></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="-383343902%2FFunctions%2F1404203640" anchor-label="setContentView" id="-383343902%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
           <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
             <div class="main-subrow keyValue ">
@@ -4562,6 +5942,21 @@
               </div>
             </div>
           </div>
+<a data-name="-1206334231%2FFunctions%2F1404203640" anchor-label="setImmersive" id="-1206334231%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1206334231%2FFunctions%2F1404203640"><span>set</span><wbr></wbr><span><span>Immersive</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1206334231%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1206334231%2FFunctions%2F1404203640"><span class="token function">setImmersive</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">i<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></span></span><span class="token punctuation">)</span></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="-1040540598%2FFunctions%2F1404203640" anchor-label="setInheritShowWhenLocked" id="-1040540598%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
           <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
             <div class="main-subrow keyValue ">
@@ -4577,6 +5972,21 @@
               </div>
             </div>
           </div>
+<a data-name="-696482206%2FFunctions%2F1404203640" anchor-label="setIntent" id="-696482206%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-696482206%2FFunctions%2F1404203640"><span>set</span><wbr></wbr><span><span>Intent</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-696482206%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-696482206%2FFunctions%2F1404203640"><span class="token function">setIntent</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">newIntent<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/Intent.html">Intent</a></span></span><span class="token punctuation">)</span></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="-212546250%2FFunctions%2F1404203640" anchor-label="setLocusContext" id="-212546250%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
           <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
             <div class="main-subrow keyValue ">
@@ -4588,6 +5998,21 @@
               <div>
                 <div class="title">
                   <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-212546250%2FFunctions%2F1404203640"><span class="token function">setLocusContext</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">locusId<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/LocusId.html">LocusId</a><span class="token punctuation">, </span></span><span class="parameter ">bundle<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/os/Bundle.html">Bundle</a></span></span><span class="token punctuation">)</span></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="345348023%2FFunctions%2F1404203640" anchor-label="setMediaController" id="345348023%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#345348023%2FFunctions%2F1404203640"><span>set</span><wbr></wbr><span>Media</span><wbr></wbr><span><span>Controller</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="345348023%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#345348023%2FFunctions%2F1404203640"><span class="token function">setMediaController</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">controller<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/media/session/MediaController.html">MediaController</a></span></span><span class="token punctuation">)</span></div></div></div>
                 </div>
               </div>
             </div>
@@ -4678,6 +6103,21 @@
               <div>
                 <div class="title">
                   <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-650477169%2FFunctions%2F1404203640"><span class="token function">setRecentsScreenshotEnabled</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">enabled<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></span></span><span class="token punctuation">)</span></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1517240057%2FFunctions%2F1404203640" anchor-label="setRequestedOrientation" id="-1517240057%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1517240057%2FFunctions%2F1404203640"><span>set</span><wbr></wbr><span>Requested</span><wbr></wbr><span><span>Orientation</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1517240057%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1517240057%2FFunctions%2F1404203640"><span class="token function">setRequestedOrientation</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">requestedOrientation<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span></div></div></div>
                 </div>
               </div>
             </div>
@@ -4832,32 +6272,47 @@
               </div>
             </div>
           </div>
-<a data-name="-1812036744%2FFunctions%2F1404203640" anchor-label="setTheme" id="-1812036744%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+<a data-name="502589749%2FFunctions%2F1404203640" anchor-label="setTheme" id="502589749%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
           <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
             <div class="main-subrow keyValue ">
               <div class=""><span class="inline-flex">
-                  <div><a href="index.html#-1812036744%2FFunctions%2F1404203640"><span>set</span><wbr></wbr><span><span>Theme</span></span></a></div>
-<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1812036744%2FFunctions%2F1404203640"></span>
+                  <div><a href="index.html#-1882571409%2FFunctions%2F1404203640"><span>set</span><wbr></wbr><span><span>Theme</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="502589749%2FFunctions%2F1404203640"></span>
                     <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
                   </span></span></div>
               <div>
                 <div class="title">
-                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1812036744%2FFunctions%2F1404203640"><span class="token function">setTheme</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">resId<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span></div></div></div>
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1882571409%2FFunctions%2F1404203640"><span class="token function">setTheme</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">theme<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/res/Resources.Theme.html">Resources.Theme</a></span></span><span class="token punctuation">)</span></div><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1812036744%2FFunctions%2F1404203640"><span class="token function">setTheme</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">resId<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span></div></div></div>
                 </div>
               </div>
             </div>
           </div>
-<a data-name="-481981473%2FFunctions%2F1404203640" anchor-label="setTitle" id="-481981473%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+<a data-name="1223103612%2FFunctions%2F1404203640" anchor-label="setTitle" id="1223103612%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
           <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
             <div class="main-subrow keyValue ">
               <div class=""><span class="inline-flex">
                   <div><a href="index.html#-481981473%2FFunctions%2F1404203640"><span>set</span><wbr></wbr><span><span>Title</span></span></a></div>
-<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-481981473%2FFunctions%2F1404203640"></span>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1223103612%2FFunctions%2F1404203640"></span>
                     <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
                   </span></span></div>
               <div>
                 <div class="title">
-                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-481981473%2FFunctions%2F1404203640"><span class="token function">setTitle</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">titleId<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span></div></div></div>
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-481981473%2FFunctions%2F1404203640"><span class="token function">setTitle</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">titleId<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span></div><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-723395735%2FFunctions%2F1404203640"><span class="token function">setTitle</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">title<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/CharSequence.html">CharSequence</a></span></span><span class="token punctuation">)</span></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-479328592%2FFunctions%2F1404203640" anchor-label="setTitleColor" id="-479328592%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-479328592%2FFunctions%2F1404203640"><span>set</span><wbr></wbr><span>Title</span><wbr></wbr><span><span>Color</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-479328592%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-479328592%2FFunctions%2F1404203640"><span class="token function">setTitleColor</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">textColor<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span></div></div></div>
                 </div>
               </div>
             </div>
@@ -4903,6 +6358,21 @@
               <div>
                 <div class="title">
                   <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1019486496%2FFunctions%2F1404203640"><span class="token function">setVisible</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">visible<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></span></span><span class="token punctuation">)</span></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="838359946%2FFunctions%2F1404203640" anchor-label="setVolumeControlStream" id="838359946%2FFunctions%2F1404203640" data-filterable-set=":/release"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/release" data-filterable-set=":/release">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#838359946%2FFunctions%2F1404203640"><span>set</span><wbr></wbr><span>Volume</span><wbr></wbr><span>Control</span><wbr></wbr><span><span>Stream</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="838359946%2FFunctions%2F1404203640"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/release"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#838359946%2FFunctions%2F1404203640"><span class="token function">setVolumeControlStream</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">streamType<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span></div></div></div>
                 </div>
               </div>
             </div>

--- a/dokka-integration-tests/gradle/projects/it-android-kotlin-mp-builtin/expectedData/html/it-android/it.android/-integration-test-activity/index.html
+++ b/dokka-integration-tests/gradle/projects/it-android-kotlin-mp-builtin/expectedData/html/it-android/it.android/-integration-test-activity/index.html
@@ -2640,6 +2640,244 @@
               </div>
             </div>
           </div>
+<a data-name="-2108225789%2FFunctions%2F1031138095" anchor-label="getActionBar" id="-2108225789%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-2108225789%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Action</span><wbr></wbr><span><span>Bar</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-2108225789%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-2108225789%2FFunctions%2F1031138095"><span class="token function">getActionBar</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/app/ActionBar.html">ActionBar</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1526237776%2FFunctions%2F1031138095" anchor-label="getApplication" id="1526237776%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1526237776%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span><span>Application</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1526237776%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#1526237776%2FFunctions%2F1031138095"><span class="token function">getApplication</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/app/Application.html">Application</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="720574270%2FFunctions%2F1031138095" anchor-label="getApplicationContext" id="720574270%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#720574270%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Application</span><wbr></wbr><span><span>Context</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="720574270%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#720574270%2FFunctions%2F1031138095"><span class="token function">getApplicationContext</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/Context.html">Context</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="875309695%2FFunctions%2F1031138095" anchor-label="getApplicationInfo" id="875309695%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#875309695%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Application</span><wbr></wbr><span><span>Info</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="875309695%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#875309695%2FFunctions%2F1031138095"><span class="token function">getApplicationInfo</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/pm/ApplicationInfo.html">ApplicationInfo</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1028304091%2FFunctions%2F1031138095" anchor-label="getAssets" id="-1028304091%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1028304091%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span><span>Assets</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1028304091%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1028304091%2FFunctions%2F1031138095"><span class="token function">getAssets</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/res/AssetManager.html">AssetManager</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="745115299%2FFunctions%2F1031138095" anchor-label="getAttributionSource" id="745115299%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#745115299%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Attribution</span><wbr></wbr><span><span>Source</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="745115299%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#745115299%2FFunctions%2F1031138095"><span class="token function">getAttributionSource</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/AttributionSource.html">AttributionSource</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-2059689374%2FFunctions%2F1031138095" anchor-label="getAttributionTag" id="-2059689374%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-2059689374%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Attribution</span><wbr></wbr><span><span>Tag</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-2059689374%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-2059689374%2FFunctions%2F1031138095"><span class="token function">getAttributionTag</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1836627711%2FFunctions%2F1031138095" anchor-label="getBaseContext" id="1836627711%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1836627711%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Base</span><wbr></wbr><span><span>Context</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1836627711%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1836627711%2FFunctions%2F1031138095"><span class="token function">getBaseContext</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/Context.html">Context</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-803358382%2FFunctions%2F1031138095" anchor-label="getCacheDir" id="-803358382%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-803358382%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Cache</span><wbr></wbr><span><span>Dir</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-803358382%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-803358382%2FFunctions%2F1031138095"><span class="token function">getCacheDir</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-2093832307%2FFunctions%2F1031138095" anchor-label="getCallingActivity" id="-2093832307%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-2093832307%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Calling</span><wbr></wbr><span><span>Activity</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-2093832307%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-2093832307%2FFunctions%2F1031138095"><span class="token function">getCallingActivity</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/ComponentName.html">ComponentName</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1745389992%2FFunctions%2F1031138095" anchor-label="getCallingPackage" id="-1745389992%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1745389992%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Calling</span><wbr></wbr><span><span>Package</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1745389992%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1745389992%2FFunctions%2F1031138095"><span class="token function">getCallingPackage</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1601610448%2FFunctions%2F1031138095" anchor-label="getChangingConfigurations" id="-1601610448%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1601610448%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Changing</span><wbr></wbr><span><span>Configurations</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1601610448%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1601610448%2FFunctions%2F1031138095"><span class="token function">getChangingConfigurations</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1242041746%2FFunctions%2F1031138095" anchor-label="getClassLoader" id="1242041746%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1242041746%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Class</span><wbr></wbr><span><span>Loader</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1242041746%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1242041746%2FFunctions%2F1031138095"><span class="token function">getClassLoader</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/ClassLoader.html">ClassLoader</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1138511077%2FFunctions%2F1031138095" anchor-label="getCodeCacheDir" id="1138511077%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1138511077%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Code</span><wbr></wbr><span>Cache</span><wbr></wbr><span><span>Dir</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1138511077%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1138511077%2FFunctions%2F1031138095"><span class="token function">getCodeCacheDir</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="1123824824%2FFunctions%2F1031138095" anchor-label="getColor" id="1123824824%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
           <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
             <div class="main-subrow keyValue ">
@@ -2674,6 +2912,91 @@
               </div>
             </div>
           </div>
+<a data-name="-1710268232%2FFunctions%2F1031138095" anchor-label="getComponentName" id="-1710268232%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1710268232%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Component</span><wbr></wbr><span><span>Name</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1710268232%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1710268232%2FFunctions%2F1031138095"><span class="token function">getComponentName</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/ComponentName.html">ComponentName</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1924753378%2FFunctions%2F1031138095" anchor-label="getContentResolver" id="-1924753378%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1924753378%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Content</span><wbr></wbr><span><span>Resolver</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1924753378%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1924753378%2FFunctions%2F1031138095"><span class="token function">getContentResolver</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/ContentResolver.html">ContentResolver</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="261968391%2FFunctions%2F1031138095" anchor-label="getContentScene" id="261968391%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#261968391%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Content</span><wbr></wbr><span><span>Scene</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="261968391%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#261968391%2FFunctions%2F1031138095"><span class="token function">getContentScene</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/transition/Scene.html">Scene</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1914863227%2FFunctions%2F1031138095" anchor-label="getContentTransitionManager" id="1914863227%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1914863227%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Content</span><wbr></wbr><span>Transition</span><wbr></wbr><span><span>Manager</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1914863227%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1914863227%2FFunctions%2F1031138095"><span class="token function">getContentTransitionManager</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/transition/TransitionManager.html">TransitionManager</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1699869637%2FFunctions%2F1031138095" anchor-label="getCurrentFocus" id="-1699869637%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1699869637%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Current</span><wbr></wbr><span><span>Focus</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1699869637%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1699869637%2FFunctions%2F1031138095"><span class="token function">getCurrentFocus</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/view/View.html">View</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="1055464536%2FFunctions%2F1031138095" anchor-label="getDatabasePath" id="1055464536%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
           <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
             <div class="main-subrow keyValue ">
@@ -2687,6 +3010,40 @@
                   <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
                     <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
 <div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1055464536%2FFunctions%2F1031138095"><span class="token function">getDatabasePath</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">name<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></span></span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="666732474%2FFunctions%2F1031138095" anchor-label="getDataDir" id="666732474%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#666732474%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Data</span><wbr></wbr><span><span>Dir</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="666732474%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#666732474%2FFunctions%2F1031138095"><span class="token function">getDataDir</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1783008893%2FFunctions%2F1031138095" anchor-label="getDelegate" id="1783008893%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1783008893%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span><span>Delegate</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1783008893%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1783008893%2FFunctions%2F1031138095"><span class="token function">getDelegate</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/appcompat/app/AppCompatDelegate.html">AppCompatDelegate</a></div></div>                  </div>
                 </div>
               </div>
             </div>
@@ -2708,6 +3065,23 @@
               </div>
             </div>
           </div>
+<a data-name="488073307%2FFunctions%2F1031138095" anchor-label="getDisplay" id="488073307%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#488073307%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span><span>Display</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="488073307%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#488073307%2FFunctions%2F1031138095"><span class="token function">getDisplay</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/view/Display.html">Display</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="-816782443%2FFunctions%2F1031138095" anchor-label="getDrawable" id="-816782443%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
           <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
             <div class="main-subrow keyValue ">
@@ -2721,6 +3095,57 @@
                   <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
                     <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
 <div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#-816782443%2FFunctions%2F1031138095"><span class="token function">getDrawable</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">id<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/graphics/drawable/Drawable.html">Drawable</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-921690152%2FFunctions%2F1031138095" anchor-label="getDrawerToggleDelegate" id="-921690152%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-921690152%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Drawer</span><wbr></wbr><span>Toggle</span><wbr></wbr><span><span>Delegate</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-921690152%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-921690152%2FFunctions%2F1031138095"><span class="token function">getDrawerToggleDelegate</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/appcompat/app/ActionBarDrawerToggle.Delegate.html">ActionBarDrawerToggle.Delegate</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="544398023%2FFunctions%2F1031138095" anchor-label="getExternalCacheDir" id="544398023%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#544398023%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>External</span><wbr></wbr><span>Cache</span><wbr></wbr><span><span>Dir</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="544398023%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#544398023%2FFunctions%2F1031138095"><span class="token function">getExternalCacheDir</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1262724320%2FFunctions%2F1031138095" anchor-label="getExternalCacheDirs" id="1262724320%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1262724320%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>External</span><wbr></wbr><span>Cache</span><wbr></wbr><span><span>Dirs</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1262724320%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1262724320%2FFunctions%2F1031138095"><span class="token function">getExternalCacheDirs</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-array/index.html">Array</a><span class="token operator">&lt;</span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a><span class="token operator">&gt;</span></div></div>                  </div>
                 </div>
               </div>
             </div>
@@ -2759,6 +3184,23 @@
               </div>
             </div>
           </div>
+<a data-name="1078368190%2FFunctions%2F1031138095" anchor-label="getExternalMediaDirs" id="1078368190%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1078368190%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>External</span><wbr></wbr><span>Media</span><wbr></wbr><span><span>Dirs</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1078368190%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1078368190%2FFunctions%2F1031138095"><span class="token function">getExternalMediaDirs</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-array/index.html">Array</a><span class="token operator">&lt;</span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a><span class="token operator">&gt;</span></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="2147131388%2FFunctions%2F1031138095" anchor-label="getExtraData" id="2147131388%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
           <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
             <div class="main-subrow keyValue ">
@@ -2772,6 +3214,23 @@
                   <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
                     <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
 <div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><span class="token operator">&lt;</span><a href="index.html#2147131388%2FFunctions%2F1031138095">T</a><span class="token operator"> : </span><a href="https://developer.android.com/reference/kotlin/androidx/core/app/ComponentActivity.ExtraData.html">ComponentActivity.ExtraData</a><span class="token operator">&gt; </span><a href="index.html#2147131388%2FFunctions%2F1031138095"><span class="token function">getExtraData</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">extraDataClass<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/Class.html">Class</a><span class="token operator">&lt;</span><a href="index.html#2147131388%2FFunctions%2F1031138095">T</a><span class="token operator">&gt;</span></span></span><span class="token punctuation">)</span><span class="token operator">: </span><a href="index.html#2147131388%2FFunctions%2F1031138095">T</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-2018610489%2FFunctions%2F1031138095" anchor-label="getFilesDir" id="-2018610489%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-2018610489%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Files</span><wbr></wbr><span><span>Dir</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-2018610489%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-2018610489%2FFunctions%2F1031138095"><span class="token function">getFilesDir</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a></div></div>                  </div>
                 </div>
               </div>
             </div>
@@ -2793,6 +3252,448 @@
               </div>
             </div>
           </div>
+<a data-name="1444016003%2FFunctions%2F1031138095" anchor-label="getFragmentManager" id="1444016003%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1444016003%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Fragment</span><wbr></wbr><span><span>Manager</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1444016003%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1444016003%2FFunctions%2F1031138095"><span class="token function">getFragmentManager</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/app/FragmentManager.html">FragmentManager</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1000759074%2FFunctions%2F1031138095" anchor-label="getIntent" id="-1000759074%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1000759074%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span><span>Intent</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1000759074%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1000759074%2FFunctions%2F1031138095"><span class="token function">getIntent</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/Intent.html">Intent</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1865555744%2FFunctions%2F1031138095" anchor-label="getLastCustomNonConfigurationInstance" id="1865555744%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1865555744%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Last</span><wbr></wbr><span>Custom</span><wbr></wbr><span>Non</span><wbr></wbr><span>Configuration</span><wbr></wbr><span><span>Instance</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1865555744%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1865555744%2FFunctions%2F1031138095"><span class="token function">getLastCustomNonConfigurationInstance</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-any/index.html">Any</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-977658074%2FFunctions%2F1031138095" anchor-label="getLastNonConfigurationInstance" id="-977658074%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-977658074%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Last</span><wbr></wbr><span>Non</span><wbr></wbr><span>Configuration</span><wbr></wbr><span><span>Instance</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-977658074%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-977658074%2FFunctions%2F1031138095"><span class="token function">getLastNonConfigurationInstance</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-any/index.html">Any</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-755744763%2FFunctions%2F1031138095" anchor-label="getLayoutInflater" id="-755744763%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-755744763%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Layout</span><wbr></wbr><span><span>Inflater</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-755744763%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-755744763%2FFunctions%2F1031138095"><span class="token function">getLayoutInflater</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/view/LayoutInflater.html">LayoutInflater</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-363549909%2FFunctions%2F1031138095" anchor-label="getLifecycle" id="-363549909%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-363549909%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span><span>Lifecycle</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-363549909%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-363549909%2FFunctions%2F1031138095"><span class="token function">getLifecycle</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/lifecycle/Lifecycle.html">Lifecycle</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="2145988102%2FFunctions%2F1031138095" anchor-label="getLoaderManager" id="2145988102%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#2145988102%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Loader</span><wbr></wbr><span><span>Manager</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="2145988102%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#2145988102%2FFunctions%2F1031138095"><span class="token function">getLoaderManager</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/app/LoaderManager.html">LoaderManager</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-376937214%2FFunctions%2F1031138095" anchor-label="getLocalClassName" id="-376937214%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-376937214%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Local</span><wbr></wbr><span>Class</span><wbr></wbr><span><span>Name</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-376937214%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-376937214%2FFunctions%2F1031138095"><span class="token function">getLocalClassName</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1205639281%2FFunctions%2F1031138095" anchor-label="getMainExecutor" id="1205639281%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1205639281%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Main</span><wbr></wbr><span><span>Executor</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1205639281%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1205639281%2FFunctions%2F1031138095"><span class="token function">getMainExecutor</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/util/concurrent/Executor.html">Executor</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="400244339%2FFunctions%2F1031138095" anchor-label="getMainLooper" id="400244339%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#400244339%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Main</span><wbr></wbr><span><span>Looper</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="400244339%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#400244339%2FFunctions%2F1031138095"><span class="token function">getMainLooper</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/os/Looper.html">Looper</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1704478464%2FFunctions%2F1031138095" anchor-label="getMaxNumPictureInPictureActions" id="-1704478464%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1704478464%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Max</span><wbr></wbr><span>Num</span><wbr></wbr><span>Picture</span><wbr></wbr><span>In</span><wbr></wbr><span>Picture</span><wbr></wbr><span><span>Actions</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1704478464%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1704478464%2FFunctions%2F1031138095"><span class="token function">getMaxNumPictureInPictureActions</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1703977600%2FFunctions%2F1031138095" anchor-label="getMediaController" id="-1703977600%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1703977600%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Media</span><wbr></wbr><span><span>Controller</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1703977600%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#-1703977600%2FFunctions%2F1031138095"><span class="token function">getMediaController</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/media/session/MediaController.html">MediaController</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="13623128%2FFunctions%2F1031138095" anchor-label="getMenuInflater" id="13623128%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#13623128%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Menu</span><wbr></wbr><span><span>Inflater</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="13623128%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#13623128%2FFunctions%2F1031138095"><span class="token function">getMenuInflater</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/view/MenuInflater.html">MenuInflater</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1811406884%2FFunctions%2F1031138095" anchor-label="getNoBackupFilesDir" id="1811406884%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1811406884%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>No</span><wbr></wbr><span>Backup</span><wbr></wbr><span>Files</span><wbr></wbr><span><span>Dir</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1811406884%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1811406884%2FFunctions%2F1031138095"><span class="token function">getNoBackupFilesDir</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="252787007%2FFunctions%2F1031138095" anchor-label="getObbDir" id="252787007%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#252787007%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Obb</span><wbr></wbr><span><span>Dir</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="252787007%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#252787007%2FFunctions%2F1031138095"><span class="token function">getObbDir</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="812717416%2FFunctions%2F1031138095" anchor-label="getObbDirs" id="812717416%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#812717416%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Obb</span><wbr></wbr><span><span>Dirs</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="812717416%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#812717416%2FFunctions%2F1031138095"><span class="token function">getObbDirs</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-array/index.html">Array</a><span class="token operator">&lt;</span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a><span class="token operator">&gt;</span></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1524217389%2FFunctions%2F1031138095" anchor-label="getOnBackInvokedDispatcher" id="-1524217389%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1524217389%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>On</span><wbr></wbr><span>Back</span><wbr></wbr><span>Invoked</span><wbr></wbr><span><span>Dispatcher</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1524217389%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1524217389%2FFunctions%2F1031138095"><span class="token function">getOnBackInvokedDispatcher</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/window/OnBackInvokedDispatcher.html">OnBackInvokedDispatcher</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1039536402%2FFunctions%2F1031138095" anchor-label="getOnBackPressedDispatcher" id="1039536402%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1039536402%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>On</span><wbr></wbr><span>Back</span><wbr></wbr><span>Pressed</span><wbr></wbr><span><span>Dispatcher</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1039536402%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#1039536402%2FFunctions%2F1031138095"><span class="token function">getOnBackPressedDispatcher</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/activity/OnBackPressedDispatcher.html">OnBackPressedDispatcher</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-814243443%2FFunctions%2F1031138095" anchor-label="getOpPackageName" id="-814243443%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-814243443%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Op</span><wbr></wbr><span>Package</span><wbr></wbr><span><span>Name</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-814243443%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-814243443%2FFunctions%2F1031138095"><span class="token function">getOpPackageName</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1681869883%2FFunctions%2F1031138095" anchor-label="getPackageCodePath" id="-1681869883%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1681869883%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Package</span><wbr></wbr><span>Code</span><wbr></wbr><span><span>Path</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1681869883%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1681869883%2FFunctions%2F1031138095"><span class="token function">getPackageCodePath</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="224992758%2FFunctions%2F1031138095" anchor-label="getPackageManager" id="224992758%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#224992758%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Package</span><wbr></wbr><span><span>Manager</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="224992758%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#224992758%2FFunctions%2F1031138095"><span class="token function">getPackageManager</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/pm/PackageManager.html">PackageManager</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1158183924%2FFunctions%2F1031138095" anchor-label="getPackageName" id="-1158183924%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1158183924%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Package</span><wbr></wbr><span><span>Name</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1158183924%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1158183924%2FFunctions%2F1031138095"><span class="token function">getPackageName</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="512700484%2FFunctions%2F1031138095" anchor-label="getPackageResourcePath" id="512700484%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#512700484%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Package</span><wbr></wbr><span>Resource</span><wbr></wbr><span><span>Path</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="512700484%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#512700484%2FFunctions%2F1031138095"><span class="token function">getPackageResourcePath</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-417920553%2FFunctions%2F1031138095" anchor-label="getParams" id="-417920553%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-417920553%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span><span>Params</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-417920553%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-417920553%2FFunctions%2F1031138095"><span class="token function">getParams</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/ContextParams.html">ContextParams</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-78472560%2FFunctions%2F1031138095" anchor-label="getParent" id="-78472560%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-78472560%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span><span>Parent</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-78472560%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#-78472560%2FFunctions%2F1031138095"><span class="token function">getParent</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/app/Activity.html">Activity</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1492932869%2FFunctions%2F1031138095" anchor-label="getParentActivityIntent" id="1492932869%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1492932869%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Parent</span><wbr></wbr><span>Activity</span><wbr></wbr><span><span>Intent</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1492932869%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1492932869%2FFunctions%2F1031138095"><span class="token function">getParentActivityIntent</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/Intent.html">Intent</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="-761855413%2FFunctions%2F1031138095" anchor-label="getPreferences" id="-761855413%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
           <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
             <div class="main-subrow keyValue ">
@@ -2806,6 +3707,91 @@
                   <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
                     <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
 <div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-761855413%2FFunctions%2F1031138095"><span class="token function">getPreferences</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">mode<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/SharedPreferences.html">SharedPreferences</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-581473925%2FFunctions%2F1031138095" anchor-label="getReferrer" id="-581473925%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-581473925%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span><span>Referrer</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-581473925%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-581473925%2FFunctions%2F1031138095"><span class="token function">getReferrer</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/net/Uri.html">Uri</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1038606840%2FFunctions%2F1031138095" anchor-label="getRequestedOrientation" id="1038606840%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1038606840%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Requested</span><wbr></wbr><span><span>Orientation</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1038606840%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1038606840%2FFunctions%2F1031138095"><span class="token function">getRequestedOrientation</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-404044493%2FFunctions%2F1031138095" anchor-label="getResources" id="-404044493%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-404044493%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span><span>Resources</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-404044493%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-404044493%2FFunctions%2F1031138095"><span class="token function">getResources</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/res/Resources.html">Resources</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="2075539550%2FFunctions%2F1031138095" anchor-label="getSavedStateRegistry" id="2075539550%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#2075539550%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Saved</span><wbr></wbr><span>State</span><wbr></wbr><span><span>Registry</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="2075539550%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#2075539550%2FFunctions%2F1031138095"><span class="token function">getSavedStateRegistry</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/savedstate/SavedStateRegistry.html">SavedStateRegistry</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-630770%2FFunctions%2F1031138095" anchor-label="getSearchEvent" id="-630770%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-630770%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Search</span><wbr></wbr><span><span>Event</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-630770%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#-630770%2FFunctions%2F1031138095"><span class="token function">getSearchEvent</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/view/SearchEvent.html">SearchEvent</a></div></div>                  </div>
                 </div>
               </div>
             </div>
@@ -2827,6 +3813,23 @@
               </div>
             </div>
           </div>
+<a data-name="-382132249%2FFunctions%2F1031138095" anchor-label="getSplashScreen" id="-382132249%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-382132249%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Splash</span><wbr></wbr><span><span>Screen</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-382132249%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#-382132249%2FFunctions%2F1031138095"><span class="token function">getSplashScreen</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/window/SplashScreen.html">SplashScreen</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="-1235756924%2FFunctions%2F1031138095" anchor-label="getString" id="-1235756924%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
           <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
             <div class="main-subrow keyValue ">
@@ -2840,6 +3843,74 @@
                   <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
                     <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
 <div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#55471304%2FFunctions%2F1031138095"><span class="token function">getString</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">resId<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></div><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#-285648560%2FFunctions%2F1031138095"><span class="token function">getString</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">resId<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a><span class="token punctuation">, </span></span><span class="parameter "><span class="token keyword">vararg </span>formatArgs<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-array/index.html">Array</a><span class="token operator">&lt;</span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-any/index.html">Any</a><span class="token operator">&gt;</span></span></span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="993354804%2FFunctions%2F1031138095" anchor-label="getSupportActionBar" id="993354804%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#993354804%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Support</span><wbr></wbr><span>Action</span><wbr></wbr><span><span>Bar</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="993354804%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#993354804%2FFunctions%2F1031138095"><span class="token function">getSupportActionBar</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/appcompat/app/ActionBar.html">ActionBar</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="396613922%2FFunctions%2F1031138095" anchor-label="getSupportFragmentManager" id="396613922%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#396613922%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Support</span><wbr></wbr><span>Fragment</span><wbr></wbr><span><span>Manager</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="396613922%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#396613922%2FFunctions%2F1031138095"><span class="token function">getSupportFragmentManager</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/fragment/app/FragmentManager.html">FragmentManager</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="97973093%2FFunctions%2F1031138095" anchor-label="getSupportLoaderManager" id="97973093%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#97973093%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Support</span><wbr></wbr><span>Loader</span><wbr></wbr><span><span>Manager</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="97973093%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#97973093%2FFunctions%2F1031138095"><span class="token function">getSupportLoaderManager</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/loader/app/LoaderManager.html">LoaderManager</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="192054068%2FFunctions%2F1031138095" anchor-label="getSupportParentActivityIntent" id="192054068%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#192054068%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Support</span><wbr></wbr><span>Parent</span><wbr></wbr><span>Activity</span><wbr></wbr><span><span>Intent</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="192054068%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#192054068%2FFunctions%2F1031138095"><span class="token function">getSupportParentActivityIntent</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/Intent.html">Intent</a></div></div>                  </div>
                 </div>
               </div>
             </div>
@@ -2878,6 +3949,23 @@
               </div>
             </div>
           </div>
+<a data-name="-1226887558%2FFunctions%2F1031138095" anchor-label="getTaskId" id="-1226887558%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1226887558%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Task</span><wbr></wbr><span><span>Id</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1226887558%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1226887558%2FFunctions%2F1031138095"><span class="token function">getTaskId</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="635200548%2FFunctions%2F1031138095" anchor-label="getText" id="635200548%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
           <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
             <div class="main-subrow keyValue ">
@@ -2891,6 +3979,193 @@
                   <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
                     <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
 <div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#635200548%2FFunctions%2F1031138095"><span class="token function">getText</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">resId<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/CharSequence.html">CharSequence</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="945814313%2FFunctions%2F1031138095" anchor-label="getTheme" id="945814313%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#945814313%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span><span>Theme</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="945814313%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#945814313%2FFunctions%2F1031138095"><span class="token function">getTheme</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/res/Resources.Theme.html">Resources.Theme</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="671976584%2FFunctions%2F1031138095" anchor-label="getTitle" id="671976584%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#671976584%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span><span>Title</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="671976584%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#671976584%2FFunctions%2F1031138095"><span class="token function">getTitle</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/CharSequence.html">CharSequence</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-815012881%2FFunctions%2F1031138095" anchor-label="getTitleColor" id="-815012881%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-815012881%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Title</span><wbr></wbr><span><span>Color</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-815012881%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#-815012881%2FFunctions%2F1031138095"><span class="token function">getTitleColor</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-123874808%2FFunctions%2F1031138095" anchor-label="getViewModelStore" id="-123874808%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-123874808%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>View</span><wbr></wbr><span>Model</span><wbr></wbr><span><span>Store</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-123874808%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-123874808%2FFunctions%2F1031138095"><span class="token function">getViewModelStore</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/lifecycle/ViewModelStore.html">ViewModelStore</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="819156245%2FFunctions%2F1031138095" anchor-label="getVoiceInteractor" id="819156245%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#819156245%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Voice</span><wbr></wbr><span><span>Interactor</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="819156245%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#819156245%2FFunctions%2F1031138095"><span class="token function">getVoiceInteractor</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/app/VoiceInteractor.html">VoiceInteractor</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="714135997%2FFunctions%2F1031138095" anchor-label="getVolumeControlStream" id="714135997%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#714135997%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Volume</span><wbr></wbr><span>Control</span><wbr></wbr><span><span>Stream</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="714135997%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#714135997%2FFunctions%2F1031138095"><span class="token function">getVolumeControlStream</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-721579237%2FFunctions%2F1031138095" anchor-label="getWallpaper" id="-721579237%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-721579237%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span><span>Wallpaper</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-721579237%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-721579237%2FFunctions%2F1031138095"><span class="token function">getWallpaper</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/graphics/drawable/Drawable.html">Drawable</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-662155776%2FFunctions%2F1031138095" anchor-label="getWallpaperDesiredMinimumHeight" id="-662155776%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-662155776%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Wallpaper</span><wbr></wbr><span>Desired</span><wbr></wbr><span>Minimum</span><wbr></wbr><span><span>Height</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-662155776%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-662155776%2FFunctions%2F1031138095"><span class="token function">getWallpaperDesiredMinimumHeight</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="295343597%2FFunctions%2F1031138095" anchor-label="getWallpaperDesiredMinimumWidth" id="295343597%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#295343597%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Wallpaper</span><wbr></wbr><span>Desired</span><wbr></wbr><span>Minimum</span><wbr></wbr><span><span>Width</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="295343597%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#295343597%2FFunctions%2F1031138095"><span class="token function">getWallpaperDesiredMinimumWidth</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1004659210%2FFunctions%2F1031138095" anchor-label="getWindow" id="1004659210%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1004659210%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span><span>Window</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1004659210%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1004659210%2FFunctions%2F1031138095"><span class="token function">getWindow</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/view/Window.html">Window</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-130996765%2FFunctions%2F1031138095" anchor-label="getWindowManager" id="-130996765%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-130996765%2FFunctions%2F1031138095"><span>get</span><wbr></wbr><span>Window</span><wbr></wbr><span><span>Manager</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-130996765%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-130996765%2FFunctions%2F1031138095"><span class="token function">getWindowManager</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/view/WindowManager.html">WindowManager</a></div></div>                  </div>
                 </div>
               </div>
             </div>
@@ -2942,6 +4217,278 @@
                   <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
                     <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
 <div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1946521782%2FFunctions%2F1031138095"><span class="token function">invalidateOptionsMenu</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1073823551%2FFunctions%2F1031138095" anchor-label="isActivityTransitionRunning" id="1073823551%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1073823551%2FFunctions%2F1031138095"><span>is</span><wbr></wbr><span>Activity</span><wbr></wbr><span>Transition</span><wbr></wbr><span><span>Running</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1073823551%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1073823551%2FFunctions%2F1031138095"><span class="token function">isActivityTransitionRunning</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1931207062%2FFunctions%2F1031138095" anchor-label="isChangingConfigurations" id="1931207062%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1931207062%2FFunctions%2F1031138095"><span>is</span><wbr></wbr><span>Changing</span><wbr></wbr><span><span>Configurations</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1931207062%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1931207062%2FFunctions%2F1031138095"><span class="token function">isChangingConfigurations</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1947658526%2FFunctions%2F1031138095" anchor-label="isChild" id="1947658526%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1947658526%2FFunctions%2F1031138095"><span>is</span><wbr></wbr><span><span>Child</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1947658526%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#1947658526%2FFunctions%2F1031138095"><span class="token function">isChild</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-423188415%2FFunctions%2F1031138095" anchor-label="isDestroyed" id="-423188415%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-423188415%2FFunctions%2F1031138095"><span>is</span><wbr></wbr><span><span>Destroyed</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-423188415%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-423188415%2FFunctions%2F1031138095"><span class="token function">isDestroyed</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1565618010%2FFunctions%2F1031138095" anchor-label="isDeviceProtectedStorage" id="1565618010%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1565618010%2FFunctions%2F1031138095"><span>is</span><wbr></wbr><span>Device</span><wbr></wbr><span>Protected</span><wbr></wbr><span><span>Storage</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1565618010%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1565618010%2FFunctions%2F1031138095"><span class="token function">isDeviceProtectedStorage</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1522152277%2FFunctions%2F1031138095" anchor-label="isFinishing" id="-1522152277%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1522152277%2FFunctions%2F1031138095"><span>is</span><wbr></wbr><span><span>Finishing</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1522152277%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1522152277%2FFunctions%2F1031138095"><span class="token function">isFinishing</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="80260575%2FFunctions%2F1031138095" anchor-label="isImmersive" id="80260575%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#80260575%2FFunctions%2F1031138095"><span>is</span><wbr></wbr><span><span>Immersive</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="80260575%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#80260575%2FFunctions%2F1031138095"><span class="token function">isImmersive</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="49252659%2FFunctions%2F1031138095" anchor-label="isInMultiWindowMode" id="49252659%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#49252659%2FFunctions%2F1031138095"><span>is</span><wbr></wbr><span>In</span><wbr></wbr><span>Multi</span><wbr></wbr><span>Window</span><wbr></wbr><span><span>Mode</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="49252659%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#49252659%2FFunctions%2F1031138095"><span class="token function">isInMultiWindowMode</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1297157635%2FFunctions%2F1031138095" anchor-label="isInPictureInPictureMode" id="-1297157635%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1297157635%2FFunctions%2F1031138095"><span>is</span><wbr></wbr><span>In</span><wbr></wbr><span>Picture</span><wbr></wbr><span>In</span><wbr></wbr><span>Picture</span><wbr></wbr><span><span>Mode</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1297157635%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1297157635%2FFunctions%2F1031138095"><span class="token function">isInPictureInPictureMode</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="386928344%2FFunctions%2F1031138095" anchor-label="isLaunchedFromBubble" id="386928344%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#386928344%2FFunctions%2F1031138095"><span>is</span><wbr></wbr><span>Launched</span><wbr></wbr><span>From</span><wbr></wbr><span><span>Bubble</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="386928344%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#386928344%2FFunctions%2F1031138095"><span class="token function">isLaunchedFromBubble</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1903895843%2FFunctions%2F1031138095" anchor-label="isLocalVoiceInteractionSupported" id="-1903895843%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1903895843%2FFunctions%2F1031138095"><span>is</span><wbr></wbr><span>Local</span><wbr></wbr><span>Voice</span><wbr></wbr><span>Interaction</span><wbr></wbr><span><span>Supported</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1903895843%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1903895843%2FFunctions%2F1031138095"><span class="token function">isLocalVoiceInteractionSupported</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1776278686%2FFunctions%2F1031138095" anchor-label="isRestricted" id="-1776278686%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1776278686%2FFunctions%2F1031138095"><span>is</span><wbr></wbr><span><span>Restricted</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1776278686%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1776278686%2FFunctions%2F1031138095"><span class="token function">isRestricted</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="2027112825%2FFunctions%2F1031138095" anchor-label="isTaskRoot" id="2027112825%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#2027112825%2FFunctions%2F1031138095"><span>is</span><wbr></wbr><span>Task</span><wbr></wbr><span><span>Root</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="2027112825%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#2027112825%2FFunctions%2F1031138095"><span class="token function">isTaskRoot</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="2131014658%2FFunctions%2F1031138095" anchor-label="isUiContext" id="2131014658%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#2131014658%2FFunctions%2F1031138095"><span>is</span><wbr></wbr><span>Ui</span><wbr></wbr><span><span>Context</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="2131014658%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#2131014658%2FFunctions%2F1031138095"><span class="token function">isUiContext</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1356218592%2FFunctions%2F1031138095" anchor-label="isVoiceInteraction" id="-1356218592%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1356218592%2FFunctions%2F1031138095"><span>is</span><wbr></wbr><span>Voice</span><wbr></wbr><span><span>Interaction</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1356218592%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1356218592%2FFunctions%2F1031138095"><span class="token function">isVoiceInteraction</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1896831266%2FFunctions%2F1031138095" anchor-label="isVoiceInteractionRoot" id="-1896831266%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1896831266%2FFunctions%2F1031138095"><span>is</span><wbr></wbr><span>Voice</span><wbr></wbr><span>Interaction</span><wbr></wbr><span><span>Root</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1896831266%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1896831266%2FFunctions%2F1031138095"><span class="token function">isVoiceInteractionRoot</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div>                  </div>
                 </div>
               </div>
             </div>
@@ -5003,6 +6550,23 @@
               </div>
             </div>
           </div>
+<a data-name="376493809%2FFunctions%2F1031138095" anchor-label="setContentTransitionManager" id="376493809%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#376493809%2FFunctions%2F1031138095"><span>set</span><wbr></wbr><span>Content</span><wbr></wbr><span>Transition</span><wbr></wbr><span><span>Manager</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="376493809%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#376493809%2FFunctions%2F1031138095"><span class="token function">setContentTransitionManager</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">tm<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/transition/TransitionManager.html">TransitionManager</a></span></span><span class="token punctuation">)</span></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="-383343902%2FFunctions%2F1031138095" anchor-label="setContentView" id="-383343902%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
           <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
             <div class="main-subrow keyValue ">
@@ -5156,6 +6720,23 @@
               </div>
             </div>
           </div>
+<a data-name="-1206334231%2FFunctions%2F1031138095" anchor-label="setImmersive" id="-1206334231%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1206334231%2FFunctions%2F1031138095"><span>set</span><wbr></wbr><span><span>Immersive</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1206334231%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1206334231%2FFunctions%2F1031138095"><span class="token function">setImmersive</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">i<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></span></span><span class="token punctuation">)</span></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="-1040540598%2FFunctions%2F1031138095" anchor-label="setInheritShowWhenLocked" id="-1040540598%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
           <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
             <div class="main-subrow keyValue ">
@@ -5173,6 +6754,23 @@
               </div>
             </div>
           </div>
+<a data-name="-696482206%2FFunctions%2F1031138095" anchor-label="setIntent" id="-696482206%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-696482206%2FFunctions%2F1031138095"><span>set</span><wbr></wbr><span><span>Intent</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-696482206%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-696482206%2FFunctions%2F1031138095"><span class="token function">setIntent</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">newIntent<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/Intent.html">Intent</a></span></span><span class="token punctuation">)</span></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="-212546250%2FFunctions%2F1031138095" anchor-label="setLocusContext" id="-212546250%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
           <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
             <div class="main-subrow keyValue ">
@@ -5186,6 +6784,23 @@
                   <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
                     <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
 <div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-212546250%2FFunctions%2F1031138095"><span class="token function">setLocusContext</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">locusId<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/LocusId.html">LocusId</a><span class="token punctuation">, </span></span><span class="parameter ">bundle<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/os/Bundle.html">Bundle</a></span></span><span class="token punctuation">)</span></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="345348023%2FFunctions%2F1031138095" anchor-label="setMediaController" id="345348023%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#345348023%2FFunctions%2F1031138095"><span>set</span><wbr></wbr><span>Media</span><wbr></wbr><span><span>Controller</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="345348023%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#345348023%2FFunctions%2F1031138095"><span class="token function">setMediaController</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">controller<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/media/session/MediaController.html">MediaController</a></span></span><span class="token punctuation">)</span></div></div>                  </div>
                 </div>
               </div>
             </div>
@@ -5288,6 +6903,23 @@
                   <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
                     <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
 <div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-650477169%2FFunctions%2F1031138095"><span class="token function">setRecentsScreenshotEnabled</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">enabled<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></span></span><span class="token punctuation">)</span></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1517240057%2FFunctions%2F1031138095" anchor-label="setRequestedOrientation" id="-1517240057%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1517240057%2FFunctions%2F1031138095"><span>set</span><wbr></wbr><span>Requested</span><wbr></wbr><span><span>Orientation</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1517240057%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1517240057%2FFunctions%2F1031138095"><span class="token function">setRequestedOrientation</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">requestedOrientation<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span></div></div>                  </div>
                 </div>
               </div>
             </div>
@@ -5462,36 +7094,53 @@
               </div>
             </div>
           </div>
-<a data-name="-1812036744%2FFunctions%2F1031138095" anchor-label="setTheme" id="-1812036744%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+<a data-name="502589749%2FFunctions%2F1031138095" anchor-label="setTheme" id="502589749%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
           <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
             <div class="main-subrow keyValue ">
               <div class=""><span class="inline-flex">
-                  <div><a href="index.html#-1812036744%2FFunctions%2F1031138095"><span>set</span><wbr></wbr><span><span>Theme</span></span></a></div>
-<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1812036744%2FFunctions%2F1031138095"></span>
+                  <div><a href="index.html#-1882571409%2FFunctions%2F1031138095"><span>set</span><wbr></wbr><span><span>Theme</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="502589749%2FFunctions%2F1031138095"></span>
                     <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
                   </span></span></div>
               <div>
                 <div class="title">
                   <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
                     <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
-<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1812036744%2FFunctions%2F1031138095"><span class="token function">setTheme</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">resId<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span></div></div>                  </div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1882571409%2FFunctions%2F1031138095"><span class="token function">setTheme</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">theme<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/res/Resources.Theme.html">Resources.Theme</a></span></span><span class="token punctuation">)</span></div><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1812036744%2FFunctions%2F1031138095"><span class="token function">setTheme</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">resId<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span></div></div>                  </div>
                 </div>
               </div>
             </div>
           </div>
-<a data-name="-481981473%2FFunctions%2F1031138095" anchor-label="setTitle" id="-481981473%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+<a data-name="1223103612%2FFunctions%2F1031138095" anchor-label="setTitle" id="1223103612%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
           <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
             <div class="main-subrow keyValue ">
               <div class=""><span class="inline-flex">
                   <div><a href="index.html#-481981473%2FFunctions%2F1031138095"><span>set</span><wbr></wbr><span><span>Title</span></span></a></div>
-<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-481981473%2FFunctions%2F1031138095"></span>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1223103612%2FFunctions%2F1031138095"></span>
                     <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
                   </span></span></div>
               <div>
                 <div class="title">
                   <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
                     <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
-<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-481981473%2FFunctions%2F1031138095"><span class="token function">setTitle</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">titleId<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span></div></div>                  </div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-481981473%2FFunctions%2F1031138095"><span class="token function">setTitle</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">titleId<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span></div><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-723395735%2FFunctions%2F1031138095"><span class="token function">setTitle</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">title<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/CharSequence.html">CharSequence</a></span></span><span class="token punctuation">)</span></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-479328592%2FFunctions%2F1031138095" anchor-label="setTitleColor" id="-479328592%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-479328592%2FFunctions%2F1031138095"><span>set</span><wbr></wbr><span>Title</span><wbr></wbr><span><span>Color</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-479328592%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-479328592%2FFunctions%2F1031138095"><span class="token function">setTitleColor</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">textColor<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span></div></div>                  </div>
                 </div>
               </div>
             </div>
@@ -5543,6 +7192,23 @@
                   <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
                     <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
 <div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1019486496%2FFunctions%2F1031138095"><span class="token function">setVisible</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">visible<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></span></span><span class="token punctuation">)</span></div></div>                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="838359946%2FFunctions%2F1031138095" anchor-label="setVolumeControlStream" id="838359946%2FFunctions%2F1031138095" data-filterable-set=":/androidMain"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#838359946%2FFunctions%2F1031138095"><span>set</span><wbr></wbr><span>Volume</span><wbr></wbr><span>Control</span><wbr></wbr><span><span>Stream</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="838359946%2FFunctions%2F1031138095"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted  with-platform-tabs" data-platform-hinted="data-platform-hinted">
+                    <div class="platform-bookmarks-row" data-toggle-list="data-toggle-list"><button class="platform-bookmark" data-filterable-current=":/androidMain" data-filterable-set=":/androidMain" data-active="" data-toggle=":/androidMain">android</button></div>
+<div class="content sourceset-dependent-content" data-active="" data-togglable=":/androidMain"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#838359946%2FFunctions%2F1031138095"><span class="token function">setVolumeControlStream</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">streamType<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span></div></div>                  </div>
                 </div>
               </div>
             </div>

--- a/dokka-integration-tests/gradle/projects/it-android/expectedData/html/it-android/it.android/-integration-test-activity/index.html
+++ b/dokka-integration-tests/gradle/projects/it-android/expectedData/html/it-android/it.android/-integration-test-activity/index.html
@@ -2192,6 +2192,201 @@
               </div>
             </div>
           </div>
+<a data-name="-2108225789%2FFunctions%2F-419168471" anchor-label="getActionBar" id="-2108225789%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-2108225789%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Action</span><wbr></wbr><span><span>Bar</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-2108225789%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-2108225789%2FFunctions%2F-419168471"><span class="token function">getActionBar</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/app/ActionBar.html">ActionBar</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1526237776%2FFunctions%2F-419168471" anchor-label="getApplication" id="1526237776%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1526237776%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span><span>Application</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1526237776%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#1526237776%2FFunctions%2F-419168471"><span class="token function">getApplication</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/app/Application.html">Application</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="720574270%2FFunctions%2F-419168471" anchor-label="getApplicationContext" id="720574270%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#720574270%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Application</span><wbr></wbr><span><span>Context</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="720574270%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#720574270%2FFunctions%2F-419168471"><span class="token function">getApplicationContext</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/Context.html">Context</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="875309695%2FFunctions%2F-419168471" anchor-label="getApplicationInfo" id="875309695%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#875309695%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Application</span><wbr></wbr><span><span>Info</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="875309695%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#875309695%2FFunctions%2F-419168471"><span class="token function">getApplicationInfo</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/pm/ApplicationInfo.html">ApplicationInfo</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1028304091%2FFunctions%2F-419168471" anchor-label="getAssets" id="-1028304091%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1028304091%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span><span>Assets</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1028304091%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1028304091%2FFunctions%2F-419168471"><span class="token function">getAssets</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/res/AssetManager.html">AssetManager</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-2059689374%2FFunctions%2F-419168471" anchor-label="getAttributionTag" id="-2059689374%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-2059689374%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Attribution</span><wbr></wbr><span><span>Tag</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-2059689374%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-2059689374%2FFunctions%2F-419168471"><span class="token function">getAttributionTag</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1836627711%2FFunctions%2F-419168471" anchor-label="getBaseContext" id="1836627711%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1836627711%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Base</span><wbr></wbr><span><span>Context</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1836627711%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1836627711%2FFunctions%2F-419168471"><span class="token function">getBaseContext</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/Context.html">Context</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-803358382%2FFunctions%2F-419168471" anchor-label="getCacheDir" id="-803358382%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-803358382%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Cache</span><wbr></wbr><span><span>Dir</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-803358382%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-803358382%2FFunctions%2F-419168471"><span class="token function">getCacheDir</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-2093832307%2FFunctions%2F-419168471" anchor-label="getCallingActivity" id="-2093832307%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-2093832307%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Calling</span><wbr></wbr><span><span>Activity</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-2093832307%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-2093832307%2FFunctions%2F-419168471"><span class="token function">getCallingActivity</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/ComponentName.html">ComponentName</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1745389992%2FFunctions%2F-419168471" anchor-label="getCallingPackage" id="-1745389992%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1745389992%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Calling</span><wbr></wbr><span><span>Package</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1745389992%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1745389992%2FFunctions%2F-419168471"><span class="token function">getCallingPackage</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1601610448%2FFunctions%2F-419168471" anchor-label="getChangingConfigurations" id="-1601610448%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1601610448%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Changing</span><wbr></wbr><span><span>Configurations</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1601610448%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1601610448%2FFunctions%2F-419168471"><span class="token function">getChangingConfigurations</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1242041746%2FFunctions%2F-419168471" anchor-label="getClassLoader" id="1242041746%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1242041746%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Class</span><wbr></wbr><span><span>Loader</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1242041746%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1242041746%2FFunctions%2F-419168471"><span class="token function">getClassLoader</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/ClassLoader.html">ClassLoader</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1138511077%2FFunctions%2F-419168471" anchor-label="getCodeCacheDir" id="1138511077%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1138511077%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Code</span><wbr></wbr><span>Cache</span><wbr></wbr><span><span>Dir</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1138511077%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1138511077%2FFunctions%2F-419168471"><span class="token function">getCodeCacheDir</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="1123824824%2FFunctions%2F-419168471" anchor-label="getColor" id="1123824824%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
           <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
             <div class="main-subrow keyValue ">
@@ -2222,6 +2417,81 @@
               </div>
             </div>
           </div>
+<a data-name="-1710268232%2FFunctions%2F-419168471" anchor-label="getComponentName" id="-1710268232%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1710268232%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Component</span><wbr></wbr><span><span>Name</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1710268232%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1710268232%2FFunctions%2F-419168471"><span class="token function">getComponentName</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/ComponentName.html">ComponentName</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1924753378%2FFunctions%2F-419168471" anchor-label="getContentResolver" id="-1924753378%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1924753378%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Content</span><wbr></wbr><span><span>Resolver</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1924753378%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1924753378%2FFunctions%2F-419168471"><span class="token function">getContentResolver</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/ContentResolver.html">ContentResolver</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="261968391%2FFunctions%2F-419168471" anchor-label="getContentScene" id="261968391%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#261968391%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Content</span><wbr></wbr><span><span>Scene</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="261968391%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#261968391%2FFunctions%2F-419168471"><span class="token function">getContentScene</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/transition/Scene.html">Scene</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1914863227%2FFunctions%2F-419168471" anchor-label="getContentTransitionManager" id="1914863227%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1914863227%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Content</span><wbr></wbr><span>Transition</span><wbr></wbr><span><span>Manager</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1914863227%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1914863227%2FFunctions%2F-419168471"><span class="token function">getContentTransitionManager</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/transition/TransitionManager.html">TransitionManager</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1699869637%2FFunctions%2F-419168471" anchor-label="getCurrentFocus" id="-1699869637%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1699869637%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Current</span><wbr></wbr><span><span>Focus</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1699869637%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1699869637%2FFunctions%2F-419168471"><span class="token function">getCurrentFocus</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/view/View.html">View</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="1055464536%2FFunctions%2F-419168471" anchor-label="getDatabasePath" id="1055464536%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
           <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
             <div class="main-subrow keyValue ">
@@ -2233,6 +2503,36 @@
               <div>
                 <div class="title">
                   <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1055464536%2FFunctions%2F-419168471"><span class="token function">getDatabasePath</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">name<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></span></span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="666732474%2FFunctions%2F-419168471" anchor-label="getDataDir" id="666732474%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#666732474%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Data</span><wbr></wbr><span><span>Dir</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="666732474%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#666732474%2FFunctions%2F-419168471"><span class="token function">getDataDir</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1783008893%2FFunctions%2F-419168471" anchor-label="getDelegate" id="1783008893%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1783008893%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span><span>Delegate</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1783008893%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1783008893%2FFunctions%2F-419168471"><span class="token function">getDelegate</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/appcompat/app/AppCompatDelegate.html">AppCompatDelegate</a></div></div></div>
                 </div>
               </div>
             </div>
@@ -2252,6 +2552,21 @@
               </div>
             </div>
           </div>
+<a data-name="488073307%2FFunctions%2F-419168471" anchor-label="getDisplay" id="488073307%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#488073307%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span><span>Display</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="488073307%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#488073307%2FFunctions%2F-419168471"><span class="token function">getDisplay</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/view/Display.html">Display</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="-816782443%2FFunctions%2F-419168471" anchor-label="getDrawable" id="-816782443%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
           <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
             <div class="main-subrow keyValue ">
@@ -2263,6 +2578,51 @@
               <div>
                 <div class="title">
                   <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#-816782443%2FFunctions%2F-419168471"><span class="token function">getDrawable</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">id<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/graphics/drawable/Drawable.html">Drawable</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-921690152%2FFunctions%2F-419168471" anchor-label="getDrawerToggleDelegate" id="-921690152%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-921690152%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Drawer</span><wbr></wbr><span>Toggle</span><wbr></wbr><span><span>Delegate</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-921690152%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-921690152%2FFunctions%2F-419168471"><span class="token function">getDrawerToggleDelegate</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/appcompat/app/ActionBarDrawerToggle.Delegate.html">ActionBarDrawerToggle.Delegate</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="544398023%2FFunctions%2F-419168471" anchor-label="getExternalCacheDir" id="544398023%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#544398023%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>External</span><wbr></wbr><span>Cache</span><wbr></wbr><span><span>Dir</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="544398023%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#544398023%2FFunctions%2F-419168471"><span class="token function">getExternalCacheDir</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1262724320%2FFunctions%2F-419168471" anchor-label="getExternalCacheDirs" id="1262724320%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1262724320%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>External</span><wbr></wbr><span>Cache</span><wbr></wbr><span><span>Dirs</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1262724320%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1262724320%2FFunctions%2F-419168471"><span class="token function">getExternalCacheDirs</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-array/index.html">Array</a><span class="token operator">&lt;</span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a><span class="token operator">&gt;</span></div></div></div>
                 </div>
               </div>
             </div>
@@ -2297,6 +2657,21 @@
               </div>
             </div>
           </div>
+<a data-name="1078368190%2FFunctions%2F-419168471" anchor-label="getExternalMediaDirs" id="1078368190%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1078368190%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>External</span><wbr></wbr><span>Media</span><wbr></wbr><span><span>Dirs</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1078368190%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1078368190%2FFunctions%2F-419168471"><span class="token function">getExternalMediaDirs</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-array/index.html">Array</a><span class="token operator">&lt;</span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a><span class="token operator">&gt;</span></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="2147131388%2FFunctions%2F-419168471" anchor-label="getExtraData" id="2147131388%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
           <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
             <div class="main-subrow keyValue ">
@@ -2308,6 +2683,21 @@
               <div>
                 <div class="title">
                   <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><span class="token operator">&lt;</span><a href="index.html#2147131388%2FFunctions%2F-419168471">T</a><span class="token operator"> : </span><a href="https://developer.android.com/reference/kotlin/androidx/core/app/ComponentActivity.ExtraData.html">ComponentActivity.ExtraData</a><span class="token operator">&gt; </span><a href="index.html#2147131388%2FFunctions%2F-419168471"><span class="token function">getExtraData</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">extraDataClass<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/Class.html">Class</a><span class="token operator">&lt;</span><a href="index.html#2147131388%2FFunctions%2F-419168471">T</a><span class="token operator">&gt;</span></span></span><span class="token punctuation">)</span><span class="token operator">: </span><a href="index.html#2147131388%2FFunctions%2F-419168471">T</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-2018610489%2FFunctions%2F-419168471" anchor-label="getFilesDir" id="-2018610489%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-2018610489%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Files</span><wbr></wbr><span><span>Dir</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-2018610489%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-2018610489%2FFunctions%2F-419168471"><span class="token function">getFilesDir</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a></div></div></div>
                 </div>
               </div>
             </div>
@@ -2327,6 +2717,366 @@
               </div>
             </div>
           </div>
+<a data-name="1444016003%2FFunctions%2F-419168471" anchor-label="getFragmentManager" id="1444016003%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1444016003%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Fragment</span><wbr></wbr><span><span>Manager</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1444016003%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1444016003%2FFunctions%2F-419168471"><span class="token function">getFragmentManager</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/app/FragmentManager.html">FragmentManager</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1000759074%2FFunctions%2F-419168471" anchor-label="getIntent" id="-1000759074%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1000759074%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span><span>Intent</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1000759074%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1000759074%2FFunctions%2F-419168471"><span class="token function">getIntent</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/Intent.html">Intent</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1865555744%2FFunctions%2F-419168471" anchor-label="getLastCustomNonConfigurationInstance" id="1865555744%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1865555744%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Last</span><wbr></wbr><span>Custom</span><wbr></wbr><span>Non</span><wbr></wbr><span>Configuration</span><wbr></wbr><span><span>Instance</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1865555744%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1865555744%2FFunctions%2F-419168471"><span class="token function">getLastCustomNonConfigurationInstance</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-any/index.html">Any</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-977658074%2FFunctions%2F-419168471" anchor-label="getLastNonConfigurationInstance" id="-977658074%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-977658074%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Last</span><wbr></wbr><span>Non</span><wbr></wbr><span>Configuration</span><wbr></wbr><span><span>Instance</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-977658074%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-977658074%2FFunctions%2F-419168471"><span class="token function">getLastNonConfigurationInstance</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-any/index.html">Any</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-755744763%2FFunctions%2F-419168471" anchor-label="getLayoutInflater" id="-755744763%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-755744763%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Layout</span><wbr></wbr><span><span>Inflater</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-755744763%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-755744763%2FFunctions%2F-419168471"><span class="token function">getLayoutInflater</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/view/LayoutInflater.html">LayoutInflater</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-363549909%2FFunctions%2F-419168471" anchor-label="getLifecycle" id="-363549909%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-363549909%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span><span>Lifecycle</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-363549909%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-363549909%2FFunctions%2F-419168471"><span class="token function">getLifecycle</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/lifecycle/Lifecycle.html">Lifecycle</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="2145988102%2FFunctions%2F-419168471" anchor-label="getLoaderManager" id="2145988102%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#2145988102%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Loader</span><wbr></wbr><span><span>Manager</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="2145988102%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#2145988102%2FFunctions%2F-419168471"><span class="token function">getLoaderManager</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/app/LoaderManager.html">LoaderManager</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-376937214%2FFunctions%2F-419168471" anchor-label="getLocalClassName" id="-376937214%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-376937214%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Local</span><wbr></wbr><span>Class</span><wbr></wbr><span><span>Name</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-376937214%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-376937214%2FFunctions%2F-419168471"><span class="token function">getLocalClassName</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1205639281%2FFunctions%2F-419168471" anchor-label="getMainExecutor" id="1205639281%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1205639281%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Main</span><wbr></wbr><span><span>Executor</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1205639281%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1205639281%2FFunctions%2F-419168471"><span class="token function">getMainExecutor</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/util/concurrent/Executor.html">Executor</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="400244339%2FFunctions%2F-419168471" anchor-label="getMainLooper" id="400244339%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#400244339%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Main</span><wbr></wbr><span><span>Looper</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="400244339%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#400244339%2FFunctions%2F-419168471"><span class="token function">getMainLooper</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/os/Looper.html">Looper</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1704478464%2FFunctions%2F-419168471" anchor-label="getMaxNumPictureInPictureActions" id="-1704478464%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1704478464%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Max</span><wbr></wbr><span>Num</span><wbr></wbr><span>Picture</span><wbr></wbr><span>In</span><wbr></wbr><span>Picture</span><wbr></wbr><span><span>Actions</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1704478464%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1704478464%2FFunctions%2F-419168471"><span class="token function">getMaxNumPictureInPictureActions</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1703977600%2FFunctions%2F-419168471" anchor-label="getMediaController" id="-1703977600%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1703977600%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Media</span><wbr></wbr><span><span>Controller</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1703977600%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#-1703977600%2FFunctions%2F-419168471"><span class="token function">getMediaController</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/media/session/MediaController.html">MediaController</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="13623128%2FFunctions%2F-419168471" anchor-label="getMenuInflater" id="13623128%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#13623128%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Menu</span><wbr></wbr><span><span>Inflater</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="13623128%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#13623128%2FFunctions%2F-419168471"><span class="token function">getMenuInflater</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/view/MenuInflater.html">MenuInflater</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1811406884%2FFunctions%2F-419168471" anchor-label="getNoBackupFilesDir" id="1811406884%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1811406884%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>No</span><wbr></wbr><span>Backup</span><wbr></wbr><span>Files</span><wbr></wbr><span><span>Dir</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1811406884%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1811406884%2FFunctions%2F-419168471"><span class="token function">getNoBackupFilesDir</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="252787007%2FFunctions%2F-419168471" anchor-label="getObbDir" id="252787007%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#252787007%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Obb</span><wbr></wbr><span><span>Dir</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="252787007%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#252787007%2FFunctions%2F-419168471"><span class="token function">getObbDir</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="812717416%2FFunctions%2F-419168471" anchor-label="getObbDirs" id="812717416%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#812717416%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Obb</span><wbr></wbr><span><span>Dirs</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="812717416%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#812717416%2FFunctions%2F-419168471"><span class="token function">getObbDirs</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-array/index.html">Array</a><span class="token operator">&lt;</span><a href="https://developer.android.com/reference/kotlin/java/io/File.html">File</a><span class="token operator">&gt;</span></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1039536402%2FFunctions%2F-419168471" anchor-label="getOnBackPressedDispatcher" id="1039536402%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1039536402%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>On</span><wbr></wbr><span>Back</span><wbr></wbr><span>Pressed</span><wbr></wbr><span><span>Dispatcher</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1039536402%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#1039536402%2FFunctions%2F-419168471"><span class="token function">getOnBackPressedDispatcher</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/activity/OnBackPressedDispatcher.html">OnBackPressedDispatcher</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-814243443%2FFunctions%2F-419168471" anchor-label="getOpPackageName" id="-814243443%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-814243443%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Op</span><wbr></wbr><span>Package</span><wbr></wbr><span><span>Name</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-814243443%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-814243443%2FFunctions%2F-419168471"><span class="token function">getOpPackageName</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1681869883%2FFunctions%2F-419168471" anchor-label="getPackageCodePath" id="-1681869883%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1681869883%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Package</span><wbr></wbr><span>Code</span><wbr></wbr><span><span>Path</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1681869883%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1681869883%2FFunctions%2F-419168471"><span class="token function">getPackageCodePath</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="224992758%2FFunctions%2F-419168471" anchor-label="getPackageManager" id="224992758%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#224992758%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Package</span><wbr></wbr><span><span>Manager</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="224992758%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#224992758%2FFunctions%2F-419168471"><span class="token function">getPackageManager</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/pm/PackageManager.html">PackageManager</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1158183924%2FFunctions%2F-419168471" anchor-label="getPackageName" id="-1158183924%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1158183924%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Package</span><wbr></wbr><span><span>Name</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1158183924%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1158183924%2FFunctions%2F-419168471"><span class="token function">getPackageName</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="512700484%2FFunctions%2F-419168471" anchor-label="getPackageResourcePath" id="512700484%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#512700484%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Package</span><wbr></wbr><span>Resource</span><wbr></wbr><span><span>Path</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="512700484%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#512700484%2FFunctions%2F-419168471"><span class="token function">getPackageResourcePath</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/String.html">String</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-78472560%2FFunctions%2F-419168471" anchor-label="getParent" id="-78472560%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-78472560%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span><span>Parent</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-78472560%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#-78472560%2FFunctions%2F-419168471"><span class="token function">getParent</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/app/Activity.html">Activity</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1492932869%2FFunctions%2F-419168471" anchor-label="getParentActivityIntent" id="1492932869%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1492932869%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Parent</span><wbr></wbr><span>Activity</span><wbr></wbr><span><span>Intent</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1492932869%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1492932869%2FFunctions%2F-419168471"><span class="token function">getParentActivityIntent</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/Intent.html">Intent</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="-761855413%2FFunctions%2F-419168471" anchor-label="getPreferences" id="-761855413%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
           <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
             <div class="main-subrow keyValue ">
@@ -2338,6 +3088,81 @@
               <div>
                 <div class="title">
                   <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-761855413%2FFunctions%2F-419168471"><span class="token function">getPreferences</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">mode<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/SharedPreferences.html">SharedPreferences</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-581473925%2FFunctions%2F-419168471" anchor-label="getReferrer" id="-581473925%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-581473925%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span><span>Referrer</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-581473925%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-581473925%2FFunctions%2F-419168471"><span class="token function">getReferrer</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/net/Uri.html">Uri</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1038606840%2FFunctions%2F-419168471" anchor-label="getRequestedOrientation" id="1038606840%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1038606840%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Requested</span><wbr></wbr><span><span>Orientation</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1038606840%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1038606840%2FFunctions%2F-419168471"><span class="token function">getRequestedOrientation</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-404044493%2FFunctions%2F-419168471" anchor-label="getResources" id="-404044493%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-404044493%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span><span>Resources</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-404044493%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-404044493%2FFunctions%2F-419168471"><span class="token function">getResources</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/res/Resources.html">Resources</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="2075539550%2FFunctions%2F-419168471" anchor-label="getSavedStateRegistry" id="2075539550%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#2075539550%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Saved</span><wbr></wbr><span>State</span><wbr></wbr><span><span>Registry</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="2075539550%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#2075539550%2FFunctions%2F-419168471"><span class="token function">getSavedStateRegistry</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/savedstate/SavedStateRegistry.html">SavedStateRegistry</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-630770%2FFunctions%2F-419168471" anchor-label="getSearchEvent" id="-630770%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-630770%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Search</span><wbr></wbr><span><span>Event</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-630770%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#-630770%2FFunctions%2F-419168471"><span class="token function">getSearchEvent</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/view/SearchEvent.html">SearchEvent</a></div></div></div>
                 </div>
               </div>
             </div>
@@ -2372,6 +3197,66 @@
               </div>
             </div>
           </div>
+<a data-name="993354804%2FFunctions%2F-419168471" anchor-label="getSupportActionBar" id="993354804%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#993354804%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Support</span><wbr></wbr><span>Action</span><wbr></wbr><span><span>Bar</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="993354804%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#993354804%2FFunctions%2F-419168471"><span class="token function">getSupportActionBar</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/appcompat/app/ActionBar.html">ActionBar</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="396613922%2FFunctions%2F-419168471" anchor-label="getSupportFragmentManager" id="396613922%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#396613922%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Support</span><wbr></wbr><span>Fragment</span><wbr></wbr><span><span>Manager</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="396613922%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#396613922%2FFunctions%2F-419168471"><span class="token function">getSupportFragmentManager</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/fragment/app/FragmentManager.html">FragmentManager</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="97973093%2FFunctions%2F-419168471" anchor-label="getSupportLoaderManager" id="97973093%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#97973093%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Support</span><wbr></wbr><span>Loader</span><wbr></wbr><span><span>Manager</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="97973093%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#97973093%2FFunctions%2F-419168471"><span class="token function">getSupportLoaderManager</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/loader/app/LoaderManager.html">LoaderManager</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="192054068%2FFunctions%2F-419168471" anchor-label="getSupportParentActivityIntent" id="192054068%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#192054068%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Support</span><wbr></wbr><span>Parent</span><wbr></wbr><span>Activity</span><wbr></wbr><span><span>Intent</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="192054068%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#192054068%2FFunctions%2F-419168471"><span class="token function">getSupportParentActivityIntent</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/Intent.html">Intent</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="152974125%2FFunctions%2F-419168471" anchor-label="getSystemService" id="152974125%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
           <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
             <div class="main-subrow keyValue ">
@@ -2402,6 +3287,21 @@
               </div>
             </div>
           </div>
+<a data-name="-1226887558%2FFunctions%2F-419168471" anchor-label="getTaskId" id="-1226887558%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1226887558%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Task</span><wbr></wbr><span><span>Id</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1226887558%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1226887558%2FFunctions%2F-419168471"><span class="token function">getTaskId</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="635200548%2FFunctions%2F-419168471" anchor-label="getText" id="635200548%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
           <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
             <div class="main-subrow keyValue ">
@@ -2413,6 +3313,171 @@
               <div>
                 <div class="title">
                   <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#635200548%2FFunctions%2F-419168471"><span class="token function">getText</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">resId<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/CharSequence.html">CharSequence</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="945814313%2FFunctions%2F-419168471" anchor-label="getTheme" id="945814313%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#945814313%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span><span>Theme</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="945814313%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#945814313%2FFunctions%2F-419168471"><span class="token function">getTheme</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/res/Resources.Theme.html">Resources.Theme</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="671976584%2FFunctions%2F-419168471" anchor-label="getTitle" id="671976584%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#671976584%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span><span>Title</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="671976584%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#671976584%2FFunctions%2F-419168471"><span class="token function">getTitle</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/CharSequence.html">CharSequence</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-815012881%2FFunctions%2F-419168471" anchor-label="getTitleColor" id="-815012881%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-815012881%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Title</span><wbr></wbr><span><span>Color</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-815012881%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#-815012881%2FFunctions%2F-419168471"><span class="token function">getTitleColor</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-123874808%2FFunctions%2F-419168471" anchor-label="getViewModelStore" id="-123874808%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-123874808%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>View</span><wbr></wbr><span>Model</span><wbr></wbr><span><span>Store</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-123874808%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-123874808%2FFunctions%2F-419168471"><span class="token function">getViewModelStore</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/androidx/lifecycle/ViewModelStore.html">ViewModelStore</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="819156245%2FFunctions%2F-419168471" anchor-label="getVoiceInteractor" id="819156245%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#819156245%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Voice</span><wbr></wbr><span><span>Interactor</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="819156245%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#819156245%2FFunctions%2F-419168471"><span class="token function">getVoiceInteractor</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/app/VoiceInteractor.html">VoiceInteractor</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="714135997%2FFunctions%2F-419168471" anchor-label="getVolumeControlStream" id="714135997%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#714135997%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Volume</span><wbr></wbr><span>Control</span><wbr></wbr><span><span>Stream</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="714135997%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#714135997%2FFunctions%2F-419168471"><span class="token function">getVolumeControlStream</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-721579237%2FFunctions%2F-419168471" anchor-label="getWallpaper" id="-721579237%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-721579237%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span><span>Wallpaper</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-721579237%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-721579237%2FFunctions%2F-419168471"><span class="token function">getWallpaper</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/graphics/drawable/Drawable.html">Drawable</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-662155776%2FFunctions%2F-419168471" anchor-label="getWallpaperDesiredMinimumHeight" id="-662155776%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-662155776%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Wallpaper</span><wbr></wbr><span>Desired</span><wbr></wbr><span>Minimum</span><wbr></wbr><span><span>Height</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-662155776%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-662155776%2FFunctions%2F-419168471"><span class="token function">getWallpaperDesiredMinimumHeight</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="295343597%2FFunctions%2F-419168471" anchor-label="getWallpaperDesiredMinimumWidth" id="295343597%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#295343597%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Wallpaper</span><wbr></wbr><span>Desired</span><wbr></wbr><span>Minimum</span><wbr></wbr><span><span>Width</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="295343597%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#295343597%2FFunctions%2F-419168471"><span class="token function">getWallpaperDesiredMinimumWidth</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1004659210%2FFunctions%2F-419168471" anchor-label="getWindow" id="1004659210%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1004659210%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span><span>Window</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1004659210%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1004659210%2FFunctions%2F-419168471"><span class="token function">getWindow</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/view/Window.html">Window</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-130996765%2FFunctions%2F-419168471" anchor-label="getWindowManager" id="-130996765%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-130996765%2FFunctions%2F-419168471"><span>get</span><wbr></wbr><span>Window</span><wbr></wbr><span><span>Manager</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-130996765%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-130996765%2FFunctions%2F-419168471"><span class="token function">getWindowManager</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/view/WindowManager.html">WindowManager</a></div></div></div>
                 </div>
               </div>
             </div>
@@ -2458,6 +3523,216 @@
               <div>
                 <div class="title">
                   <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1946521782%2FFunctions%2F-419168471"><span class="token function">invalidateOptionsMenu</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1073823551%2FFunctions%2F-419168471" anchor-label="isActivityTransitionRunning" id="1073823551%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1073823551%2FFunctions%2F-419168471"><span>is</span><wbr></wbr><span>Activity</span><wbr></wbr><span>Transition</span><wbr></wbr><span><span>Running</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1073823551%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1073823551%2FFunctions%2F-419168471"><span class="token function">isActivityTransitionRunning</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1931207062%2FFunctions%2F-419168471" anchor-label="isChangingConfigurations" id="1931207062%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1931207062%2FFunctions%2F-419168471"><span>is</span><wbr></wbr><span>Changing</span><wbr></wbr><span><span>Configurations</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1931207062%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1931207062%2FFunctions%2F-419168471"><span class="token function">isChangingConfigurations</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1947658526%2FFunctions%2F-419168471" anchor-label="isChild" id="1947658526%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1947658526%2FFunctions%2F-419168471"><span>is</span><wbr></wbr><span><span>Child</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1947658526%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#1947658526%2FFunctions%2F-419168471"><span class="token function">isChild</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-423188415%2FFunctions%2F-419168471" anchor-label="isDestroyed" id="-423188415%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-423188415%2FFunctions%2F-419168471"><span>is</span><wbr></wbr><span><span>Destroyed</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-423188415%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-423188415%2FFunctions%2F-419168471"><span class="token function">isDestroyed</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="1565618010%2FFunctions%2F-419168471" anchor-label="isDeviceProtectedStorage" id="1565618010%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#1565618010%2FFunctions%2F-419168471"><span>is</span><wbr></wbr><span>Device</span><wbr></wbr><span>Protected</span><wbr></wbr><span><span>Storage</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1565618010%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#1565618010%2FFunctions%2F-419168471"><span class="token function">isDeviceProtectedStorage</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1522152277%2FFunctions%2F-419168471" anchor-label="isFinishing" id="-1522152277%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1522152277%2FFunctions%2F-419168471"><span>is</span><wbr></wbr><span><span>Finishing</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1522152277%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1522152277%2FFunctions%2F-419168471"><span class="token function">isFinishing</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="80260575%2FFunctions%2F-419168471" anchor-label="isImmersive" id="80260575%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#80260575%2FFunctions%2F-419168471"><span>is</span><wbr></wbr><span><span>Immersive</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="80260575%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#80260575%2FFunctions%2F-419168471"><span class="token function">isImmersive</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="49252659%2FFunctions%2F-419168471" anchor-label="isInMultiWindowMode" id="49252659%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#49252659%2FFunctions%2F-419168471"><span>is</span><wbr></wbr><span>In</span><wbr></wbr><span>Multi</span><wbr></wbr><span>Window</span><wbr></wbr><span><span>Mode</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="49252659%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#49252659%2FFunctions%2F-419168471"><span class="token function">isInMultiWindowMode</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1297157635%2FFunctions%2F-419168471" anchor-label="isInPictureInPictureMode" id="-1297157635%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1297157635%2FFunctions%2F-419168471"><span>is</span><wbr></wbr><span>In</span><wbr></wbr><span>Picture</span><wbr></wbr><span>In</span><wbr></wbr><span>Picture</span><wbr></wbr><span><span>Mode</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1297157635%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1297157635%2FFunctions%2F-419168471"><span class="token function">isInPictureInPictureMode</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1903895843%2FFunctions%2F-419168471" anchor-label="isLocalVoiceInteractionSupported" id="-1903895843%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1903895843%2FFunctions%2F-419168471"><span>is</span><wbr></wbr><span>Local</span><wbr></wbr><span>Voice</span><wbr></wbr><span>Interaction</span><wbr></wbr><span><span>Supported</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1903895843%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1903895843%2FFunctions%2F-419168471"><span class="token function">isLocalVoiceInteractionSupported</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1776278686%2FFunctions%2F-419168471" anchor-label="isRestricted" id="-1776278686%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1776278686%2FFunctions%2F-419168471"><span>is</span><wbr></wbr><span><span>Restricted</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1776278686%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1776278686%2FFunctions%2F-419168471"><span class="token function">isRestricted</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="2027112825%2FFunctions%2F-419168471" anchor-label="isTaskRoot" id="2027112825%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#2027112825%2FFunctions%2F-419168471"><span>is</span><wbr></wbr><span>Task</span><wbr></wbr><span><span>Root</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="2027112825%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#2027112825%2FFunctions%2F-419168471"><span class="token function">isTaskRoot</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1356218592%2FFunctions%2F-419168471" anchor-label="isVoiceInteraction" id="-1356218592%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1356218592%2FFunctions%2F-419168471"><span>is</span><wbr></wbr><span>Voice</span><wbr></wbr><span><span>Interaction</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1356218592%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1356218592%2FFunctions%2F-419168471"><span class="token function">isVoiceInteraction</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1896831266%2FFunctions%2F-419168471" anchor-label="isVoiceInteractionRoot" id="-1896831266%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1896831266%2FFunctions%2F-419168471"><span>is</span><wbr></wbr><span>Voice</span><wbr></wbr><span>Interaction</span><wbr></wbr><span><span>Root</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1896831266%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1896831266%2FFunctions%2F-419168471"><span class="token function">isVoiceInteractionRoot</span></a><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></div></div></div>
                 </div>
               </div>
             </div>
@@ -4232,6 +5507,21 @@
               </div>
             </div>
           </div>
+<a data-name="376493809%2FFunctions%2F-419168471" anchor-label="setContentTransitionManager" id="376493809%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#376493809%2FFunctions%2F-419168471"><span>set</span><wbr></wbr><span>Content</span><wbr></wbr><span>Transition</span><wbr></wbr><span><span>Manager</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="376493809%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#376493809%2FFunctions%2F-419168471"><span class="token function">setContentTransitionManager</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">tm<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/transition/TransitionManager.html">TransitionManager</a></span></span><span class="token punctuation">)</span></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="-383343902%2FFunctions%2F-419168471" anchor-label="setContentView" id="-383343902%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
           <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
             <div class="main-subrow keyValue ">
@@ -4367,6 +5657,21 @@
               </div>
             </div>
           </div>
+<a data-name="-1206334231%2FFunctions%2F-419168471" anchor-label="setImmersive" id="-1206334231%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1206334231%2FFunctions%2F-419168471"><span>set</span><wbr></wbr><span><span>Immersive</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1206334231%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1206334231%2FFunctions%2F-419168471"><span class="token function">setImmersive</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">i<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></span></span><span class="token punctuation">)</span></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="-1040540598%2FFunctions%2F-419168471" anchor-label="setInheritShowWhenLocked" id="-1040540598%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
           <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
             <div class="main-subrow keyValue ">
@@ -4382,6 +5687,21 @@
               </div>
             </div>
           </div>
+<a data-name="-696482206%2FFunctions%2F-419168471" anchor-label="setIntent" id="-696482206%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-696482206%2FFunctions%2F-419168471"><span>set</span><wbr></wbr><span><span>Intent</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-696482206%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-696482206%2FFunctions%2F-419168471"><span class="token function">setIntent</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">newIntent<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/Intent.html">Intent</a></span></span><span class="token punctuation">)</span></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
 <a data-name="-212546250%2FFunctions%2F-419168471" anchor-label="setLocusContext" id="-212546250%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
           <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
             <div class="main-subrow keyValue ">
@@ -4393,6 +5713,21 @@
               <div>
                 <div class="title">
                   <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-212546250%2FFunctions%2F-419168471"><span class="token function">setLocusContext</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">locusId<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/LocusId.html">LocusId</a><span class="token punctuation">, </span></span><span class="parameter ">bundle<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/os/Bundle.html">Bundle</a></span></span><span class="token punctuation">)</span></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="345348023%2FFunctions%2F-419168471" anchor-label="setMediaController" id="345348023%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#345348023%2FFunctions%2F-419168471"><span>set</span><wbr></wbr><span>Media</span><wbr></wbr><span><span>Controller</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="345348023%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#345348023%2FFunctions%2F-419168471"><span class="token function">setMediaController</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">controller<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/media/session/MediaController.html">MediaController</a></span></span><span class="token punctuation">)</span></div></div></div>
                 </div>
               </div>
             </div>
@@ -4468,6 +5803,21 @@
               <div>
                 <div class="title">
                   <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#1080978182%2FFunctions%2F-419168471"><span class="token function">setProgressBarVisibility</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">visible<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></span></span><span class="token punctuation">)</span></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-1517240057%2FFunctions%2F-419168471" anchor-label="setRequestedOrientation" id="-1517240057%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-1517240057%2FFunctions%2F-419168471"><span>set</span><wbr></wbr><span>Requested</span><wbr></wbr><span><span>Orientation</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1517240057%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1517240057%2FFunctions%2F-419168471"><span class="token function">setRequestedOrientation</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">requestedOrientation<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span></div></div></div>
                 </div>
               </div>
             </div>
@@ -4607,32 +5957,47 @@
               </div>
             </div>
           </div>
-<a data-name="-1812036744%2FFunctions%2F-419168471" anchor-label="setTheme" id="-1812036744%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+<a data-name="502589749%2FFunctions%2F-419168471" anchor-label="setTheme" id="502589749%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
           <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
             <div class="main-subrow keyValue ">
               <div class=""><span class="inline-flex">
-                  <div><a href="index.html#-1812036744%2FFunctions%2F-419168471"><span>set</span><wbr></wbr><span><span>Theme</span></span></a></div>
-<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1812036744%2FFunctions%2F-419168471"></span>
+                  <div><a href="index.html#-1882571409%2FFunctions%2F-419168471"><span>set</span><wbr></wbr><span><span>Theme</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="502589749%2FFunctions%2F-419168471"></span>
                     <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
                   </span></span></div>
               <div>
                 <div class="title">
-                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1812036744%2FFunctions%2F-419168471"><span class="token function">setTheme</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">resId<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span></div></div></div>
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1882571409%2FFunctions%2F-419168471"><span class="token function">setTheme</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">theme<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/android/content/res/Resources.Theme.html">Resources.Theme</a></span></span><span class="token punctuation">)</span></div><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1812036744%2FFunctions%2F-419168471"><span class="token function">setTheme</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">resId<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span></div></div></div>
                 </div>
               </div>
             </div>
           </div>
-<a data-name="-481981473%2FFunctions%2F-419168471" anchor-label="setTitle" id="-481981473%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+<a data-name="1223103612%2FFunctions%2F-419168471" anchor-label="setTitle" id="1223103612%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
           <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
             <div class="main-subrow keyValue ">
               <div class=""><span class="inline-flex">
                   <div><a href="index.html#-481981473%2FFunctions%2F-419168471"><span>set</span><wbr></wbr><span><span>Title</span></span></a></div>
-<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-481981473%2FFunctions%2F-419168471"></span>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1223103612%2FFunctions%2F-419168471"></span>
                     <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
                   </span></span></div>
               <div>
                 <div class="title">
-                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-481981473%2FFunctions%2F-419168471"><span class="token function">setTitle</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">titleId<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span></div></div></div>
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-481981473%2FFunctions%2F-419168471"><span class="token function">setTitle</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">titleId<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span></div><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-723395735%2FFunctions%2F-419168471"><span class="token function">setTitle</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">title<span class="token operator">: </span><a href="https://developer.android.com/reference/kotlin/java/lang/CharSequence.html">CharSequence</a></span></span><span class="token punctuation">)</span></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="-479328592%2FFunctions%2F-419168471" anchor-label="setTitleColor" id="-479328592%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#-479328592%2FFunctions%2F-419168471"><span>set</span><wbr></wbr><span>Title</span><wbr></wbr><span><span>Color</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-479328592%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-479328592%2FFunctions%2F-419168471"><span class="token function">setTitleColor</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">textColor<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span></div></div></div>
                 </div>
               </div>
             </div>
@@ -4678,6 +6043,21 @@
               <div>
                 <div class="title">
                   <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">open </span><span class="token keyword">fun </span><a href="index.html#-1019486496%2FFunctions%2F-419168471"><span class="token function">setVisible</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">visible<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-boolean/index.html">Boolean</a></span></span><span class="token punctuation">)</span></div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+<a data-name="838359946%2FFunctions%2F-419168471" anchor-label="setVolumeControlStream" id="838359946%2FFunctions%2F-419168471" data-filterable-set=":/main"></a>
+          <div class="table-row table-row_content" data-filterable-current=":/main" data-filterable-set=":/main">
+            <div class="main-subrow keyValue ">
+              <div class=""><span class="inline-flex">
+                  <div><a href="index.html#838359946%2FFunctions%2F-419168471"><span>set</span><wbr></wbr><span>Volume</span><wbr></wbr><span>Control</span><wbr></wbr><span><span>Stream</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="838359946%2FFunctions%2F-419168471"></span>
+                    <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
+                  </span></span></div>
+              <div>
+                <div class="title">
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":/main"><div class="symbol monospace"><span class="token keyword">fun </span><a href="index.html#838359946%2FFunctions%2F-419168471"><span class="token function">setVolumeControlStream</span></a><span class="token punctuation">(</span><span class="parameters "><span class="parameter ">streamType<span class="token operator">: </span><a href="https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/index.html">Int</a></span></span><span class="token punctuation">)</span></div></div></div>
                 </div>
               </div>
             </div>

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/DefaultSymbolToDocumentableTranslator.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/DefaultSymbolToDocumentableTranslator.kt
@@ -461,15 +461,8 @@ internal class DokkaSymbolVisitor(
         val javaFields = callables.filterIsInstance<KaJavaFieldSymbol>()
             .filterOutSyntheticJavaPropBackingField()
 
-
-        fun List<KaNamedFunctionSymbol>.filterOutSyntheticJavaPropAccessors() = filterNot { fn ->
-            if ((fn.origin == KaSymbolOrigin.JAVA_SOURCE || fn.origin == KaSymbolOrigin.JAVA_LIBRARY) && fn.psi != null)
-                syntheticJavaProperties.any { fn.psi == it.javaGetterSymbol.psi || fn.psi == it.javaSetterSymbol?.psi }
-            else false
-        }
-
         val functions = callables.filterIsInstance<KaNamedFunctionSymbol>()
-            .filterOutSyntheticJavaPropAccessors().map { visitFunctionSymbol(it, dri, isJavaContext) }
+            .map { visitFunctionSymbol(it, dri, isJavaContext) }
 
 
         val properties = callables.filterIsInstance<KaPropertySymbol>().map { visitPropertySymbol(it, dri, isJavaContext) } +

--- a/dokka-subprojects/plugin-base/src/test/kotlin/superFields/DescriptorSuperPropertiesTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/superFields/DescriptorSuperPropertiesTest.kt
@@ -220,7 +220,7 @@ class DescriptorSuperPropertiesTest : BaseAbstractTest() {
                 assertEquals("setA", property.setter?.name)
 
 
-                assertEquals(0, testedClass.functions.size)
+                assertEquals(2, testedClass.functions.size)
 
                 val inheritedFrom = property.extra[InheritedMember]?.inheritedFrom?.values?.single()
                 assertEquals(DRI(packageName = "test", classNames = "A"), inheritedFrom)
@@ -230,6 +230,7 @@ class DescriptorSuperPropertiesTest : BaseAbstractTest() {
         }
     }
 
+    @OnlySymbols("do not filter out accessors of Java synthetic properties")
     @Test
     fun `should inherit property visibility from getter`() {
         val configuration = dokkaConfiguration {
@@ -264,7 +265,7 @@ class DescriptorSuperPropertiesTest : BaseAbstractTest() {
         ) {
             documentablesMergingStage = { module ->
                 val testedClass = module.packages.single().classlikes.single { it.name == "B" }
-                assertEquals(0, testedClass.functions.size)
+                assertEquals(2, testedClass.functions.size)
 
                 val property = testedClass.properties.single { it.name == "a" }
 

--- a/dokka-subprojects/plugin-base/src/test/kotlin/superFields/DescriptorSuperPropertiesTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/superFields/DescriptorSuperPropertiesTest.kt
@@ -318,7 +318,7 @@ class DescriptorSuperPropertiesTest : BaseAbstractTest() {
                 assertEquals("setA", property.setter?.name)
 
 
-                assertEquals(0, testedClass.functions.size)
+                assertEquals(2, testedClass.functions.size)
 
                 val inheritedFrom = property.extra[InheritedMember]?.inheritedFrom?.values?.single()
                 assertEquals(DRI(packageName = "test", classNames = "A"), inheritedFrom)
@@ -328,6 +328,7 @@ class DescriptorSuperPropertiesTest : BaseAbstractTest() {
         }
     }
 
+    @OnlySymbols("do not filter out accessors of Java synthetic properties")
     @Test
     fun `should inherit property visibility from getter`() {
         val configuration = dokkaConfiguration {
@@ -362,7 +363,7 @@ class DescriptorSuperPropertiesTest : BaseAbstractTest() {
         ) {
             documentablesMergingStage = { module ->
                 val testedClass = module.packages.single().classlikes.single { it.name == "B" }
-                assertEquals(0, testedClass.functions.size)
+                assertEquals(2, testedClass.functions.size)
 
                 val property = testedClass.properties.single { it.name == "a" }
 

--- a/dokka-subprojects/plugin-base/src/test/kotlin/translators/DefaultPsiToDocumentableTranslatorTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/translators/DefaultPsiToDocumentableTranslatorTest.kt
@@ -412,8 +412,9 @@ class DefaultPsiToDocumentableTranslatorTest : BaseAbstractTest() {
         }
     }
 
+    @OnlyJavaPsi("do not filter out accessors of Java synthetic properties")
     @Test
-    fun `should ignore additional non-accessor setters`() {
+    fun `javaPSI - should ignore additional non-accessor setters`() {
         testInline(
             """
             |/src/main/java/test/A.java
@@ -450,6 +451,49 @@ class DefaultPsiToDocumentableTranslatorTest : BaseAbstractTest() {
 
                 val regularSetterFunctions = testClass.functions.filter { it.name == "setA" }
                 assertEquals(4, regularSetterFunctions.size)
+            }
+        }
+    }
+
+    @Test
+    @OnlyJavaSymbols("do not filter out accessors of Java synthetic properties")
+    fun `should ignore additional non-accessor setters`() {
+        testInline(
+            """
+            |/src/main/java/test/A.java
+            |package test;
+            |public class A {
+            |   private int a = 1;
+            |
+            |   public int getA() { return a; }
+            |
+            |   public void setA(long a) { }
+            |   public void setA(Number a) {}
+            |
+            |   // the qualifying setter is intentionally in the middle
+            |   // to rule out the order making a difference
+            |   public void setA(int a) { }
+            |
+            |   public void setA(String a) {}
+            |   public void setA() {}
+            |
+            |}
+        """.trimIndent(),
+            configuration
+        ) {
+            documentablesMergingStage = { module ->
+                val testClass = module.packages.single().classlikes.single { it.name == "A" }
+
+                val property = testClass.properties.single { it.name == "a" }
+                assertNotNull(property.getter)
+
+                val setter = property.setter
+                assertNotNull(setter)
+                assertEquals(1, setter.parameters.size)
+                assertEquals(PrimitiveJavaType("int"), setter.parameters[0].type)
+
+                val regularSetterFunctions = testClass.functions.filter { it.name == "setA" }
+                assertEquals(5, regularSetterFunctions.size)
             }
         }
     }
@@ -531,6 +575,7 @@ class DefaultPsiToDocumentableTranslatorTest : BaseAbstractTest() {
     }
 
     @Test
+    @OnlyJavaSymbols("do not filter out accessors of Java synthetic properties")
     fun `should not mark a multi-param setter overload as an accessor`() {
         testInline(
             """
@@ -554,7 +599,7 @@ class DefaultPsiToDocumentableTranslatorTest : BaseAbstractTest() {
 
 
                 // the setField function should not qualify to be an accessor due to the second param
-                assertEquals(1, testClass.functions.size)
+                assertEquals(2, testClass.functions.size)
                 assertEquals("setField", testClass.functions[0].name)
             }
         }


### PR DESCRIPTION
When Java synthetic properties are formed by "merging" getters and setters, documentation from their accessors can be lost. To preserve this information, we should avoid filtering them out and instead show the original accessors alongside their corresponding synthetic property.
Further, [this issue](https://github.com/Kotlin/dokka/issues/4250) should be addressed.

Original https://github.com/Kotlin/dokka/pull/4502#issuecomment-4450591779 