### PR TITLE
Update kotlinx-collections-immutable to 0.5.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ gradlePlugin-kotlin = "2.3.21"
 gradlePlugin-android = "7.3.1"
 
 kotlinx-coroutines = "1.7.3"
-kotlinx-collections-immutable = "0.3.6"
+kotlinx-collections-immutable = "0.5.0"
 kotlinx-serialization = "1.6.0"
 kotlinx-bcv = "0.17.0"
 


### PR DESCRIPTION
0.5.0 is the first stable release of kotlinx.collections.immutable after 0.4.0. Dokka consumes it only as a `runtimeOnly` dependency, so the bump needs no source changes.