### PR TITLE
Exclude companion extensions from subclass and implementor pages

### DIFF
--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/transformers/documentables/ExtensionExtractorTransformer.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/transformers/documentables/ExtensionExtractorTransformer.kt
@@ -6,6 +6,7 @@ package org.jetbrains.dokka.base.transformers.documentables
 
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
+import org.jetbrains.dokka.ExperimentalDokkaApi
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.links.DriOfAny
 import org.jetbrains.dokka.model.*
@@ -119,13 +120,27 @@ public class ExtensionExtractorTransformer : DocumentableTransformer {
     ): CallableExtensions? {
         val resultSet = mutableSetOf<Callable>()
 
-        fun collectFrom(element: DRI) {
-            extensionMap[element]?.let { resultSet.addAll(it) }
-            sourceSets.forEach { sourceSet -> classGraph[sourceSet]?.get(element)?.forEach { collectFrom(it) } }
+        fun collectFrom(element: DRI, isSupertype: Boolean) {
+            extensionMap[element]?.forEach { extension ->
+                // A companion extension belongs to the companion scope of its receiver type only.
+                // Such a scope is not inherited: it cannot be accessed through the name of a subtype
+                // (see KEEP-0449 §2.5), so companion extensions of supertypes are not collected here.
+                if (!isSupertype || !extension.isCompanionExtension()) resultSet.add(extension)
+            }
+            sourceSets.forEach { sourceSet ->
+                classGraph[sourceSet]?.get(element)?.forEach { collectFrom(it, isSupertype = true) }
+            }
         }
-        collectFrom(dri)
+        collectFrom(dri, isSupertype = false)
 
         return if (resultSet.isEmpty()) null else CallableExtensions(resultSet)
+    }
+
+    @OptIn(ExperimentalDokkaApi::class)
+    private fun Callable.isCompanionExtension(): Boolean = when (this) {
+        is DFunction -> extra[IsCompanion] != null
+        is DProperty -> extra[IsCompanion] != null
+        else -> false
     }
 
     private fun Callable.asPairsWithReceiverDRIs(): Sequence<Pair<DRI, Callable>> =

--- a/dokka-subprojects/plugin-base/src/test/kotlin/transformers/CompanionSectionsTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/transformers/CompanionSectionsTest.kt
@@ -414,6 +414,77 @@ class CompanionSectionsTest : BaseAbstractTest() {
         }
     }
 
+    /**
+     * The companion scope of a supertype is not accessible through the name of a subtype
+     * (see KEEP-0449 §2.5), so companion extensions must not be listed on subclass pages.
+     *
+     * See https://github.com/Kotlin/dokka/issues/4562
+     */
+    @Test
+    fun `companion extension of a parent does not appear on a child page`() {
+        testInline(
+            """
+            |/src/main/kotlin/example/Util.kt
+            |package example
+            |open class Parent
+            |class Child : Parent()
+            |
+            |companion val Parent.companionExtProperty: String get() = ""
+            |companion fun Parent.companionExtFunction(): String = ""
+            |
+            |val Parent.instanceExtProperty: String get() = ""
+            |fun Parent.instanceExtFunction(): String = ""
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesTransformationStage = { root ->
+                val parentPage = root.dfs { it.name == "Parent" } as? ClasslikePageNode
+                    ?: error("Parent page not found")
+                assertEquals(listOf("companionExtProperty"), parentPage.sectionTexts("Companion properties"))
+                assertEquals(listOf("companionExtFunction"), parentPage.sectionTexts("Companion functions"))
+                assertEquals(listOf("instanceExtProperty"), parentPage.sectionTexts("Properties"))
+                assertEquals(listOf("instanceExtFunction"), parentPage.sectionTexts("Functions"))
+
+                val childPage = root.dfs { it.name == "Child" } as? ClasslikePageNode
+                    ?: error("Child page not found")
+                // the parent's companion scope is not reachable through the child's name
+                assertNull(childPage.sectionTexts("Companion properties"))
+                assertNull(childPage.sectionTexts("Companion functions"))
+                // while plain extensions of the parent are applicable to the child and must be kept
+                assertEquals(listOf("instanceExtProperty"), childPage.sectionTexts("Properties"))
+                assertEquals(listOf("instanceExtFunction"), childPage.sectionTexts("Functions"))
+            }
+        }
+    }
+
+    @Test
+    fun `companion extension of an interface does not appear on an implementor page`() {
+        testInline(
+            """
+            |/src/main/kotlin/example/Util.kt
+            |package example
+            |interface Marker
+            |class Impl : Marker
+            |
+            |companion fun Marker.create(): String = ""
+            |fun Marker.describe(): String = ""
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesTransformationStage = { root ->
+                val markerPage = root.dfs { it.name == "Marker" } as? ClasslikePageNode
+                    ?: error("Marker page not found")
+                assertEquals(listOf("create"), markerPage.sectionTexts("Companion functions"))
+                assertEquals(listOf("describe"), markerPage.sectionTexts("Functions"))
+
+                val implPage = root.dfs { it.name == "Impl" } as? ClasslikePageNode
+                    ?: error("Impl page not found")
+                assertNull(implPage.sectionTexts("Companion functions"))
+                assertEquals(listOf("describe"), implPage.sectionTexts("Functions"))
+            }
+        }
+    }
+
     @Test
     fun `plain top-level extension stays in regular Functions section`() {
         testInline(


### PR DESCRIPTION
fixes #4562
Implements KEEP-0449 rules in `ExtensionExtractorTransformer` to ensure companion extensions of supertypes are not inherited.