### PR TITLE
Exit from CLI runner when an exception is thrown

### DIFF
--- a/dokka-integration-tests/cli/src/cliIntegrationTest/kotlin/org/jetbrains/dokka/it/cli/CliIntegrationTest.kt
+++ b/dokka-integration-tests/cli/src/cliIntegrationTest/kotlin/org/jetbrains/dokka/it/cli/CliIntegrationTest.kt
@@ -133,7 +133,7 @@ class CliIntegrationTest : AbstractCliIntegrationTest() {
         val result = process.awaitProcessResult()
         assertEquals(1, result.exitCode, "Expected exitCode 1 (Fail)")
 
-        assertTrue(result.output.contains("Exception in thread \"main\" org.jetbrains.dokka.DokkaException: Failed with warningCount"))
+        assertTrue(result.output.contains("org.jetbrains.dokka.DokkaException: Failed with warningCount"))
     }
 
     @Test

--- a/dokka-runners/runner-cli/src/main/kotlin/org/jetbrains/dokka/main.kt
+++ b/dokka-runners/runner-cli/src/main/kotlin/org/jetbrains/dokka/main.kt
@@ -7,11 +7,20 @@ package org.jetbrains.dokka
 import org.jetbrains.dokka.DokkaConfiguration.ExternalDocumentationLink
 import org.jetbrains.dokka.utilities.*
 import java.nio.file.Paths
+import kotlin.system.exitProcess
 
 public fun main(args: Array<String>) {
     val globalArguments = GlobalArguments(args)
     val configuration = initializeConfiguration(globalArguments)
-    DokkaGenerator(configuration, globalArguments.logger).generate()
+    var exitCode = 0
+    try {
+        DokkaGenerator(configuration, globalArguments.logger).generate()
+    } catch (e: Throwable) {
+        exitCode = 1
+        e.printStackTrace()
+    } finally {
+        exitProcess(exitCode)
+    }
 }
 
 public fun initializeConfiguration(globalArguments: GlobalArguments): DokkaConfiguration {

--- a/examples/cli/dokka-cli-example/README.md
+++ b/examples/cli/dokka-cli-example/README.md
@@ -1,0 +1,7 @@
+# Dokka CLI example
+
+This directory contains a small project which is set up to run Dokka through the CLI runner.
+It does this by setting up a Gradle task that invokes the CLI runner.
+
+To run it, first run `./gradlew publishToMavenLocal` from the checkout root.
+Then run `../../../gradlew run` from this directory.

--- a/examples/cli/dokka-cli-example/build.gradle.kts
+++ b/examples/cli/dokka-cli-example/build.gradle.kts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+plugins {
+    kotlin("jvm") version "2.3.21"
+}
+
+@CacheableTask
+abstract class DokkaRunner : DefaultTask() {
+    @get:Inject abstract val execOperations: ExecOperations
+    @get:Classpath abstract val dokkaClasspath: ConfigurableFileCollection
+    @get:Classpath abstract val pluginsClasspath: ConfigurableFileCollection
+    @get:[InputFiles PathSensitive(PathSensitivity.NONE)] abstract val sourceDirectory: DirectoryProperty
+    @get:OutputDirectory abstract val outputDirectory: DirectoryProperty
+
+    @TaskAction
+    fun exec() {
+        execOperations.javaexec {
+            classpath = dokkaClasspath
+            args = listOf(
+                "-pluginsClasspath",
+                pluginsClasspath.files.joinToString(";"),
+                "-sourceSet",
+                "-src ${sourceDirectory.get().asFile.absolutePath}",
+                "-outputDir",
+                outputDirectory.get().asFile.absolutePath,
+            )
+        }
+    }
+}
+
+val runTask = tasks.register<DokkaRunner>("run") {
+    dokkaClasspath.from(configurations.create("runnerJar") {
+        dependencies.add(
+            project.dependencies.create("org.jetbrains.dokka:dokka-cli:2.3.0-SNAPSHOT")
+        )
+    })
+    pluginsClasspath.from(
+        configurations.create("pluginsJars") {
+            dependencies.add(
+                project.dependencies.create("org.jetbrains.dokka:dokka-base:2.3.0-SNAPSHOT")
+            )
+            dependencies.add(
+                project.dependencies.create("org.jetbrains.dokka:analysis-kotlin-symbols:2.3.0-SNAPSHOT")
+            )
+        }
+    )
+    sourceDirectory.set(project.layout.projectDirectory.dir("src/main/kotlin"))
+    outputDirectory.set(project.layout.buildDirectory.dir("docs"))
+}

--- a/examples/cli/dokka-cli-example/settings.gradle.kts
+++ b/examples/cli/dokka-cli-example/settings.gradle.kts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+pluginManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+}

--- a/examples/cli/dokka-cli-example/src/main/kotlin/demo/HelloWorld.kt
+++ b/examples/cli/dokka-cli-example/src/main/kotlin/demo/HelloWorld.kt
@@ -1,0 +1,20 @@
+package demo
+
+/**
+ * This class supports greeting people by name.
+ *
+ * @property name The name of the person to be greeted.
+ */
+class Greeter(val name: String) {
+
+    /**
+     * Prints the greeting to the standard output.
+     */
+    fun greet() {
+        println("Hello $name!")
+    }
+}
+
+fun main(args: Array<String>) {
+    Greeter(args[0]).greet()
+}


### PR DESCRIPTION
Currently, if an exception is thrown when dokka is invoked through the CLI runner, the process does not exit correctly. This addresses the issue 


To test:
* In `SingleModuleGeneration.kt`, add the line `throw IllegalStateException("exit")` at the end of the `try` block in the `generate` function.
* Run `./gradlew publishToMavenLocal` from the checkout root directory
* From `examples/cli/dokka-cli-example`, run `../../../gradlew run`

Without this change, the process hangs after the error is thrown. With this change, it prints the error stack trace and then exits.

Fixes: #4537 