### PR TITLE
Fix table header parsing: use Th nodes for Markdown tables

### DIFF
--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/transformers/pages/comments/DocTagToContentConverter.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/transformers/pages/comments/DocTagToContentConverter.kt
@@ -210,7 +210,8 @@ public open class DocTagToContentConverter : CommentsToContentConverter {
                 } else {
                     listOf(
                         ContentTable(
-                            header = buildTableRows(docTag.children.filterIsInstance<Tr>(), CommentTable),
+                            // Markdown tables use a Th node for the header row
+                            header = buildTableRows(docTag.children.filterIsInstance<Th>(), CommentTable),
                             caption = null,
                             buildTableRows(docTag.children.filterIsInstance<Tr>(), CommentTable),
                             dci,

--- a/dokka-subprojects/plugin-base/src/test/kotlin/transformers/CommentsToContentConverterTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/transformers/CommentsToContentConverterTest.kt
@@ -38,6 +38,31 @@ class CommentsToContentConverterTest {
     }
 
     @Test
+    fun `markdown table keeps its header row`() {
+        val table = Table(
+            children = listOf(
+                Th(children = listOf(Td(children = listOf(Text("header"))))),
+                Tr(children = listOf(Td(children = listOf(Text("value")))))
+            )
+        )
+
+        val contentTable = converter.buildContent(
+            table,
+            DCI(setOf(DRI("kotlin", "Any")), ContentKind.Comment),
+            emptySet()
+        ).single() as ContentTable
+
+        assertEquals(
+            "header",
+            ((contentTable.header.single().children.single() as ContentGroup).children.single() as ContentText).text
+        )
+        assertEquals(
+            "value",
+            ((contentTable.children.single().children.single() as ContentGroup).children.single() as ContentText).text
+        )
+    }
+
+    @Test
     fun `simple text`() {
         val docTag = P(listOf(Text("This is simple test of string Next line")))
         executeTest(docTag) {


### PR DESCRIPTION
fixes #4586