### PR TITLE
Fix unresolved Javadoc `@link` to an override of a classpath method

### DIFF
--- a/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/parsers/doctag/PsiElementToHtmlConverter.kt
+++ b/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/parsers/doctag/PsiElementToHtmlConverter.kt
@@ -169,7 +169,7 @@ internal class PsiElementToHtmlConverter(
         private fun PsiElement.toDocumentationLinkString(label: String = ""): String {
             val displayLabel = label.ifBlank { defaultLabel().text }
 
-            val driId = reference?.resolve()?.takeIf { it !is PsiParameter }?.let {
+            val driId = reference?.resolveToDocumentedElement()?.takeIf { it !is PsiParameter }?.let {
                 val dri = DRI.from(it)
                 val id = docTagParserContext.store(dri)
                 id

--- a/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/util/resolveToGetDri.kt
+++ b/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/util/resolveToGetDri.kt
@@ -5,7 +5,52 @@
 package org.jetbrains.dokka.analysis.java.util
 
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiPolyVariantReference
+import com.intellij.psi.PsiReference
+import com.intellij.psi.util.InheritanceUtil
 
 // TODO [beresnev] get rid of
 internal fun PsiElement.resolveToGetDri(): PsiElement? =
-    reference?.resolve()
+    reference?.resolveToDocumentedElement()
+
+/**
+ * Resolves a JavaDoc reference (used for `{@link}`, `{@linkplain}` and `@see` tags).
+ *
+ * [PsiReference.resolve] returns `null` for an ambiguous method reference. This happens, in particular,
+ * when a method overrides a method from the classpath that is also declared in several inherited
+ * interfaces: e.g. `LinkedList#getFirst` is also declared in `Deque` and `SequencedCollection`, so a
+ * `{@link #getFirst()}` inside a `LinkedList` subclass resolves to more than one candidate.
+ *
+ * In the IDE such a reference offers a choice between navigating to the parent or to the child
+ * declaration. Here we default to the child (most-derived) declaration, since the parent can always be
+ * linked explicitly via its class name.
+ *
+ * See https://github.com/Kotlin/dokka/issues/4543
+ */
+internal fun PsiReference.resolveToDocumentedElement(): PsiElement? {
+    resolve()?.let { return it }
+    if (this is PsiPolyVariantReference) {
+        return multiResolve(false).mapNotNull { it.element }.mostDerivedMethodOrNull()
+    }
+    return null
+}
+
+/**
+ * Returns the single method whose containing class is a subtype of every other candidate's containing
+ * class, or `null` if there is no such method (i.e. the candidates are genuinely ambiguous or not all
+ * methods). This is used to pick the overriding (child) declaration among the candidates of a JavaDoc
+ * method reference.
+ */
+private fun List<PsiElement>.mostDerivedMethodOrNull(): PsiElement? {
+    val methods = filterIsInstance<PsiMethod>()
+    if (methods.isEmpty() || methods.size != size) return null
+    return methods.singleOrNull { candidate ->
+        val candidateClass = candidate.containingClass ?: return@singleOrNull false
+        methods.all { other ->
+            other === candidate || other.containingClass?.let { otherClass ->
+                InheritanceUtil.isInheritorOrSelf(candidateClass, otherClass, true)
+            } == true
+        }
+    }
+}

--- a/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/util/resolveToGetDri.kt
+++ b/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/util/resolveToGetDri.kt
@@ -5,10 +5,8 @@
 package org.jetbrains.dokka.analysis.java.util
 
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiPolyVariantReference
 import com.intellij.psi.PsiReference
-import com.intellij.psi.util.InheritanceUtil
 
 // TODO [beresnev] get rid of
 internal fun PsiElement.resolveToGetDri(): PsiElement? =
@@ -17,40 +15,24 @@ internal fun PsiElement.resolveToGetDri(): PsiElement? =
 /**
  * Resolves a JavaDoc reference (used for `{@link}`, `{@linkplain}` and `@see` tags).
  *
- * [PsiReference.resolve] returns `null` for an ambiguous method reference. This happens, in particular,
- * when a method overrides a method from the classpath that is also declared in several inherited
- * interfaces: e.g. `LinkedList#getFirst` is also declared in `Deque` and `SequencedCollection`, so a
- * `{@link #getFirst()}` inside a `LinkedList` subclass resolves to more than one candidate.
- *
- * In the IDE such a reference offers a choice between navigating to the parent or to the child
- * declaration. Here we default to the child (most-derived) declaration, since the parent can always be
- * linked explicitly via its class name.
- *
- * See https://github.com/Kotlin/dokka/issues/4543
- */
+*/
 internal fun PsiReference.resolveToDocumentedElement(): PsiElement? {
+    /**
+    * [PsiReference.resolve] returns `null` for an ambiguous reference. This happens, in particular,
+    * when a method overrides a method from the classpath that is also declared in several inherited
+    * interfaces: e.g. `LinkedList#getFirst` is also declared in `Deque` and `SequencedCollection`, so a
+    * `{@link #getFirst()}` inside a `LinkedList` subclass resolves to more than one candidate.
+    *
+    * Dokka links always point to a single declaration, so in that case we just take the first candidate.
+    * It is the declaration from the nearest scope (PSI lists a class's own declarations before inherited
+    * ones), so for an override of a classpath method it is the override itself — the natural default, since
+    * the parent can always be linked explicitly via its class name.
+    *
+    * See https://github.com/Kotlin/dokka/issues/4543
+    */
     resolve()?.let { return it }
     if (this is PsiPolyVariantReference) {
-        return multiResolve(false).mapNotNull { it.element }.mostDerivedMethodOrNull()
+        return multiResolve(false).firstOrNull()?.element
     }
     return null
-}
-
-/**
- * Returns the single method whose containing class is a subtype of every other candidate's containing
- * class, or `null` if there is no such method (i.e. the candidates are genuinely ambiguous or not all
- * methods). This is used to pick the overriding (child) declaration among the candidates of a JavaDoc
- * method reference.
- */
-private fun List<PsiElement>.mostDerivedMethodOrNull(): PsiElement? {
-    val methods = filterIsInstance<PsiMethod>()
-    if (methods.isEmpty() || methods.size != size) return null
-    return methods.singleOrNull { candidate ->
-        val candidateClass = candidate.containingClass ?: return@singleOrNull false
-        methods.all { other ->
-            other === candidate || other.containingClass?.let { otherClass ->
-                InheritanceUtil.isInheritorOrSelf(candidateClass, otherClass, true)
-            } == true
-        }
-    }
 }

--- a/dokka-subprojects/plugin-base/src/test/kotlin/translators/JavadocParserTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/translators/JavadocParserTest.kt
@@ -5,7 +5,9 @@
 package translators
 
 import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
+import org.jetbrains.dokka.links.Callable
 import org.jetbrains.dokka.links.DRI
+import org.jetbrains.dokka.links.JavaClassReference
 import org.jetbrains.dokka.model.DModule
 import org.jetbrains.dokka.model.childrenOfType
 import org.jetbrains.dokka.model.dfs
@@ -18,6 +20,7 @@ import utils.text
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class JavadocParserTest : BaseAbstractTest() {
 
@@ -128,8 +131,65 @@ class JavadocParserTest : BaseAbstractTest() {
                 assertEquals("LinkedList", parentLink.dri.classNames)
 
                 assertEquals(
-                    emptyList<String>(),
-                    logger.warnMessages.filter { "Couldn't resolve JavaDoc link" in it },
+                    0,
+                    logger.warningsCount,
+                    "There should be no unresolved JavaDoc link warnings"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `should resolve ambiguous JavaDoc link to several overloads`() {
+        val configuration = dokkaConfiguration {
+            sourceSets {
+                sourceSet {
+                    sourceRoots = listOf("src/main/java")
+                }
+            }
+        }
+
+        testInline(
+            """
+            /src/main/java/sample/Overloads.java
+            package sample;
+
+            public class Overloads {
+                /**
+                 * link: {@link #foo n}
+                 */
+                public void doc() {}
+
+                public void foo(int x) {}
+                public void foo(String s) {}
+            }
+            """.trimIndent(),
+            configuration
+        ) {
+            documentablesMergingStage = { module ->
+                val doc = module.dfs { it.name == "doc" && it is DFunction } as DFunction
+                val description = doc.documentation.values.single().children
+                    .filterIsInstance<Description>().single()
+
+                val allLinks = mutableListOf<DocumentationLink>()
+                fun collect(node: DocTag) {
+                    if (node is DocumentationLink) allLinks += node
+                    node.children.forEach { collect(it) }
+                }
+                description.children.forEach { collect(it) }
+
+                // A paren-less reference carries no signature to pick a specific overload. Since Dokka
+                // links to a single declaration, it must still resolve to one of the existing overloads.
+                val link = allLinks.single { it.text().trim() == "n" }
+                val overloadDris = listOf(
+                    DRI("sample", "Overloads", Callable("foo", null, listOf(JavaClassReference("int")))),
+                    DRI("sample", "Overloads", Callable("foo", null, listOf(JavaClassReference("java.lang.String")))),
+                )
+                assertTrue(link.dri in overloadDris, "Expected ${link.dri} to be one of $overloadDris")
+
+                assertEquals(
+                    0,
+                    logger.warningsCount,
                     "There should be no unresolved JavaDoc link warnings"
                 )
             }

--- a/dokka-subprojects/plugin-base/src/test/kotlin/translators/JavadocParserTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/translators/JavadocParserTest.kt
@@ -20,7 +20,6 @@ import utils.text
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 class JavadocParserTest : BaseAbstractTest() {
 
@@ -125,10 +124,9 @@ class JavadocParserTest : BaseAbstractTest() {
                 val withClassLink = allLinks.single { it.text().trim() == "b" }
                 val parentLink = allLinks.single { it.text().trim() == "c" }
 
-                assertEquals("sample", noClassLink.dri.packageName)
-                assertEquals("StringList", noClassLink.dri.classNames)
-                assertEquals("StringList", withClassLink.dri.classNames)
-                assertEquals("LinkedList", parentLink.dri.classNames)
+                assertEquals(DRI("sample", "StringList", Callable("getFirst", null, emptyList())), noClassLink.dri)
+                assertEquals(DRI("sample", "StringList", Callable("getFirst", null, emptyList())), withClassLink.dri)
+                assertEquals(DRI("java.util", "LinkedList", Callable("getFirst", null, emptyList())), parentLink.dri)
 
                 assertEquals(
                     0,
@@ -181,11 +179,7 @@ class JavadocParserTest : BaseAbstractTest() {
                 // A paren-less reference carries no signature to pick a specific overload. Since Dokka
                 // links to a single declaration, it must still resolve to one of the existing overloads.
                 val link = allLinks.single { it.text().trim() == "n" }
-                val overloadDris = listOf(
-                    DRI("sample", "Overloads", Callable("foo", null, listOf(JavaClassReference("int")))),
-                    DRI("sample", "Overloads", Callable("foo", null, listOf(JavaClassReference("java.lang.String")))),
-                )
-                assertTrue(link.dri in overloadDris, "Expected ${link.dri} to be one of $overloadDris")
+                assertEquals(DRI("sample", "Overloads", Callable("foo", null, listOf(JavaClassReference("int")))), link.dri)
 
                 assertEquals(
                     0,

--- a/dokka-subprojects/plugin-base/src/test/kotlin/translators/JavadocParserTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/translators/JavadocParserTest.kt
@@ -13,6 +13,7 @@ import org.jetbrains.dokka.model.DFunction
 import org.jetbrains.dokka.model.doc.*
 import org.jetbrains.dokka.model.firstChildOfType
 import org.jetbrains.dokka.model.firstMemberOfType
+import utils.OnlyJavaPsi
 import utils.text
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -66,6 +67,71 @@ class JavadocParserTest : BaseAbstractTest() {
                     assertNull(address?.callable)
                     assertEquals("java.util.List", name)
                 }
+            }
+        }
+    }
+
+    @OnlyJavaPsi("Symbol-based Java analysis represents the overriding getter as a synthetic property")
+    @Test
+    fun `should resolve javadoc link to a method overriding a classpath method #4543`() {
+        val configuration = dokkaConfiguration {
+            sourceSets {
+                sourceSet {
+                    sourceRoots = listOf("src/main/java")
+                }
+            }
+        }
+
+        testInline(
+            """
+            /src/main/java/sample/StringList.java
+            package sample;
+            import java.util.LinkedList;
+
+            public class StringList extends LinkedList<String> {
+                /**
+                 * no class: {@link #getFirst() a}
+                 * with class: {@link StringList#getFirst() b}
+                 * parent: {@link LinkedList#getFirst() c}
+                 */
+                @Override
+                public String getFirst() {
+                    return super.getFirst();
+                }
+            }
+            """.trimIndent(),
+            configuration
+        ) {
+            documentablesMergingStage = { module ->
+                val fn = module.dfs { it.name == "getFirst" && it is DFunction } as DFunction
+                val description = fn.documentation.values.single().children
+                    .filterIsInstance<Description>().single()
+
+                val allLinks = mutableListOf<DocumentationLink>()
+                fun collect(node: DocTag) {
+                    if (node is DocumentationLink) allLinks += node
+                    node.children.forEach { collect(it) }
+                }
+                description.children.forEach { collect(it) }
+
+                // All three links must resolve, and the ones without an explicit parent class
+                // must point to the overriding (child) declaration in StringList, not the parent.
+                assertEquals(3, allLinks.size, "Expected all three @link references to resolve")
+
+                val noClassLink = allLinks.single { it.text().trim() == "a" }
+                val withClassLink = allLinks.single { it.text().trim() == "b" }
+                val parentLink = allLinks.single { it.text().trim() == "c" }
+
+                assertEquals("sample", noClassLink.dri.packageName)
+                assertEquals("StringList", noClassLink.dri.classNames)
+                assertEquals("StringList", withClassLink.dri.classNames)
+                assertEquals("LinkedList", parentLink.dri.classNames)
+
+                assertEquals(
+                    emptyList<String>(),
+                    logger.warnMessages.filter { "Couldn't resolve JavaDoc link" in it },
+                    "There should be no unresolved JavaDoc link warnings"
+                )
             }
         }
     }


### PR DESCRIPTION
Fixes #4543

**Root cause**

IntelliJ's `PsiDocMethodOrFieldRef.MyReference.resolve() `only returns a result when there is exactly one candidate. For an override of a classpath method that is also declared in several inherited interfaces, the super-signature de-duplication leaves more than one candidate, so `resolve()` returns null:
```
multiResolve count=2 for 'getFirst': sample.StringList#getFirst, java.util.Deque#getFirst   → resolve() == null
multiResolve count=1 for 'getFirst': java.util.LinkedList#getFirst                          → resolves fine
```
(`LinkedList#getFirst` is also declared in Deque/SequencedCollection, and the inheritance paths aren't merged.)
