### PR TITLE
Handle `KaIntersectionType` in `TypeTranslator`

### DIFF
--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/TypeTranslator.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/TypeTranslator.kt
@@ -138,9 +138,10 @@ internal class TypeTranslator(
             // but the PSI module doesn't wrap Java types in Nullable, and changing that would be too invasive.
             // Using the lower bound (non-nullable) for consistency with the PSI implementation.
             is KaFlexibleType -> toBoundFrom(type.lowerBound, location)
-            is KaCapturedType -> throw NotImplementedError()
-            is KaIntersectionType -> throw NotImplementedError()
-            else -> throw NotImplementedError()
+            // can occur in the return type of Kotlin getters
+            is KaIntersectionType -> toBoundFromNoAbbreviation(@OptIn(KaExperimentalApi::class) type.approximateToDenotableSupertypeOrSelf(false), location)
+            is KaCapturedType -> throw NotImplementedError("`KaCapturedType` is not supported")
+            else -> throw NotImplementedError("$type is unknown type")
         }.let {
             asNullableIfMarked(type, it)
         }

--- a/dokka-subprojects/plugin-base/src/test/kotlin/model/TypesTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/model/TypesTest.kt
@@ -12,6 +12,7 @@ import utils.AbstractModelTest
 import utils.OnlyDescriptors
 import utils.OnlySymbols
 import utils.assertIsInstance
+import utils.assertNotNull
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -279,6 +280,39 @@ class TypesTest : AbstractModelTest("/src/main/kotlin/classes/Test.kt", "types")
                 nestedTypeAlias.assertIsInstance<TypeAliased>()
                 nestedTypeAlias.driOrNull equals DRI("types", "AliasHolder.NestedAlias")
                 nestedTypeAlias.inner.driOrNull equals DRI("kotlin", "String")
+            }
+        }
+    }
+
+    @Test
+    fun `getter type of a val with an inferred type from a list of providers`() {
+        inlineModelTest(
+            """
+            |interface ParameterDataProvider<T : Any>
+            |internal abstract class AbstractParameterDataProvider<T : Any> : ParameterDataProvider<T>
+            |internal class BooleanParameterDataProvider : AbstractParameterDataProvider<Boolean>()
+            |internal class EnumParameterDataProvider : ParameterDataProvider<Enum<*>>
+            |
+            |val defaultDataProviders by lazy { listOf(BooleanParameterDataProvider(), EnumParameterDataProvider()) }"""
+        ) {
+            with((this / "types" / "defaultDataProviders").cast<DProperty>()) {
+                name equals "defaultDataProviders"
+                type equals getter?.type
+
+                with(getter.assertNotNull("Getter")) {
+                    // the getter return type must match the property's inferred type
+                    val getterType = type
+                    getterType.assertIsInstance<GenericTypeConstructor>()
+                    getterType.driOrNull equals DRI("kotlin.collections", "List")
+
+                    val elementType = (getterType.projections.single() as Variance<*>).inner
+                    elementType.assertIsInstance<GenericTypeConstructor>()
+                    elementType.driOrNull equals DRI("types", "ParameterDataProvider")
+
+                    val elementTypeOfParameterDataProvider = (elementType.projections.single() as Variance<*>).inner
+                    elementTypeOfParameterDataProvider.assertIsInstance<GenericTypeConstructor>()
+                    elementTypeOfParameterDataProvider.driOrNull equals DRI("kotlin", "Any")
+                }
             }
         }
     }


### PR DESCRIPTION
In some edge cases, the compiler can return an intersection type that Dokka did not handle.