### PR TITLE
Add test for accessor docs of override properties (#4539)

### DIFF
--- a/dokka-subprojects/plugin-base/src/test/kotlin/model/PropertyTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/model/PropertyTest.kt
@@ -152,6 +152,34 @@ class PropertyTest : AbstractModelTest("/src/main/kotlin/property/Test.kt", "pro
     }
 
     @Test
+    fun `accessors of override property should get docs from override`() {
+        inlineModelTest(
+            """
+            |open class Parent {
+            |    /** parent property docs */
+            |    open var v = 0
+            |}
+            |class Child : Parent() {
+            |    /** child property docs */
+            |    override var v = 0
+            |}
+            """
+        ) {
+            with((this / "property").cast<DPackage>()) {
+                with((this / "Child" / "v").cast<DProperty>()) {
+                    documentation.values.single().children.single().text().trim() equals "child property docs"
+                    with(getter.assertNotNull("Getter")) {
+                        documentation.values.single().children.single().text().trim() equals "child property docs"
+                    }
+                    with(setter.assertNotNull("Setter")) {
+                        documentation.values.single().children.single().text().trim() equals "child property docs"
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
     fun propertyInherited() {
         inlineModelTest(
             """


### PR DESCRIPTION
Adds a regression test for #4539.

```kotlin
open class Parent {
    /** parent property docs */
    open var v = 0
}
class Child : Parent() {
    /** child property docs */
    override var v = 0
}
```

The generated `getter`/`setter` `DFunction`s of an override property must inherit the documentation from the **override**, not from the overridden parent property. The `DProperty` itself is already correct — only the accessors regressed (between `2.3.0-dev-425` and `2.3.0-dev-426`).

This PR contains the test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
