### PR TITLE
Move `ProcessIsolation` convention values to `ProcessIsolation` factory function

### DIFF
--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaBasePlugin.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaBasePlugin.kt
@@ -111,30 +111,7 @@ constructor(
             dokkaEngineVersion.convention(DokkaConstants.DOKKA_VERSION)
         }
 
-        dokkaExtension.dokkaGeneratorIsolation.convention(
-            dokkaExtension.ProcessIsolation {
-                maxHeapSize.convention("2g")
-                debug.convention(false)
-                jvmArgs.convention(
-                    listOf(
-                        //"-XX:MaxMetaspaceSize=512m",
-                        "-XX:+HeapDumpOnOutOfMemoryError",
-                        "-XX:+AlwaysPreTouch", // https://github.com/gradle/gradle/issues/3093#issuecomment-387259298
-                        //"-XX:StartFlightRecording=disk=true,name={path.drop(1).map { if (it.isLetterOrDigit()) it else '-' }.joinToString("")},dumponexit=true,duration=30s",
-                        //"-XX:FlightRecorderOptions=repository=$baseDir/jfr,stackdepth=512",
-                    ) + if (JavaVersion.current() >= JavaVersion.VERSION_24) {
-                        // https://openjdk.org/jeps/498
-                        // the option has been available since Java 24,
-                        // has `warn` value since Java 25,
-                        // will have `deny` value at some point after Java 26
-                        //
-                        // suppresses: sun.misc.Unsafe::objectFieldOffset has been called by com.intellij.util.containers.Unsafe
-                        // requires IntelliJ platform update to resolve the issue
-                        listOf("--sun-misc-unsafe-memory-access=allow")
-                    } else emptyList()
-                )
-            }
-        )
+        dokkaExtension.dokkaGeneratorIsolation.convention(dokkaExtension.ProcessIsolation())
 
         @Suppress("DEPRECATION")
         dokkaExtension.suppressInheritedMembers.convention(false)

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaExtension.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaExtension.kt
@@ -307,10 +307,10 @@ constructor(
                 // and classloaders could really be GC-ed only in case all heap memory is used in this case,
                 // which for small modules will never happen.
                 // So metaspace memory will grow unconditionally.
-                // That's why we set a reasonable default of 512 MB, which enough for proper Dokka execution.
+                // That's why we set a reasonable default of 1 GM, which enough for proper Dokka execution.
                 // Additionally, this will help to discover potential classloader leaks on user projects.
                 // See https://github.com/Kotlin/dokka/pull/4512 for more details.
-                add("-XX:MaxMetaspaceSize=512m")
+                add("-XX:MaxMetaspaceSize=1g")
                 if (JavaVersion.current() <= JavaVersion.VERSION_1_8) {
                     // On JVM 8: GC doesn't collect soft references fast enough.
                     // The property helps GC to collect them faster.

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaExtension.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaExtension.kt
@@ -3,6 +3,7 @@
  */
 package org.jetbrains.dokka.gradle
 
+import org.gradle.api.JavaVersion
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
@@ -295,7 +296,28 @@ constructor(
      * @see dokkaGeneratorIsolation
      */
     fun ProcessIsolation(configure: ProcessIsolation.() -> Unit = {}): ProcessIsolation =
-        objects.newInstance<ProcessIsolation>().apply(configure)
+        objects.newInstance<ProcessIsolation>().apply {
+            maxHeapSize.convention("2g")
+            debug.convention(false)
+            jvmArgs.convention(
+                listOf(
+                    //"-XX:MaxMetaspaceSize=512m",
+                    "-XX:+HeapDumpOnOutOfMemoryError",
+                    "-XX:+AlwaysPreTouch", // https://github.com/gradle/gradle/issues/3093#issuecomment-387259298
+                    //"-XX:StartFlightRecording=disk=true,name={path.drop(1).map { if (it.isLetterOrDigit()) it else '-' }.joinToString("")},dumponexit=true,duration=30s",
+                    //"-XX:FlightRecorderOptions=repository=$baseDir/jfr,stackdepth=512",
+                ) + if (JavaVersion.current() >= JavaVersion.VERSION_24) {
+                    // https://openjdk.org/jeps/498
+                    // the option has been available since Java 24,
+                    // has `warn` value since Java 25,
+                    // will have `deny` value at some point after Java 26
+                    //
+                    // suppresses: sun.misc.Unsafe::objectFieldOffset has been called by com.intellij.util.containers.Unsafe
+                    // requires IntelliJ platform update to resolve the issue
+                    listOf("--sun-misc-unsafe-memory-access=allow")
+                } else emptyList()
+            )
+        }.apply(configure)
 
 
     //region deprecated properties

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaExtension.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaExtension.kt
@@ -299,14 +299,25 @@ constructor(
         objects.newInstance<ProcessIsolation>().apply {
             maxHeapSize.convention("2g")
             debug.convention(false)
-            jvmArgs.convention(
-                listOf(
-                    //"-XX:MaxMetaspaceSize=512m",
-                    "-XX:+HeapDumpOnOutOfMemoryError",
-                    "-XX:+AlwaysPreTouch", // https://github.com/gradle/gradle/issues/3093#issuecomment-387259298
-                    //"-XX:StartFlightRecording=disk=true,name={path.drop(1).map { if (it.isLetterOrDigit()) it else '-' }.joinToString("")},dumponexit=true,duration=30s",
-                    //"-XX:FlightRecorderOptions=repository=$baseDir/jfr,stackdepth=512",
-                ) + if (JavaVersion.current() >= JavaVersion.VERSION_24) {
+
+            val defaultJvmArgs = mutableListOf<String>().apply {
+                add("-XX:+HeapDumpOnOutOfMemoryError")
+                // By default, there is no limit for metaspace memory.
+                // Currently we create a new classloader inside of a worker for every Dokka execution
+                // and classloaders could really be GC-ed only in case all heap memory is used in this case,
+                // which for small modules will never happen.
+                // So metaspace memory will grow unconditionally.
+                // That's why we set a reasonable default of 512 MB, which enough for proper Dokka execution.
+                // Additionally, this will help to discover potential classloader leaks on user projects.
+                // See https://github.com/Kotlin/dokka/pull/4512 for more details.
+                add("-XX:MaxMetaspaceSize=512m")
+                if (JavaVersion.current() <= JavaVersion.VERSION_1_8) {
+                    // On JVM 8: GC doesn't collect soft references fast enough.
+                    // The property helps GC to collect them faster.
+                    // For better description of the property see https://www.jasonpearson.dev/softreflrupolicymspermb-in-jvm-builds/
+                    add("-XX:SoftRefLRUPolicyMSPerMB=1")
+                }
+                if (JavaVersion.current() >= JavaVersion.VERSION_24) {
                     // https://openjdk.org/jeps/498
                     // the option has been available since Java 24,
                     // has `warn` value since Java 25,
@@ -314,9 +325,15 @@ constructor(
                     //
                     // suppresses: sun.misc.Unsafe::objectFieldOffset has been called by com.intellij.util.containers.Unsafe
                     // requires IntelliJ platform update to resolve the issue
-                    listOf("--sun-misc-unsafe-memory-access=allow")
-                } else emptyList()
-            )
+                    add("--sun-misc-unsafe-memory-access=allow")
+                }
+            }
+            // We use `set` instead of `convention` because we want for end-users to always use our default JVM args
+            // even in case they use `jvmArgs.add`
+            // See https://github.com/gradle/gradle/issues/18352 for more details.
+            // it will still allow for users to override some flags, like `-XX:MaxMetaspaceSize`,
+            // as the last argument will be used by JVM
+            jvmArgs.set(defaultJvmArgs)
         }.apply(configure)
 
 

--- a/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/MemoryStressTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/MemoryStressTest.kt
@@ -10,7 +10,14 @@ import org.jetbrains.dokka.gradle.utils.projects.defaultKgpTestVersion
 
 class MemoryStressTest : FunSpec({
     context("when subprojects have 50 modules and uses single worker") {
-        val project = setupProject(50, "500m")
+        val project = setupProject(
+            numberOfProjects = 50,
+            // we have just one class with stdlib in dependencies, so no need for a lot of memory,
+            // but we explicitly set heap size bigger to not cause automatic GC of classloaders created inside workers
+            maxHeapSize = "4g",
+            // overall, it's current default, set here just to be explicit about it in case it's changed to test that everything works fine
+            maxMetaspaceSize = "512m"
+        )
 
         test("generate HTML publication") {
             project.runner
@@ -31,7 +38,8 @@ class MemoryStressTest : FunSpec({
 
 private fun setupProject(
     numberOfProjects: Int,
-    metaspaceMemory: String
+    maxHeapSize: String,
+    maxMetaspaceSize: String
 ): GradleProjectTest = gradleKtsProjectTest("MemoryStressTest-$numberOfProjects") {
     val projectNames = List(numberOfProjects) { "subproject_$it" }
     settingsGradleKts += projectNames.joinToString("\n") { """include(":$it")""" }
@@ -62,9 +70,8 @@ private fun setupProject(
                 |
                 |dokka {
                 |  dokkaGeneratorIsolation.set(ProcessIsolation {
-                |      maxHeapSize.set("1g")
-                |      jvmArgs.add("-XX:MaxMetaspaceSize=$metaspaceMemory") // limit metaspace
-                |      jvmArgs.add("-XX:SoftRefLRUPolicyMSPerMB=10")
+                |      maxHeapSize.set("$maxHeapSize")
+                |      jvmArgs.add("-XX:MaxMetaspaceSize=$maxMetaspaceSize")
                 |  })
                 |}
                 |

--- a/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/MemoryStressTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/MemoryStressTest.kt
@@ -16,7 +16,7 @@ class MemoryStressTest : FunSpec({
             // but we explicitly set heap size bigger to not cause automatic GC of classloaders created inside workers
             maxHeapSize = "4g",
             // overall, it's current default, set here just to be explicit about it in case it's changed to test that everything works fine
-            maxMetaspaceSize = "512m"
+            maxMetaspaceSize = "1g"
         )
 
         test("generate HTML publication") {


### PR DESCRIPTION
Move `ProcessIsolation` convention values to `ProcessIsolation` factory function, so that if final users override just maxHeapSize, everything else will use preconfigured values.
If users need to modify `jvmArgs`, they can use `jvmArgs.set` to replace or `jvmArgs.add` to append to' jvmArgs' when creating a `ProcessIsolation` object. Which is most likely never needed.

In addition, update the `ProcessIsolation` convention to limit metaspace memory.