### PR TITLE
Better fix for markdown blockqoutes handling

### DIFF
--- a/dokka-subprojects/analysis-markdown-jb/src/main/kotlin/org/jetbrains/dokka/analysis/markdown/jb/MarkdownParser.kt
+++ b/dokka-subprojects/analysis-markdown-jb/src/main/kotlin/org/jetbrains/dokka/analysis/markdown/jb/MarkdownParser.kt
@@ -454,7 +454,62 @@ public open class MarkdownParser(
         this.filterNot { it.type == MarkdownTokenTypes.WHITE_SPACE || it.type == MarkdownTokenTypes.EOL }
 
     private fun List<ASTNode>.evaluateChildren(keepAllFormatting: Boolean = false): List<DocTag> =
-        this.removeUselessTokens().swapImagesThatShouldBeLinks(keepAllFormatting).mergeLeafASTNodes().flatMap { visitNode(it, keepAllFormatting) }
+        this.removeUselessTokens().swapImagesThatShouldBeLinks(keepAllFormatting).mergeLeafASTNodes().flatMap { visitNode(it, keepAllFormatting) }.mergeAdjacentTextNodes()
+
+    /**
+     * Merges adjacent [Text] nodes into a single [Text] node, but only if they have the same [Text.params].
+     *
+     * This is needed because some tokens (like [MarkdownTokenTypes.BLOCK_QUOTE]) act as separators
+     * during AST processing but produce no output (return `emptyList()`), leaving adjacent [Text]
+     * nodes that should logically be one continuous text.
+     *
+     * Text nodes with different params (e.g., HTML comments with `content-type=html`) are kept separate.
+     *
+     * When merging, if one text ends with a space and the next starts with a space,
+     * the duplicate space at the boundary is removed.
+     */
+    private fun List<DocTag>.mergeAdjacentTextNodes(): List<DocTag> {
+        fun canMergeTextWithNext(index: Int): Boolean {
+            if (index + 1 > lastIndex) return false
+            val current = this[index]
+            val next = this[index + 1]
+            return current is Text && next is Text && current.params == next.params
+        }
+
+        fun mergedTextNode(startIndex: Int, endIndex: Int): Text {
+            val first = this[startIndex] as Text
+            if (startIndex == endIndex) return first
+
+            val mergedBody = StringBuilder(first.body)
+            for (i in (startIndex + 1)..endIndex) {
+                val next = (this[i] as Text).body
+                // Avoid double space at the merge boundary
+                if (mergedBody.endsWith(' ') && next.startsWith(' ')) {
+                    mergedBody.append(next, 1, next.length)
+                } else {
+                    mergedBody.append(next)
+                }
+            }
+            return first.copy(body = mergedBody.toString())
+        }
+
+        val result = mutableListOf<DocTag>()
+        var index = 0
+        while (index <= lastIndex) {
+            val current = this[index]
+            if (current !is Text) {
+                result += current
+            } else {
+                val startIndex = index
+                while (canMergeTextWithNext(index)) {
+                    index++
+                }
+                result += mergedTextNode(startIndex, index)
+            }
+            index++
+        }
+        return result
+    }
 
     private fun List<ASTNode>.swapImagesThatShouldBeLinks(keepAllFormatting: Boolean): List<ASTNode> =
         if (keepAllFormatting) {

--- a/dokka-subprojects/analysis-markdown-jb/src/main/kotlin/org/jetbrains/dokka/analysis/markdown/jb/MarkdownParser.kt
+++ b/dokka-subprojects/analysis-markdown-jb/src/main/kotlin/org/jetbrains/dokka/analysis/markdown/jb/MarkdownParser.kt
@@ -132,21 +132,12 @@ public open class MarkdownParser(
     private fun List<ASTNode>.evaluateChildrenWithDroppedEnclosingTokens(count: Int) =
         drop(count).dropLast(count).evaluateChildren()
 
-    /**
-     * Tracks if we are currently processing elements inside of [MarkdownElementTypes.BLOCK_QUOTE] element.
-     * More info on the specifics and why we need it, in the documentation of [preprocessTextElement]
-     */
-    private var isInsideBlockquote = false
-    private fun blockquotesHandler(node: ASTNode): List<DocTag> {
-        isInsideBlockquote = true
-        val result = DocTagsFromIElementFactory.getInstance(
+    private fun blockquotesHandler(node: ASTNode) =
+        DocTagsFromIElementFactory.getInstance(
             node.type, children = node.children
                 .filterIsInstance<CompositeASTNode>()
                 .evaluateChildren()
         )
-        isInsideBlockquote = false
-        return result
-    }
 
     private fun listsHandler(node: ASTNode): List<DocTag> {
 
@@ -287,12 +278,18 @@ public open class MarkdownParser(
         body = text.substring(node.startOffset, node.endOffset)
     )
 
+    /**
+     * When parsing the following Markdown:
+     * ```text
+     * First line
+     * Second line
+     * ```
+     * Text element will contain: `First line\n Second line`.
+     * But it's still a single paragraph that should be concatenated into a single line.
+     */
     private fun textHandler(node: ASTNode, keepAllFormatting: Boolean) = DocTagsFromIElementFactory.getInstance(
         MarkdownTokenTypes.TEXT,
-        body = preprocessTextElement(
-            text = text.substring(node.startOffset, node.endOffset),
-            isInsideBlockquotesHandler = isInsideBlockquote
-        ),
+        body = text.substring(node.startOffset, node.endOffset).replace('\n', ' '),
         keepFormatting = keepAllFormatting
     )
 
@@ -440,6 +437,7 @@ public open class MarkdownParser(
             MarkdownTokenTypes.CODE_LINE,
             -> codeLineHandler(node)
             MarkdownTokenTypes.TEXT -> textHandler(node, keepAllFormatting)
+            MarkdownTokenTypes.BLOCK_QUOTE -> emptyList()
             MarkdownElementTypes.MARKDOWN_FILE -> markdownFileHandler(node)
             GFMElementTypes.STRIKETHROUGH -> strikeThroughHandler(node)
             GFMElementTypes.TABLE -> tableHandler(node)
@@ -491,7 +489,8 @@ public open class MarkdownParser(
         MarkdownTokenTypes.HORIZONTAL_RULE,
         MarkdownTokenTypes.HARD_LINE_BREAK,
         MarkdownTokenTypes.HTML_TAG,
-        MarkdownTokenTypes.HTML_BLOCK_CONTENT
+        MarkdownTokenTypes.HTML_BLOCK_CONTENT,
+        MarkdownTokenTypes.BLOCK_QUOTE
     )
 
     private fun ASTNode.isNotLeaf() = this is CompositeASTNode || this.type in notLeafNodes
@@ -554,42 +553,6 @@ public open class MarkdownParser(
             return listOfNotNull(this.packageName, this.classNames, this.callable?.name)
                 .joinToString(separator = ".")
                 .takeIf { it.isNotBlank() }
-        }
-
-        // Note: Regex creation is a complex operation, and so it should be created once
-        private val blockquoteNewLineRegex = Regex("\n>+ ")
-
-        /**
-         * Performs preprocessing of the Markdown text element.
-         *
-         * First replacement: blockquotes' handling, executed if [isInsideBlockquotesHandler] is `true`
-         * Markdown parser,
-         * when handling blockquotes will handle (remove) `>` symbols only for the first line
-         * and will do nothing for further lines.
-         * So we need to do it manually, for example, when parsing the following Markdown:
-         * ```text
-         * > First line
-         * > Second line
-         * ```
-         * Text element will contain: `First line\n> Second line`.
-         *
-         * Second replacement: combining multiple lines into a single paragraph
-         * When parsing the following Markdown:
-         * ```text
-         * First line
-         * Second line
-         * ```
-         * Text element will contain: `First line\n Second line`.
-         * But it's still a single paragraph that should be concatenated into a single one.
-         *
-         * @param isInsideBlockquotesHandler `true` if the text is inside of blockquotes, and so additional blockquotes preprocessing is required.
-         */
-        private fun preprocessTextElement(text: String, isInsideBlockquotesHandler: Boolean): String {
-            // Note: we need to first do blockquote replacement so that the next lines will be concatenated into a single paragraph.
-            return when {
-                isInsideBlockquotesHandler -> text.replace(blockquoteNewLineRegex, "\n")
-                else -> text
-            }.replace('\n', ' ')
         }
     }
 }

--- a/dokka-subprojects/plugin-base/src/test/kotlin/markdown/ParserTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/markdown/ParserTest.kt
@@ -954,6 +954,329 @@ class ParserTest : KDocTest() {
     }
 
     @Test
+    fun `Blockquote with formatting should merge text around inline elements`() {
+        val kdoc = """
+        | > text **bold** text
+        | > more text
+        """.trimMargin()
+        val expectedDocumentationNode = DocumentationNode(
+            listOf(
+                Description(
+                    CustomDocTag(
+                        listOf(
+                            BlockQuote(
+                                listOf(
+                                    P(
+                                        listOf(
+                                            Text("text "),
+                                            Strong(listOf(Text("bold"))),
+                                            Text(" text more text")
+                                        )
+                                    )
+                                )
+                            )
+                        ), name = MARKDOWN_ELEMENT_FILE_NAME
+                    )
+                )
+            )
+        )
+        executeTest(kdoc, expectedDocumentationNode)
+    }
+
+    @Test
+    fun `Blockquote with three lines should merge all text`() {
+        val kdoc = """
+        | > line 1
+        | > line 2
+        | > line 3
+        """.trimMargin()
+        val expectedDocumentationNode = DocumentationNode(
+            listOf(
+                Description(
+                    CustomDocTag(
+                        listOf(
+                            BlockQuote(
+                                listOf(
+                                    P(listOf(Text("line 1 line 2 line 3")))
+                                )
+                            )
+                        ), name = MARKDOWN_ELEMENT_FILE_NAME
+                    )
+                )
+            )
+        )
+        executeTest(kdoc, expectedDocumentationNode)
+    }
+
+    @Test
+    fun `Blockquote triple nested`() {
+        val kdoc = """
+        | > level 1
+        | >> level 2
+        | >>> level 3
+        """.trimMargin()
+        val expectedDocumentationNode = DocumentationNode(
+            listOf(
+                Description(
+                    CustomDocTag(
+                        listOf(
+                            BlockQuote(
+                                listOf(
+                                    P(listOf(Text("level 1"))),
+                                    BlockQuote(
+                                        listOf(
+                                            P(listOf(Text("level 2"))),
+                                            BlockQuote(
+                                                listOf(
+                                                    P(listOf(Text("level 3")))
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        ), name = MARKDOWN_ELEMENT_FILE_NAME
+                    )
+                )
+            )
+        )
+        executeTest(kdoc, expectedDocumentationNode)
+    }
+
+    @Test
+    fun `Blockquote with code span should not merge across it`() {
+        val kdoc = """
+        | > before `code` after
+        | > more text
+        """.trimMargin()
+        val expectedDocumentationNode = DocumentationNode(
+            listOf(
+                Description(
+                    CustomDocTag(
+                        listOf(
+                            BlockQuote(
+                                listOf(
+                                    P(
+                                        listOf(
+                                            Text("before "),
+                                            CodeInline(listOf(Text("code"))),
+                                            Text(" after more text")
+                                        )
+                                    )
+                                )
+                            )
+                        ), name = MARKDOWN_ELEMENT_FILE_NAME
+                    )
+                )
+            )
+        )
+        executeTest(kdoc, expectedDocumentationNode)
+    }
+
+    @Test
+    fun `Blockquote with link should merge text around it`() {
+        val kdoc = """
+        | > before [link](http://example.com) after
+        | > more text
+        """.trimMargin()
+        val expectedDocumentationNode = DocumentationNode(
+            listOf(
+                Description(
+                    CustomDocTag(
+                        listOf(
+                            BlockQuote(
+                                listOf(
+                                    P(
+                                        listOf(
+                                            Text("before "),
+                                            A(
+                                                listOf(Text("link")),
+                                                mapOf("href" to "http://example.com")
+                                            ),
+                                            Text(" after more text")
+                                        )
+                                    )
+                                )
+                            )
+                        ), name = MARKDOWN_ELEMENT_FILE_NAME
+                    )
+                )
+            )
+        )
+        executeTest(kdoc, expectedDocumentationNode)
+    }
+
+    @Test
+    fun `Blockquote with fenced code block`() {
+        val kdoc = """
+        | > Before code
+        | >
+        | > ```kotlin
+        | > val x = 1
+        | > val y = 2
+        | > ```
+        | >
+        | > After code
+         """.trimMargin()
+
+        val expectedDocumentationNode = DocumentationNode(
+            listOf(
+                Description(
+                    CustomDocTag(
+                        listOf(
+                            BlockQuote(
+                                listOf(
+                                    P(listOf(Text("Before code"))),
+                                    CodeBlock(
+                                        listOf(
+                                            Text("val x = 1"), Br,
+                                            Text("val y = 2")
+                                        ),
+                                        params = mapOf("lang" to "kotlin")
+                                    ),
+                                    P(listOf(Text("After code")))
+                                )
+                            )
+                        ), name = MARKDOWN_ELEMENT_FILE_NAME
+                    )
+                )
+            )
+        )
+        executeTest(kdoc, expectedDocumentationNode)
+    }
+
+    @Test
+    fun `Blockquote with unordered list`() {
+        val kdoc = """
+        | > Shopping list:
+        | >
+        | > * Apples
+        | > * Oranges
+        | >     * Blood oranges
+        | >     * Mandarins
+        | > * Bananas
+         """.trimMargin()
+
+        val expectedDocumentationNode = DocumentationNode(
+            listOf(
+                Description(
+                    CustomDocTag(
+                        listOf(
+                            BlockQuote(
+                                listOf(
+                                    P(listOf(Text("Shopping list:"))),
+                                    Ul(
+                                        listOf(
+                                            Li(listOf(P(listOf(Text("Apples"))))),
+                                            Li(listOf(P(listOf(Text("Oranges"))))),
+                                            Ul(
+                                                listOf(
+                                                    Li(listOf(P(listOf(Text("Blood oranges"))))),
+                                                    Li(listOf(P(listOf(Text("Mandarins")))))
+                                                )
+                                            ),
+                                            Li(listOf(P(listOf(Text("Bananas")))))
+                                        )
+                                    )
+                                )
+                            )
+                        ), name = MARKDOWN_ELEMENT_FILE_NAME
+                    )
+                )
+            )
+        )
+        executeTest(kdoc, expectedDocumentationNode)
+    }
+
+    @Test
+    fun `Blockquote with ordered list`() {
+        val kdoc = """
+        | > Steps:
+        | >
+        | > 3. Prepare
+        | > 4. Run
+        | >     1. Build
+        | >     2. Test
+        | > 5. Publish
+         """.trimMargin()
+
+        val expectedDocumentationNode = DocumentationNode(
+            listOf(
+                Description(
+                    CustomDocTag(
+                        listOf(
+                            BlockQuote(
+                                listOf(
+                                    P(listOf(Text("Steps:"))),
+                                    Ol(
+                                        listOf(
+                                            Li(listOf(P(listOf(Text("Prepare"))))),
+                                            Li(listOf(P(listOf(Text("Run"))))),
+                                            Ol(
+                                                listOf(
+                                                    Li(listOf(P(listOf(Text("Build"))))),
+                                                    Li(listOf(P(listOf(Text("Test")))))
+                                                ),
+                                                mapOf("start" to "1")
+                                            ),
+                                            Li(listOf(P(listOf(Text("Publish")))))
+                                        ),
+                                        mapOf("start" to "3")
+                                    )
+                                )
+                            )
+                        ), name = MARKDOWN_ELEMENT_FILE_NAME
+                    )
+                )
+            )
+        )
+        executeTest(kdoc, expectedDocumentationNode)
+    }
+
+    @Test
+    fun `Blockquote with list containing code block`() {
+        val kdoc = """
+        | > * Item with code:
+        | >
+        | >     ```kotlin
+        | >     println("quoted")
+        | >     ```
+        | >
+        | > * Next item
+         """.trimMargin()
+
+        val expectedDocumentationNode = DocumentationNode(
+            listOf(
+                Description(
+                    CustomDocTag(
+                        listOf(
+                            BlockQuote(
+                                listOf(
+                                    Ul(
+                                        listOf(
+                                            Li(
+                                                listOf(
+                                                    P(listOf(Text("Item with code:"))),
+                                                    CodeBlock(
+                                                        listOf(Text("  println(\"quoted\")")),
+                                                        params = mapOf("lang" to "kotlin")
+                                                    ),
+                                                )
+                                            ),
+                                            Li(listOf(P(listOf(Text("Next item")))))
+                                        )
+                                    )
+                                )
+                            )
+                        ), name = MARKDOWN_ELEMENT_FILE_NAME
+                    )
+                )
+            )
+        )
+        executeTest(kdoc, expectedDocumentationNode)
+    }
+
+    @Test
     fun `Blockquote nested with fancy text enhancement`() {
         val kdoc = """
         | > text **1**
@@ -1004,6 +1327,45 @@ class ParserTest : KDocTest() {
                             BlockQuote(
                                 listOf(
                                     P(listOf(Text("Quote")))
+                                )
+                            )
+                        ), name = MARKDOWN_ELEMENT_FILE_NAME
+                    )
+                )
+            )
+        )
+        executeTest(kdoc, expectedDocumentationNode)
+    }
+
+    @Test
+    fun `List containing code block`() {
+        val kdoc = """
+        | * Item with code:
+        |
+        |     ```kotlin
+        |     println("quoted")
+        |     ```
+        |
+        | * Next item
+         """.trimMargin()
+
+        val expectedDocumentationNode = DocumentationNode(
+            listOf(
+                Description(
+                    CustomDocTag(
+                        listOf(
+                            Ul(
+                                listOf(
+                                    Li(
+                                        listOf(
+                                            P(listOf(Text("Item with code:"))),
+                                            CodeBlock(
+                                                listOf(Text("  println(\"quoted\")")),
+                                                params = mapOf("lang" to "kotlin")
+                                            ),
+                                        )
+                                    ),
+                                    Li(listOf(P(listOf(Text("Next item")))))
                                 )
                             )
                         ), name = MARKDOWN_ELEMENT_FILE_NAME


### PR DESCRIPTION
Replaces the approach used in #4210 to fix #3775 with a more robust solution.

The first commit (3ee3171f443716a7edf7f21b1f64635dfd7ffc92) adds additional tests covering various edge cases related to blockquote handling. All new test passes even without the other changes.

The second commit (63e43acec15da59c005763c3dc0daa9e5c4e1710) changes how we handle block quotes. At some point, after some investigation, I understood that because we try to be smart and merge "[non-leaf](https://github.com/Kotlin/dokka/blob/baa4a0c0962ebd6eecb583c997136609b67532c3/dokka-subprojects/analysis-markdown-jb/src/main/kotlin/org/jetbrains/dokka/analysis/markdown/jb/MarkdownParser.kt#L490-L503)" nodes, so that we can get the complete [text node](https://github.com/Kotlin/dokka/blob/baa4a0c0962ebd6eecb583c997136609b67532c3/dokka-subprojects/analysis-markdown-jb/src/main/kotlin/org/jetbrains/dokka/analysis/markdown/jb/MarkdownParser.kt#L293) by just getting a substring of the original markdown comment. But it hasn't taken into account the blockquotes and treated them like a part of the text - that's why we needed a regex to filter them out. New approach uses block quotes as a "separator", so now we create two text nodes if they are split by a new line & block quote.

The third commit (215ba2ef49cd3ce22af09758e486b57342aa5cc4) merges those split text nodes back. Overall, this commit is not strictly required, and everything will continue to work, though tests will need to be adapted. It mostly needed to preserve the current behavior, where `Text` DocTags are split only if they have a different node in the middle, which sounds reasonable. Feel free to suggest a better approach here!

P.S. Overall, the branch was there for a while on my side, but I forgot about it. Recently, while pruning local branches, I spotted it and decided to clean it up and finalize the fix. :)