### PR TITLE
Update Annotations merge strategy to combine annotations for each source set

### DIFF
--- a/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/model/additionalExtras.kt
+++ b/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/model/additionalExtras.kt
@@ -32,8 +32,18 @@ public data class Annotations(
     private val myContent: SourceSetDependent<List<Annotation>>
 ) : ExtraProperty<AnnotationTarget> {
     public companion object : ExtraProperty.Key<AnnotationTarget, Annotations> {
-        override fun mergeStrategyFor(left: Annotations, right: Annotations): MergeStrategy<AnnotationTarget> =
-            MergeStrategy.Replace(Annotations(left.myContent + right.myContent))
+        override fun mergeStrategyFor(left: Annotations, right: Annotations): MergeStrategy<AnnotationTarget> {
+            val sourceSets = left.myContent.keys + right.myContent.keys
+            // For each source set, merge the annotations from the `left` and `right`, if they exist.
+            return MergeStrategy.Replace(
+                Annotations(
+                    sourceSets.associateWith { sourceSet ->
+                        left.myContent.getOrDefault(sourceSet, emptyList()) +
+                                right.myContent.getOrDefault(sourceSet, emptyList())
+                    }
+                )
+            )
+        }
     }
 
     override val key: ExtraProperty.Key<AnnotationTarget, *> = Annotations

--- a/dokka-subprojects/plugin-base/src/test/kotlin/model/annotations/JavaAnnotationsTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/model/annotations/JavaAnnotationsTest.kt
@@ -9,6 +9,7 @@ import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.model.*
 import translators.findClasslike
+import translators.findPackage
 import kotlin.test.*
 
 class JavaAnnotationsTest : BaseAbstractTest() {
@@ -250,6 +251,62 @@ class JavaAnnotationsTest : BaseAbstractTest() {
                         mustBeDocumented = true
                     ), annotation2
                 )
+            }
+        }
+    }
+
+    @Test
+    fun `package level annotation for java only package`() {
+        testInline(
+            """
+                /src/main/java/annotation/package-info.java
+                @Deprecated
+                package annotation;
+
+                /src/main/java/annotation/JavaClass.java
+                package annotation;
+                public class JavaClass {}
+            """.trimIndent(),
+            configuration,
+        ) {
+            documentablesTransformationStage = { module ->
+                val pkg = module.findPackage("annotation")
+                assertNotNull(pkg)
+                val pkgAnnotations = pkg.extra[Annotations]
+                assertNotNull(pkgAnnotations)
+                val sourceSetPkgAnnotations = pkgAnnotations.directAnnotations.values.single()
+                assertEquals(sourceSetPkgAnnotations.size, 1)
+                assertEquals(sourceSetPkgAnnotations.single().dri.classNames, "Deprecated")
+            }
+        }
+    }
+
+    @Test
+    fun `package level annotation for java and kotlin package`() {
+        testInline(
+            """
+                /src/main/java/annotation/package-info.java
+                @Deprecated
+                package annotation;
+
+                /src/main/java/annotation/JavaClass.java
+                package annotation;
+                public class JavaClass {}
+
+                /src/main/kotlin/annotation/KotlinClass.kt
+                package annotation
+                class KotlinClass
+            """.trimIndent(),
+            configuration,
+        ) {
+            documentablesTransformationStage = { module ->
+                val pkg = module.findPackage("annotation")
+                assertNotNull(pkg)
+                val pkgAnnotations = pkg.extra[Annotations]
+                assertNotNull(pkgAnnotations)
+                val sourceSetPkgAnnotations = pkgAnnotations.directAnnotations.values.single()
+                assertEquals(sourceSetPkgAnnotations.size, 1)
+                assertEquals(sourceSetPkgAnnotations.single().dri.classNames, "Deprecated")
             }
         }
     }


### PR DESCRIPTION
Currently, `Annotations.mergeStrategyFor` uses `+` on two `Map`s. This means that if the same key is present in both `Map`s, the value for that key in the resultant `Map` is the value from the second `Map`, with the value from the first `Map` getting ignored.

This behavior means that if a mixed java and kotlin package has annotations in the `package-info.java`, they might get dropped during the merge of the java and kotlin `DPackage`s.

This PR updates the merge behavior to avoid dropping annotations. I'm not sure if this is always the best way to handle annotation merging (for instance, if there were the same annotations in both `left` and `right`, should the annotations be duplicated?). Let me know if a different approach would make more sense.

Fixes #4558