### PR TITLE
Update Jackson to the latest version

### DIFF
--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/TestedVersions.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/TestedVersions.kt
@@ -23,7 +23,7 @@ object TestedVersions {
      */
     val ALL_SUPPORTED =
         BuildVersions.permutations(
-            gradleVersions = listOf("7.6.3"),
+            gradleVersions = listOf("7.6.6"),
             kotlinVersions = listOf("2.2.21", "2.1.21", "2.0.21", "1.9.25"),
         ) + LATEST
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ jetbrains-markdown = "0.7.3"
 
 ## JSON
 # jackson 2.15.3 is the latest version, which works correctly with Kotlin API/Language 1.4 and Gradle 7.6.3+
-jackson = "2.15.3"
+jackson = "2.22.2"
 
 ## Maven
 apacheMaven-core = "3.5.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,11 @@ kotlinx-html = "0.9.1"
 jetbrains-markdown = "0.7.3"
 
 ## JSON
-# jackson 2.15.3 is the latest version, which works correctly with Kotlin API/Language 1.4 and Gradle 7.6.3+
+# When updating jackson, make sure that it's working correctly with different Gradle versions.
+# https://github.com/FasterXML/jackson-module-kotlin wasn't really specified a minimum Kotlin version it supports until recently.
+# E.g., in 2.15.0 it dropped support for Kotlin 1.4, but it was still working with Gradle 7.6, which uses Kotlin API/Language 1.4.
+# Since 2.21.2 it explicitly specifies, API/language version 1.9 (https://github.com/FasterXML/jackson-module-kotlin/issues/1129).
+# Though, as it doesn't really use any newer APIs/language features, it's still compatible with older versions, used in Gradle 7.6.
 jackson = "2.22.2"
 
 ## Maven


### PR DESCRIPTION
Update Jackson to the latest version (2.22.2) to avoid vulnerabilities, and update Gradle versions in IT to use Gradle 7.6.6, which includes a fix that allows multi-release JARs.
In theory, it means we drop support for Gradle 7.6.3 and below, though I think that those who use Gradle 7.6 could easily update the patch version if needed.