### PR TITLE
[JavaSymbols] Use `declaredScope` to avoid Java to Kotlin mapping

### DIFF
--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/DefaultSymbolToDocumentableTranslator.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/DefaultSymbolToDocumentableTranslator.kt
@@ -5,6 +5,8 @@
 package org.jetbrains.dokka.analysis.kotlin.symbols.translators
 
 
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiClassOwner
 import com.intellij.psi.PsiField
 import com.intellij.psi.PsiJavaFile
 import com.intellij.psi.PsiMethod
@@ -45,6 +47,7 @@ import org.jetbrains.kotlin.analysis.api.*
 import org.jetbrains.kotlin.analysis.api.annotations.KaAnnotated
 import org.jetbrains.kotlin.analysis.api.symbols.*
 import org.jetbrains.kotlin.analysis.api.types.*
+import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.JvmStandardClassIds
 import org.jetbrains.kotlin.name.SpecialNames.UNDERSCORE_FOR_UNUSED_VAR
@@ -467,8 +470,46 @@ internal class DokkaSymbolVisitor(
                 syntheticJavaProperties.any { fn.psi == it.javaGetterSymbol.psi || fn.psi == it.javaSetterSymbol?.psi }
             else false
         }
+        val psi = namedClassOrObjectSymbol.psi
+        val functionSymbols =  if(psi is PsiClass) {
+            val declaredMethods = if(includeStaticScope) namedClassOrObjectSymbol.combinedDeclaredMemberScope.callables.filterIsInstance<KaNamedFunctionSymbol>().toList()
+                else namedClassOrObjectSymbol.declaredMemberScope.callables.filterIsInstance<KaNamedFunctionSymbol>().toList()
+            val supertypesSymbols = mutableListOf<KaClassSymbol>()
 
-        val functions = callables.filterIsInstance<KaNamedFunctionSymbol>()
+            fun collectSupertypes(psi: PsiClass) {
+                psi.superTypes.mapNotNull {
+                    val classPsi = it.resolve()
+                    // classPsi?.namedClassSymbol // does not work since the AA throws the exception: "Class symbol not found for PSI class" late
+                    // t.asKaType(useSitePosition = psi) is not applicable since it maps Java types to Kotlin
+
+                    classPsi?.classId()?.let { it1 ->
+                        findClass(it1)?.let { element ->
+                            supertypesSymbols.add(element)
+                        }
+                    }
+                    classPsi?.let { it1 -> collectSupertypes(it1) }
+                }
+            }
+            collectSupertypes(psi)
+            val superMethods = mutableListOf<KaNamedFunctionSymbol>()
+            supertypesSymbols.forEach {
+                val methods = it.declaredMemberScope.callables.filterIsInstance<KaNamedFunctionSymbol>().toList()
+                superMethods.addAll(methods)
+            }
+
+            // A method declared in this class, or in a more-derived supertype, overrides some of the collected
+            // super methods. Exclude those overridden super declarations to avoid showing them as duplicates.
+            val overriddenSuperMethods = (declaredMethods + superMethods)
+                .flatMap { it.allOverriddenSymbols }
+                .mapNotNull { it.psi }
+                .toSet()
+            val notOverriddenSuperMethods = superMethods.filterNot { it.psi in overriddenSuperMethods }
+
+            notOverriddenSuperMethods + declaredMethods
+        } else  callables.filterIsInstance<KaNamedFunctionSymbol>()
+
+
+       val functions = functionSymbols
             .filterOutSyntheticJavaPropAccessors().map { visitFunctionSymbol(it, dri, isJavaContext) }
 
 
@@ -1184,4 +1225,15 @@ internal class DokkaSymbolVisitor(
         KaSymbolVisibility.PACKAGE_PRIVATE -> JavaVisibility.Default
         KaSymbolVisibility.UNKNOWN, KaSymbolVisibility.LOCAL -> if (isJavaSource) JavaVisibility.Public else KotlinVisibility.Public
     }
+}
+
+
+private fun PsiClass.classId(): ClassId? {
+    val packageName = (containingFile as? PsiClassOwner)?.packageName ?: return null
+    // outermost → innermost simple names
+    val names = generateSequence(this) { it.containingClass }
+        .map { it.name ?: return@map null }   // null name => local/anonymous => no ClassId
+        .toList()
+        .asReversed()
+    return ClassId(FqName(packageName), FqName.fromSegments(names), /* isLocal = */ false)
 }

--- a/dokka-subprojects/plugin-base/src/test/kotlin/transformers/ObviousAndInheritedFunctionsDocumentableFilterTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/transformers/ObviousAndInheritedFunctionsDocumentableFilterTest.kt
@@ -222,7 +222,7 @@ class ObviousAndInheritedFunctionsDocumentableFilterTest : BaseAbstractTest() {
         }
     }
 
-    @OnlyJavaPsi("type-mapping: AA's combinedMemberScope does not include all java.lang.Object methods (notify/notifyAll) - mapped types")
+    //@OnlyJavaPsi("type-mapping: AA's combinedMemberScope does not include all java.lang.Object methods (notify/notifyAll) - mapped types")
     @ParameterizedTest
     @MethodSource(value = ["nonSuppressingObviousConfiguration", "nonSuppressingInheritedConfiguration"])
     fun `should not suppress toString, equals and hashcode if custom config is provided in Java`(

--- a/dokka-subprojects/plugin-base/src/test/kotlin/translators/DefaultPsiToDocumentableTranslatorTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/translators/DefaultPsiToDocumentableTranslatorTest.kt
@@ -813,6 +813,7 @@ class DefaultPsiToDocumentableTranslatorTest : BaseAbstractTest() {
         }
     }
 
+    // still actual for combinedDeclaredScope
     @OnlyJavaPsi("type-mapping: in the inherited `valueOf`, kotlin.String instead of java.lang.String in parameters")
     @Test
     fun `should have documentation for synthetic Enum valueOf functions`() {
@@ -1005,6 +1006,34 @@ class DefaultPsiToDocumentableTranslatorTest : BaseAbstractTest() {
 
                 assertEquals(1, testedClass.constructors.size, "Expect 1 declared constructor")
                 assertEquals(JavaVisibility.Private, testedClass.constructors.first().visibility())
+            }
+        }
+    }
+
+    @Test
+    @OnlyJavaPsi("keeps `annotationType`, but for unknown reasons skips declared \"equals\", \"hashCode\", \"toString\"")
+    fun `java annotation should have all methods inherited from Annotation interface`() {
+        testInline(
+            """
+            |/src/main/java/test/MyAnnotation.java
+            |package test;
+            |public @interface MyAnnotation {
+            |    String value();
+            |}
+            """.trimIndent(),
+            configuration
+        ) {
+            documentablesMergingStage = { module ->
+                val annotation = module.findClasslike(packageName = "test", "MyAnnotation") as DAnnotation
+
+                // A Java annotation implicitly extends java.lang.annotation.Annotation,
+                // which declares annotationType(), equals(Object), hashCode() and toString().
+                val functionNames = annotation.functions.map { it.name }
+                assertTrue(
+                    functionNames.containsAll(listOf("annotationType", "equals", "hashCode", "toString")),
+                    "A Java annotation should inherit all methods from java.lang.annotation.Annotation, " +
+                            "but got: $functionNames"
+                )
             }
         }
     }


### PR DESCRIPTION
#4511
Supertypes: 
`java.lang.Object` - shows all methods
`java.lang.Enum` - show all methods, but types in them are still mapped
`java.lang.annotation.Annotation` - show only `annotationType`, but others (`"equals", "hashCode", "toString"`) are still missing. 


 