### PR TITLE
Update markdown library version

### DIFF
--- a/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/parsers/doctag/markdown/MarkdownToHtmlConverter.kt
+++ b/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/parsers/doctag/markdown/MarkdownToHtmlConverter.kt
@@ -6,6 +6,7 @@ package org.jetbrains.dokka.analysis.java.parsers.doctag.markdown
 
 import org.intellij.markdown.flavours.MarkdownFlavourDescriptor
 import org.intellij.markdown.html.HtmlGenerator
+import org.intellij.markdown.parser.CancellationToken
 import org.intellij.markdown.parser.LinkMap
 import org.intellij.markdown.parser.MarkdownParser
 import java.net.URI
@@ -24,7 +25,10 @@ internal class MarkdownToHtmlConverter(
      * @return The HTML representation of the provided Markdown content.
      */
     fun convertMarkdownToHtml(markdownText: String, server: String? = null): String {
-        val parsedTree = MarkdownParser(flavourDescriptor).buildMarkdownTreeFromString(markdownText)
+        val parsedTree = MarkdownParser(
+            flavour = flavourDescriptor,
+            cancellationToken = CancellationToken.NonCancellable
+        ).buildMarkdownTreeFromString(markdownText as CharSequence)
         val providers = flavourDescriptor.createHtmlGeneratingProviders(
             linkMap = LinkMap.buildLinkMap(parsedTree, markdownText),
             baseURI = server?.let { URI(it) }

--- a/dokka-subprojects/analysis-markdown-jb/src/main/kotlin/org/jetbrains/dokka/analysis/markdown/jb/MarkdownParser.kt
+++ b/dokka-subprojects/analysis-markdown-jb/src/main/kotlin/org/jetbrains/dokka/analysis/markdown/jb/MarkdownParser.kt
@@ -14,6 +14,7 @@ import org.intellij.markdown.flavours.gfm.GFMElementTypes
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 import org.intellij.markdown.flavours.gfm.GFMTokenTypes
 import org.intellij.markdown.html.HtmlGenerator
+import org.intellij.markdown.parser.CancellationToken
 import org.jetbrains.dokka.InternalDokkaApi
 import org.jetbrains.dokka.analysis.markdown.jb.factories.DocTagsFromIElementFactory
 import org.jetbrains.dokka.links.DRI
@@ -34,7 +35,10 @@ public open class MarkdownParser(
 
     override fun parseStringToDocNode(extractedString: String): DocTag {
         val gfmFlavourDescriptor = GFMFlavourDescriptor()
-        val markdownAstRoot = IntellijMarkdownParser(gfmFlavourDescriptor).buildMarkdownTreeFromString(extractedString)
+        val markdownAstRoot = IntellijMarkdownParser(
+            flavour = gfmFlavourDescriptor,
+            cancellationToken = CancellationToken.NonCancellable
+        ).buildMarkdownTreeFromString(extractedString as CharSequence)
         destinationLinksMap = getAllDestinationLinks(extractedString, markdownAstRoot).toMap()
         text = extractedString
 

--- a/dokka-subprojects/plugin-base/src/test/kotlin/markdown/LinkTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/markdown/LinkTest.kt
@@ -1548,6 +1548,145 @@ class LinkTest : BaseAbstractTest() {
         }
     }
 
+    // https://github.com/Kotlin/dokka/issues/4234
+    // https://youtrack.jetbrains.com/issue/KTIJ-35552
+    @Test
+    fun `should resolve KDoc link back to back with other links and elements`() {
+        testInline(
+            """
+            |/src/main/kotlin/Testing.kt
+            |package example
+            |/**
+            | * `a`[Int]`b`[Long]`c`
+            | */
+            |fun protocol(text: String) {}
+        """.trimMargin(),
+            configuration
+        ) {
+            documentablesMergingStage = { module ->
+                val doc = module.packages.single()
+                    .functions.single { it.name == "protocol" }
+                    .documentation.values.single()
+
+                val expectedDocumentationNode = DocumentationNode(
+                    listOf(
+                        Description(
+                            CustomDocTag(
+                                listOf(
+                                    P(
+                                        listOf(
+                                            CodeInline(listOf(Text("a"))),
+                                            DocumentationLink(
+                                                dri = DRI("kotlin", "Int"),
+                                                children = listOf(Text("Int")),
+                                                params = mapOf("href" to "[Int]")
+                                            ),
+                                            CodeInline(listOf(Text("b"))),
+                                            DocumentationLink(
+                                                dri = DRI("kotlin", "Long"),
+                                                children = listOf(Text("Long")),
+                                                params = mapOf("href" to "[Long]")
+                                            ),
+                                            CodeInline(listOf(Text("c"))),
+                                        )
+                                    )
+                                ), name = MARKDOWN_ELEMENT_FILE_NAME
+                            )
+                        )
+                    )
+                )
+                assertEquals(expectedDocumentationNode, doc)
+            }
+        }
+    }
+
+    // https://youtrack.jetbrains.com/issue/KTIJ-35278
+    @Test
+    fun `should resolve KDoc link followed by other link`() {
+        testInline(
+            """
+            |/src/main/kotlin/Testing.kt
+            |package example
+            |/**
+            | * A [Int] [Long] works!
+            | *
+            | * A [Int] [label][Long] works!
+            | *
+            | * A [label][Int] [Long] works!
+            | *
+            | * A [labelA][Int] [labelB][Long] works!
+            | */
+            |fun protocol(text: String) {}
+        """.trimMargin(),
+            configuration
+        ) {
+            documentablesMergingStage = { module ->
+                val doc = module.packages.single()
+                    .functions.single { it.name == "protocol" }
+                    .documentation.values.single()
+
+                val intLink = DocumentationLink(
+                    dri = DRI("kotlin", "Int"),
+                    children = listOf(Text("Int")),
+                    params = mapOf("href" to "[Int]")
+                )
+                val longLink = DocumentationLink(
+                    dri = DRI("kotlin", "Long"),
+                    children = listOf(Text("Long")),
+                    params = mapOf("href" to "[Long]")
+                )
+
+                val expectedDocumentationNode = DocumentationNode(
+                    listOf(
+                        Description(
+                            CustomDocTag(
+                                listOf(
+                                    P(
+                                        listOf(
+                                            Text("A "),
+                                            intLink,
+                                            Text(" "),
+                                            longLink,
+                                            Text(" works!"),
+                                        )
+                                    ),
+                                    P(
+                                        listOf(
+                                            Text("A "),
+                                            intLink,
+                                            Text(" "),
+                                            longLink.copy(children = listOf(Text("label"))),
+                                            Text(" works!"),
+                                        )
+                                    ),
+                                    P(
+                                        listOf(
+                                            Text("A "),
+                                            intLink.copy(children = listOf(Text("label"))),
+                                            Text(" "),
+                                            longLink,
+                                            Text(" works!"),
+                                        )
+                                    ),
+                                    P(
+                                        listOf(
+                                            Text("A "),
+                                            intLink.copy(children = listOf(Text("labelA"))),
+                                            Text(" "),
+                                            longLink.copy(children = listOf(Text("labelB"))),
+                                            Text(" works!"),
+                                        )
+                                    ),
+                                ), name = MARKDOWN_ELEMENT_FILE_NAME
+                            )
+                        )
+                    )
+                )
+                assertEquals(expectedDocumentationNode, doc)
+            }
+        }
+    }
+
     @Test
     fun `should warn about unresolved links`() {
         testInline(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ korlibs-template = "4.0.10"
 kotlinx-html = "0.9.1"
 
 ## Markdown
-jetbrains-markdown = "0.7.3"
+jetbrains-markdown = "0.7.10"
 
 ## JSON
 # jackson 2.15.3 is the latest version, which works correctly with Kotlin API/Language 1.4 and Gradle 7.6.3+


### PR DESCRIPTION
Fixes #4234

Update the markdown parser library to the latest one (0.7.10).
The issue found in #4234 was fixed in https://github.com/JetBrains/markdown/commit/30f606b85b15f235c43440a11ccb240295aa4586 and was part of [0.7.8](https://github.com/JetBrains/markdown/blob/master/CHANGELOG.md#078) release.
