### PR TITLE
Add clean up extension point which runs in finally block

### DIFF
--- a/dokka-integration-tests/cli/src/cliIntegrationTest/kotlin/org/jetbrains/dokka/it/cli/CliIntegrationTest.kt
+++ b/dokka-integration-tests/cli/src/cliIntegrationTest/kotlin/org/jetbrains/dokka/it/cli/CliIntegrationTest.kt
@@ -5,6 +5,7 @@ package org.jetbrains.dokka.it.cli
 
 import org.jetbrains.dokka.it.awaitProcessResult
 import java.io.File
+import java.util.concurrent.TimeUnit
 import kotlin.test.*
 
 class CliIntegrationTest : AbstractCliIntegrationTest() {
@@ -117,6 +118,7 @@ class CliIntegrationTest : AbstractCliIntegrationTest() {
             "-outputDir", dokkaOutputDir.path,
             "-pluginsClasspath", dokkaPluginsClasspath,
             "-moduleName", "Basic Project",
+            // The failure here happens after all generation is complete.
             "-failOnWarning",
             "-sourceSet",
             buildString {
@@ -134,6 +136,41 @@ class CliIntegrationTest : AbstractCliIntegrationTest() {
         assertEquals(1, result.exitCode, "Expected exitCode 1 (Fail)")
 
         assertTrue(result.output.contains("Exception in thread \"main\" org.jetbrains.dokka.DokkaException: Failed with warningCount"))
+    }
+
+    @Test
+    fun failCliDuringGeneration() {
+        val dokkaOutputDir = File(projectDir, "output")
+        assertTrue(dokkaOutputDir.mkdirs())
+        // Making the output unwritable causes a failure before all steps of generation are complete. This verifies that
+        // clean up actions run successfully (if they didn't, the test would time out).
+        assertTrue(dokkaOutputDir.setWritable(false))
+
+        val process = ProcessBuilder(
+            "java",
+            "-jar", dokkaCliJarPath,
+            "-outputDir", dokkaOutputDir.path,
+            "-pluginsClasspath", dokkaPluginsClasspath,
+            "-moduleName", "Basic Project",
+            "-sourceSet",
+            buildString {
+                append(" -sourceSetName cliMain")
+                append(" -src ${File(projectDir, "src").path}")
+                append(" -jdkVersion 8")
+                append(" -analysisPlatform jvm")
+            }
+        )
+            .redirectErrorStream(true)
+            .start()
+
+        // Forces the test to time out if the process does not terminate within 30 seconds.
+        val complete = process.waitFor(30, TimeUnit.SECONDS)
+        assertTrue(complete)
+
+        val result = process.awaitProcessResult()
+        assertEquals(1, result.exitCode, "Expected exitCode 1 (Fail)")
+
+        assertTrue(result.output.contains("Failed to write"))
     }
 
     @Test

--- a/dokka-subprojects/analysis-kotlin-api/src/testFixtures/kotlin/org/jetbrains/dokka/analysis/test/api/analysis/TestProjectAnalyzer.kt
+++ b/dokka-subprojects/analysis-kotlin-api/src/testFixtures/kotlin/org/jetbrains/dokka/analysis/test/api/analysis/TestProjectAnalyzer.kt
@@ -246,11 +246,12 @@ internal object TestProjectAnalyzer {
 
     /**
      * Cleans up memory used during analysis by invoking all Dokka post-actions
-     * which will dispose KotlinAnalysis sessions for both K1 and K2 analysis.
-     * After this, [context] should not be used.
+     * and clean-up actions which will dispose KotlinAnalysis sessions for both
+     * K1 and K2 analysis. After this, [context] should not be used.
      */
     private fun cleanup(context: DokkaContext) {
         context[CoreExtensions.postActions].forEach { action -> action.invoke() }
+        context[CoreExtensions.cleanUpActions].forEach { action -> action.invoke() }
     }
 
 }

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/SymbolsAnalysisPlugin.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/SymbolsAnalysisPlugin.kt
@@ -20,9 +20,9 @@ import org.jetbrains.dokka.analysis.kotlin.symbols.services.*
 import org.jetbrains.dokka.analysis.kotlin.symbols.services.KotlinDocumentableSourceLanguageParser
 import org.jetbrains.dokka.analysis.kotlin.symbols.services.SymbolExternalDocumentablesProvider
 import org.jetbrains.dokka.analysis.kotlin.symbols.translators.DefaultSymbolToDocumentableTranslator
+import org.jetbrains.dokka.generation.CleanUpAction
 import org.jetbrains.dokka.model.DModule
 import org.jetbrains.dokka.plugability.*
-import org.jetbrains.dokka.renderers.PostAction
 import org.jetbrains.dokka.transformers.sources.SourceToDocumentableTranslator
 import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
 import org.jetbrains.kotlin.asJava.elements.KtLightAbstractAnnotation
@@ -41,10 +41,9 @@ public class SymbolsAnalysisPlugin : DokkaPlugin() {
         }
     }
 
-
     internal val disposeKotlinAnalysisPostAction by extending {
-        CoreExtensions.postActions providing { context ->
-            PostAction {
+        CoreExtensions.cleanUp providing { context ->
+            CleanUpAction {
                 querySingle { kotlinAnalysis }.close()
                 if (context.configuration.finalizeCoroutines) {
                     /**

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/SymbolsAnalysisPlugin.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/SymbolsAnalysisPlugin.kt
@@ -42,7 +42,7 @@ public class SymbolsAnalysisPlugin : DokkaPlugin() {
     }
 
     internal val disposeKotlinAnalysisPostAction by extending {
-        CoreExtensions.cleanUp providing { context ->
+        CoreExtensions.cleanUpActions providing { context ->
             CleanUpAction {
                 querySingle { kotlinAnalysis }.close()
                 if (context.configuration.finalizeCoroutines) {

--- a/dokka-subprojects/core/api/dokka-core.api
+++ b/dokka-subprojects/core/api/dokka-core.api
@@ -20,7 +20,7 @@ public final class org/jetbrains/dokka/ConfigurationKt {
 
 public final class org/jetbrains/dokka/CoreExtensions {
 	public static final field INSTANCE Lorg/jetbrains/dokka/CoreExtensions;
-	public final fun getCleanUp ()Lorg/jetbrains/dokka/plugability/ExtensionPoint;
+	public final fun getCleanUpActions ()Lorg/jetbrains/dokka/plugability/ExtensionPoint;
 	public final fun getDocumentableMerger ()Lorg/jetbrains/dokka/plugability/ExtensionPoint;
 	public final fun getDocumentableToPageTranslator ()Lorg/jetbrains/dokka/plugability/ExtensionPoint;
 	public final fun getDocumentableTransformer ()Lorg/jetbrains/dokka/plugability/ExtensionPoint;

--- a/dokka-subprojects/core/api/dokka-core.api
+++ b/dokka-subprojects/core/api/dokka-core.api
@@ -20,6 +20,7 @@ public final class org/jetbrains/dokka/ConfigurationKt {
 
 public final class org/jetbrains/dokka/CoreExtensions {
 	public static final field INSTANCE Lorg/jetbrains/dokka/CoreExtensions;
+	public final fun getCleanUp ()Lorg/jetbrains/dokka/plugability/ExtensionPoint;
 	public final fun getDocumentableMerger ()Lorg/jetbrains/dokka/plugability/ExtensionPoint;
 	public final fun getDocumentableToPageTranslator ()Lorg/jetbrains/dokka/plugability/ExtensionPoint;
 	public final fun getDocumentableTransformer ()Lorg/jetbrains/dokka/plugability/ExtensionPoint;
@@ -461,6 +462,9 @@ public final class org/jetbrains/dokka/Timer {
 	public final fun dump (Ljava/lang/String;)V
 	public static synthetic fun dump$default (Lorg/jetbrains/dokka/Timer;Ljava/lang/String;ILjava/lang/Object;)V
 	public final fun report (Ljava/lang/String;)V
+}
+
+public abstract interface class org/jetbrains/dokka/generation/CleanUpAction : kotlin/jvm/functions/Function0 {
 }
 
 public abstract interface class org/jetbrains/dokka/generation/Generation {

--- a/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/CoreExtensions.kt
+++ b/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/CoreExtensions.kt
@@ -4,6 +4,7 @@
 
 package org.jetbrains.dokka
 
+import org.jetbrains.dokka.generation.CleanUpAction
 import org.jetbrains.dokka.generation.Generation
 import org.jetbrains.dokka.plugability.ExtensionPoint
 import org.jetbrains.dokka.renderers.PostAction
@@ -35,6 +36,8 @@ public object CoreExtensions {
     public val renderer: ExtensionPoint<Renderer> by coreExtensionPoint<Renderer>()
 
     public val postActions: ExtensionPoint<PostAction> by coreExtensionPoint<PostAction>()
+
+    public val cleanUp: ExtensionPoint<CleanUpAction> by coreExtensionPoint<CleanUpAction>()
 
     private fun <T : Any> coreExtensionPoint() = object {
         operator fun provideDelegate(thisRef: CoreExtensions, property: KProperty<*>): Lazy<ExtensionPoint<T>> =

--- a/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/CoreExtensions.kt
+++ b/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/CoreExtensions.kt
@@ -37,7 +37,7 @@ public object CoreExtensions {
 
     public val postActions: ExtensionPoint<PostAction> by coreExtensionPoint<PostAction>()
 
-    public val cleanUp: ExtensionPoint<CleanUpAction> by coreExtensionPoint<CleanUpAction>()
+    public val cleanUpActions: ExtensionPoint<CleanUpAction> by coreExtensionPoint<CleanUpAction>()
 
     private fun <T : Any> coreExtensionPoint() = object {
         operator fun provideDelegate(thisRef: CoreExtensions, property: KProperty<*>): Lazy<ExtensionPoint<T>> =

--- a/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/generation/CleanUpAction.kt
+++ b/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/generation/CleanUpAction.kt
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package org.jetbrains.dokka.generation
+
+/** Runs before generation exits. This action is run even if generation fails. */
+public fun interface CleanUpAction : () -> Unit

--- a/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/renderers/PostAction.kt
+++ b/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/renderers/PostAction.kt
@@ -4,4 +4,8 @@
 
 package org.jetbrains.dokka.renderers
 
+/**
+ * Runs after rendering is complete. If there is an exception thrown during generation, these actions will not be run.
+ * For actions that must run even if there is an error, use [org.jetbrains.dokka.generation.CleanUpAction] instead.
+ */
 public fun interface PostAction : () -> Unit

--- a/dokka-subprojects/plugin-all-modules-page/api/plugin-all-modules-page.api
+++ b/dokka-subprojects/plugin-all-modules-page/api/plugin-all-modules-page.api
@@ -1,5 +1,6 @@
 public final class org/jetbrains/dokka/allModulesPage/AllModulesPageGeneration : org/jetbrains/dokka/generation/Generation {
 	public fun <init> (Lorg/jetbrains/dokka/plugability/DokkaContext;)V
+	public final fun cleanUp ()V
 	public final fun createAllModulesPage (Lorg/jetbrains/dokka/allModulesPage/AllModulesPageGeneration$DefaultAllModulesContext;)Lorg/jetbrains/dokka/pages/RootPageNode;
 	public final fun finishProcessingSubmodules ()V
 	public fun generate (Lorg/jetbrains/dokka/Timer;)V

--- a/dokka-subprojects/plugin-all-modules-page/src/main/kotlin/org/jetbrains/dokka/allModulesPage/AllModulesPageGeneration.kt
+++ b/dokka-subprojects/plugin-all-modules-page/src/main/kotlin/org/jetbrains/dokka/allModulesPage/AllModulesPageGeneration.kt
@@ -44,7 +44,8 @@ public class AllModulesPageGeneration(private val context: DokkaContext) : Gener
         report("Running post-actions")
         runPostActions()
     } finally {
-        PackageList.clearCache()
+        report("Cleaning up")
+        cleanUp()
     }
 
     override val generationName: String = "index page for project"
@@ -61,6 +62,18 @@ public class AllModulesPageGeneration(private val context: DokkaContext) : Gener
 
     public fun runPostActions() {
         context[CoreExtensions.postActions].forEach { it() }
+    }
+
+    public fun cleanUp() {
+        // Don't allow errors to block other clean up steps from running.
+        context[CoreExtensions.cleanUpActions].forEach {
+            try {
+                it()
+            } catch (e: Exception) {
+                context.logger.error("Failed to run ${it.javaClass.name}: ${e.message}")
+            }
+        }
+        PackageList.clearCache()
     }
 
     public fun processSubmodules(): DefaultAllModulesContext {

--- a/dokka-subprojects/plugin-base-test-utils/src/main/kotlin/org/jetbrains/dokka/base/testApi/testRunner/baseTestApi.kt
+++ b/dokka-subprojects/plugin-base-test-utils/src/main/kotlin/org/jetbrains/dokka/base/testApi/testRunner/baseTestApi.kt
@@ -68,7 +68,7 @@ public class BaseDokkaTestGenerator(
 
                 singleModuleGeneration.runPostActions()
 
-                singleModuleGenerationForCleanUp.reportAfterRendering()
+                singleModuleGeneration.reportAfterRendering()
             }
         } finally {
             singleModuleGenerationForCleanUp?.cleanUp()

--- a/dokka-subprojects/plugin-base-test-utils/src/main/kotlin/org/jetbrains/dokka/base/testApi/testRunner/baseTestApi.kt
+++ b/dokka-subprojects/plugin-base-test-utils/src/main/kotlin/org/jetbrains/dokka/base/testApi/testRunner/baseTestApi.kt
@@ -8,7 +8,6 @@ import org.jetbrains.dokka.CoreExtensions
 import org.jetbrains.dokka.DokkaConfiguration
 import org.jetbrains.dokka.DokkaGenerator
 import org.jetbrains.dokka.base.generation.SingleModuleGeneration
-import org.jetbrains.dokka.base.resolvers.shared.PackageList
 import org.jetbrains.dokka.model.DModule
 import org.jetbrains.dokka.pages.RootPageNode
 import org.jetbrains.dokka.plugability.DokkaContext
@@ -30,7 +29,7 @@ public class BaseDokkaTestGenerator(
 ) : DokkaTestGenerator<BaseTestMethods>(configuration, logger, testMethods, additionalPlugins) {
 
     override fun generate(): Unit {
-        var singleModuleGeneration: SingleModuleGeneration? = null
+        var singleModuleGenerationForCleanUp: SingleModuleGeneration? = null
         try {
             with(testMethods) {
                 val dokkaGenerator = DokkaGenerator(configuration, logger)
@@ -39,7 +38,8 @@ public class BaseDokkaTestGenerator(
                     dokkaGenerator.initializePlugins(configuration, logger, additionalPlugins)
                 pluginsSetupStage(context)
 
-                singleModuleGeneration = context.single(CoreExtensions.generation) as SingleModuleGeneration
+                val singleModuleGeneration = context.single(CoreExtensions.generation) as SingleModuleGeneration
+                singleModuleGenerationForCleanUp = singleModuleGeneration
 
                 verificationStage { singleModuleGeneration.validityCheck(context) }
 
@@ -69,9 +69,9 @@ public class BaseDokkaTestGenerator(
                 singleModuleGeneration.runPostActions()
             }
         } finally {
-            singleModuleGeneration?.cleanUp()
+            singleModuleGenerationForCleanUp?.cleanUp()
 
-            singleModuleGeneration?.reportAfterGeneration()
+            singleModuleGenerationForCleanUp?.reportAfterRendering()
         }
     }
 }

--- a/dokka-subprojects/plugin-base-test-utils/src/main/kotlin/org/jetbrains/dokka/base/testApi/testRunner/baseTestApi.kt
+++ b/dokka-subprojects/plugin-base-test-utils/src/main/kotlin/org/jetbrains/dokka/base/testApi/testRunner/baseTestApi.kt
@@ -29,45 +29,50 @@ public class BaseDokkaTestGenerator(
     additionalPlugins: List<DokkaPlugin> = emptyList()
 ) : DokkaTestGenerator<BaseTestMethods>(configuration, logger, testMethods, additionalPlugins) {
 
-    override fun generate(): Unit = try {
-        with(testMethods) {
-            val dokkaGenerator = DokkaGenerator(configuration, logger)
+    override fun generate(): Unit {
+        var singleModuleGeneration: SingleModuleGeneration? = null
+        try {
+            with(testMethods) {
+                val dokkaGenerator = DokkaGenerator(configuration, logger)
 
-            val context =
-                dokkaGenerator.initializePlugins(configuration, logger, additionalPlugins)
-            pluginsSetupStage(context)
+                val context =
+                    dokkaGenerator.initializePlugins(configuration, logger, additionalPlugins)
+                pluginsSetupStage(context)
 
-            val singleModuleGeneration = context.single(CoreExtensions.generation) as SingleModuleGeneration
+                singleModuleGeneration = context.single(CoreExtensions.generation) as SingleModuleGeneration
 
-            verificationStage { singleModuleGeneration.validityCheck(context) }
+                verificationStage { singleModuleGeneration.validityCheck(context) }
 
-            val modulesFromPlatforms = singleModuleGeneration.createDocumentationModels()
-            documentablesCreationStage(modulesFromPlatforms)
+                val modulesFromPlatforms = singleModuleGeneration.createDocumentationModels()
+                documentablesCreationStage(modulesFromPlatforms)
 
-            val filteredModules = singleModuleGeneration.transformDocumentationModelBeforeMerge(modulesFromPlatforms)
-            documentablesFirstTransformationStep(filteredModules)
+                val filteredModules =
+                    singleModuleGeneration.transformDocumentationModelBeforeMerge(modulesFromPlatforms)
+                documentablesFirstTransformationStep(filteredModules)
 
-            val documentationModel = singleModuleGeneration.mergeDocumentationModels(filteredModules)
-            documentablesMergingStage(documentationModel!!)
+                val documentationModel = singleModuleGeneration.mergeDocumentationModels(filteredModules)
+                documentablesMergingStage(documentationModel!!)
 
-            val transformedDocumentation = singleModuleGeneration.transformDocumentationModelAfterMerge(documentationModel)
-            documentablesTransformationStage(transformedDocumentation)
+                val transformedDocumentation =
+                    singleModuleGeneration.transformDocumentationModelAfterMerge(documentationModel)
+                documentablesTransformationStage(transformedDocumentation)
 
-            val pages = singleModuleGeneration.createPages(transformedDocumentation)
-            pagesGenerationStage(pages)
+                val pages = singleModuleGeneration.createPages(transformedDocumentation)
+                pagesGenerationStage(pages)
 
-            val transformedPages = singleModuleGeneration.transformPages(pages)
-            pagesTransformationStage(transformedPages)
+                val transformedPages = singleModuleGeneration.transformPages(pages)
+                pagesTransformationStage(transformedPages)
 
-            singleModuleGeneration.render(transformedPages)
-            renderingStage(transformedPages, context)
+                singleModuleGeneration.render(transformedPages)
+                renderingStage(transformedPages, context)
 
-            singleModuleGeneration.runPostActions()
+                singleModuleGeneration.runPostActions()
+            }
+        } finally {
+            singleModuleGeneration?.cleanUp()
 
-            singleModuleGeneration.reportAfterRendering()
+            singleModuleGeneration?.reportAfterGeneration()
         }
-    } finally {
-        PackageList.clearCache()
     }
 }
 

--- a/dokka-subprojects/plugin-base-test-utils/src/main/kotlin/org/jetbrains/dokka/base/testApi/testRunner/baseTestApi.kt
+++ b/dokka-subprojects/plugin-base-test-utils/src/main/kotlin/org/jetbrains/dokka/base/testApi/testRunner/baseTestApi.kt
@@ -67,11 +67,11 @@ public class BaseDokkaTestGenerator(
                 renderingStage(transformedPages, context)
 
                 singleModuleGeneration.runPostActions()
+
+                singleModuleGenerationForCleanUp.reportAfterRendering()
             }
         } finally {
             singleModuleGenerationForCleanUp?.cleanUp()
-
-            singleModuleGenerationForCleanUp?.reportAfterRendering()
         }
     }
 }

--- a/dokka-subprojects/plugin-base/api/plugin-base.api
+++ b/dokka-subprojects/plugin-base/api/plugin-base.api
@@ -104,6 +104,7 @@ public final class org/jetbrains/dokka/base/DokkaBaseConfiguration$Companion {
 
 public final class org/jetbrains/dokka/base/generation/SingleModuleGeneration : org/jetbrains/dokka/generation/Generation {
 	public fun <init> (Lorg/jetbrains/dokka/plugability/DokkaContext;)V
+	public final fun cleanUp ()V
 	public final fun createDocumentationModels ()Ljava/util/List;
 	public final fun createPages (Lorg/jetbrains/dokka/model/DModule;)Lorg/jetbrains/dokka/pages/RootPageNode;
 	public fun generate (Lorg/jetbrains/dokka/Timer;)V

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/generation/SingleModuleGeneration.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/generation/SingleModuleGeneration.kt
@@ -60,8 +60,6 @@ public class SingleModuleGeneration(private val context: DokkaContext) : Generat
     } finally {
         report("Cleaning up")
         cleanUp()
-
-        reportAfterRendering()
     }
 
     override val generationName: String = "documentation for ${context.configuration.moduleName}"

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/generation/SingleModuleGeneration.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/generation/SingleModuleGeneration.kt
@@ -55,6 +55,8 @@ public class SingleModuleGeneration(private val context: DokkaContext) : Generat
 
         report("Running post-actions")
         runPostActions()
+
+        reportAfterRendering()
     } finally {
         report("Cleaning up")
         cleanUp()
@@ -104,7 +106,7 @@ public class SingleModuleGeneration(private val context: DokkaContext) : Generat
 
     public fun cleanUp() {
         // Don't allow errors to block other clean up steps from running.
-        context[CoreExtensions.cleanUp].forEach {
+        context[CoreExtensions.cleanUpActions].forEach {
             try {
                 it()
             } catch (e: Exception) {

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/generation/SingleModuleGeneration.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/generation/SingleModuleGeneration.kt
@@ -59,7 +59,7 @@ public class SingleModuleGeneration(private val context: DokkaContext) : Generat
         report("Cleaning up")
         cleanUp()
 
-        reportAfterGeneration()
+        reportAfterRendering()
     }
 
     override val generationName: String = "documentation for ${context.configuration.moduleName}"
@@ -123,7 +123,7 @@ public class SingleModuleGeneration(private val context: DokkaContext) : Generat
         )
     }
 
-    public fun reportAfterGeneration() {
+    public fun reportAfterRendering() {
         context.unusedPoints.takeIf { it.isNotEmpty() }?.also {
             context.logger.info("Unused extension points found: ${it.joinToString(", ")}")
         }

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/generation/SingleModuleGeneration.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/generation/SingleModuleGeneration.kt
@@ -55,10 +55,11 @@ public class SingleModuleGeneration(private val context: DokkaContext) : Generat
 
         report("Running post-actions")
         runPostActions()
-
-        reportAfterRendering()
     } finally {
-        PackageList.clearCache()
+        report("Cleaning up")
+        cleanUp()
+
+        reportAfterGeneration()
     }
 
     override val generationName: String = "documentation for ${context.configuration.moduleName}"
@@ -101,6 +102,18 @@ public class SingleModuleGeneration(private val context: DokkaContext) : Generat
         context[CoreExtensions.postActions].forEach { it() }
     }
 
+    public fun cleanUp() {
+        // Don't allow errors to block other clean up steps from running.
+        context[CoreExtensions.cleanUp].forEach {
+            try {
+                it()
+            } catch (e: Exception) {
+                context.logger.error("Failed to run ${it.javaClass.name}: ${e.message}")
+            }
+        }
+        PackageList.clearCache()
+    }
+
     public fun validityCheck(context: DokkaContext) {
         val (preGenerationCheckResult, checkMessages) = context[CoreExtensions.preGenerationCheck].fold(
             Pair(true, emptyList<String>())
@@ -110,7 +123,7 @@ public class SingleModuleGeneration(private val context: DokkaContext) : Generat
         )
     }
 
-    public fun reportAfterRendering() {
+    public fun reportAfterGeneration() {
         context.unusedPoints.takeIf { it.isNotEmpty() }?.also {
             context.logger.info("Unused extension points found: ${it.joinToString(", ")}")
         }


### PR DESCRIPTION
Currently, if an exception is thrown during generation but before the post actions are run, the dokka process doesn't terminate because `disposeKotlinAnalysisPostAction` from `SymbolsAnalysisPlugin` is never run. I've added a test in `CliIntegrationTest` that would demonstrate this issue by forcing an error when trying to write to the output directory.

To address this, this PR adds a new `CleanUpAction` extension point, which unlike `PostAction` will run in the `finally` block of generation so that it is guaranteed to run even if generation fails. This switches `disposeKotlinAnalysisPostAction` from `SymbolsAnalysisPlugin` to a `CleanUpAction`.

Fixes #4537