### PR TITLE
Update Analysis API to 2.4.20-dev-8332

### DIFF
--- a/dokka-subprojects/analysis-kotlin-symbols/build.gradle.kts
+++ b/dokka-subprojects/analysis-kotlin-symbols/build.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
     // copy-pasted from Analysis API https://github.com/JetBrains/kotlin/blob/a10042f9099e20a656dec3ecf1665eea340a3633/analysis/low-level-api-fir/build.gradle.kts#L37
     runtimeOnly("com.github.ben-manes.caffeine:caffeine:2.9.3")
 
-    runtimeOnly(libs.kotlinx.collections.immutable)
+    //runtimeOnly(libs.kotlinx.collections.immutable)
     implementation(libs.kotlin.compiler.k2) {
         isTransitive = false
     }

--- a/dokka-subprojects/analysis-kotlin-symbols/build.gradle.kts
+++ b/dokka-subprojects/analysis-kotlin-symbols/build.gradle.kts
@@ -27,6 +27,11 @@ dependencies {
         // a stripped one is already presented in `kotlin-compiler`
         // also, it prevents using `aalto-xml` in `jackson` by excluding Stax API services files
        exclude("com.fasterxml", "aalto-xml")
+        // `kotlinx-collections-immutable` is embedded (shaded under its original package) in `kotlin-compiler`.
+        // The IntelliJ platform pulls in a separate, older external artifact transitively, which shadows the
+        // embedded one on the classpath and lacks `PersistentList.adding` (renamed from `add` in 0.5.0),
+        // causing a NoSuchMethodError in KaBaseLifetimeTracker. Exclude it so the embedded copy is used.
+       exclude("org.jetbrains.kotlinx", "kotlinx-collections-immutable-jvm")
     }
 
     // ----------- Analysis dependencies ----------------------------------------------------------------------------
@@ -56,7 +61,6 @@ dependencies {
     // copy-pasted from Analysis API https://github.com/JetBrains/kotlin/blob/a10042f9099e20a656dec3ecf1665eea340a3633/analysis/low-level-api-fir/build.gradle.kts#L37
     runtimeOnly("com.github.ben-manes.caffeine:caffeine:2.9.3")
 
-    //runtimeOnly(libs.kotlinx.collections.immutable)
     implementation(libs.kotlin.compiler.k2) {
         isTransitive = false
     }

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/AnnotationTranslator.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/AnnotationTranslator.kt
@@ -22,6 +22,7 @@ import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtFile
 
 /**
@@ -99,7 +100,8 @@ internal class AnnotationTranslator(private val logger: DokkaLogger) {
                 )
             },
             mustBeDocumented = mustBeDocumented(annotation),
-            scope = annotation.useSiteTarget?.toDokkaAnnotationScope() ?: Annotations.AnnotationScope.DIRECT
+            scope = (annotation.psi as? KtAnnotationEntry)?.useSiteTarget?.getAnnotationUseSiteTarget()
+                ?.toDokkaAnnotationScope() ?: Annotations.AnnotationScope.DIRECT
         )
 
     @OptIn(ExperimentalUnsignedTypes::class)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ ktor = "2.3.11"
 javaDiffUtils = "4.12"
 
 ## Analysis
-kotlin-compiler-k2 = "2.4.20-dev-5364"
+kotlin-compiler-k2 = "2.4.20-dev-8332"
 
 # MUST match the version of the intellij platform used in the kotlin compiler,
 # otherwise this will lead to different versions of psi API and implementations

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,6 @@ gradlePlugin-kotlin = "2.3.21"
 gradlePlugin-android = "7.3.1"
 
 kotlinx-coroutines = "1.7.3"
-kotlinx-collections-immutable = "0.3.6"
 kotlinx-serialization = "1.6.0"
 kotlinx-bcv = "0.17.0"
 
@@ -81,7 +80,6 @@ kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5" }
 
 #### Kotlin Libs ####
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
-kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm", version.ref = "kotlinx-collections-immutable" }
 kotlinxSerialization-bom = { module = "org.jetbrains.kotlinx:kotlinx-serialization-bom", version.ref = "kotlinx-serialization" }
 kotlinxSerialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json" }
 


### PR DESCRIPTION
Contains  https://youtrack.jetbrains.com/issue/KT-87143/findKDoc-returns-parent-property-KDoc-for-accessors-of-an-overriding-property 