### PR TITLE
Update Jsoup to the latest version

### DIFF
--- a/dokka-integration-tests/gradle/src/testExampleProjects/expectedData/exampleProjects/versioning-multimodule-example/html/older/0.9/not-found-version.html
+++ b/dokka-integration-tests/gradle/src/testExampleProjects/expectedData/exampleProjects/versioning-multimodule-example/html/older/0.9/not-found-version.html
@@ -132,7 +132,7 @@ window.onload = function() {
 </script>
 
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position: absolute; width: 0; height: 0" id="__SVG_SPRITE_NODE__">
-    <symbol xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewbox="0 0 64 64" id="404">
+    <symbol xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 64 64" id="404">
         <g>
             <rect y="0" width="64" height="64"></rect>
             <rect x="5.9" y="52" fill="#fff" width="24" height="4"></rect>
@@ -140,7 +140,7 @@ window.onload = function() {
             <text x="5" y="35" fill="#fff" class="heavy">FOUND</text>
         </g>
     </symbol>
-    <symbol xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewbox="183 -134 978 1061" id="page-404-beam">
+    <symbol xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="183 -134 978 1061" id="page-404-beam">
         <g style="opacity:0.49;">
             <path style="fill-opacity:0;stroke:#D9D9D9;stroke-dasharray:10,3;" d="M1117.5,424.5l-535-476l87,449L1117.5,424.5z"></path>
             <path style="fill-opacity:0;stroke:#E1E1E1;stroke-dasharray:10,3;" d="M1118.3,465.9c-23.3,0-42.2-18.9-42.2-42.2   s18.9-42.2,42.2-42.2c23.3,0,42.2,18.9,42.2,42.2S1141.6,465.9,1118.3,465.9z M583.6,34.4c-46.3,0-83.9-37.6-83.9-83.9   s37.6-83.9,83.9-83.9s83.9,37.6,83.9,83.9S630,34.4,583.6,34.4z M536.2,841.7c0,46.8-37.9,84.8-84.7,84.8s-84.7-37.9-84.7-84.8   s37.9-84.8,84.7-84.8S536.2,794.9,536.2,841.7z M273.9,263.1c-49.9,0-90.4-40.5-90.4-90.4s40.5-90.4,90.4-90.4s90.4,40.5,90.4,90.4   S323.8,263.1,273.9,263.1z"></path>

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/kdoc/java/KotlinInheritDocTagContentProvider.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/kdoc/java/KotlinInheritDocTagContentProvider.kt
@@ -30,6 +30,8 @@ internal class KotlinInheritDocTagContentProvider(
             parseWithChildren = false
         )
         val id = docTagParserContext.store(inheritedDocNode)
-        return """<inheritdoc id="$id"/>"""
+        // not a "self-closing" tag, as it's a custom HTML tag which is then replaced during Javadoc HTML parsing
+        // see https://github.com/jhy/jsoup/issues/2300
+        return """<inheritdoc id="$id"></inheritdoc>"""
     }
 }

--- a/dokka-subprojects/analysis-markdown-jb/src/main/kotlin/org/jetbrains/dokka/analysis/markdown/jb/ParseUtils.kt
+++ b/dokka-subprojects/analysis-markdown-jb/src/main/kotlin/org/jetbrains/dokka/analysis/markdown/jb/ParseUtils.kt
@@ -10,7 +10,7 @@ import org.jetbrains.dokka.InternalDokkaApi
 import org.jetbrains.dokka.model.doc.DocTag
 import org.jetbrains.dokka.model.doc.Text
 import org.jsoup.internal.StringUtil
-import org.jsoup.nodes.Entities
+import org.jsoup.nodes.TextNode
 
 @InternalDokkaApi
 public fun String.parseHtmlEncodedWithNormalisedSpaces(
@@ -21,12 +21,16 @@ public fun String.parseHtmlEncodedWithNormalisedSpaces(
     var lastWasWhite = false
 
     forEachCodePoint { c ->
-        if (renderWhiteCharactersAsSpaces && StringUtil.isWhitespace(c)) {
-            if (!lastWasWhite) {
-                accum.append(' ')
-                lastWasWhite = true
+        if (StringUtil.isWhitespace(c)) {
+            if (renderWhiteCharactersAsSpaces) {
+                if (!lastWasWhite) {
+                    accum.append(' ')
+                    lastWasWhite = true
+                }
+            } else {
+                accum.appendCodePoint(c)
             }
-        } else if (Compat.codePointToString(c).let { it != Entities.escape(it) }) {
+        } else if (Compat.codePointToString(c).let { it != TextNode(it).toString() }) {
             accum.toString().takeIf { it.isNotBlank() }?.let { tags.add(Text(it)) }
             accum.delete(0, accum.length)
 

--- a/dokka-subprojects/plugin-javadoc/src/test/kotlin/org/jetbrains/dokka/javadoc/JavadocAccessorNamingTest.kt
+++ b/dokka-subprojects/plugin-javadoc/src/test/kotlin/org/jetbrains/dokka/javadoc/JavadocAccessorNamingTest.kt
@@ -84,9 +84,9 @@ internal class JavadocAccessorNamingTest : AbstractJavadocTemplateMapTest() {
                 ), descriptionLinks.toSet())
 
                 // Make sure that the ids from above actually exist
-                assertEquals(1, html.select("[id = isFoo()]").size)
+                assertEquals(1, html.select("[id=isFoo()]").size)
                 // Bug! Nothing in the doc has the right id
-                assertEquals(0, html.select("[id = issuesFetched]").size)
+                assertEquals(0, html.select("[id=issuesFetched]").size)
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ kotlin-compiler-k2 = "2.5.0-dev-3229"
 intellij-platform = "261.24374.151"
 
 ## HTML
-jsoup = "1.16.1"
+jsoup = "1.23.2"
 freemarker = "2.3.32"
 korlibs-template = "4.0.10"
 kotlinx-html = "0.9.1"


### PR DESCRIPTION
Update Jsoup to the latest version (1.23.2, [changelog](https://github.com/jhy/jsoup/blob/master/CHANGES.md)) to avoid vulnerabilities.

By simply updating the version, several things were broken:

1. escaping of `'` and `"` - fixed in a7b108bc66c7dbf6d824d6bd9aa4403aa68197f9
2. `inheritDoc` injection - fixed in 16b585dc58b99bc800757822f421ce8718b6d258
3. accessors in javadoc format tests couldn't be found - fixed in 9cb675340522b66612ab3337be6f79de4d505b2b
4. expectedData used `viewbox` attribute for some reason, while [original](https://github.com/Kotlin/dokka/blob/d4d457d357627fd8100e4f0d47868020485996ec/dokka-subprojects/plugin-versioning/src/main/resources/dokka/not-found-version.html#L136-L144) page always contained `viewBox` - fixed in 5f1eacb1e5b3451a750519ce84ab6a11b40d64fa